### PR TITLE
docs: comprehensive docstrings across the public API

### DIFF
--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -1,3 +1,23 @@
+/// 3D rendering for Flutter, built on Flutter GPU and Impeller.
+///
+/// The entry points most applications need are:
+///
+///  * [Scene] — the scene graph root and renderer. Construct one, attach
+///    [Node]s, and call [Scene.render] from a `CustomPainter` (or any
+///    `dart:ui` [Canvas]).
+///  * [Node] — a transform in the scene graph that may carry a [Mesh] and
+///    child nodes. Load 3D models with [Node.fromAsset] (preprocessed
+///    `.model` files) or [Node.fromGlbBytes] / [Node.fromGlbAsset]
+///    (runtime glTF binary).
+///  * [Camera] / [PerspectiveCamera] — view configuration passed to
+///    [Scene.render].
+///  * [Material], [PhysicallyBasedMaterial], [UnlitMaterial],
+///    [Environment] — shading.
+///  * [Animation], [AnimationClip], [AnimationPlayer] — playback and
+///    blending of imported animations.
+///
+/// Flutter Scene currently requires the Flutter master channel because it
+/// depends on the Flutter GPU API.
 library;
 
 export 'src/animation.dart';

--- a/packages/flutter_scene/lib/src/animation.dart
+++ b/packages/flutter_scene/lib/src/animation.dart
@@ -1,3 +1,15 @@
+/// Animation playback for `flutter_scene`.
+///
+/// Models loaded from `.model` or glTF files carry [Animation] objects
+/// describing keyframed translation, rotation, and scale changes for
+/// individual nodes. Instantiate one for playback by calling
+/// [Node.createAnimationClip], which returns an [AnimationClip] bound to
+/// the target subtree.
+///
+/// An internal [AnimationPlayer] on each animated node blends multiple
+/// concurrent clips by their [AnimationClip.weight], normalizing weights
+/// when their sum exceeds `1`. Each frame [AnimationPlayer.update]
+/// recomputes node transforms from a stored bind pose.
 library;
 
 import 'dart:math';

--- a/packages/flutter_scene/lib/src/animation/animation.dart
+++ b/packages/flutter_scene/lib/src/animation/animation.dart
@@ -1,11 +1,32 @@
 part of '../animation.dart';
 
