### PR TITLE
Fix normal map placeholder color (closes #95)

### DIFF
--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -48,7 +48,7 @@ abstract class Material {
       throw Exception('Failed to create normal placeholder texture.');
     }
     _normalPlaceholderTexture!.overwrite(
-      Uint32List.fromList(<int>[0xFFFF7574]).buffer.asByteData(),
+      Uint32List.fromList(<int>[0xFFFF7F7F]).buffer.asByteData(),
     );
     return _normalPlaceholderTexture!;
   }


### PR DESCRIPTION
## Summary

`_normalPlaceholderTexture` (used when a material doesn't supply an explicit normal map) was initialized with bytes `0xFFFF7574`, decoding to RGBA(116, 117, 255, 255). The canonical flat tangent-space normal is (0.5, 0.5, 1.0) → RGBA(127, 127, 255, 255) → `0xFFFF7F7F`.

Materials without an explicit normal map were being shaded as if their surface had a small uniform tilt instead of being truly flat. Subtle but wrong.

Surfaced while reviewing the surrounding code for #86 — looks like the constants for the white and normal placeholders got partially scrambled at some point in the past.

## Test plan

- [x] `dart analyze` clean
- [x] `flutter test` passes
- [ ] CI

Closes #95.