### PR TITLE
Migrate from native_assets_cli to hooks 1.0 (closes #82)

### DIFF
--- a/examples/flutter_app/hook/build.dart
+++ b/examples/flutter_app/hook/build.dart
@@ -1,4 +1,4 @@
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:hooks/hooks.dart';
 import 'package:flutter_scene_importer/build_hooks.dart';
 
 void main(List<String> args) {

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_scene: ^0.9.2-0
   flutter_scene_importer: ^0.9.0-0
-  native_assets_cli: '>=0.13.0 <0.14.0'
+  hooks: ^1.0.0
   vector_math: ^2.1.4
 
 dev_dependencies:

--- a/packages/flutter_scene/hook/build.dart
+++ b/packages/flutter_scene/hook/build.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_scene_importer/offline_import.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:hooks/hooks.dart';
 
 import 'package:flutter_gpu_shaders/build.dart';
 

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -22,9 +22,7 @@ dependencies:
     sdk: flutter
   flutter_gpu:
     sdk: flutter
-  # TODO: switch to a published version (^0.4.0) once flutter_gpu_shaders 0.4.0 ships.
-  flutter_gpu_shaders:
-    path: ../../../flutter_gpu_shaders
+  flutter_gpu_shaders: ^0.4.0
   flutter_scene_importer: ^0.9.0-0
   hooks: ^1.0.0
   vector_math: ^2.1.4

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -22,9 +22,11 @@ dependencies:
     sdk: flutter
   flutter_gpu:
     sdk: flutter
-  flutter_gpu_shaders: ^0.3.0
+  # TODO: switch to a published version (^0.4.0) once flutter_gpu_shaders 0.4.0 ships.
+  flutter_gpu_shaders:
+    path: ../../../flutter_gpu_shaders
   flutter_scene_importer: ^0.9.0-0
-  native_assets_cli: '>=0.13.0 <0.14.0'
+  hooks: ^1.0.0
   vector_math: ^2.1.4
 
 dev_dependencies:

--- a/packages/flutter_scene_importer/hook/build.dart
+++ b/packages/flutter_scene_importer/hook/build.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
+import 'package:hooks/hooks.dart';
 import 'package:logging/logging.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await build(args, (config, output) async {

--- a/packages/flutter_scene_importer/lib/build_hooks.dart
+++ b/packages/flutter_scene_importer/lib/build_hooks.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:hooks/hooks.dart';
 
 void buildModels({
   required BuildInput buildInput,
@@ -26,12 +26,11 @@ void buildModels({
     outputFileName =
         '${outputFileName.substring(0, outputFileName.lastIndexOf('.'))}.model';
 
-    /// dart --enable-experiment=native-assets run flutter_scene_importer:import \
-    ///      --input <input> --output <output> --working-directory <working-directory>
+    /// dart run flutter_scene_importer:import \
+    ///     --input <input> --output <output> --working-directory <working-directory>
     final importerResult = Process.runSync(
       dartExec.toFilePath(),
       [
-        '--enable-experiment=native-assets',
         'run',
         'flutter_scene_importer:import',
         '--input',

--- a/packages/flutter_scene_importer/pubspec.yaml
+++ b/packages/flutter_scene_importer/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
     sdk: flutter
   flutter_gpu:
     sdk: flutter
+  hooks: ^1.0.0
   logging: ^1.2.0
-  native_assets_cli: '>=0.13.0 <0.14.0'
   vector_math: ^2.1.4
 
 dev_dependencies:


### PR DESCRIPTION
## Summary

Migrates flutter_scene's build hooks from the discontinued `native_assets_cli` package to `hooks` 1.0. This also drops the now-obsolete `--enable-experiment=native-assets` flag from the importer's process invocation, which was the literal cause of #82 — the experiment graduated in Dart 3.10+ and is no longer recognized.

## Changes

- **All four hook entry points** swap `package:native_assets_cli/native_assets_cli.dart` → `package:hooks/hooks.dart`:
  - `packages/flutter_scene/hook/build.dart`
  - `packages/flutter_scene_importer/hook/build.dart`
  - `packages/flutter_scene_importer/lib/build_hooks.dart`
  - `examples/flutter_app/hook/build.dart`
- `build_hooks.dart` also drops `'--enable-experiment=native-assets'` from the args list passed to `dart run flutter_scene_importer:import`.
- All four `pubspec.yaml` files swap `native_assets_cli '>=0.13.0 <0.14.0'` → `hooks: ^1.0.0`.
- `flutter_gpu_shaders` dep bumped to `^0.4.0` (which was just published with the same migration).

The `BuildInput`/`BuildOutputBuilder` API surface used at call sites carries over from `hooks` 1.0 unchanged, so no further changes were needed.

## Test plan

- [x] `dart analyze packages examples` — clean
- [x] `flutter test` passes in `packages/flutter_scene` (3 tests)
- [x] `flutter test` passes in `packages/flutter_scene_importer` (1 test)
- [x] `flutter build macos --debug` — clean build, importer runs with no experiment flag
- [x] `flutter run -d macos --enable-flutter-gpu --enable-impeller` — app launches, Impeller (Metal) backend engages, no exceptions
- [ ] CI passes on this branch

Closes #82.

Note: PR #84 had effectively the same idea but targeted the pre-pub-workspaces layout. We can close that with thanks once this lands.