### PR TITLE
Default importer working-directory to CWD (closes #50)

### DIFF
--- a/packages/flutter_scene_importer/bin/import.dart
+++ b/packages/flutter_scene_importer/bin/import.dart
@@ -6,9 +6,27 @@ import 'package:flutter_scene_importer/offline_import.dart';
 void main(List<String> args) {
   final parser =
       ArgParser()
-        ..addOption('input', abbr: 'i', help: 'Input glTF file path')
-        ..addOption('output', abbr: 'o', help: 'Output model file path')
-        ..addOption('working-directory', abbr: 'w', help: 'Working directory');
+        ..addOption(
+          'input',
+          abbr: 'i',
+          help:
+              'Input glTF (.glb) file path. Resolved relative to '
+              '--working-directory.',
+        )
+        ..addOption(
+          'output',
+          abbr: 'o',
+          help:
+              'Output .model file path. Resolved relative to '
+              '--working-directory.',
+        )
+        ..addOption(
+          'working-directory',
+          abbr: 'w',
+          help:
+              'Directory used to resolve relative --input and --output paths. '
+              'Defaults to the current working directory.',
+        );
 
   final results = parser.parse(args);
 

--- a/packages/flutter_scene_importer/lib/offline_import.dart
+++ b/packages/flutter_scene_importer/lib/offline_import.dart
@@ -105,8 +105,12 @@ void importGltf(
   // bode well with Windows paths.
   final inputGltfFilePathUri = Uri.file(inputGltfFilePath);
   final outputModelFilePathUri = Uri.file(outputModelFilePath);
+  // Default to the caller's CWD when no working directory is supplied, so
+  // command-line invocations like `dart run flutter_scene_importer:import`
+  // resolve input/output paths relative to where the user ran the command
+  // (not relative to the importer package's root in pub-cache).
   final workingDirectoryUri = Uri.directory(
-    workingDirectory ?? packageRoot.toFilePath(),
+    workingDirectory ?? Directory.current.path,
   );
   inputGltfFilePath =
       workingDirectoryUri.resolveUri(inputGltfFilePathUri).toFilePath();


### PR DESCRIPTION
## Summary

#50 reported that running the importer from the command line without `--working-directory` produces a confusing error:

```
Failed to open input file:
  /Users/.../.pub-cache/hosted/pub.dev/flutter_scene_importer-0.X.Y/models/model.glb
```

The workaround (`-w .`) wasn't documented. Looking at the code, this is more than a docs gap — `lib/offline_import.dart` was defaulting `workingDirectory` to the *importer's package root in pub-cache* when the user omitted the flag, which is never what anyone wants.

This PR makes the default what users expect: when `--working-directory` is omitted, fall back to `Directory.current.path`. Build hooks pass the flag explicitly already, so they're unaffected.

## Changes

- `packages/flutter_scene_importer/lib/offline_import.dart`: change the null-fallback in `importGltf` from `packageRoot.toFilePath()` to `Directory.current.path`. Add an explanatory comment.
- `packages/flutter_scene_importer/bin/import.dart`: expand the `--help` text on each option to document the relationship between `--input`/`--output` and `--working-directory`.

## Test plan

- [x] `dart analyze` clean
- [x] Build hook flow unchanged (both `flutter_scene/hook/build.dart` and `examples/flutter_app/hook/build.dart` already pass `--working-directory` explicitly via `buildModels` / the importer call)
- [ ] CI passes

Closes #50.