### PR TITLE
[Fix] Image URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 3D library for Flutter.
 
-![Failed to load Screenshot](./screenshots/flutter_scene_logo.png)
+![Failed to load Screenshot](https://raw.githubusercontent.com/bdero/flutter_scene/master/screenshots/flutter_scene_logo.png)
 
 Now running on a phone near you!
 


### PR DESCRIPTION
on pub, image from the readme in not loading due to short URL.

![Screenshot_20240807-003055](https://github.com/user-attachments/assets/f39a5c2c-8eea-4687-8e9f-c174ab936cca)
