### PR TITLE
CI: split lint and test into parallel jobs

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -26,9 +26,23 @@ jobs:
         run: dart analyze packages examples
       - name: Dart format
         run: dart format --output none --set-exit-if-changed $(find . -name '**.dart' -not -name '*_flatbuffers.dart' -not -path '*/build/*' -not -path '*/third_party/*')
-      - name: Run flutter_scene tests
-        working-directory: packages/flutter_scene
-        run: flutter test --enable-impeller
-      - name: Run flutter_scene_importer tests
-        working-directory: packages/flutter_scene_importer
-        run: flutter test --enable-impeller
+      - name: Run all workspace tests
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          ran_any=false
+          for pkg in packages/flutter_scene packages/flutter_scene_importer examples/flutter_app; do
+            tests=("$pkg"/test/*_test.dart)
+            if (( ${#tests[@]} == 0 )); then
+              echo "::notice::Skipping $pkg (no *_test.dart files)"
+              continue
+            fi
+            echo "::group::Tests for $pkg"
+            (cd "$pkg" && flutter test --enable-impeller)
+            echo "::endgroup::"
+            ran_any=true
+          done
+          if [ "$ran_any" = false ]; then
+            echo "::error::No workspace tests were discovered"
+            exit 1
+          fi

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -7,8 +7,8 @@ on:
     branches: [ "master" ]
 
 jobs:
-  lint-and-test:
-    name: Lint and Test
+  lint:
+    name: Lint
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,23 +26,26 @@ jobs:
         run: dart analyze packages examples
       - name: Dart format
         run: dart format --output none --set-exit-if-changed $(find . -name '**.dart' -not -name '*_flatbuffers.dart' -not -path '*/build/*' -not -path '*/third_party/*')
-      - name: Run all workspace tests
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          ran_any=false
-          for pkg in packages/flutter_scene packages/flutter_scene_importer examples/flutter_app; do
-            tests=("$pkg"/test/*_test.dart)
-            if (( ${#tests[@]} == 0 )); then
-              echo "::notice::Skipping $pkg (no *_test.dart files)"
-              continue
-            fi
-            echo "::group::Tests for $pkg"
-            (cd "$pkg" && flutter test --enable-impeller)
-            echo "::endgroup::"
-            ran_any=true
-          done
-          if [ "$ran_any" = false ]; then
-            echo "::error::No workspace tests were discovered"
-            exit 1
-          fi
+
+  test:
+    name: Test ${{ matrix.package }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - packages/flutter_scene
+          - packages/flutter_scene_importer
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: master
+      - name: Resolve workspace dependencies
+        run: flutter pub get
+      - name: Enable asset building
+        run: flutter config --enable-native-assets
+      - name: Run tests
+        working-directory: ${{ matrix.package }}
+        run: flutter test --enable-impeller


### PR DESCRIPTION
## Summary

- Splits the single `lint-and-test` job into a `Lint` job (analyze + format) and a `Test` job that uses a matrix to run each package's tests as a separate check.
- Test packages are listed explicitly in the matrix — `packages/flutter_scene` and `packages/flutter_scene_importer` — same set CI ran before, no change in coverage.
- All three checks run in parallel on `macos-latest`. `fail-fast: false` so one package's failure doesn't kill the others mid-flight.

## Why

- The previous CI ran lint then both test suites serially in one job. Splitting moves them onto parallel runners so wall-clock time is roughly `setup + slowest single test suite` instead of `setup + sum of suites`.
- Per-package test checks make it obvious which suite failed without scrolling the lint-and-test combined log.

## Test plan

- [ ] CI on this PR shows three separate checks: `Lint`, `Test packages/flutter_scene`, `Test packages/flutter_scene_importer`.
- [ ] All three pass.
- [ ] Wall-clock time on the PR is lower than the previous single-job run.