### PR TITLE
Release 0.10.0

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Lint analysis
         run: dart analyze packages examples
       - name: Dart format
-        run: dart format --output none --set-exit-if-changed $(find . -name '**.dart' -not -name '*_flatbuffers.dart' -not -path '*/build/*')
+        run: dart format --output none --set-exit-if-changed $(find . -name '**.dart' -not -name '*_flatbuffers.dart' -not -path '*/build/*' -not -path '*/third_party/*')
       - name: Run flutter_scene tests
         working-directory: packages/flutter_scene
         run: flutter test --enable-impeller

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_scene: ^0.9.2-0
-  flutter_scene_importer: ^0.9.0-0
+  flutter_scene: ^0.10.0
+  flutter_scene_importer: ^0.10.0
   hooks: ^1.0.0
   vector_math: ^2.1.4
 

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -75,3 +75,16 @@
 ## 0.9.2-0
 
 * Fix globalTransform calculation.
+
+## 0.10.0
+
+* Migrate from `native_assets_cli` (discontinued) to `hooks` 1.0.
+  Breaking: build hook authors must now `import 'package:hooks/hooks.dart'`
+  instead of `package:native_assets_cli/native_assets_cli.dart`. (#82)
+* Drop the `--enable-experiment=native-assets` flag from the importer
+  process invocation. The flag was rejected by Dart 3.10+ and was the
+  literal cause of build failures for users on recent Dart channels. (#82)
+* Reorganize the repository as a pub workspace with separate `flutter_scene`
+  and `flutter_scene_importer` packages and an `examples/` sibling. No
+  user-facing surface changes from this; consumers see a cleaner package. (#36)
+* Update `flutter_gpu_shaders` to `^0.4.0` (also migrated to `hooks`).

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_scene
 description: 3D rendering library for Flutter. Currently only supported when Impeller is enabled.
-version: 0.9.2-0
+version: 0.10.0
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
 platforms:
@@ -13,7 +13,7 @@ platforms:
 resolution: workspace
 
 environment:
-  sdk: '>=3.7.0-75.0.dev <4.0.0'
+  sdk: ^3.7.0
   flutter: ">=3.29.0-1.0.pre.242"
 
 dependencies:
@@ -23,7 +23,7 @@ dependencies:
   flutter_gpu:
     sdk: flutter
   flutter_gpu_shaders: ^0.4.0
-  flutter_scene_importer: ^0.9.0-0
+  flutter_scene_importer: ^0.10.0
   hooks: ^1.0.0
   vector_math: ^2.1.4
 

--- a/packages/flutter_scene_importer/CHANGELOG.md
+++ b/packages/flutter_scene_importer/CHANGELOG.md
@@ -50,3 +50,13 @@
 
 * Update to native_assets_cli 0.13.0.
   Breaking: `BuildConfig` is now `BuildInput`
+
+## 0.10.0
+
+* Migrate from `native_assets_cli` (discontinued) to `hooks` 1.0.
+  Breaking: build hook authors must now `import 'package:hooks/hooks.dart'`
+  instead of `package:native_assets_cli/native_assets_cli.dart`. (#82)
+* Drop the `--enable-experiment=native-assets` flag from the
+  `flutter_scene_importer:import` process invocation. (#82)
+* Reorganize the repository as a pub workspace. Package contents
+  are unchanged. (#36)

--- a/packages/flutter_scene_importer/bin/import.dart
+++ b/packages/flutter_scene_importer/bin/import.dart
@@ -4,10 +4,11 @@ import 'package:args/args.dart';
 import 'package:flutter_scene_importer/offline_import.dart';
 
 void main(List<String> args) {
-  final parser = ArgParser()
-    ..addOption('input', abbr: 'i', help: 'Input glTF file path')
-    ..addOption('output', abbr: 'o', help: 'Output model file path')
-    ..addOption('working-directory', abbr: 'w', help: 'Working directory');
+  final parser =
+      ArgParser()
+        ..addOption('input', abbr: 'i', help: 'Input glTF file path')
+        ..addOption('output', abbr: 'o', help: 'Output model file path')
+        ..addOption('working-directory', abbr: 'w', help: 'Working directory');
 
   final results = parser.parse(args);
 
@@ -18,7 +19,8 @@ void main(List<String> args) {
   if (input == null || output == null) {
     // ignore: avoid_print
     print(
-        'Usage: importer --input <input> --output <output> [--working-directory <working-directory>]');
+      'Usage: importer --input <input> --output <output> [--working-directory <working-directory>]',
+    );
     exit(1);
   }
 

--- a/packages/flutter_scene_importer/hook/build.dart
+++ b/packages/flutter_scene_importer/hook/build.dart
@@ -5,10 +5,11 @@ import 'package:logging/logging.dart';
 
 void main(List<String> args) async {
   await build(args, (config, output) async {
-    final logger = Logger('')
-      ..level = Level.ALL
-      // ignore: avoid_print
-      ..onRecord.listen((record) => print(record.message));
+    final logger =
+        Logger('')
+          ..level = Level.ALL
+          // ignore: avoid_print
+          ..onRecord.listen((record) => print(record.message));
 
     //-------------------------------------------------------------------------
     /// Ensure the "build/" directory exists.
@@ -23,13 +24,10 @@ void main(List<String> args) async {
     /// `cmake -Bbuild -DCMAKE_BUILD_TYPE=Debug`
     ///
     logger.info('Running cmake gen step...');
-    final cmakeGenResult = Process.runSync(
-        'cmake',
-        [
-          '-Bbuild',
-          '-DCMAKE_BUILD_TYPE=Debug',
-        ],
-        workingDirectory: config.packageRoot.toFilePath());
+    final cmakeGenResult = Process.runSync('cmake', [
+      '-Bbuild',
+      '-DCMAKE_BUILD_TYPE=Debug',
+    ], workingDirectory: config.packageRoot.toFilePath());
     if (cmakeGenResult.exitCode != 0) {
       String error =
           'CMake generate step failed (exit code ${cmakeGenResult.exitCode}):\nSTDERR: ${cmakeGenResult.stderr}\nSTDOUT: ${cmakeGenResult.stdout}';
@@ -42,16 +40,13 @@ void main(List<String> args) async {
     /// `cmake --build build --target=importer -j 4`
     ///
     logger.info('Running cmake build step...');
-    final cmakeBuildResult = Process.runSync(
-        'cmake',
-        [
-          '--build',
-          'build',
-          '--target=importer',
-          '-j',
-          '4',
-        ],
-        workingDirectory: config.packageRoot.toFilePath());
+    final cmakeBuildResult = Process.runSync('cmake', [
+      '--build',
+      'build',
+      '--target=importer',
+      '-j',
+      '4',
+    ], workingDirectory: config.packageRoot.toFilePath());
     if (cmakeBuildResult.exitCode != 0) {
       String error =
           'CMake build step failed (exit code ${cmakeBuildResult.exitCode}):\nSTDERR: ${cmakeBuildResult.stderr}\nSTDOUT: ${cmakeBuildResult.stdout}';

--- a/packages/flutter_scene_importer/lib/build_hooks.dart
+++ b/packages/flutter_scene_importer/lib/build_hooks.dart
@@ -7,8 +7,9 @@ void buildModels({
   required List<String> inputFilePaths,
   String outputDirectory = 'build/models/',
 }) {
-  final outDir =
-      Directory.fromUri(buildInput.packageRoot.resolve(outputDirectory));
+  final outDir = Directory.fromUri(
+    buildInput.packageRoot.resolve(outputDirectory),
+  );
   outDir.createSync(recursive: true);
 
   final Uri dartExec = Uri.file(Platform.resolvedExecutable);
@@ -19,7 +20,8 @@ void buildModels({
     // Verify that the input file is a glTF file
     if (!outputFileName.endsWith('.glb')) {
       throw Exception(
-          'Input file must be a .glb file. Given file path: $inputFilePath');
+        'Input file must be a .glb file. Given file path: $inputFilePath',
+      );
     }
 
     // Replace output extension with .model
@@ -28,22 +30,20 @@ void buildModels({
 
     /// dart run flutter_scene_importer:import \
     ///     --input <input> --output <output> --working-directory <working-directory>
-    final importerResult = Process.runSync(
-      dartExec.toFilePath(),
-      [
-        'run',
-        'flutter_scene_importer:import',
-        '--input',
-        inputFilePath,
-        '--output',
-        outDir.uri.resolve(outputFileName).toFilePath(),
-        '--working-directory',
-        buildInput.packageRoot.toFilePath(),
-      ],
-    );
+    final importerResult = Process.runSync(dartExec.toFilePath(), [
+      'run',
+      'flutter_scene_importer:import',
+      '--input',
+      inputFilePath,
+      '--output',
+      outDir.uri.resolve(outputFileName).toFilePath(),
+      '--working-directory',
+      buildInput.packageRoot.toFilePath(),
+    ]);
     if (importerResult.exitCode != 0) {
       throw Exception(
-          'Failed to run flutter_scene_importer:import command in build hook (exit code ${importerResult.exitCode}):\nSTDERR: ${importerResult.stderr}\nSTDOUT: ${importerResult.stdout}');
+        'Failed to run flutter_scene_importer:import command in build hook (exit code ${importerResult.exitCode}):\nSTDERR: ${importerResult.stderr}\nSTDOUT: ${importerResult.stdout}',
+      );
     }
   }
 }

--- a/packages/flutter_scene_importer/lib/flatbuffer.dart
+++ b/packages/flutter_scene_importer/lib/flatbuffer.dart
@@ -14,7 +14,7 @@ extension MatrixHelpers on fb.Matrix {
       m0, m1, m2, m3, //
       m4, m5, m6, m7, //
       m8, m9, m10, m11, //
-      m12, m13, m14, m15 //
+      m12, m13, m14, m15, //
     ]);
   }
 }
@@ -74,9 +74,10 @@ extension TextureHelpers on fb.Texture {
       throw Exception('Texture has no embedded image');
     }
     gpu.Texture texture = gpu.gpuContext.createTexture(
-        gpu.StorageMode.hostVisible,
-        embeddedImage!.width,
-        embeddedImage!.height);
+      gpu.StorageMode.hostVisible,
+      embeddedImage!.width,
+      embeddedImage!.height,
+    );
     Uint8List textureData = embeddedImage!.bytes! as Uint8List;
     texture.overwrite(ByteData.sublistView(textureData));
 

--- a/packages/flutter_scene_importer/lib/importer.dart
+++ b/packages/flutter_scene_importer/lib/importer.dart
@@ -14,7 +14,8 @@ class ImportedScene {
 
   static ImportedScene fromFlatbuffer(ByteData data) {
     final fb.Scene scene = fb.Scene(
-        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes));
+      data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+    );
 
     return ImportedScene._(scene);
   }

--- a/packages/flutter_scene_importer/lib/offline_import.dart
+++ b/packages/flutter_scene_importer/lib/offline_import.dart
@@ -1,8 +1,11 @@
 import 'dart:io';
 import 'dart:isolate';
 
-Uri findBuiltExecutable(String executableName, Uri packageRoot,
-    {String dir = 'build/'}) {
+Uri findBuiltExecutable(
+  String executableName,
+  Uri packageRoot, {
+  String dir = 'build/',
+}) {
   List<String> locations = [
     'Release/$executableName',
     'Release/$executableName.exe',
@@ -25,51 +28,61 @@ Uri findBuiltExecutable(String executableName, Uri packageRoot,
   }
   if (found == null) {
     throw Exception(
-        'Unable to find build executable $executableName! Tried the following locations: $tried');
+      'Unable to find build executable $executableName! Tried the following locations: $tried',
+    );
   }
   return found;
 }
 
 Uri findImporterPackageRoot() {
-  Uri importerPackageUri = Isolate.resolvePackageUriSync(
-      Uri.parse('package:flutter_scene_importer/'))!;
+  Uri importerPackageUri =
+      Isolate.resolvePackageUriSync(
+        Uri.parse('package:flutter_scene_importer/'),
+      )!;
   return importerPackageUri.resolve('../');
 }
 
-void generateImporterFlatbufferDart(
-    {String generatedOutputDirectory = "lib/generated/"}) {
+void generateImporterFlatbufferDart({
+  String generatedOutputDirectory = "lib/generated/",
+}) {
   final packageRoot = findImporterPackageRoot();
-  final flatc = findBuiltExecutable('flatc', packageRoot,
-      dir: 'build/_deps/flatbuffers-build/');
+  final flatc = findBuiltExecutable(
+    'flatc',
+    packageRoot,
+    dir: 'build/_deps/flatbuffers-build/',
+  );
 
-  final flatcResult = Process.runSync(
-      flatc.toFilePath(),
-      [
-        '-o',
-        generatedOutputDirectory,
-        '--warnings-as-errors',
-        '--gen-object-api',
-        '--filename-suffix',
-        '_flatbuffers',
-        '--dart',
-        'scene.fbs',
-      ],
-      workingDirectory: packageRoot.toFilePath());
+  final flatcResult = Process.runSync(flatc.toFilePath(), [
+    '-o',
+    generatedOutputDirectory,
+    '--warnings-as-errors',
+    '--gen-object-api',
+    '--filename-suffix',
+    '_flatbuffers',
+    '--dart',
+    'scene.fbs',
+  ], workingDirectory: packageRoot.toFilePath());
   if (flatcResult.exitCode != 0) {
     throw Exception(
-        'Failed to generate importer flatbuffer: ${flatcResult.stderr}\n${flatcResult.stdout}');
+      'Failed to generate importer flatbuffer: ${flatcResult.stderr}\n${flatcResult.stdout}',
+    );
   }
 
   /// Update the generated file's flatbuffer include to use a patched version
   /// that allows for flatbuffer arrays to be accessed without copies.
   /// TODO(bdero): Remove after https://github.com/google/flatbuffers/pull/8289
   ///              makes it into the Dart package.
-  final generatedFile = File.fromUri(packageRoot
-      .resolve(generatedOutputDirectory)
-      .resolve('scene_impeller.fb_flatbuffers.dart'));
+  final generatedFile = File.fromUri(
+    packageRoot
+        .resolve(generatedOutputDirectory)
+        .resolve('scene_impeller.fb_flatbuffers.dart'),
+  );
   final lines = generatedFile.readAsLinesSync();
-  final importLineIndex = lines.indexWhere((element) => element
-      .contains("import 'package:flat_buffers/flat_buffers.dart' as fb;"));
+  final importLineIndex = lines.indexWhere(
+    (element) => element.contains(
+      "import 'package:flat_buffers/flat_buffers.dart' as fb;",
+    ),
+  );
   if (importLineIndex == -1) {
     throw Exception('Failed to find flat_buffer import line in generated file');
   }
@@ -79,8 +92,11 @@ void generateImporterFlatbufferDart(
 }
 
 /// Takes an input model (glTF file) and
-void importGltf(String inputGltfFilePath, String outputModelFilePath,
-    {String? workingDirectory}) {
+void importGltf(
+  String inputGltfFilePath,
+  String outputModelFilePath, {
+  String? workingDirectory,
+}) {
   final packageRoot = findImporterPackageRoot();
   final importer = findBuiltExecutable('importer', packageRoot);
 
@@ -89,23 +105,22 @@ void importGltf(String inputGltfFilePath, String outputModelFilePath,
   // bode well with Windows paths.
   final inputGltfFilePathUri = Uri.file(inputGltfFilePath);
   final outputModelFilePathUri = Uri.file(outputModelFilePath);
-  final workingDirectoryUri =
-      Uri.directory(workingDirectory ?? packageRoot.toFilePath());
+  final workingDirectoryUri = Uri.directory(
+    workingDirectory ?? packageRoot.toFilePath(),
+  );
   inputGltfFilePath =
       workingDirectoryUri.resolveUri(inputGltfFilePathUri).toFilePath();
   outputModelFilePath =
       workingDirectoryUri.resolveUri(outputModelFilePathUri).toFilePath();
   //throw Exception('root $packageRoot input $inputGltfFilePath output $outputModelFilePath');
 
-  final importerResult = Process.runSync(
-      importer.toFilePath(),
-      [
-        inputGltfFilePath,
-        outputModelFilePath,
-      ],
-      workingDirectory: workingDirectory);
+  final importerResult = Process.runSync(importer.toFilePath(), [
+    inputGltfFilePath,
+    outputModelFilePath,
+  ], workingDirectory: workingDirectory);
   if (importerResult.exitCode != 0) {
     throw Exception(
-        'Failed to run importer: ${importerResult.stderr}\n${importerResult.stdout}');
+      'Failed to run importer: ${importerResult.stderr}\n${importerResult.stdout}',
+    );
   }
 }

--- a/packages/flutter_scene_importer/pubspec.yaml
+++ b/packages/flutter_scene_importer/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_scene_importer
 description: "An offline 3D model importer for Flutter. Converts glTF files into the Flutter Scene model format."
-version: 0.9.0-0
+version: 0.10.0
 homepage: https://github.com/bdero/flutter_scene
 platforms:
   linux:
@@ -12,7 +12,7 @@ platforms:
 resolution: workspace
 
 environment:
-  sdk: '>=3.6.0-0 <4.0.0'
+  sdk: ^3.7.0
   flutter: ">=3.29.0-1.0.pre.242"
 
 dependencies:


### PR DESCRIPTION
## Summary

First non-prerelease release. Cuts the \`-0\` prerelease suffix that's been on every release since 0.2.1-0 and bumps both packages from 0.9.x-0 to **0.10.0**.

This release bundles the work from #90 and #91:

- **Hooks 1.0 migration** (closes #82). \`native_assets_cli\` is discontinued; build hook authors must now \`import 'package:hooks/hooks.dart'\`.
- **Pub workspaces repo refactor** (closes #36). Internal-only — package contents are unchanged.
- **flutter_gpu_shaders bumped** to \`^0.4.0\` (also migrated to \`hooks\` and just published).

## Why drop the \`-0\` suffix?

The previous SDK constraints were \`>=3.7.0-75.0.dev\` (prerelease-pinned), which forced pub.dev to require prerelease versioning. Those prerelease pins were left over from active development against specific dev builds and weren't actually needed — the Flutter SDK constraint already captures the "needs Flutter master" requirement. Normalizing to \`^3.7.0\` lets us publish a clean 0.10.0.

## Test plan

- [x] \`flutter pub get\` resolves clean
- [x] \`dart analyze packages examples\` clean
- [x] \`flutter test\` passes in both packages
- [x] \`flutter pub publish --dry-run\` from \`packages/flutter_scene_importer\` — 0 warnings, 1 hint (version-bump suggestion: confirms 0.10.0 is right for a breaking release)
- [x] \`flutter pub publish --dry-run\` from \`packages/flutter_scene\` — 1 warning (pre-existing \`lib/scene.dart\` naming, not in scope)
- [ ] CI passes
- [ ] Publish in order: \`flutter_scene_importer\` first (since flutter_scene depends on it), then \`flutter_scene\`