-enum AnimationProperty { translation, rotation, scale }
+/// One of the three node-local transform components an animation channel
+/// can drive.
+enum AnimationProperty {
+  /// Animates [Node.localTransform]'s translation.
+  translation,
 
+  /// Animates [Node.localTransform]'s rotation.
+  rotation,
+
+  /// Animates [Node.localTransform]'s scale.
+  scale,
+}
+
+/// Identifies a single animation target as a (node name, property) pair.
+///
+/// Channel resolution is name-based rather than reference-based so that
+/// an [Animation] parsed from a model can be applied to any matching
+/// subtree (including cloned subtrees).
 class BindKey implements Comparable<BindKey> {
+  /// Name of the [Node] this channel targets, matched via
+  /// [Node.getChildByName].
   final String nodeName;
+
+  /// Which component of the node's transform this channel drives.
   final AnimationProperty property;
 
+  /// Creates a key that targets [nodeName] / [property].
   BindKey({
     required this.nodeName,
     this.property = AnimationProperty.translation,
@@ -20,18 +41,39 @@ class BindKey implements Comparable<BindKey> {
   }
 }
 
+/// One keyframed track within an [Animation], pairing a [BindKey] target
+/// with a [PropertyResolver] that produces values over time.
 class AnimationChannel {
+  /// The (node, property) target this channel writes to.
   final BindKey bindTarget;
+
+  /// The keyframe interpolator that produces values for [bindTarget].
   final PropertyResolver resolver;
 
+  /// Creates a channel that drives [bindTarget] with [resolver].
   AnimationChannel({required this.bindTarget, required this.resolver});
 }
 
+/// A reusable description of an animation, parsed from a model.
+///
+/// An `Animation` is essentially a named bundle of [AnimationChannel]s,
+/// each driving a single (node, property) target via a
+/// [PropertyResolver]. To play an animation, instantiate it as an
+/// [AnimationClip] bound to a target subtree with
+/// [Node.createAnimationClip].
 class Animation {
+  /// Display name of the animation, used by [Node.findAnimationByName].
   final String name;
+
+  /// All keyframed channels in this animation.
   final List<AnimationChannel> channels;
+
   final double _endTime;
 
+  /// Creates an [Animation] with the given [name] and [channels].
+  ///
+  /// [endTime] is computed as the maximum end time across all channels'
+  /// [PropertyResolver]s.
   Animation({this.name = '', List<AnimationChannel>? channels})
     : channels = channels ?? [],
       _endTime =
@@ -43,6 +85,12 @@ class Animation {
           }) ??
           0.0;
 
+  /// Builds an [Animation] from a deserialized flatbuffer animation
+  /// description.
+  ///
+  /// Channels with missing or malformed keyframe data are skipped with
+  /// no error. Node references are resolved against [sceneNodes] to
+  /// recover the target name for each channel's [BindKey].
   factory Animation.fromFlatbuffer(
     fb.Animation animation,
     List<Node> sceneNodes,
@@ -119,5 +167,9 @@ class Animation {
     return Animation(name: animation.name!.toString(), channels: channels);
   }
 
+  /// Time of the last keyframe across all channels, in seconds.
+  ///
+  /// [AnimationClip.advance] uses this to clamp playback time and
+  /// implement looping.
   double get endTime => _endTime;
 }

--- a/packages/flutter_scene/lib/src/animation/animation_clip.dart
+++ b/packages/flutter_scene/lib/src/animation/animation_clip.dart
@@ -8,49 +8,91 @@ class _ChannelBinding {
 }
 
 /// An instance of an [Animation] that has been bound to a specific [Node].
+///
+/// Create one with [Node.createAnimationClip]. Each clip carries its own
+/// [playing], [playbackTime], [playbackTimeScale], [weight], and [loop]
+/// state, so the same [Animation] can be played at different speeds and
+/// blends across multiple subtrees.
+///
+/// Multiple clips on the same node are blended by an internal
+/// [AnimationPlayer] that normalizes their weights when the sum exceeds
+/// `1`.
 class AnimationClip {
   final Animation _animation;
   final List<_ChannelBinding> _bindings = [];
 
   double _playbackTime = 0;
+
+  /// The current playback position in seconds, in `[0, Animation.endTime]`.
+  ///
+  /// Assigning is equivalent to calling [seek].
   double get playbackTime => _playbackTime;
   set playbackTime(double timeInSeconds) {
     seek(timeInSeconds);
   }
 
+  /// Speed multiplier applied to delta times when [advance] is called.
+  ///
+  /// `1` is real-time; `2` plays the clip at double speed; negative
+  /// values play in reverse.
   double playbackTimeScale = 1;
 
   double _weight = 1;
+
+  /// Blend weight in `[0, 1]`, used by [AnimationPlayer] to mix this
+  /// clip with other concurrently playing clips on the same node.
+  ///
+  /// Assignments are clamped to the valid range.
   double get weight => _weight;
   set weight(double value) {
     _weight = clampDouble(value, 0, 1);
   }
 
+  /// Whether [advance] should integrate elapsed time into [playbackTime].
+  ///
+  /// Toggle indirectly with [play], [pause], or [stop].
   bool playing = false;
 
+  /// Whether the clip should wrap around at the end of the animation
+  /// (or the beginning, when playing in reverse) instead of pausing.
   bool loop = false;
 
+  /// Binds [_animation] to the node subtree rooted at [bindTarget].
+  ///
+  /// Only channels whose [BindKey.nodeName] is found in the subtree are
+  /// retained; missing nodes are silently ignored.
   AnimationClip(this._animation, Node bindTarget) {
     _bindToTarget(bindTarget);
   }
 
+  /// Starts (or resumes) playback. Equivalent to setting [playing] to
+  /// `true`.
   void play() {
     playing = true;
   }
 
+  /// Pauses playback at the current [playbackTime].
   void pause() {
     playing = false;
   }
 
+  /// Pauses playback and seeks back to the beginning.
   void stop() {
     playing = false;
     seek(0);
   }
 
+  /// Sets [playbackTime] to [time] (clamped to `[0, Animation.endTime]`).
   void seek(double time) {
     _playbackTime = clampDouble(time, 0, _animation.endTime);
   }
 
+  /// Advances [playbackTime] by [deltaTime] seconds (scaled by
+  /// [playbackTimeScale]).
+  ///
+  /// No-op when the clip is not [playing] or `deltaTime <= 0`. Handles
+  /// looping behavior: if [loop] is `false`, playback clamps and pauses
+  /// at the boundaries; if `true`, it wraps around.
   void advance(double deltaTime) {
     if (!playing || deltaTime <= 0) {
       return;
@@ -97,6 +139,12 @@ class AnimationClip {
     }
   }
 
+  /// Evaluates each bound channel at [playbackTime] and accumulates the
+  /// result into [transformDecomps].
+  ///
+  /// Called once per frame by [AnimationPlayer.update]. [weightMultiplier]
+  /// is the player-wide normalization applied when concurrent clips'
+  /// weights sum to more than `1`.
   void applyToBindings(
     Map<Node, AnimationTransforms> transformDecomps,
     double weightMultiplier,

--- a/packages/flutter_scene/lib/src/animation/animation_player.dart
+++ b/packages/flutter_scene/lib/src/animation/animation_player.dart
@@ -1,10 +1,27 @@
 part of '../animation.dart';
 
+/// Drives playback and blending for the [AnimationClip]s on a single
+/// node subtree.
+///
+/// Each animated [Node] lazily owns one `AnimationPlayer`; applications
+/// usually interact with it indirectly through [Node.createAnimationClip]
+/// and [AnimationClip].
+///
+/// [update] is called automatically during [Node.render]. It advances
+/// every clip by the wall-clock delta since the previous frame, blends
+/// their results into the bind pose, and writes the resulting transforms
+/// back to the bound nodes.
 class AnimationPlayer {
   final Map<Node, AnimationTransforms> _targetTransforms = {};
   final Map<String, AnimationClip> _clips = {};
   int? _previousTimeInMilliseconds;
 
+  /// Instantiates [animation] as an [AnimationClip] bound to [bindTarget]
+  /// and registers it with this player.
+  ///
+  /// The clip starts paused at time `0`; call [AnimationClip.play] to
+  /// begin playback. Subsequent calls with the same [Animation.name]
+  /// replace the previously registered clip.
   AnimationClip createAnimationClip(Animation animation, Node bindTarget) {
     final clip = AnimationClip(animation, bindTarget);
 
@@ -20,10 +37,19 @@ class AnimationPlayer {
     return clip;
   }
 
+  /// Returns the registered clip whose [Animation.name] equals [name],
+  /// or `null` if none is registered.
   AnimationClip? getClipByName(String name) {
     return _clips[name];
   }
 
+  /// Advances all registered clips by the wall-clock delta since the
+  /// previous call and applies their blended result to the bound nodes.
+  ///
+  /// Resets each animated node to its bind pose, advances every clip by
+  /// the delta, normalizes weights when their sum exceeds `1`, and then
+  /// writes the resulting `(translation, rotation, scale)` decomposition
+  /// back to [Node.localTransform].
   void update() {
     // Initialize the previous time if it has not been set yet.
     _previousTimeInMilliseconds ??= DateTime.now().millisecondsSinceEpoch;

--- a/packages/flutter_scene/lib/src/animation/animation_transform.dart
+++ b/packages/flutter_scene/lib/src/animation/animation_transform.dart
@@ -35,6 +35,7 @@ class DecomposedTransform {
     return Matrix4.compose(translation, rotation, scale);
   }
 
+  /// Returns a deep copy of this transform.
   DecomposedTransform clone() {
     return DecomposedTransform(
       translation: translation.clone(),
@@ -44,13 +45,25 @@ class DecomposedTransform {
   }
 }
 
+/// Per-node animation state held by an [AnimationPlayer].
+///
+/// Pairs the node's static [bindPose] (its rest transform) with a
+/// scratch [animatedPose] that the player resets each frame and that
+/// active [AnimationClip]s additively blend into.
 class AnimationTransforms {
+  /// The node's rest-pose transform, captured when the node is first
+  /// registered with an [AnimationPlayer].
   DecomposedTransform bindPose;
+
+  /// Scratch transform mutated by clips during [AnimationPlayer.update].
+  ///
+  /// Reset to a copy of [bindPose] at the start of each frame.
   DecomposedTransform animatedPose = DecomposedTransform(
     translation: Vector3.zero(),
     rotation: Quaternion.identity(),
     scale: Vector3.all(1.0),
   );
 
+  /// Creates an [AnimationTransforms] anchored at the supplied bind pose.
   AnimationTransforms({required this.bindPose});
 }

--- a/packages/flutter_scene/lib/src/animation/property_resolver.dart
+++ b/packages/flutter_scene/lib/src/animation/property_resolver.dart
@@ -1,5 +1,12 @@
 part of '../animation.dart';
 
+/// Computes a per-property animated value from a timeline of keyframes.
+///
+/// Subclasses cover the three [AnimationProperty] flavors with the
+/// correct interpolator: linear interpolation for translation and scale,
+/// spherical linear interpolation for rotation. Use the [PropertyResolver]
+/// factories to construct one rather than instantiating subclasses
+/// directly.
 abstract class PropertyResolver {
   /// Returns the end time of the property in seconds.
   double getEndTime();
@@ -11,6 +18,11 @@ abstract class PropertyResolver {
   /// applying several AnimationClips.
   void apply(AnimationTransforms target, double timeInSeconds, double weight);
 
+  /// Creates a translation resolver that linearly interpolates between
+  /// the keyframe positions in [values] at the corresponding [times].
+  ///
+  /// `times` and `values` must have the same length and `times` must be
+  /// monotonically non-decreasing.
   static PropertyResolver makeTranslationTimeline(
     List<double> times,
     List<Vector3> values,
@@ -18,6 +30,11 @@ abstract class PropertyResolver {
     return TranslationTimelineResolver._(times, values);
   }
 
+  /// Creates a rotation resolver that spherically interpolates between
+  /// the keyframe quaternions in [values] at the corresponding [times].
+  ///
+  /// `times` and `values` must have the same length and `times` must be
+  /// monotonically non-decreasing.
   static PropertyResolver makeRotationTimeline(
     List<double> times,
     List<Quaternion> values,
@@ -25,6 +42,11 @@ abstract class PropertyResolver {
     return RotationTimelineResolver._(times, values);
   }
 
+  /// Creates a scale resolver that linearly interpolates between the
+  /// keyframe scales in [values] at the corresponding [times].
+  ///
+  /// `times` and `values` must have the same length and `times` must be
+  /// monotonically non-decreasing.
   static PropertyResolver makeScaleTimeline(
     List<double> times,
     List<Vector3> values,
@@ -44,6 +66,11 @@ class _TimelineKey {
   _TimelineKey(this.index, this.lerp);
 }
 
+/// Shared keyframe lookup for the per-property timeline resolvers.
+///
+/// Implementations supply the value-array storage and per-frame
+/// interpolation; this base class handles binary-style search through
+/// the time axis to compute a `(index, lerp)` pair.
 abstract class TimelineResolver implements PropertyResolver {
   final List<double> _times;
 
@@ -71,6 +98,9 @@ abstract class TimelineResolver implements PropertyResolver {
   }
 }
 
+/// Resolves a translation timeline with per-component linear
+/// interpolation, blended into [AnimationTransforms.animatedPose] as an
+/// offset from the bind pose.
 class TranslationTimelineResolver extends TimelineResolver {
   final List<Vector3> _values;
 
@@ -96,6 +126,9 @@ class TranslationTimelineResolver extends TimelineResolver {
   }
 }
 
+/// Resolves a rotation timeline with spherical linear interpolation,
+/// slerping the current animated rotation toward the keyframed rotation
+/// by the supplied weight.
 class RotationTimelineResolver extends TimelineResolver {
   final List<Quaternion> _values;
 
@@ -123,6 +156,11 @@ class RotationTimelineResolver extends TimelineResolver {
   }
 }
 
+/// Resolves a scale timeline with per-component linear interpolation.
+///
+/// The blended scale is normalized against the bind pose so weighted
+/// blends behave multiplicatively (a weight of `1` reaches the keyframe
+/// scale exactly).
 class ScaleTimelineResolver extends TimelineResolver {
   final List<Vector3> _values;
 

--- a/packages/flutter_scene/lib/src/asset_helpers.dart
+++ b/packages/flutter_scene/lib/src/asset_helpers.dart
@@ -3,6 +3,15 @@ import 'dart:ui' as ui;
 import 'package:flutter/services.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 
+/// Uploads a decoded `dart:ui` [ui.Image] to a Flutter GPU texture.
+///
+/// The image is read as raw RGBA bytes and copied into a host-visible
+/// GPU texture matching the image's dimensions. The returned texture is
+/// suitable for binding to materials such as [UnlitMaterial.baseColorTexture]
+/// or [PhysicallyBasedMaterial.baseColorTexture], or for building an
+/// [EnvironmentMap].
+///
+/// Throws if the image can't be read as RGBA.
 Future<gpu.Texture> gpuTextureFromImage(ui.Image image) async {
   final byteData = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
   if (byteData == null) {
@@ -20,6 +29,12 @@ Future<gpu.Texture> gpuTextureFromImage(ui.Image image) async {
   return texture;
 }
 
+/// Loads an image from the asset bundle at [assetPath] and uploads it as
+/// a Flutter GPU texture.
+///
+/// The asset is decoded with `dart:ui`'s built-in image codecs (PNG, JPEG,
+/// etc.) and then uploaded via [gpuTextureFromImage]. Throws if the asset
+/// is not present in the bundle or cannot be decoded.
 Future<gpu.Texture> gpuTextureFromAsset(String assetPath) async {
   // Load resource from the asset bundle. Throws exception if the asset couldn't
   // be found in the bundle.

--- a/packages/flutter_scene/lib/src/camera.dart
+++ b/packages/flutter_scene/lib/src/camera.dart
@@ -3,8 +3,24 @@ import 'dart:ui' as ui;
 
 import 'package:vector_math/vector_math.dart';
 
+/// Base class for camera implementations passed to [Scene.render].
+///
+/// A camera owns the transform that converts world-space coordinates into
+/// clip-space coordinates for a given render target size. Subclasses
+/// configure projection and view conventions; [PerspectiveCamera] is the
+/// built-in option, but applications can subclass [Camera] to implement
+/// orthographic or other custom projections.
 abstract class Camera {
+  /// The world-space position of the camera. Used by materials for
+  /// view-dependent shading (e.g. specular reflections).
   Vector3 get position;
+
+  /// Returns the combined projection-and-view transform for a render target
+  /// of the given [dimensions].
+  ///
+  /// Called once per [Scene.render] call. Implementations may read
+  /// [dimensions] (typically to compute aspect ratio) and any subclass
+  /// configuration to build the matrix.
   Matrix4 getViewTransform(ui.Size dimensions);
 }
 
@@ -62,7 +78,22 @@ Matrix4 _matrix4Perspective(
   );
 }
 
+/// A standard pinhole-style perspective camera.
+///
+/// Defined by an eye [position], a look-at [target], an [up] direction, a
+/// vertical field-of-view ([fovRadiansY]), and a near/far frustum
+/// ([fovNear]/[fovFar]). The horizontal field of view is derived from the
+/// render target's aspect ratio at draw time.
+///
+/// Default placement is at `(0, 0, -5)` looking at the origin with `+Y`
+/// up, suitable for inspecting a model that fits within a unit cube
+/// centered on the origin.
 class PerspectiveCamera extends Camera {
+  /// Creates a [PerspectiveCamera].
+  ///
+  /// All parameters are optional; omitting them yields the default
+  /// placement (eye at `(0, 0, -5)`, looking at the origin, `+Y` up) and
+  /// a 45° vertical field of view with a `0.1`–`1000.0` clip range.
   PerspectiveCamera({
     this.fovRadiansY = 45 * degrees2Radians,
     Vector3? position,
@@ -74,12 +105,29 @@ class PerspectiveCamera extends Camera {
        target = target ?? Vector3(0, 0, 0),
        up = up ?? Vector3(0, 1, 0);
 
+  /// Vertical field of view, in radians.
+  ///
+  /// The horizontal field of view is computed at render time from this
+  /// value and the render target's aspect ratio.
   double fovRadiansY;
+
+  /// World-space position of the camera (the eye point).
   @override
   Vector3 position = Vector3(0, 0, -5);
+
+  /// World-space point the camera is looking at.
   Vector3 target;
+
+  /// World-space "up" direction used to orient the camera around the
+  /// view vector. Typically `Vector3(0, 1, 0)`.
   Vector3 up;
+
+  /// Distance to the near clipping plane. Geometry closer than this is
+  /// clipped away.
   double fovNear;
+
+  /// Distance to the far clipping plane. Geometry beyond this is clipped
+  /// away. Must be greater than [fovNear].
   double fovFar;
 
   @override

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -8,6 +8,22 @@ import 'package:flutter_scene/src/shaders.dart';
 import 'package:flutter_scene_importer/constants.dart';
 import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
 
+/// Vertex (and optional index) data along with the vertex shader used to
+/// transform it.
+///
+/// `Geometry` is the geometry half of a [MeshPrimitive] — the shading half
+/// is supplied by a [Material]. Built-in subclasses cover the two
+/// supported vertex layouts:
+///
+///  * [UnskinnedGeometry] — 48-byte vertices: position, normal, UV, color.
+///  * [SkinnedGeometry] — 80-byte vertices: unskinned + 4 joint indices +
+///    4 joint weights. Used in conjunction with a [Skin].
+///
+/// Construct an instance directly and call [uploadVertexData] (or
+/// [setVertices]/[setIndices] with already-uploaded buffer views) to
+/// supply mesh data, or use [Geometry.fromFlatbuffer] when deserializing
+/// a `.model` payload. [CuboidGeometry] is provided as a built-in
+/// example.
 abstract class Geometry {
   gpu.BufferView? _vertices;
   int _vertexCount = 0;
@@ -17,6 +33,11 @@ abstract class Geometry {
   int _indexCount = 0;
 
   gpu.Shader? _vertexShader;
+
+  /// The vertex shader used when rendering this geometry.
+  ///
+  /// Set by subclasses (or via [setVertexShader]) before the first frame.
+  /// Throws if accessed before a shader has been assigned.
   gpu.Shader get vertexShader {
     if (_vertexShader == null) {
       throw Exception('Vertex shader has not been set');
@@ -24,6 +45,13 @@ abstract class Geometry {
     return _vertexShader!;
   }
 
+  /// Constructs a [Geometry] from a deserialized flatbuffer mesh
+  /// primitive, choosing [UnskinnedGeometry] or [SkinnedGeometry] based
+  /// on the embedded vertex buffer type.
+  ///
+  /// The vertex buffer must be a multiple of the layout size (48 bytes
+  /// unskinned, 80 bytes skinned); a partial trailing vertex is dropped
+  /// with a debug warning.
   static Geometry fromFlatbuffer(fb.MeshPrimitive fbPrimitive) {
     Uint8List vertices;
     bool isSkinned =
@@ -77,11 +105,23 @@ abstract class Geometry {
     return geometry;
   }
 
+  /// Binds an already-uploaded vertex buffer view as this geometry's
+  /// vertex source.
+  ///
+  /// Use this when the caller manages its own [gpu.DeviceBuffer] (for
+  /// example, when packing many meshes into a single buffer). For a
+  /// turn-key path that allocates and uploads in one step, see
+  /// [uploadVertexData].
   void setVertices(gpu.BufferView vertices, int vertexCount) {
     _vertices = vertices;
     _vertexCount = vertexCount;
   }
 
+  /// Binds an already-uploaded index buffer view, with element width
+  /// determined by [indexType].
+  ///
+  /// The element count is computed automatically from the buffer view's
+  /// byte length.
   void setIndices(gpu.BufferView indices, gpu.IndexType indexType) {
     _indices = indices;
     _indexType = indexType;
@@ -93,6 +133,13 @@ abstract class Geometry {
     }
   }
 
+  /// Allocates a [gpu.DeviceBuffer] and uploads [vertices] (and optional
+  /// [indices]) into it in one step.
+  ///
+  /// The vertices must match this geometry subclass's expected layout
+  /// (48 bytes per vertex for [UnskinnedGeometry], 80 bytes for
+  /// [SkinnedGeometry]). When [indices] is supplied, the buffer is sized
+  /// to hold both ranges back-to-back and bound via [setIndices].
   void uploadVertexData(
     ByteData vertices,
     int vertexCount,
@@ -132,12 +179,29 @@ abstract class Geometry {
     }
   }
 
+  /// Assigns the vertex [shader] used when this geometry is drawn.
+  ///
+  /// The built-in subclasses set this in their constructor. Custom
+  /// subclasses may override it with their own shader, typically pulled
+  /// from [baseShaderLibrary] or another shader bundle.
   void setVertexShader(gpu.Shader shader) {
     _vertexShader = shader;
   }
 
+  /// Hook for skinned geometries to receive the joints texture computed
+  /// by [Skin.getJointsTexture].
+  ///
+  /// The default implementation does nothing; [SkinnedGeometry] overrides
+  /// it to bind the texture in [bind].
   void setJointsTexture(gpu.Texture? texture, int width) {}
 
+  /// Binds vertex/index buffers and per-frame uniforms onto [pass] in
+  /// preparation for a draw call.
+  ///
+  /// Implementations write the model and camera transforms (and any
+  /// subclass-specific values, like the joints texture for skinned
+  /// geometry) into the supplied transient buffer and bind the resulting
+  /// uniform views.
   void bind(
     gpu.RenderPass pass,
     gpu.HostBuffer transientsBuffer,
@@ -147,7 +211,14 @@ abstract class Geometry {
   );
 }
 
+/// Geometry whose vertices use the unskinned 48-byte layout: position
+/// (`vec3`), normal (`vec3`), tex coords (`vec2`), color (`vec4`).
+///
+/// This is the default vertex format for static (non-animated) meshes
+/// imported from `.model` or glTF.
 class UnskinnedGeometry extends Geometry {
+  /// Creates an [UnskinnedGeometry] preconfigured with the
+  /// `UnskinnedVertex` shader from [baseShaderLibrary].
   UnskinnedGeometry() {
     setVertexShader(baseShaderLibrary['UnskinnedVertex']!);
   }
@@ -217,10 +288,18 @@ class UnskinnedGeometry extends Geometry {
   }
 }
 
+/// Geometry whose vertices use the skinned 80-byte layout: the
+/// unskinned attributes followed by 4 joint indices and 4 joint weights.
+///
+/// Used for meshes attached to a [Skin] for skeletal animation. The
+/// joints texture supplied by the skin must be assigned before each draw
+/// via [setJointsTexture].
 class SkinnedGeometry extends Geometry {
   gpu.Texture? _jointsTexture;
   int _jointsTextureWidth = 0;
 
+  /// Creates a [SkinnedGeometry] preconfigured with the `SkinnedVertex`
+  /// shader from [baseShaderLibrary].
   SkinnedGeometry() {
     setVertexShader(baseShaderLibrary['SkinnedVertex']!);
   }
@@ -314,7 +393,13 @@ class SkinnedGeometry extends Geometry {
   }
 }
 
+/// A unit-cube geometry sized to the supplied extents.
+///
+/// Useful as a quick placeholder or for debugging — pair with any
+/// [Material] to render an axis-aligned box. Each face has unique
+/// vertex colors, which can be visualized with [UnlitMaterial].
 class CuboidGeometry extends UnskinnedGeometry {
+  /// Builds a cuboid spanning `-extents/2` to `+extents/2` on each axis.
   CuboidGeometry(vm.Vector3 extents) {
     final e = extents / 2;
     // Layout: Position, normal, uv, color

--- a/packages/flutter_scene/lib/src/material/environment.dart
+++ b/packages/flutter_scene/lib/src/material/environment.dart
@@ -4,13 +4,32 @@ import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/asset_helpers.dart';
 import 'package:flutter_scene/src/material/material.dart';
 
+/// A pair of textures used for image-based lighting.
+///
+/// The radiance texture supplies high-frequency reflections (used for
+/// specular sampling), while the optional irradiance texture supplies
+/// low-frequency ambient lighting (used for diffuse). Both textures are
+/// currently expected to be equirectangular maps; cubemap support will
+/// land once Flutter GPU exposes cubemaps.
+///
+/// Use [EnvironmentMap.fromAssets] or [EnvironmentMap.fromUIImages] to
+/// construct one from images, [EnvironmentMap.fromGpuTextures] when you
+/// already hold GPU textures, or [EnvironmentMap.empty] for a no-op
+/// placeholder.
 base class EnvironmentMap {
   EnvironmentMap._(this._radianceTexture, this._irradianceTexture);
 
+  /// Creates an empty environment map. Both [radianceTexture] and
+  /// [irradianceTexture] return a white placeholder, contributing no
+  /// directional lighting.
   factory EnvironmentMap.empty() {
     return EnvironmentMap._(null, null);
   }
 
+  /// Wraps already-uploaded GPU textures.
+  ///
+  /// [irradianceTexture] is optional; when omitted, irradiance sampling
+  /// falls back to a white placeholder.
   factory EnvironmentMap.fromGpuTextures({
     required gpu.Texture radianceTexture,
     gpu.Texture? irradianceTexture,
@@ -18,6 +37,8 @@ base class EnvironmentMap {
     return EnvironmentMap._(radianceTexture, irradianceTexture);
   }
 
+  /// Builds an [EnvironmentMap] from already-decoded `dart:ui` images,
+  /// uploading them to GPU textures.
   static Future<EnvironmentMap> fromUIImages({
     required ui.Image radianceImage,
     ui.Image? irradianceImage,
@@ -35,6 +56,10 @@ base class EnvironmentMap {
     );
   }
 
+  /// Loads an [EnvironmentMap] from the asset bundle.
+  ///
+  /// [radianceImagePath] is required; [irradianceImagePath] is optional
+  /// and falls back to a white placeholder when omitted.
   static Future<EnvironmentMap> fromAssets({
     required String radianceImagePath,
     String? irradianceImagePath,
@@ -52,6 +77,10 @@ base class EnvironmentMap {
     );
   }
 
+  /// Whether this environment map has no radiance texture.
+  ///
+  /// An empty environment contributes no IBL; the [Scene] swaps it for
+  /// the package's bundled default at draw time.
   bool isEmpty() => _radianceTexture == null;
 
   gpu.Texture? _radianceTexture;
@@ -79,12 +108,19 @@ base class EnvironmentMap {
 /// applied to all materials. Individual [Material]s may optionally override the
 /// default environment.
 base class Environment {
+  /// Creates an [Environment] with the given image-based-lighting map
+  /// and shared tone-mapping parameters.
+  ///
+  /// All parameters are optional; the defaults pair an empty
+  /// [EnvironmentMap] with `intensity = 1.0` and `exposure = 2.0`.
   Environment({
     EnvironmentMap? environmentMap,
     this.intensity = 1.0,
     this.exposure = 2.0,
   }) : environmentMap = environmentMap ?? EnvironmentMap.empty();
 
+  /// Returns a copy of this environment with a different
+  /// [environmentMap], preserving [intensity] and [exposure].
   Environment withNewEnvironmentMap(EnvironmentMap environmentMap) {
     return Environment(
       environmentMap: environmentMap,

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -8,9 +8,24 @@ import 'package:flutter_scene/src/material/physically_based_material.dart';
 import 'package:flutter_scene/src/material/unlit_material.dart';
 import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
 
+/// Base class for shading a [MeshPrimitive].
+///
+/// A material owns the fragment shader plus any per-material parameters
+/// (colors, factors, textures) bound when the primitive is drawn. The
+/// built-in subclasses are [UnlitMaterial] (constant color / texture)
+/// and [PhysicallyBasedMaterial] (PBR metallic-roughness with image-based
+/// lighting). Custom subclasses can be implemented by overriding
+/// [bind] and supplying their own fragment shader.
+///
+/// The default [bind] enables back-face culling with counter-clockwise
+/// winding, matching the [glTF coordinate convention](https://github.com/KhronosGroup/glTF/tree/main/specification/2.0#coordinate-system-and-units).
 abstract class Material {
   static gpu.Texture? _whitePlaceholderTexture;
 
+  /// Returns a 1×1 opaque-white texture, lazily created on first use.
+  ///
+  /// Used as a default for missing color textures so shader code can
+  /// always sample without conditionals.
   static gpu.Texture getWhitePlaceholderTexture() {
     if (_whitePlaceholderTexture != null) {
       return _whitePlaceholderTexture!;
@@ -29,12 +44,18 @@ abstract class Material {
     return _whitePlaceholderTexture!;
   }
 
+  /// Returns [texture] if non-null, otherwise [getWhitePlaceholderTexture].
   static gpu.Texture whitePlaceholder(gpu.Texture? texture) {
     return texture ?? getWhitePlaceholderTexture();
   }
 
   static gpu.Texture? _normalPlaceholderTexture;
 
+  /// Returns a 1×1 "flat" tangent-space normal texture (`(0.5, 0.5, 1)`),
+  /// lazily created on first use.
+  ///
+  /// Used as a default for missing normal maps so shader code can always
+  /// sample without conditionals.
   static gpu.Texture getNormalPlaceholderTexture() {
     if (_normalPlaceholderTexture != null) {
       return _normalPlaceholderTexture!;
@@ -53,6 +74,7 @@ abstract class Material {
     return _normalPlaceholderTexture!;
   }
 
+  /// Returns [texture] if non-null, otherwise [getNormalPlaceholderTexture].
   static gpu.Texture normalPlaceholder(gpu.Texture? texture) {
     return texture ?? getNormalPlaceholderTexture();
   }
@@ -61,6 +83,11 @@ abstract class Material {
   static gpu.Texture? _defaultRadianceTexture;
   static gpu.Texture? _defaultIrradianceTexture;
 
+  /// Returns the precomputed BRDF lookup texture used by the PBR
+  /// fragment shader for environment-map specular sampling.
+  ///
+  /// Loaded by [initializeStaticResources]; throws if accessed before
+  /// initialization completes.
   static gpu.Texture getBrdfLutTexture() {
     if (_brdfLutTexture == null) {
       throw Exception('BRDF LUT texture has not been initialized.');
@@ -68,6 +95,12 @@ abstract class Material {
     return _brdfLutTexture!;
   }
 
+  /// Returns the package's bundled "Royal Esplanade" image-based
+  /// lighting environment as an [EnvironmentMap].
+  ///
+  /// Used as the [Scene]-wide default when no environment is configured.
+  /// Loaded by [initializeStaticResources]; throws if accessed before
+  /// initialization completes.
   static EnvironmentMap getDefaultEnvironmentMap() {
     if (_defaultRadianceTexture == null || _defaultIrradianceTexture == null) {
       throw Exception('Default environment map has not been initialized.');
@@ -78,6 +111,12 @@ abstract class Material {
     );
   }
 
+  /// Loads the bundled BRDF lookup texture and the default
+  /// "Royal Esplanade" radiance/irradiance environment maps.
+  ///
+  /// Called by the [Scene] constructor; rendering is gated on the
+  /// returned [Future] completing. The same future is reused on
+  /// subsequent calls.
   static Future<void> initializeStaticResources() {
     List<Future<void>> futures = [
       gpuTextureFromAsset(
@@ -99,6 +138,9 @@ abstract class Material {
     return Future.wait(futures);
   }
 
+  /// Constructs the appropriate concrete [Material] subclass for the
+  /// supplied flatbuffer material description, resolving texture
+  /// indices against [textures].
   static Material fromFlatbuffer(
     fb.Material fbMaterial,
     List<gpu.Texture> textures,
@@ -114,6 +156,12 @@ abstract class Material {
   }
 
   gpu.Shader? _fragmentShader;
+
+  /// The fragment shader used when rendering geometry with this material.
+  ///
+  /// Subclasses set this in their constructor (typically via
+  /// [setFragmentShader]). Throws if accessed before a shader has been
+  /// assigned.
   gpu.Shader get fragmentShader {
     if (_fragmentShader == null) {
       throw Exception('Fragment shader has not been set');
@@ -121,10 +169,19 @@ abstract class Material {
     return _fragmentShader!;
   }
 
+  /// Assigns the fragment [shader] used when this material is drawn.
   void setFragmentShader(gpu.Shader shader) {
     _fragmentShader = shader;
   }
 
+  /// Binds this material's render-pass state, uniforms, and textures.
+  ///
+  /// The base implementation enables back-face culling with
+  /// counter-clockwise winding (matching the glTF convention). Subclasses
+  /// must call `super.bind` and then bind any per-material uniforms and
+  /// textures expected by their fragment shader. [environment] supplies
+  /// the [Scene]-level IBL environment that materials default to when
+  /// they have no per-material override.
   void bind(
     gpu.RenderPass pass,
     gpu.HostBuffer transientsBuffer,
@@ -134,6 +191,12 @@ abstract class Material {
     pass.setWindingOrder(gpu.WindingOrder.counterClockwise);
   }
 
+  /// Whether geometry rendered with this material is fully opaque.
+  ///
+  /// The renderer uses this to split draws into the opaque and
+  /// translucent passes (see [SceneEncoder]). Translucent draws are
+  /// depth-sorted and drawn after the opaque pass with alpha blending
+  /// enabled.
   bool isOpaque() {
     return true;
   }

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -7,7 +7,29 @@ import 'package:flutter_scene/src/shaders.dart';
 import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
 import 'package:vector_math/vector_math.dart';
 
+/// A glTF-style metallic-roughness physically based material with
+/// image-based lighting.
+///
+/// Wraps the `StandardFragment` shader and exposes the parameters from
+/// the [glTF 2.0 PBR metallic-roughness model](https://github.com/KhronosGroup/glTF/tree/main/specification/2.0#materials):
+///
+///  * Albedo: [baseColorFactor], [baseColorTexture] (multiplied with the
+///    optional per-vertex color, weighted by [vertexColorWeight]).
+///  * Metallic-roughness: [metallicFactor], [roughnessFactor],
+///    [metallicRoughnessTexture] (B = metallic, G = roughness).
+///  * Normal: [normalTexture] with [normalScale].
+///  * Emissive: [emissiveFactor], [emissiveTexture].
+///  * Occlusion: [occlusionTexture] with [occlusionStrength].
+///  * Lighting: [environment] (overrides the [Scene]-wide environment
+///    when set).
+///
+/// Translucency is determined by [baseColorFactor]'s alpha component;
+/// the material is treated as opaque when alpha is exactly `1`.
 class PhysicallyBasedMaterial extends Material {
+  /// Builds a [PhysicallyBasedMaterial] from a flatbuffer material
+  /// description, resolving texture indices against [textures].
+  ///
+  /// Throws if [fbMaterial] is not a PBR material.
   static PhysicallyBasedMaterial fromFlatbuffer(
     fb.Material fbMaterial,
     List<gpu.Texture> textures,
@@ -83,6 +105,12 @@ class PhysicallyBasedMaterial extends Material {
     return material;
   }
 
+  /// Creates a PBR material with the given textures.
+  ///
+  /// All textures are optional; missing textures are replaced with
+  /// neutral placeholders at draw time. Per-channel scaling factors
+  /// (e.g. [metallicFactor], [roughnessFactor]) default to neutral and
+  /// can be tweaked after construction.
   PhysicallyBasedMaterial({
     this.baseColorTexture,
     this.metallicRoughnessTexture,
@@ -94,23 +122,57 @@ class PhysicallyBasedMaterial extends Material {
     setFragmentShader(baseShaderLibrary['StandardFragment']!);
   }
 
+  /// The albedo (base color) texture, sampled in linear space and
+  /// multiplied by [baseColorFactor]. Defaults to white when null.
   gpu.Texture? baseColorTexture;
+
+  /// Linear RGBA tint multiplied with [baseColorTexture]. Alpha controls
+  /// translucency: values below `1` push the material into the depth-
+  /// sorted translucent pass.
   Vector4 baseColorFactor = Colors.white;
+
+  /// How strongly per-vertex colors influence the final albedo. `0`
+  /// disables vertex color contribution; `1` (the default) fully
+  /// applies it.
   double vertexColorWeight = 1.0;
 
+  /// The combined metallic-roughness texture (B = metallic,
+  /// G = roughness). Defaults to white when null.
   gpu.Texture? metallicRoughnessTexture;
+
+  /// Scalar multiplier applied to the metallic channel. `0` is fully
+  /// dielectric, `1` is fully metallic.
   double metallicFactor = 1.0;
+
+  /// Scalar multiplier applied to the roughness channel. `0` is a
+  /// perfect mirror, `1` is fully diffuse.
   double roughnessFactor = 1.0;
 
+  /// Tangent-space normal map. Defaults to a flat normal when null.
   gpu.Texture? normalTexture;
+
+  /// Strength of [normalTexture]'s perturbation. `1` is the unmodified
+  /// map.
   double normalScale = 1.0;
 
+  /// Optional emissive texture. Defaults to white when null and is
+  /// gated by [emissiveFactor].
   gpu.Texture? emissiveTexture;
+
+  /// Linear RGBA emissive tint. Alpha is unused; the default
+  /// `Vector4.zero()` disables emission.
   Vector4 emissiveFactor = Vector4.zero();
 
+  /// Optional ambient-occlusion texture (R channel). Defaults to white
+  /// when null.
   gpu.Texture? occlusionTexture;
+
+  /// Strength of [occlusionTexture]'s effect. `0` ignores the map; `1`
+  /// applies it fully.
   double occlusionStrength = 1.0;
 
+  /// Per-material image-based-lighting environment, overriding the
+  /// [Scene]-wide environment when set.
   Environment? environment;
 
   @override

--- a/packages/flutter_scene/lib/src/material/unlit_material.dart
+++ b/packages/flutter_scene/lib/src/material/unlit_material.dart
@@ -8,7 +8,19 @@ import 'package:flutter_scene/src/shaders.dart';
 import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
 import 'package:vector_math/vector_math.dart';
 
+/// A material that draws geometry with a flat color or texture, ignoring
+/// scene lighting.
+///
+/// Useful for UI overlays, debug visualization, or stylized rendering.
+/// The final color is `baseColorFactor * baseColorTexture`, optionally
+/// blended with the per-vertex color via [vertexColorWeight].
+///
+/// Wraps the `UnlitFragment` shader from [baseShaderLibrary].
 class UnlitMaterial extends Material {
+  /// Builds an [UnlitMaterial] from a flatbuffer material description,
+  /// resolving texture indices against [textures].
+  ///
+  /// Throws if [fbMaterial] is not an unlit material.
   static UnlitMaterial fromFlatbuffer(
     fb.Material fbMaterial,
     List<gpu.Texture> textures,
@@ -36,13 +48,27 @@ class UnlitMaterial extends Material {
     return material;
   }
 
+  /// Creates an [UnlitMaterial], optionally textured.
+  ///
+  /// When [colorTexture] is null a 1×1 white placeholder is used so the
+  /// final color reduces to [baseColorFactor].
   UnlitMaterial({gpu.Texture? colorTexture}) {
     setFragmentShader(baseShaderLibrary['UnlitFragment']!);
     baseColorTexture = Material.whitePlaceholder(colorTexture);
   }
 
+  /// The base color texture, sampled and multiplied by [baseColorFactor].
+  ///
+  /// Always non-null after construction; pass `null` to the constructor
+  /// to fall back to a 1×1 white placeholder.
   late gpu.Texture baseColorTexture;
+
+  /// Linear RGBA tint multiplied with [baseColorTexture].
   Vector4 baseColorFactor = Colors.white;
+
+  /// How strongly per-vertex colors influence the final color. `0`
+  /// disables vertex color contribution; `1` (the default) fully
+  /// applies it.
   double vertexColorWeight = 1.0;
 
   @override

--- a/packages/flutter_scene/lib/src/math_extensions.dart
+++ b/packages/flutter_scene/lib/src/math_extensions.dart
@@ -2,7 +2,12 @@ import 'dart:math';
 
 import 'package:vector_math/vector_math.dart';
 
+/// Per-component arithmetic helpers on [Vector3].
 extension Vector3Lerp on Vector3 {
+  /// Linearly interpolates each component of this vector toward [to].
+  ///
+  /// `weight` of `0` returns this vector unchanged; `1` returns [to].
+  /// Values outside `[0, 1]` extrapolate.
   Vector3 lerp(Vector3 to, double weight) {
     return Vector3(
       x + (to.x - x) * weight,
@@ -11,16 +16,31 @@ extension Vector3Lerp on Vector3 {
     );
   }
 
+  /// Returns the per-component quotient of this vector and [other].
+  ///
+  /// Equivalent to `Vector3(x / other.x, y / other.y, z / other.z)`.
   Vector3 divided(Vector3 other) {
     return Vector3(x / other.x, y / other.y, z / other.z);
   }
 }
 
+/// Spherical interpolation helpers on [Quaternion].
 extension QuaternionSlerp on Quaternion {
+  /// Returns the 4D dot product of this quaternion and [other].
+  ///
+  /// The sign of the result indicates whether the two rotations point in
+  /// the same hemisphere; values near `1` (or `-1`) mean the rotations
+  /// are nearly identical.
   double dot(Quaternion other) {
     return x * other.x + y * other.y + z * other.z + w * other.w;
   }
 
+  /// Spherical linear interpolation from this quaternion toward [to].
+  ///
+  /// `weight` of `0` returns this rotation; `1` returns [to]. The
+  /// implementation falls back to normalized linear interpolation when
+  /// the two rotations are very close, which is both faster and
+  /// numerically more stable.
   Quaternion slerp(Quaternion to, double weight) {
     double cosine = dot(to);
     if (cosine.abs() < 1.0 - 1e-3 /* epsilon */ ) {

--- a/packages/flutter_scene/lib/src/mesh.dart
+++ b/packages/flutter_scene/lib/src/mesh.dart
@@ -16,9 +16,13 @@ import 'package:vector_math/vector_math.dart';
 /// Each of these parts of the car has its own [Geometry] and [Material], and together
 /// they form the complete model.
 base class MeshPrimitive {
+  /// Pairs [geometry] with the [material] used to shade it.
   MeshPrimitive(this.geometry, this.material);
 
+  /// The vertex/index data drawn by this primitive.
   Geometry geometry;
+
+  /// The shader and per-material parameters used to render [geometry].
   Material material;
 }
 
@@ -32,6 +36,10 @@ base class Mesh {
   Mesh(Geometry geometry, Material material)
     : primitives = [MeshPrimitive(geometry, material)];
 
+  /// Creates a `Mesh` composed of the supplied [MeshPrimitive] list.
+  ///
+  /// Use this constructor for multi-material models, where each
+  /// [MeshPrimitive] pairs a separate [Geometry] with its own [Material].
   Mesh.primitives({required this.primitives});
 
   /// The list of [MeshPrimitive] objects that make up the [Geometry] and [Material] of the 3D model.

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -24,6 +24,10 @@ import 'package:vector_math/vector_math.dart';
 /// and child nodes. Nodes are used to build complex scenes by establishing relationships
 /// between different elements, allowing for transformations to propagate down the hierarchy.
 base class Node implements SceneGraph {
+  /// Creates a node with an optional [name], [localTransform], and [mesh].
+  ///
+  /// When omitted, [localTransform] defaults to the identity matrix and the
+  /// node has no associated geometry.
   Node({this.name = '', Matrix4? localTransform, this.mesh})
     : localTransform = localTransform ?? Matrix4.identity();
 
@@ -42,6 +46,12 @@ base class Node implements SceneGraph {
   /// importers (both the offline .model path and the runtime glTF/GLB loader).
   Skin? skin;
 
+  /// Assigns the world-space transform of this node, automatically computing
+  /// the [localTransform] needed to place the node at [transform] given the
+  /// current parent transform.
+  ///
+  /// If the node has no parent, this is equivalent to assigning
+  /// [localTransform] directly.
   set globalTransform(Matrix4 transform) {
     final parent = _parent;
     if (parent == null) {
@@ -95,6 +105,15 @@ base class Node implements SceneGraph {
 
   AnimationPlayer? _animationPlayer;
 
+  /// Searches this node's descendants for the first child whose [Node.name]
+  /// matches [name].
+  ///
+  /// Performs a depth-first search of the subtree rooted at this node and
+  /// returns the first match, or `null` if no descendant has the given name.
+  ///
+  /// When [excludeAnimationPlayers] is `true`, descendants that already
+  /// have an animation player attached are skipped — primarily used
+  /// internally to avoid recursing into clip-attached subtrees.
   Node? getChildByName(String name, {bool excludeAnimationPlayers = false}) {
     for (var child in children) {
       if (excludeAnimationPlayers && child._animationPlayer != null) {
@@ -121,6 +140,14 @@ base class Node implements SceneGraph {
     return _animations.firstWhereOrNull((element) => element.name == name);
   }
 
+  /// Instantiates [animation] as an [AnimationClip] bound to this node.
+  ///
+  /// The returned clip starts paused at time 0; call [AnimationClip.play] to
+  /// begin playback. Multiple clips may be created on the same node and are
+  /// blended together by an internal [AnimationPlayer] each frame.
+  ///
+  /// To enumerate animations parsed from a model, use [parsedAnimations] or
+  /// [findAnimationByName].
   AnimationClip createAnimationClip(Animation animation) {
     _animationPlayer ??= AnimationPlayer();
     return _animationPlayer!.createAnimationClip(animation, this);
@@ -350,7 +377,14 @@ base class Node implements SceneGraph {
     }
   }
 
-  /// Returns the name lookup path from the ancestor node to the child node.
+  /// Returns the sequence of [Node.name] values that walks from [ancestor]
+  /// down to [child] through the scene graph.
+  ///
+  /// Useful for serializing a stable reference to a descendant node that
+  /// can later be resolved with [getChildByNamePath].
+  ///
+  /// Returns `null` (and prints a debug warning) if [ancestor] is not an
+  /// actual ancestor of [child].
   static Iterable<String>? getNamePath(Node ancestor, Node child) {
     List<String> result = [];
     Node? current = child;
@@ -368,7 +402,15 @@ base class Node implements SceneGraph {
     return null;
   }
 
-  /// Returns the index lookup path from the ancestor node to the child node.
+  /// Returns the sequence of child indices that walks from [ancestor] down
+  /// to [child] through the scene graph.
+  ///
+  /// Each entry is the index into the corresponding parent's [children] at
+  /// that level. Useful for re-resolving a node reference on a cloned
+  /// subtree (see [clone]).
+  ///
+  /// Returns `null` (and prints a debug warning) if [ancestor] is not an
+  /// actual ancestor of [child].
   static Iterable<int>? getIndexPath(Node ancestor, Node child) {
     List<int> result = [];
     Node? current = child;
@@ -389,7 +431,8 @@ base class Node implements SceneGraph {
     return null;
   }
 
-  /// Returns the child node at the specified name path.
+  /// Resolves a [namePath] (as produced by [getNamePath]) to a descendant
+  /// node, or `null` if any segment does not match.
   Node? getChildByNamePath(Iterable<String> namePath) {
     Node? current = this;
     for (var name in namePath) {
@@ -401,7 +444,8 @@ base class Node implements SceneGraph {
     return current;
   }
 
-  /// Returns the child node at the specified index path.
+  /// Resolves an [indexPath] (as produced by [getIndexPath]) to a descendant
+  /// node, or `null` if any segment is out of range.
   Node? getChildByIndexPath(Iterable<int> indexPath) {
     Node? current = this;
     for (var index in indexPath) {

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -33,7 +33,20 @@ mixin SceneGraph {
   void removeAll();
 }
 
-enum AntiAliasingMode { none, msaa }
+/// Anti-aliasing strategy used when rendering a [Scene].
+///
+/// Set on a [Scene] via [Scene.antiAliasingMode]. The default is [msaa]
+/// when the GPU backend supports offscreen MSAA, otherwise [none].
+enum AntiAliasingMode {
+  /// No anti-aliasing. Geometry edges are rendered at the render target's
+  /// native resolution.
+  none,
+
+  /// 4x multi-sample anti-aliasing. Requires offscreen MSAA support on
+  /// the active Flutter GPU backend; setting this mode is silently
+  /// ignored (with a debug warning) when MSAA is unavailable.
+  msaa,
+}
 
 /// Represents a 3D scene, which is a collection of nodes that can be rendered onto the screen.
 ///
@@ -52,6 +65,13 @@ base class Scene implements SceneGraph {
 
   AntiAliasingMode _antiAliasingMode = AntiAliasingMode.none;
 
+  /// The anti-aliasing strategy used when rendering this [Scene].
+  ///
+  /// Defaults to [AntiAliasingMode.msaa] (set in the constructor) and falls
+  /// back to [AntiAliasingMode.none] when the active Flutter GPU backend
+  /// does not support offscreen MSAA. Assigning [AntiAliasingMode.msaa]
+  /// on an unsupported backend is silently ignored, leaving the previous
+  /// value in place.
   set antiAliasingMode(AntiAliasingMode value) {
     switch (value) {
       case AntiAliasingMode.none:

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -15,7 +15,32 @@ base class _TranslucentRecord {
   final Material material;
 }
 
+/// Records draw calls for one frame of a [Scene].
+///
+/// `SceneEncoder` is the bridge between the scene graph and Flutter GPU.
+/// [Scene.render] constructs an encoder for each frame, walks the scene
+/// graph with [Node.render] (which forwards to [encode]), then calls
+/// [finish] to submit the recorded command buffer.
+///
+/// The encoder splits draws into two passes:
+///
+/// 1. **Opaque pass**, with depth writes enabled and color blending
+///    disabled, executed in submission order as [encode] is called.
+/// 2. **Translucent pass**, automatically deferred and depth-sorted back
+///    to front from the camera, drawn with premultiplied source-over
+///    blending.
+///
+/// Applications typically do not construct `SceneEncoder` directly;
+/// custom [Geometry] or [Material] subclasses interact with it through
+/// the `bind` callback.
 base class SceneEncoder {
+  /// Creates an encoder targeting [renderTarget] from the perspective of
+  /// the supplied camera.
+  ///
+  /// `dimensions` is the viewport size used to compute the camera's view
+  /// transform; the supplied environment is the default IBL environment
+  /// applied to materials that don't override it. The opaque render pass
+  /// is opened immediately.
   SceneEncoder(
     gpu.RenderTarget renderTarget,
     this._camera,
@@ -41,6 +66,12 @@ base class SceneEncoder {
   late final gpu.RenderPass _renderPass;
   final List<_TranslucentRecord> _translucentRecords = [];
 
+  /// Records a draw call for [geometry] with [material] at
+  /// [worldTransform].
+  ///
+  /// Opaque draws are encoded immediately into the active render pass.
+  /// Translucent draws (where [Material.isOpaque] returns `false`) are
+  /// queued and re-emitted in [finish] after a back-to-front depth sort.
   void encode(Matrix4 worldTransform, Geometry geometry, Material material) {
     if (material.isOpaque()) {
       _encode(worldTransform, geometry, material);
@@ -70,6 +101,13 @@ base class SceneEncoder {
     _renderPass.draw();
   }
 
+  /// Flushes the deferred translucent pass and submits the command
+  /// buffer.
+  ///
+  /// Translucent records are sorted back-to-front by translation distance
+  /// to the camera, then drawn with premultiplied source-over blending
+  /// and depth writes disabled. After this call the encoder's command
+  /// buffer is no longer usable.
   void finish() {
     _translucentRecords.sort((a, b) {
       var aDistance = a.worldTransform.getTranslation().distanceTo(

--- a/packages/flutter_scene/lib/src/shaders.dart
+++ b/packages/flutter_scene/lib/src/shaders.dart
@@ -4,6 +4,16 @@ const String _kBaseShaderBundlePath =
     'packages/flutter_scene/build/shaderbundles/base.shaderbundle';
 
 gpu.ShaderLibrary? _baseShaderLibrary;
+
+/// The shader bundle shipped with `flutter_scene`, lazily loaded on first
+/// access.
+///
+/// Contains the vertex and fragment shaders used by the built-in
+/// geometries (`UnskinnedVertex`, `SkinnedVertex`) and materials
+/// (`StandardFragment`, `UnlitFragment`). Custom [Geometry] or [Material]
+/// subclasses can pull additional shaders from this library.
+///
+/// Throws if the bundled shader asset cannot be loaded.
 gpu.ShaderLibrary get baseShaderLibrary {
   if (_baseShaderLibrary != null) {
     return _baseShaderLibrary!;

--- a/packages/flutter_scene/lib/src/skin.dart
+++ b/packages/flutter_scene/lib/src/skin.dart
@@ -23,10 +23,36 @@ int _getNextPowerOfTwoSize(int x) {
   return x + 1;
 }
 
+/// A skeletal binding used by skinned meshes for animation.
+///
+/// A `Skin` pairs an ordered list of [joints] (scene-graph [Node]s acting as
+/// bones) with the [inverseBindMatrices] that transform a mesh from model
+/// space into each joint's rest-pose local space. The vertex shader
+/// combines these with the joints' current transforms to deform the mesh.
+///
+/// `Skin` instances are usually populated by an importer rather than
+/// constructed directly. They are attached to the mesh-bearing [Node] via
+/// [Node.skin].
 base class Skin {
+  /// The bone nodes referenced by this skin, in shader-binding order.
+  ///
+  /// Entries may be `null` when [Node.clone] is unable to relocate a joint
+  /// in the cloned subtree; the renderer treats null joints as identity
+  /// transforms.
   final List<Node?> joints = [];
+
+  /// The inverse bind matrix for each joint, transforming a vertex from
+  /// model space into the joint's rest-pose local space.
+  ///
+  /// Parallel to [joints]: `inverseBindMatrices[i]` corresponds to
+  /// `joints[i]`.
   final List<Matrix4> inverseBindMatrices = [];
 
+  /// Creates a [Skin] from a deserialized flatbuffer skin description,
+  /// resolving each joint reference against the supplied [sceneNodes].
+  ///
+  /// Throws if joints and inverse bind matrices are absent or have mismatched
+  /// lengths, or if a joint index falls outside [sceneNodes].
   static Skin fromFlatbuffer(fb.Skin skin, List<Node> sceneNodes) {
     if (skin.joints == null ||
         skin.inverseBindMatrices == null ||
@@ -56,6 +82,15 @@ base class Skin {
     return result;
   }
 
+  /// Computes the joint matrices for the current frame and uploads them as
+  /// a square `RGBA32F` GPU texture.
+  ///
+  /// Each joint occupies four texels (one matrix). The texture's edge
+  /// length is rounded up to the next power of two to satisfy GPU sampling
+  /// requirements; unused slots are initialized to identity.
+  ///
+  /// The companion [getTextureWidth] returns the same edge length so the
+  /// vertex shader can index into the texture.
   gpu.Texture getJointsTexture() {
     // Each joint has a matrix. 1 matrix = 16 floats. 1 pixel = 4 floats.
     // Therefore, each joint needs 4 pixels.
@@ -125,6 +160,8 @@ base class Skin {
     return texture;
   }
 
+  /// The edge length, in texels, of the joints texture produced by
+  /// [getJointsTexture].
   int getTextureWidth() {
     return _getNextPowerOfTwoSize(sqrt(joints.length * 4).ceil());
   }

--- a/packages/flutter_scene/lib/src/surface.dart
+++ b/packages/flutter_scene/lib/src/surface.dart
@@ -2,6 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 
+/// Manages a small ring of [gpu.RenderTarget]s used to draw a [Scene].
+///
+/// Each [Scene] owns one `Surface`. On every frame the renderer asks the
+/// surface for a render target via [getNextRenderTarget]; the surface
+/// either reuses an existing target from its ring or creates a new one
+/// (along with an MSAA resolve attachment if requested). The ring resets
+/// whenever the requested size changes.
+///
+/// Applications typically don't interact with `Surface` directly — it is
+/// driven internally by [Scene.render].
 class Surface {
   // TODO(bdero): There should be a method on the Flutter GPU context to pull
   //              this information.
@@ -13,6 +23,12 @@ class Surface {
   int _cursor = 0;
   Size _previousSize = const Size(0, 0);
 
+  /// Returns the next [gpu.RenderTarget] in the rotating ring.
+  ///
+  /// Allocates a fresh target (color + depth attachments, plus a 4x MSAA
+  /// resolve attachment when [enableMsaa] is `true`) when the ring is not
+  /// yet full. The ring is dropped and rebuilt whenever [size] changes
+  /// from the previous call.
   gpu.RenderTarget getNextRenderTarget(Size size, bool enableMsaa) {
     if (size != _previousSize) {
       _cursor = 0;

--- a/packages/flutter_scene_importer/lib/build_hooks.dart
+++ b/packages/flutter_scene_importer/lib/build_hooks.dart
@@ -2,6 +2,17 @@ import 'dart:io';
 
 import 'package:hooks/hooks.dart';
 
+/// Converts each `.glb` file in [inputFilePaths] to the Flutter Scene
+/// `.model` format and writes the result into [outputDirectory] (resolved
+/// relative to [BuildInput.packageRoot]).
+///
+/// Intended to be called from a `build_hooks.dart` entry point in the
+/// consuming package. The [outputDirectory] is created if it doesn't
+/// already exist; the importer is invoked per file via
+/// `dart run flutter_scene_importer:import`.
+///
+/// Throws if any input file does not have a `.glb` extension or if the
+/// underlying importer process fails.
 void buildModels({
   required BuildInput buildInput,
   required List<String> inputFilePaths,

--- a/packages/flutter_scene_importer/lib/constants.dart
+++ b/packages/flutter_scene_importer/lib/constants.dart
@@ -1,5 +1,11 @@
-// position: 3, normal: 3, textureCoords: 2, color: 4 :: 12 floats :: 48 bytes
+/// Bytes per vertex in the unskinned vertex layout: position (`vec3`),
+/// normal (`vec3`), tex coords (`vec2`), color (`vec4`) — 12 floats.
+///
+/// Match this layout exactly when emitting unskinned vertex buffers.
 const int kUnskinnedPerVertexSize = 48;
 
-// vertex: 12, joints: 4, weights: 4 :: 20 floats :: 80 bytes
+/// Bytes per vertex in the skinned vertex layout: the unskinned 12
+/// floats plus 4 joint indices and 4 joint weights — 20 floats.
+///
+/// Match this layout exactly when emitting skinned vertex buffers.
 const int kSkinnedPerVertexSize = 80;

--- a/packages/flutter_scene_importer/lib/flatbuffer.dart
+++ b/packages/flutter_scene_importer/lib/flatbuffer.dart
@@ -8,7 +8,9 @@ import 'package:flutter_scene_importer/generated/scene_impeller.fb_flatbuffers.d
     as fb;
 export 'package:flutter_scene_importer/generated/scene_impeller.fb_flatbuffers.dart';
 
+/// Conversion helpers from the flatbuffer 4×4 matrix type.
 extension MatrixHelpers on fb.Matrix {
+  /// Returns this flatbuffer matrix as a `vector_math` [Matrix4].
   Matrix4 toMatrix4() {
     return Matrix4.fromList(<double>[
       m0, m1, m2, m3, //
@@ -19,19 +21,27 @@ extension MatrixHelpers on fb.Matrix {
   }
 }
 
+/// Conversion helpers from the flatbuffer 3-vector type.
 extension Vector3Helpers on fb.Vec3 {
+  /// Returns this flatbuffer vec3 as a `vector_math` [Vector3].
   Vector3 toVector3() {
     return Vector3(x, y, z);
   }
 }
 
+/// Conversion helpers from the flatbuffer 4-vector type, interpreted as
+/// a quaternion (`(x, y, z, w)`).
 extension QuaternionHelpers on fb.Vec4 {
+  /// Returns this flatbuffer vec4 as a `vector_math` [Quaternion].
   Quaternion toQuaternion() {
     return Quaternion(x, y, z, w);
   }
 }
 
+/// Conversion helpers from the flatbuffer index-type enum.
 extension IndexTypeHelpers on fb.IndexType {
+  /// Maps the flatbuffer index type to the matching Flutter GPU
+  /// [gpu.IndexType].
   gpu.IndexType toIndexType() {
     switch (this) {
       case fb.IndexType.k16Bit:
@@ -43,12 +53,16 @@ extension IndexTypeHelpers on fb.IndexType {
   }
 }
 
+/// Convenience helpers on the flatbuffer scene root.
 extension SceneHelpers on fb.Scene {
+  /// Returns the scene's root transform as a [Matrix4], or the identity
+  /// matrix when the scene has no transform set.
   Matrix4 transformAsMatrix4() {
     return transform?.toMatrix4() ?? Matrix4.identity();
   }
 
-  /// Find a root child node in the scene.
+  /// Returns the [index]-th direct child of the scene root, or `null`
+  /// if the index is out of range or the scene has no children.
   fb.Node? getChild(int index) {
     int? childIndex = children?[index];
     if (childIndex == null) {
@@ -58,7 +72,11 @@ extension SceneHelpers on fb.Scene {
   }
 }
 
+/// Convenience helpers on flatbuffer node references.
 extension NodeHelpers on fb.Node {
+  /// Returns the [index]-th direct child of this node, resolved against
+  /// [scene]'s shared node table, or `null` if the index is out of
+  /// range.
   fb.Node? getChild(fb.Scene scene, int index) {
     int? childIndex = children?[index];
     if (childIndex == null) {
@@ -68,7 +86,14 @@ extension NodeHelpers on fb.Node {
   }
 }
 
+/// Conversion helper for embedded textures in a `.model` payload.
 extension TextureHelpers on fb.Texture {
+  /// Uploads this texture's embedded image data to a Flutter GPU
+  /// texture.
+  ///
+  /// Throws if the texture has no embedded image (for example, a URI-only
+  /// texture reference). Callers needing URI fallback should sample the
+  /// asset bundle themselves before calling.
   gpu.Texture toTexture() {
     if (embeddedImage == null || embeddedImage!.bytes == null) {
       throw Exception('Texture has no embedded image');

--- a/packages/flutter_scene_importer/lib/importer.dart
+++ b/packages/flutter_scene_importer/lib/importer.dart
@@ -5,13 +5,23 @@ import 'package:flutter/services.dart' show rootBundle;
 
 import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
 
+/// A deserialized Flutter Scene `.model` payload.
+///
+/// `flutter_scene` consumes these via `Node.fromAsset` and
+/// `Node.fromFlatbuffer`, but applications can also load one directly to
+/// inspect or transform the underlying flatbuffer. The
+/// `flutter_scene_importer` package owns the schema; the
+/// [`flatbuffer.dart`](flatbuffer.dart) library re-exports the generated
+/// flatbuffer types and provides a few helpful extensions on them.
 class ImportedScene {
+  /// Loads and deserializes a `.model` asset from the asset bundle.
   static Future<ImportedScene> fromAsset(String asset) {
     return rootBundle.loadStructuredBinaryData<ImportedScene>(asset, (data) {
       return fromFlatbuffer(data);
     });
   }
 
+  /// Deserializes a `.model` payload from already-loaded bytes.
   static ImportedScene fromFlatbuffer(ByteData data) {
     final fb.Scene scene = fb.Scene(
       data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
@@ -24,5 +34,9 @@ class ImportedScene {
 
   final fb.Scene _scene;
 
+  /// The deserialized flatbuffer root.
+  ///
+  /// Returns the generated `fb.Scene` accessor; cast at the call site
+  /// when type information is needed.
   get flatbuffer => _scene;
 }

--- a/packages/flutter_scene_importer/lib/offline_import.dart
+++ b/packages/flutter_scene_importer/lib/offline_import.dart
@@ -1,6 +1,13 @@
 import 'dart:io';
 import 'dart:isolate';
 
+/// Searches for a built native executable named [executableName] under
+/// `<packageRoot>/<dir>`, checking the conventional CMake layouts
+/// (`Release/`, `Debug/`, and the bare directory) on both POSIX and
+/// Windows.
+///
+/// Returns the first matching [Uri], or throws with the list of paths it
+/// tried.
 Uri findBuiltExecutable(
   String executableName,
   Uri packageRoot, {
@@ -34,6 +41,12 @@ Uri findBuiltExecutable(
   return found;
 }
 
+/// Returns the file-system root of the resolved
+/// `flutter_scene_importer` package.
+///
+/// Used when running build tooling that needs to locate the bundled
+/// importer binary or its `.fbs` schema regardless of where the package
+/// was resolved from (workspace, pub-cache, or path dependency).
 Uri findImporterPackageRoot() {
   Uri importerPackageUri =
       Isolate.resolvePackageUriSync(
@@ -42,6 +55,15 @@ Uri findImporterPackageRoot() {
   return importerPackageUri.resolve('../');
 }
 
+/// Regenerates the Dart bindings for the flatbuffer schema bundled with
+/// this package by invoking `flatc`.
+///
+/// Used by the importer's own build to (re)generate
+/// `lib/generated/scene_impeller.fb_flatbuffers.dart`. Consumer apps do
+/// not need to call this — the bindings are committed to the package.
+///
+/// After generation, the import line is rewritten to point at the
+/// vendored `flat_buffers` copy under `third_party/`.
 void generateImporterFlatbufferDart({
   String generatedOutputDirectory = "lib/generated/",
 }) {
@@ -91,7 +113,16 @@ void generateImporterFlatbufferDart({
   generatedFile.writeAsStringSync(lines.join('\n'));
 }
 
-/// Takes an input model (glTF file) and
+/// Converts a single glTF binary at [inputGltfFilePath] to a Flutter
+/// Scene `.model` file at [outputModelFilePath], invoking the bundled
+/// native importer as a subprocess.
+///
+/// Both paths can be relative; they are resolved against
+/// [workingDirectory] (defaulting to the caller's current working
+/// directory). The `dart run flutter_scene_importer:import` CLI is a
+/// thin wrapper around this function.
+///
+/// Throws if the importer process exits with a non-zero status.
 void importGltf(
   String inputGltfFilePath,
   String outputModelFilePath, {


### PR DESCRIPTION
Closes #13.

## Summary
Documents the public API surface of `flutter_scene` and `flutter_scene_importer`. Adds a top-level library doc to `package:flutter_scene/scene.dart` pointing users at the main entry points, and fills in dartdoc across:

- **Scene graph core**: `Scene`/`AntiAliasingMode`, `Node` (lifecycle, transforms, path lookups, animations), `Mesh`/`MeshPrimitive`, `Skin`.
- **Camera + helpers**: `Camera`/`PerspectiveCamera`, `gpuTextureFromImage`/`gpuTextureFromAsset`, `Vector3Lerp`/`QuaternionSlerp`, `baseShaderLibrary`.
- **Render pipeline**: `Surface` (render-target ring) and `SceneEncoder` (opaque/translucent two-pass model).
- **Geometry**: `Geometry` abstract class, `UnskinnedGeometry`/`SkinnedGeometry` layouts (48/80 byte references), `CuboidGeometry`, plus `fromFlatbuffer`, `setVertices`/`setIndices`/`uploadVertexData`, `setVertexShader`, `setJointsTexture`, `bind`.
- **Materials**: `Material` abstract class and static helpers (placeholder textures, BRDF LUT, default environment, `initializeStaticResources`), full `PhysicallyBasedMaterial` PBR field set, `UnlitMaterial`, plus `Environment`/`EnvironmentMap` factories and `isEmpty`.
- **Animation system**: a library-level summary, `AnimationProperty`/`BindKey`/`AnimationChannel`/`Animation`, `AnimationClip` lifecycle (play/pause/stop/seek/advance/loop/weight), `AnimationPlayer` (createAnimationClip/getClipByName/update with bind-pose blending), `AnimationTransforms`, and the `PropertyResolver` factories + per-property timeline resolvers.
- **Importer package**: `buildModels` build hook, `ImportedScene` loader factories, `importGltf` and the build-helper trio (`findBuiltExecutable`, `findImporterPackageRoot`, `generateImporterFlatbufferDart`), the `kUnskinnedPerVertexSize`/`kSkinnedPerVertexSize` layout constants, and the `flatbuffer.dart` extension helpers (`Matrix`, `Vec3`, `Vec4`, `IndexType`, scene/node/texture).

Split into 8 file-group commits for review (library + Scene; Node + Mesh + Skin; Camera + helpers + math + shaders; Surface + SceneEncoder; Geometry; Materials; Animation; Importer public API).

## Verification
- \`dart analyze packages/flutter_scene/lib packages/flutter_scene_importer/lib\` — clean.
- \`dart_style 3.1.9\` — no formatting changes (matches CI master-channel formatter per CLAUDE.md).
- \`flutter test\` in both \`flutter_scene\` and \`flutter_scene_importer\` packages — all passing.

Doc-comment changes only; no behavioral or runtime changes.

## Test plan
- [x] dart analyze passes for both packages
- [x] flutter test passes for both packages
- [x] dart_style 3.1.9 reports no formatting drift