### PR TITLE
Bake and expose local-space bounds for cull groundwork

### DIFF
--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -34,6 +34,29 @@ abstract class Geometry {
 
   gpu.Shader? _vertexShader;
 
+  vm.Aabb3? _localBounds;
+  vm.Sphere? _localBoundingSphere;
+
+  /// Local-space axis-aligned bounding box of this geometry's vertex
+  /// positions, or `null` if bounds are unknown. Computed by
+  /// [uploadVertexData] for procedural geometry, populated from the
+  /// `.model` flatbuffer for imported geometry, and (for the advanced
+  /// [setVertices] path where the caller manages its own GPU buffer)
+  /// left `null` unless the caller assigns it via [setLocalBounds].
+  vm.Aabb3? get localBounds => _localBounds;
+
+  /// Local-space bounding sphere paired with [localBounds]. Same
+  /// nullability semantics.
+  vm.Sphere? get localBoundingSphere => _localBoundingSphere;
+
+  /// Override the bounds. Useful for callers driving [setVertices] from
+  /// a caller-managed [gpu.DeviceBuffer] who want to participate in
+  /// bounds-driven scene queries (e.g. frustum culling).
+  void setLocalBounds(vm.Aabb3? aabb, vm.Sphere? sphere) {
+    _localBounds = aabb;
+    _localBoundingSphere = sphere;
+  }
+
   /// The vertex shader used when rendering this geometry.
   ///
   /// Set by subclasses (or via [setVertexShader]) before the first frame.
@@ -94,6 +117,24 @@ abstract class Geometry {
         geometry = SkinnedGeometry();
       default:
         throw Exception('Unknown vertex buffer type');
+    }
+
+    // Pre-populate bounds from the flatbuffer when present so
+    // uploadVertexData can skip the position scan. Geometry written by
+    // older importers (without bounds) falls back to a scan.
+    final fbAabb = fbPrimitive.boundsAabb;
+    if (fbAabb != null) {
+      geometry._localBounds = vm.Aabb3.minMax(
+        vm.Vector3(fbAabb.min.x, fbAabb.min.y, fbAabb.min.z),
+        vm.Vector3(fbAabb.max.x, fbAabb.max.y, fbAabb.max.z),
+      );
+    }
+    final fbSphere = fbPrimitive.boundsSphere;
+    if (fbSphere != null) {
+      geometry._localBoundingSphere = vm.Sphere.centerRadius(
+        vm.Vector3(fbSphere.center.x, fbSphere.center.y, fbSphere.center.z),
+        fbSphere.radius,
+      );
     }
 
     geometry.uploadVertexData(
@@ -177,6 +218,50 @@ abstract class Geometry {
         indexType,
       );
     }
+
+    if (_localBounds == null && vertexCount > 0) {
+      _scanLocalBoundsFromVertices(vertices, vertexCount);
+    }
+  }
+
+  /// Scan the position attribute (the first 12 bytes of each vertex,
+  /// shared across the unskinned 48-byte and skinned 80-byte layouts)
+  /// to populate [_localBounds] and [_localBoundingSphere].
+  void _scanLocalBoundsFromVertices(ByteData vertices, int vertexCount) {
+    final stride = vertices.lengthInBytes ~/ vertexCount;
+    if (stride < 12) {
+      return;
+    }
+    double minX = double.infinity,
+        minY = double.infinity,
+        minZ = double.infinity;
+    double maxX = double.negativeInfinity,
+        maxY = double.negativeInfinity,
+        maxZ = double.negativeInfinity;
+    for (int i = 0; i < vertexCount; i++) {
+      final off = i * stride;
+      final x = vertices.getFloat32(off, Endian.little);
+      final y = vertices.getFloat32(off + 4, Endian.little);
+      final z = vertices.getFloat32(off + 8, Endian.little);
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+      if (z > maxZ) maxZ = z;
+    }
+    final aabb = vm.Aabb3.minMax(
+      vm.Vector3(minX, minY, minZ),
+      vm.Vector3(maxX, maxY, maxZ),
+    );
+    _localBounds = aabb;
+    _localBoundingSphere ??= _circumscribedSphere(aabb);
+  }
+
+  static vm.Sphere _circumscribedSphere(vm.Aabb3 aabb) {
+    final center = (aabb.min + aabb.max) * 0.5;
+    final extents = (aabb.max - aabb.min) * 0.5;
+    return vm.Sphere.centerRadius(center, extents.length);
   }
 
   /// Assigns the vertex [shader] used when this geometry is drawn.

--- a/packages/flutter_scene/lib/src/mesh.dart
+++ b/packages/flutter_scene/lib/src/mesh.dart
@@ -2,7 +2,7 @@ import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/scene_encoder.dart';
-import 'package:vector_math/vector_math.dart';
+import 'package:vector_math/vector_math.dart' as vm;
 
 /// Represents a single part of a [Mesh], containing both [Geometry] and [Material] properties.
 ///
@@ -45,6 +45,38 @@ base class Mesh {
   /// The list of [MeshPrimitive] objects that make up the [Geometry] and [Material] of the 3D model.
   final List<MeshPrimitive> primitives;
 
+  vm.Aabb3? _localBoundsCache;
+  bool _localBoundsCached = false;
+
+  /// Local-space union of every primitive's [Geometry.localBounds], or
+  /// `null` when no primitive has computable bounds. Cached; call
+  /// [markLocalBoundsDirty] after replacing a primitive's geometry or
+  /// mutating geometry that participates in the union.
+  vm.Aabb3? get localBounds {
+    if (_localBoundsCached) return _localBoundsCache;
+    vm.Aabb3? result;
+    for (final p in primitives) {
+      final b = p.geometry.localBounds;
+      if (b == null) continue;
+      if (result == null) {
+        result = vm.Aabb3.copy(b);
+      } else {
+        result.hull(b);
+      }
+    }
+    _localBoundsCache = result;
+    _localBoundsCached = true;
+    return result;
+  }
+
+  /// Invalidate the cached [localBounds]. Call this after replacing a
+  /// primitive's geometry or mutating geometry that participates in the
+  /// union.
+  void markLocalBoundsDirty() {
+    _localBoundsCache = null;
+    _localBoundsCached = false;
+  }
+
   /// Draws the [Geometry] and [Material] data of each [MeshPrimitive] onto the screen.
   ///
   /// This method prepares the [Mesh] for rendering by passing its data to a [SceneEncoder].
@@ -52,7 +84,7 @@ base class Mesh {
   /// the joint [gpu.Texture] data is also included to ensure proper rendering of animated features.
   void render(
     SceneEncoder encoder,
-    Matrix4 worldTransform,
+    vm.Matrix4 worldTransform,
     gpu.Texture? jointsTexture,
     int jointTextureWidth,
   ) {

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -17,6 +17,7 @@ import 'package:flutter_scene/src/skin.dart';
 import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
 import 'package:flutter_scene_importer/importer.dart';
 import 'package:vector_math/vector_math.dart';
+import 'package:vector_math/vector_math.dart' as vm;
 
 /// A `Node` represents a single element in a 3D scene graph.
 ///
@@ -28,8 +29,9 @@ base class Node implements SceneGraph {
   ///
   /// When omitted, [localTransform] defaults to the identity matrix and the
   /// node has no associated geometry.
-  Node({this.name = '', Matrix4? localTransform, this.mesh})
-    : localTransform = localTransform ?? Matrix4.identity();
+  Node({this.name = '', Matrix4? localTransform, Mesh? mesh})
+    : localTransform = localTransform ?? Matrix4.identity(),
+      _mesh = mesh;
 
   /// The name of this node, used for identification.
   String name;
@@ -83,10 +85,99 @@ base class Node implements SceneGraph {
   Node? get parent => _parent;
   bool _isSceneRoot = false;
 
+  Mesh? _mesh;
+
   /// The collection of [MeshPrimitive] objects that represent the 3D geometry and material properties of this node.
   ///
   /// This property is `null` if this node does not have any associated geometry or material.
-  Mesh? mesh;
+  Mesh? get mesh => _mesh;
+  set mesh(Mesh? value) {
+    if (identical(_mesh, value)) return;
+    _mesh = value;
+    markBoundsDirty();
+  }
+
+  // Combined local-space AABB cache. Three states:
+  //   * _combinedBoundsCached == false: not yet computed (fall through
+  //     to the lazy compute path on first access).
+  //   * _combinedBoundsCached == true, _combinedBoundsCache == null:
+  //     subtree is unbounded (skinned content, or geometry without
+  //     computable bounds); treat as always visible.
+  //   * _combinedBoundsCached == true, _combinedBoundsCache != null:
+  //     valid cached AABB.
+  vm.Aabb3? _combinedBoundsCache;
+  bool _combinedBoundsCached = false;
+
+  /// Local-space AABB covering this node's mesh and every descendant's
+  /// (transformed) bounds. Returns `null` when the subtree contains
+  /// skinned content or geometry without computable bounds, signalling
+  /// "treat as always visible." Cached; invalidated by [markBoundsDirty].
+  ///
+  /// Mutating a `localTransform` matrix in place (rather than
+  /// reassigning it) does not automatically invalidate the cache. Call
+  /// [markBoundsDirty] after any in-place transform mutation.
+  vm.Aabb3? get combinedLocalBounds {
+    if (_combinedBoundsCached) return _combinedBoundsCache;
+    _computeAndCacheCombinedLocalBounds();
+    return _combinedBoundsCache;
+  }
+
+  void _computeAndCacheCombinedLocalBounds() {
+    // A node with a skin can't be soundly bounded by its bind-pose
+    // mesh extents; the rendered pose can extend arbitrarily far when
+    // joints animate. PR 3 will replace this branch with a baked
+    // pose-union AABB.
+    if (skin != null) {
+      _combinedBoundsCache = null;
+      _combinedBoundsCached = true;
+      return;
+    }
+
+    vm.Aabb3? result;
+    bool subtreeBounded = true;
+
+    final m = _mesh;
+    if (m != null) {
+      final mb = m.localBounds;
+      if (mb != null) {
+        result = vm.Aabb3.copy(mb);
+      } else if (m.primitives.isNotEmpty) {
+        // Mesh with primitives but no localBounds (caller-managed
+        // buffers without an override) acts as unbounded.
+        subtreeBounded = false;
+      }
+    }
+
+    for (final child in children) {
+      final childBounds = child.combinedLocalBounds;
+      if (childBounds == null) {
+        subtreeBounded = false;
+        continue;
+      }
+      final transformed = vm.Aabb3.copy(childBounds)
+        ..transform(child.localTransform);
+      if (result == null) {
+        result = transformed;
+      } else {
+        result.hull(transformed);
+      }
+    }
+
+    _combinedBoundsCache = subtreeBounded ? result : null;
+    _combinedBoundsCached = true;
+  }
+
+  /// Mark this node's [combinedLocalBounds] cache (and every ancestor's)
+  /// stale. Call after replacing a mesh, mutating a child's local
+  /// transform in place, or any other change that affects the bound.
+  void markBoundsDirty() {
+    Node? current = this;
+    while (current != null && current._combinedBoundsCached) {
+      current._combinedBoundsCache = null;
+      current._combinedBoundsCached = false;
+      current = current._parent;
+    }
+  }
 
   /// Whether this node is a joint in a skeleton for animation.
   bool isJoint = false;
@@ -295,7 +386,8 @@ base class Node implements SceneGraph {
     name = fbNode.name ?? '';
     localTransform = fbNode.transform?.toMatrix4() ?? Matrix4.identity();
 
-    // Unpack mesh.
+    // Unpack mesh. Assign through the private field so we don't trip
+    // markBoundsDirty before we install the baked combined AABB below.
     if (fbNode.meshPrimitives != null) {
       List<MeshPrimitive> meshPrimitives = [];
       for (fb.MeshPrimitive fbPrimitive in fbNode.meshPrimitives!) {
@@ -306,20 +398,39 @@ base class Node implements SceneGraph {
                 : UnlitMaterial();
         meshPrimitives.add(MeshPrimitive(geometry, material));
       }
-      mesh = Mesh.primitives(primitives: meshPrimitives);
+      _mesh = Mesh.primitives(primitives: meshPrimitives);
     }
 
-    // Connect children.
+    // Connect children. Same private-field assignment to avoid
+    // ancestor-chain invalidation churn while building the graph.
     for (int childIndex in fbNode.children ?? []) {
       if (childIndex < 0 || childIndex >= sceneNodes.length) {
         throw Exception('Node child index out of range.');
       }
-      add(sceneNodes[childIndex]);
+      final child = sceneNodes[childIndex];
+      if (child._parent != null) {
+        throw Exception('Child already has a parent');
+      }
+      children.add(child);
+      child._parent = this;
     }
 
     // Skin.
     if (fbNode.skin != null) {
       skin = Skin.fromFlatbuffer(fbNode.skin!, sceneNodes);
+    }
+
+    // Adopt the baked combined-local AABB when present so we don't
+    // recompute it at runtime. When omitted (older files, or the bake
+    // determined the subtree was unbounded), fall through to the lazy
+    // compute path on first access.
+    final fbAabb = fbNode.combinedLocalAabb;
+    if (fbAabb != null) {
+      _combinedBoundsCache = vm.Aabb3.minMax(
+        Vector3(fbAabb.min.x, fbAabb.min.y, fbAabb.min.z),
+        Vector3(fbAabb.max.x, fbAabb.max.y, fbAabb.max.z),
+      );
+      _combinedBoundsCached = true;
     }
   }
 
@@ -348,6 +459,7 @@ base class Node implements SceneGraph {
     }
     children.add(child);
     child._parent = this;
+    markBoundsDirty();
   }
 
   @override
@@ -370,6 +482,7 @@ base class Node implements SceneGraph {
     }
     children.remove(child);
     child._parent = null;
+    markBoundsDirty();
   }
 
   @override

--- a/packages/flutter_scene/test/bounds_test.dart
+++ b/packages/flutter_scene/test/bounds_test.dart
@@ -60,7 +60,10 @@ void main() {
       );
       expect(g.localBounds!.min, Vector3(-1, -2, -3));
       expect(g.localBounds!.max, Vector3(1, 2, 3));
-      expect(g.localBoundingSphere!.radius, closeTo(Vector3(1, 2, 3).length, 1e-6));
+      expect(
+        g.localBoundingSphere!.radius,
+        closeTo(Vector3(1, 2, 3).length, 1e-6),
+      );
     });
 
     test('null bounds when not set', () {
@@ -254,21 +257,24 @@ void main() {
       expect(root.combinedLocalBounds!.max, Vector3(5, 5, 5));
     });
 
-    test('returns null for skinned subtrees regardless of primitive bounds', () {
-      // Skinned bind-pose extents are misleading: animated joints can
-      // place geometry far outside them. The bounds API treats any
-      // skinned node as "always visible" until PR 3 bakes a pose-union
-      // AABB.
-      final node = Node(
-        mesh: Mesh.primitives(
-          primitives: [
-            _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
-          ],
-        ),
-      );
-      node.skin = Skin();
-      expect(node.combinedLocalBounds, isNull);
-    });
+    test(
+      'returns null for skinned subtrees regardless of primitive bounds',
+      () {
+        // Skinned bind-pose extents are misleading: animated joints can
+        // place geometry far outside them. The bounds API treats any
+        // skinned node as "always visible" until PR 3 bakes a pose-union
+        // AABB.
+        final node = Node(
+          mesh: Mesh.primitives(
+            primitives: [
+              _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+            ],
+          ),
+        );
+        node.skin = Skin();
+        expect(node.combinedLocalBounds, isNull);
+      },
+    );
 
     test('mesh setter invalidates the cache', () {
       final node = Node(

--- a/packages/flutter_scene/test/bounds_test.dart
+++ b/packages/flutter_scene/test/bounds_test.dart
@@ -1,0 +1,290 @@
+// Bounds API tests. Exercises Mesh.localBounds, Node.combinedLocalBounds,
+// and the markBoundsDirty invalidation chain. Uses a stub Geometry that
+// skips shader-library access so the tests don't need a Flutter GPU
+// context.
+
+import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// Geometry that skips shader-library access. Lets us exercise bounds
+/// logic without a Flutter GPU context.
+class _StubGeometry extends Geometry {
+  _StubGeometry({Aabb3? aabb}) {
+    if (aabb != null) {
+      setLocalBounds(
+        aabb,
+        Sphere.centerRadius(
+          (aabb.min + aabb.max) * 0.5,
+          ((aabb.max - aabb.min) * 0.5).length,
+        ),
+      );
+    }
+  }
+
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Matrix4 modelTransform,
+    Matrix4 cameraTransform,
+    Vector3 cameraPosition,
+  ) {
+    throw UnsupportedError('Stub geometry is not renderable');
+  }
+}
+
+/// Material that doesn't try to load a fragment shader on construction.
+class _StubMaterial extends Material {
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Environment environment,
+  ) {
+    throw UnsupportedError('Stub material is not renderable');
+  }
+}
+
+Aabb3 _aabb(Vector3 a, Vector3 b) => Aabb3.minMax(a, b);
+
+MeshPrimitive _primWithBounds(Aabb3? aabb) =>
+    MeshPrimitive(_StubGeometry(aabb: aabb), _StubMaterial());
+
+void main() {
+  group('Geometry.setLocalBounds', () {
+    test('round-trips an explicitly-set AABB and sphere', () {
+      final g = _StubGeometry(
+        aabb: _aabb(Vector3(-1, -2, -3), Vector3(1, 2, 3)),
+      );
+      expect(g.localBounds!.min, Vector3(-1, -2, -3));
+      expect(g.localBounds!.max, Vector3(1, 2, 3));
+      expect(g.localBoundingSphere!.radius, closeTo(Vector3(1, 2, 3).length, 1e-6));
+    });
+
+    test('null bounds when not set', () {
+      final g = _StubGeometry();
+      expect(g.localBounds, isNull);
+      expect(g.localBoundingSphere, isNull);
+    });
+  });
+
+  group('Mesh.localBounds', () {
+    test('returns the bound when the mesh has a single primitive', () {
+      final m = Mesh.primitives(
+        primitives: [
+          _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+        ],
+      );
+      expect(m.localBounds!.min, Vector3(-1, -1, -1));
+      expect(m.localBounds!.max, Vector3(1, 1, 1));
+    });
+
+    test('unions multiple primitives', () {
+      final m = Mesh.primitives(
+        primitives: [
+          _primWithBounds(_aabb(Vector3(-1, 0, 0), Vector3(0, 1, 1))),
+          _primWithBounds(_aabb(Vector3(0, -1, 0), Vector3(1, 0, 1))),
+        ],
+      );
+      expect(m.localBounds!.min, Vector3(-1, -1, 0));
+      expect(m.localBounds!.max, Vector3(1, 1, 1));
+    });
+
+    test('returns null when no primitive contributes bounds', () {
+      final m = Mesh.primitives(
+        primitives: [_primWithBounds(null), _primWithBounds(null)],
+      );
+      expect(m.localBounds, isNull);
+    });
+
+    test('skips primitives without bounds when others have them', () {
+      final m = Mesh.primitives(
+        primitives: [
+          _primWithBounds(null),
+          _primWithBounds(_aabb(Vector3(1, 1, 1), Vector3(2, 2, 2))),
+        ],
+      );
+      expect(m.localBounds!.min, Vector3(1, 1, 1));
+      expect(m.localBounds!.max, Vector3(2, 2, 2));
+    });
+
+    test('caches the result and rebuilds on markLocalBoundsDirty', () {
+      final p = _primWithBounds(_aabb(Vector3(0, 0, 0), Vector3(1, 1, 1)));
+      final m = Mesh.primitives(primitives: [p]);
+      // Prime the cache.
+      expect(m.localBounds!.max, Vector3(1, 1, 1));
+      // Swap in a different geometry; without invalidation, the cache
+      // would still report the old extents.
+      p.geometry = _StubGeometry(
+        aabb: _aabb(Vector3(0, 0, 0), Vector3(5, 5, 5)),
+      );
+      expect(m.localBounds!.max, Vector3(1, 1, 1), reason: 'cache hit');
+      m.markLocalBoundsDirty();
+      expect(m.localBounds!.max, Vector3(5, 5, 5), reason: 'after dirty');
+    });
+  });
+
+  group('Node.combinedLocalBounds', () {
+    test('null on an empty node', () {
+      expect(Node().combinedLocalBounds, isNull);
+    });
+
+    test('matches own mesh bounds with no children', () {
+      final node = Node(
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+          ],
+        ),
+      );
+      expect(node.combinedLocalBounds!.min, Vector3(-1, -1, -1));
+      expect(node.combinedLocalBounds!.max, Vector3(1, 1, 1));
+    });
+
+    test('unions child bounds transformed by the child local transform', () {
+      final parent = Node(
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+          ],
+        ),
+      );
+      final child = Node(
+        localTransform: Matrix4.translationValues(10, 0, 0),
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+          ],
+        ),
+      );
+      parent.add(child);
+
+      // Child contributes a [9,11] x [-1,1] x [-1,1] AABB into parent
+      // local space; union with parent's own [-1,1]^3.
+      expect(parent.combinedLocalBounds!.min, Vector3(-1, -1, -1));
+      expect(parent.combinedLocalBounds!.max, Vector3(11, 1, 1));
+    });
+
+    test('handles negative-determinant child transforms correctly', () {
+      // The scene-root coordinate flip uses a (1,1,-1) scale; verify the
+      // transformed AABB is still correct.
+      final parent = Node();
+      final child = Node(
+        localTransform: Matrix4.identity()..setEntry(2, 2, -1.0),
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-1, -2, 3), Vector3(1, 2, 5))),
+          ],
+        ),
+      );
+      parent.add(child);
+      // Child's z range [3,5] flips to [-5,-3] under the (1,1,-1) scale.
+      expect(parent.combinedLocalBounds!.min, Vector3(-1, -2, -5));
+      expect(parent.combinedLocalBounds!.max, Vector3(1, 2, -3));
+    });
+
+    test('ignores subtrees whose primitives have no bounds', () {
+      final parent = Node();
+      parent.add(
+        Node(mesh: Mesh.primitives(primitives: [_primWithBounds(null)])),
+      );
+      // The single subtree contributes nothing usable, so the parent
+      // is unbounded too.
+      expect(parent.combinedLocalBounds, isNull);
+    });
+
+    test('caches the result and invalidates on add/remove', () {
+      final parent = Node(
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+          ],
+        ),
+      );
+      // Prime the cache.
+      expect(parent.combinedLocalBounds!.max, Vector3(1, 1, 1));
+
+      final child = Node(
+        localTransform: Matrix4.translationValues(10, 0, 0),
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+          ],
+        ),
+      );
+      parent.add(child);
+      expect(
+        parent.combinedLocalBounds!.max,
+        Vector3(11, 1, 1),
+        reason: 'add() should invalidate the cache',
+      );
+
+      parent.remove(child);
+      expect(
+        parent.combinedLocalBounds!.max,
+        Vector3(1, 1, 1),
+        reason: 'remove() should invalidate the cache',
+      );
+    });
+
+    test('invalidates ancestors on markBoundsDirty', () {
+      final root = Node();
+      final mid = Node();
+      final leaf = Node(
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(0, 0, 0), Vector3(1, 1, 1))),
+          ],
+        ),
+      );
+      root.add(mid);
+      mid.add(leaf);
+      // Prime caches at every level.
+      expect(root.combinedLocalBounds!.max, Vector3(1, 1, 1));
+
+      // Mutate the leaf's mesh contents and call markBoundsDirty on the
+      // leaf. The root's cache should drop too.
+      leaf.mesh!.primitives[0].geometry = _StubGeometry(
+        aabb: _aabb(Vector3(0, 0, 0), Vector3(5, 5, 5)),
+      );
+      leaf.mesh!.markLocalBoundsDirty();
+      leaf.markBoundsDirty();
+      expect(root.combinedLocalBounds!.max, Vector3(5, 5, 5));
+    });
+
+    test('returns null for skinned subtrees regardless of primitive bounds', () {
+      // Skinned bind-pose extents are misleading: animated joints can
+      // place geometry far outside them. The bounds API treats any
+      // skinned node as "always visible" until PR 3 bakes a pose-union
+      // AABB.
+      final node = Node(
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+          ],
+        ),
+      );
+      node.skin = Skin();
+      expect(node.combinedLocalBounds, isNull);
+    });
+
+    test('mesh setter invalidates the cache', () {
+      final node = Node(
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+          ],
+        ),
+      );
+      expect(node.combinedLocalBounds!.max, Vector3(1, 1, 1));
+      node.mesh = Mesh.primitives(
+        primitives: [
+          _primWithBounds(_aabb(Vector3(-2, -2, -2), Vector3(2, 2, 2))),
+        ],
+      );
+      expect(node.combinedLocalBounds!.max, Vector3(2, 2, 2));
+    });
+  });
+}

--- a/packages/flutter_scene_importer/lib/generated/scene_impeller.fb_flatbuffers.dart
+++ b/packages/flutter_scene_importer/lib/generated/scene_impeller.fb_flatbuffers.dart
@@ -98,7 +98,8 @@ class VertexBufferTypeId {
     final result = values[value];
     if (result == null) {
       throw StateError(
-          'Invalid value $value for bit flag enum VertexBufferTypeId');
+        'Invalid value $value for bit flag enum VertexBufferTypeId',
+      );
     }
     return result;
   }
@@ -111,13 +112,14 @@ class VertexBufferTypeId {
   static bool containsValue(int value) => values.containsKey(value);
 
   static const VertexBufferTypeId NONE = VertexBufferTypeId._(0);
-  static const VertexBufferTypeId UnskinnedVertexBuffer =
-      VertexBufferTypeId._(1);
+  static const VertexBufferTypeId UnskinnedVertexBuffer = VertexBufferTypeId._(
+    1,
+  );
   static const VertexBufferTypeId SkinnedVertexBuffer = VertexBufferTypeId._(2);
   static const Map<int, VertexBufferTypeId> values = {
     0: NONE,
     1: UnskinnedVertexBuffer,
-    2: SkinnedVertexBuffer
+    2: SkinnedVertexBuffer,
   };
 
   static const fb.Reader<VertexBufferTypeId> reader =
@@ -190,7 +192,8 @@ class KeyframesTypeId {
     final result = values[value];
     if (result == null) {
       throw StateError(
-          'Invalid value $value for bit flag enum KeyframesTypeId');
+        'Invalid value $value for bit flag enum KeyframesTypeId',
+      );
     }
     return result;
   }
@@ -210,7 +213,7 @@ class KeyframesTypeId {
     0: NONE,
     1: TranslationKeyframes,
     2: RotationKeyframes,
-    3: ScaleKeyframes
+    3: ScaleKeyframes,
   };
 
   static const fb.Reader<KeyframesTypeId> reader = _KeyframesTypeIdReader();
@@ -320,10 +323,10 @@ class ColorObjectBuilder extends fb.ObjectBuilder {
     required double g,
     required double b,
     required double a,
-  })  : _r = r,
-        _g = g,
-        _b = b,
-        _a = a;
+  }) : _r = r,
+       _g = g,
+       _b = b,
+       _a = a;
 
   /// Finish building, and store into the [fbBuilder].
   @override
@@ -361,7 +364,8 @@ class EmbeddedImage {
   int get componentCount =>
       const fb.Uint8Reader().vTableGet(_bc, _bcOffset, 6, 0);
   ComponentType get componentType => ComponentType.fromValue(
-      const fb.Int8Reader().vTableGet(_bc, _bcOffset, 8, 0));
+    const fb.Int8Reader().vTableGet(_bc, _bcOffset, 8, 0),
+  );
   int get width => const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 10, 0);
   int get height => const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 12, 0);
 
@@ -371,12 +375,14 @@ class EmbeddedImage {
   }
 
   EmbeddedImageT unpack() => EmbeddedImageT(
-      bytes: const fb.Uint8ListReader(lazy: false)
-          .vTableGetNullable(_bc, _bcOffset, 4),
-      componentCount: componentCount,
-      componentType: componentType,
-      width: width,
-      height: height);
+    bytes: const fb.Uint8ListReader(
+      lazy: false,
+    ).vTableGetNullable(_bc, _bcOffset, 4),
+    componentCount: componentCount,
+    componentType: componentType,
+    width: width,
+    height: height,
+  );
 
   static int pack(fb.Builder fbBuilder, EmbeddedImageT? object) {
     if (object == null) return 0;
@@ -391,17 +397,19 @@ class EmbeddedImageT implements fb.Packable {
   int width;
   int height;
 
-  EmbeddedImageT(
-      {this.bytes,
-      this.componentCount = 0,
-      this.componentType = ComponentType.k8Bit,
-      this.width = 0,
-      this.height = 0});
+  EmbeddedImageT({
+    this.bytes,
+    this.componentCount = 0,
+    this.componentType = ComponentType.k8Bit,
+    this.width = 0,
+    this.height = 0,
+  });
 
   @override
   int pack(fb.Builder fbBuilder) {
-    final int? bytesOffset =
-        bytes == null ? null : fbBuilder.writeListUint8(bytes!);
+    final int? bytesOffset = bytes == null
+        ? null
+        : fbBuilder.writeListUint8(bytes!);
     fbBuilder.startTable(5);
     fbBuilder.addOffset(0, bytesOffset);
     fbBuilder.addUint8(1, componentCount);
@@ -477,17 +485,18 @@ class EmbeddedImageObjectBuilder extends fb.ObjectBuilder {
     ComponentType? componentType,
     int? width,
     int? height,
-  })  : _bytes = bytes,
-        _componentCount = componentCount,
-        _componentType = componentType,
-        _width = width,
-        _height = height;
+  }) : _bytes = bytes,
+       _componentCount = componentCount,
+       _componentType = componentType,
+       _width = width,
+       _height = height;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? bytesOffset =
-        _bytes == null ? null : fbBuilder.writeListUint8(_bytes!);
+    final int? bytesOffset = _bytes == null
+        ? null
+        : fbBuilder.writeListUint8(_bytes!);
     fbBuilder.startTable(5);
     fbBuilder.addOffset(0, bytesOffset);
     fbBuilder.addUint8(1, _componentCount);
@@ -609,18 +618,17 @@ class TextureObjectBuilder extends fb.ObjectBuilder {
   final String? _uri;
   final EmbeddedImageObjectBuilder? _embeddedImage;
 
-  TextureObjectBuilder({
-    String? uri,
-    EmbeddedImageObjectBuilder? embeddedImage,
-  })  : _uri = uri,
-        _embeddedImage = embeddedImage;
+  TextureObjectBuilder({String? uri, EmbeddedImageObjectBuilder? embeddedImage})
+    : _uri = uri,
+      _embeddedImage = embeddedImage;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
     final int? uriOffset = _uri == null ? null : fbBuilder.writeString(_uri!);
-    final int? embeddedImageOffset =
-        _embeddedImage?.getOrCreateOffset(fbBuilder);
+    final int? embeddedImageOffset = _embeddedImage?.getOrCreateOffset(
+      fbBuilder,
+    );
     fbBuilder.startTable(2);
     fbBuilder.addOffset(0, uriOffset);
     fbBuilder.addOffset(1, embeddedImageOffset);
@@ -653,7 +661,8 @@ class Material {
   final int _bcOffset;
 
   MaterialType get type => MaterialType.fromValue(
-      const fb.Int8Reader().vTableGet(_bc, _bcOffset, 4, 0));
+    const fb.Int8Reader().vTableGet(_bc, _bcOffset, 4, 0),
+  );
   Color? get baseColorFactor =>
       Color.reader.vTableGetNullable(_bc, _bcOffset, 6);
   int get baseColorTexture =>
@@ -682,18 +691,19 @@ class Material {
   }
 
   MaterialT unpack() => MaterialT(
-      type: type,
-      baseColorFactor: baseColorFactor?.unpack(),
-      baseColorTexture: baseColorTexture,
-      metallicFactor: metallicFactor,
-      roughnessFactor: roughnessFactor,
-      metallicRoughnessTexture: metallicRoughnessTexture,
-      normalScale: normalScale,
-      normalTexture: normalTexture,
-      emissiveFactor: emissiveFactor?.unpack(),
-      emissiveTexture: emissiveTexture,
-      occlusionStrength: occlusionStrength,
-      occlusionTexture: occlusionTexture);
+    type: type,
+    baseColorFactor: baseColorFactor?.unpack(),
+    baseColorTexture: baseColorTexture,
+    metallicFactor: metallicFactor,
+    roughnessFactor: roughnessFactor,
+    metallicRoughnessTexture: metallicRoughnessTexture,
+    normalScale: normalScale,
+    normalTexture: normalTexture,
+    emissiveFactor: emissiveFactor?.unpack(),
+    emissiveTexture: emissiveTexture,
+    occlusionStrength: occlusionStrength,
+    occlusionTexture: occlusionTexture,
+  );
 
   static int pack(fb.Builder fbBuilder, MaterialT? object) {
     if (object == null) return 0;
@@ -719,19 +729,20 @@ class MaterialT implements fb.Packable {
   double occlusionStrength;
   int occlusionTexture;
 
-  MaterialT(
-      {this.type = MaterialType.kUnlit,
-      this.baseColorFactor,
-      this.baseColorTexture = -1,
-      this.metallicFactor = 0.0,
-      this.roughnessFactor = 0.5,
-      this.metallicRoughnessTexture = -1,
-      this.normalScale = 1.0,
-      this.normalTexture = -1,
-      this.emissiveFactor,
-      this.emissiveTexture = -1,
-      this.occlusionStrength = 1.0,
-      this.occlusionTexture = -1});
+  MaterialT({
+    this.type = MaterialType.kUnlit,
+    this.baseColorFactor,
+    this.baseColorTexture = -1,
+    this.metallicFactor = 0.0,
+    this.roughnessFactor = 0.5,
+    this.metallicRoughnessTexture = -1,
+    this.normalScale = 1.0,
+    this.normalTexture = -1,
+    this.emissiveFactor,
+    this.emissiveTexture = -1,
+    this.occlusionStrength = 1.0,
+    this.occlusionTexture = -1,
+  });
 
   @override
   int pack(fb.Builder fbBuilder) {
@@ -870,18 +881,18 @@ class MaterialObjectBuilder extends fb.ObjectBuilder {
     int? emissiveTexture,
     double? occlusionStrength,
     int? occlusionTexture,
-  })  : _type = type,
-        _baseColorFactor = baseColorFactor,
-        _baseColorTexture = baseColorTexture,
-        _metallicFactor = metallicFactor,
-        _roughnessFactor = roughnessFactor,
-        _metallicRoughnessTexture = metallicRoughnessTexture,
-        _normalScale = normalScale,
-        _normalTexture = normalTexture,
-        _emissiveFactor = emissiveFactor,
-        _emissiveTexture = emissiveTexture,
-        _occlusionStrength = occlusionStrength,
-        _occlusionTexture = occlusionTexture;
+  }) : _type = type,
+       _baseColorFactor = baseColorFactor,
+       _baseColorTexture = baseColorTexture,
+       _metallicFactor = metallicFactor,
+       _roughnessFactor = roughnessFactor,
+       _metallicRoughnessTexture = metallicRoughnessTexture,
+       _normalScale = normalScale,
+       _normalTexture = normalTexture,
+       _emissiveFactor = emissiveFactor,
+       _emissiveTexture = emissiveTexture,
+       _occlusionStrength = occlusionStrength,
+       _occlusionTexture = occlusionTexture;
 
   /// Finish building, and store into the [fbBuilder].
   @override
@@ -988,11 +999,7 @@ class Vec2ObjectBuilder extends fb.ObjectBuilder {
   final double _x;
   final double _y;
 
-  Vec2ObjectBuilder({
-    required double x,
-    required double y,
-  })  : _x = x,
-        _y = y;
+  Vec2ObjectBuilder({required double x, required double y}) : _x = x, _y = y;
 
   /// Finish building, and store into the [fbBuilder].
   @override
@@ -1085,13 +1092,10 @@ class Vec3ObjectBuilder extends fb.ObjectBuilder {
   final double _y;
   final double _z;
 
-  Vec3ObjectBuilder({
-    required double x,
-    required double y,
-    required double z,
-  })  : _x = x,
-        _y = y,
-        _z = z;
+  Vec3ObjectBuilder({required double x, required double y, required double z})
+    : _x = x,
+      _y = y,
+      _z = z;
 
   /// Finish building, and store into the [fbBuilder].
   @override
@@ -1195,10 +1199,10 @@ class Vec4ObjectBuilder extends fb.ObjectBuilder {
     required double y,
     required double z,
     required double w,
-  })  : _x = x,
-        _y = y,
-        _z = z,
-        _w = w;
+  }) : _x = x,
+       _y = y,
+       _z = z,
+       _w = w;
 
   /// Finish building, and store into the [fbBuilder].
   @override
@@ -1207,6 +1211,196 @@ class Vec4ObjectBuilder extends fb.ObjectBuilder {
     fbBuilder.putFloat32(_z);
     fbBuilder.putFloat32(_y);
     fbBuilder.putFloat32(_x);
+    return fbBuilder.offset;
+  }
+
+  /// Convenience method to serialize to byte list.
+  @override
+  Uint8List toBytes([String? fileIdentifier]) {
+    final fbBuilder = fb.Builder(deduplicateTables: false);
+    fbBuilder.finish(finish(fbBuilder), fileIdentifier);
+    return fbBuilder.buffer;
+  }
+}
+
+///  Axis-aligned bounding box in some local space (typically the space of
+///  the vertex positions on a primitive, or the local space of a node).
+class Aabb3 {
+  Aabb3._(this._bc, this._bcOffset);
+
+  static const fb.Reader<Aabb3> reader = _Aabb3Reader();
+
+  final fb.BufferContext _bc;
+  final int _bcOffset;
+
+  Vec3 get min => Vec3.reader.read(_bc, _bcOffset + 0);
+  Vec3 get max => Vec3.reader.read(_bc, _bcOffset + 12);
+
+  @override
+  String toString() {
+    return 'Aabb3{min: ${min}, max: ${max}}';
+  }
+
+  Aabb3T unpack() => Aabb3T(min: min.unpack(), max: max.unpack());
+
+  static int pack(fb.Builder fbBuilder, Aabb3T? object) {
+    if (object == null) return 0;
+    return object.pack(fbBuilder);
+  }
+}
+
+///  Axis-aligned bounding box in some local space (typically the space of
+///  the vertex positions on a primitive, or the local space of a node).
+class Aabb3T implements fb.Packable {
+  Vec3T min;
+  Vec3T max;
+
+  Aabb3T({required this.min, required this.max});
+
+  @override
+  int pack(fb.Builder fbBuilder) {
+    max.pack(fbBuilder);
+    min.pack(fbBuilder);
+    return fbBuilder.offset;
+  }
+
+  @override
+  String toString() {
+    return 'Aabb3T{min: ${min}, max: ${max}}';
+  }
+}
+
+class _Aabb3Reader extends fb.StructReader<Aabb3> {
+  const _Aabb3Reader();
+
+  @override
+  int get size => 24;
+
+  @override
+  Aabb3 createObject(fb.BufferContext bc, int offset) => Aabb3._(bc, offset);
+}
+
+class Aabb3Builder {
+  Aabb3Builder(this.fbBuilder);
+
+  final fb.Builder fbBuilder;
+
+  int finish(fb.StructBuilder min, fb.StructBuilder max) {
+    max();
+    min();
+    return fbBuilder.offset;
+  }
+}
+
+class Aabb3ObjectBuilder extends fb.ObjectBuilder {
+  final Vec3ObjectBuilder _min;
+  final Vec3ObjectBuilder _max;
+
+  Aabb3ObjectBuilder({
+    required Vec3ObjectBuilder min,
+    required Vec3ObjectBuilder max,
+  }) : _min = min,
+       _max = max;
+
+  /// Finish building, and store into the [fbBuilder].
+  @override
+  int finish(fb.Builder fbBuilder) {
+    _max.finish(fbBuilder);
+    _min.finish(fbBuilder);
+    return fbBuilder.offset;
+  }
+
+  /// Convenience method to serialize to byte list.
+  @override
+  Uint8List toBytes([String? fileIdentifier]) {
+    final fbBuilder = fb.Builder(deduplicateTables: false);
+    fbBuilder.finish(finish(fbBuilder), fileIdentifier);
+    return fbBuilder.buffer;
+  }
+}
+
+///  Bounding sphere in the same space as an associated `Aabb3`.
+class Sphere {
+  Sphere._(this._bc, this._bcOffset);
+
+  static const fb.Reader<Sphere> reader = _SphereReader();
+
+  final fb.BufferContext _bc;
+  final int _bcOffset;
+
+  Vec3 get center => Vec3.reader.read(_bc, _bcOffset + 0);
+  double get radius => const fb.Float32Reader().read(_bc, _bcOffset + 12);
+
+  @override
+  String toString() {
+    return 'Sphere{center: ${center}, radius: ${radius}}';
+  }
+
+  SphereT unpack() => SphereT(center: center.unpack(), radius: radius);
+
+  static int pack(fb.Builder fbBuilder, SphereT? object) {
+    if (object == null) return 0;
+    return object.pack(fbBuilder);
+  }
+}
+
+///  Bounding sphere in the same space as an associated `Aabb3`.
+class SphereT implements fb.Packable {
+  Vec3T center;
+  double radius;
+
+  SphereT({required this.center, required this.radius});
+
+  @override
+  int pack(fb.Builder fbBuilder) {
+    fbBuilder.putFloat32(radius);
+    center.pack(fbBuilder);
+    return fbBuilder.offset;
+  }
+
+  @override
+  String toString() {
+    return 'SphereT{center: ${center}, radius: ${radius}}';
+  }
+}
+
+class _SphereReader extends fb.StructReader<Sphere> {
+  const _SphereReader();
+
+  @override
+  int get size => 16;
+
+  @override
+  Sphere createObject(fb.BufferContext bc, int offset) => Sphere._(bc, offset);
+}
+
+class SphereBuilder {
+  SphereBuilder(this.fbBuilder);
+
+  final fb.Builder fbBuilder;
+
+  int finish(fb.StructBuilder center, double radius) {
+    fbBuilder.putFloat32(radius);
+    center();
+    return fbBuilder.offset;
+  }
+}
+
+class SphereObjectBuilder extends fb.ObjectBuilder {
+  final Vec3ObjectBuilder _center;
+  final double _radius;
+
+  SphereObjectBuilder({
+    required Vec3ObjectBuilder center,
+    required double radius,
+  }) : _center = center,
+       _radius = radius;
+
+  /// Finish building, and store into the [fbBuilder].
+  @override
+  int finish(fb.Builder fbBuilder) {
+    fbBuilder.putFloat32(_radius);
+    _center.finish(fbBuilder);
     return fbBuilder.offset;
   }
 
@@ -1238,10 +1432,11 @@ class Vertex {
   }
 
   VertexT unpack() => VertexT(
-      position: position.unpack(),
-      normal: normal.unpack(),
-      textureCoords: textureCoords.unpack(),
-      color: color.unpack());
+    position: position.unpack(),
+    normal: normal.unpack(),
+    textureCoords: textureCoords.unpack(),
+    color: color.unpack(),
+  );
 
   static int pack(fb.Builder fbBuilder, VertexT? object) {
     if (object == null) return 0;
@@ -1255,11 +1450,12 @@ class VertexT implements fb.Packable {
   Vec2T textureCoords;
   ColorT color;
 
-  VertexT(
-      {required this.position,
-      required this.normal,
-      required this.textureCoords,
-      required this.color});
+  VertexT({
+    required this.position,
+    required this.normal,
+    required this.textureCoords,
+    required this.color,
+  });
 
   @override
   int pack(fb.Builder fbBuilder) {
@@ -1291,8 +1487,12 @@ class VertexBuilder {
 
   final fb.Builder fbBuilder;
 
-  int finish(fb.StructBuilder position, fb.StructBuilder normal,
-      fb.StructBuilder textureCoords, fb.StructBuilder color) {
+  int finish(
+    fb.StructBuilder position,
+    fb.StructBuilder normal,
+    fb.StructBuilder textureCoords,
+    fb.StructBuilder color,
+  ) {
     color();
     textureCoords();
     normal();
@@ -1312,10 +1512,10 @@ class VertexObjectBuilder extends fb.ObjectBuilder {
     required Vec3ObjectBuilder normal,
     required Vec2ObjectBuilder textureCoords,
     required ColorObjectBuilder color,
-  })  : _position = position,
-        _normal = normal,
-        _textureCoords = textureCoords,
-        _color = color;
+  }) : _position = position,
+       _normal = normal,
+       _textureCoords = textureCoords,
+       _color = color;
 
   /// Finish building, and store into the [fbBuilder].
   @override
@@ -1360,9 +1560,11 @@ class UnskinnedVertexBuffer {
   }
 
   UnskinnedVertexBufferT unpack() => UnskinnedVertexBufferT(
-      vertices: const fb.Uint8ListReader(lazy: false)
-          .vTableGetNullable(_bc, _bcOffset, 4),
-      vertexCount: vertexCount);
+    vertices: const fb.Uint8ListReader(
+      lazy: false,
+    ).vTableGetNullable(_bc, _bcOffset, 4),
+    vertexCount: vertexCount,
+  );
 
   static int pack(fb.Builder fbBuilder, UnskinnedVertexBufferT? object) {
     if (object == null) return 0;
@@ -1378,8 +1580,9 @@ class UnskinnedVertexBufferT implements fb.Packable {
 
   @override
   int pack(fb.Builder fbBuilder) {
-    final int? verticesOffset =
-        vertices == null ? null : fbBuilder.writeListUint8(vertices!);
+    final int? verticesOffset = vertices == null
+        ? null
+        : fbBuilder.writeListUint8(vertices!);
     fbBuilder.startTable(2);
     fbBuilder.addOffset(0, verticesOffset);
     fbBuilder.addUint32(1, vertexCount);
@@ -1429,17 +1632,16 @@ class UnskinnedVertexBufferObjectBuilder extends fb.ObjectBuilder {
   final List<int>? _vertices;
   final int? _vertexCount;
 
-  UnskinnedVertexBufferObjectBuilder({
-    List<int>? vertices,
-    int? vertexCount,
-  })  : _vertices = vertices,
-        _vertexCount = vertexCount;
+  UnskinnedVertexBufferObjectBuilder({List<int>? vertices, int? vertexCount})
+    : _vertices = vertices,
+      _vertexCount = vertexCount;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? verticesOffset =
-        _vertices == null ? null : fbBuilder.writeListUint8(_vertices!);
+    final int? verticesOffset = _vertices == null
+        ? null
+        : fbBuilder.writeListUint8(_vertices!);
     fbBuilder.startTable(2);
     fbBuilder.addOffset(0, verticesOffset);
     fbBuilder.addUint32(1, _vertexCount);
@@ -1480,9 +1682,10 @@ class SkinnedVertex {
   }
 
   SkinnedVertexT unpack() => SkinnedVertexT(
-      vertex: vertex.unpack(),
-      joints: joints.unpack(),
-      weights: weights.unpack());
+    vertex: vertex.unpack(),
+    joints: joints.unpack(),
+    weights: weights.unpack(),
+  );
 
   static int pack(fb.Builder fbBuilder, SkinnedVertexT? object) {
     if (object == null) return 0;
@@ -1502,8 +1705,11 @@ class SkinnedVertexT implements fb.Packable {
   ///  joints.
   Vec4T weights;
 
-  SkinnedVertexT(
-      {required this.vertex, required this.joints, required this.weights});
+  SkinnedVertexT({
+    required this.vertex,
+    required this.joints,
+    required this.weights,
+  });
 
   @override
   int pack(fb.Builder fbBuilder) {
@@ -1535,8 +1741,11 @@ class SkinnedVertexBuilder {
 
   final fb.Builder fbBuilder;
 
-  int finish(fb.StructBuilder vertex, fb.StructBuilder joints,
-      fb.StructBuilder weights) {
+  int finish(
+    fb.StructBuilder vertex,
+    fb.StructBuilder joints,
+    fb.StructBuilder weights,
+  ) {
     weights();
     joints();
     vertex();
@@ -1553,9 +1762,9 @@ class SkinnedVertexObjectBuilder extends fb.ObjectBuilder {
     required VertexObjectBuilder vertex,
     required Vec4ObjectBuilder joints,
     required Vec4ObjectBuilder weights,
-  })  : _vertex = vertex,
-        _joints = joints,
-        _weights = weights;
+  }) : _vertex = vertex,
+       _joints = joints,
+       _weights = weights;
 
   /// Finish building, and store into the [fbBuilder].
   @override
@@ -1599,9 +1808,11 @@ class SkinnedVertexBuffer {
   }
 
   SkinnedVertexBufferT unpack() => SkinnedVertexBufferT(
-      vertices: const fb.Uint8ListReader(lazy: false)
-          .vTableGetNullable(_bc, _bcOffset, 4),
-      vertexCount: vertexCount);
+    vertices: const fb.Uint8ListReader(
+      lazy: false,
+    ).vTableGetNullable(_bc, _bcOffset, 4),
+    vertexCount: vertexCount,
+  );
 
   static int pack(fb.Builder fbBuilder, SkinnedVertexBufferT? object) {
     if (object == null) return 0;
@@ -1617,8 +1828,9 @@ class SkinnedVertexBufferT implements fb.Packable {
 
   @override
   int pack(fb.Builder fbBuilder) {
-    final int? verticesOffset =
-        vertices == null ? null : fbBuilder.writeListUint8(vertices!);
+    final int? verticesOffset = vertices == null
+        ? null
+        : fbBuilder.writeListUint8(vertices!);
     fbBuilder.startTable(2);
     fbBuilder.addOffset(0, verticesOffset);
     fbBuilder.addUint32(1, vertexCount);
@@ -1667,17 +1879,16 @@ class SkinnedVertexBufferObjectBuilder extends fb.ObjectBuilder {
   final List<int>? _vertices;
   final int? _vertexCount;
 
-  SkinnedVertexBufferObjectBuilder({
-    List<int>? vertices,
-    int? vertexCount,
-  })  : _vertices = vertices,
-        _vertexCount = vertexCount;
+  SkinnedVertexBufferObjectBuilder({List<int>? vertices, int? vertexCount})
+    : _vertices = vertices,
+      _vertexCount = vertexCount;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? verticesOffset =
-        _vertices == null ? null : fbBuilder.writeListUint8(_vertices!);
+    final int? verticesOffset = _vertices == null
+        ? null
+        : fbBuilder.writeListUint8(_vertices!);
     fbBuilder.startTable(2);
     fbBuilder.addOffset(0, verticesOffset);
     fbBuilder.addUint32(1, _vertexCount);
@@ -1709,7 +1920,8 @@ class Indices {
       const fb.Uint8ListReader().vTableGetNullable(_bc, _bcOffset, 4);
   int get count => const fb.Uint32Reader().vTableGet(_bc, _bcOffset, 6, 0);
   IndexType get type => IndexType.fromValue(
-      const fb.Int8Reader().vTableGet(_bc, _bcOffset, 8, 0));
+    const fb.Int8Reader().vTableGet(_bc, _bcOffset, 8, 0),
+  );
 
   @override
   String toString() {
@@ -1717,10 +1929,12 @@ class Indices {
   }
 
   IndicesT unpack() => IndicesT(
-      data: const fb.Uint8ListReader(lazy: false)
-          .vTableGetNullable(_bc, _bcOffset, 4),
-      count: count,
-      type: type);
+    data: const fb.Uint8ListReader(
+      lazy: false,
+    ).vTableGetNullable(_bc, _bcOffset, 4),
+    count: count,
+    type: type,
+  );
 
   static int pack(fb.Builder fbBuilder, IndicesT? object) {
     if (object == null) return 0;
@@ -1737,8 +1951,9 @@ class IndicesT implements fb.Packable {
 
   @override
   int pack(fb.Builder fbBuilder) {
-    final int? dataOffset =
-        data == null ? null : fbBuilder.writeListUint8(data!);
+    final int? dataOffset = data == null
+        ? null
+        : fbBuilder.writeListUint8(data!);
     fbBuilder.startTable(3);
     fbBuilder.addOffset(0, dataOffset);
     fbBuilder.addUint32(1, count);
@@ -1794,19 +2009,17 @@ class IndicesObjectBuilder extends fb.ObjectBuilder {
   final int? _count;
   final IndexType? _type;
 
-  IndicesObjectBuilder({
-    List<int>? data,
-    int? count,
-    IndexType? type,
-  })  : _data = data,
-        _count = count,
-        _type = type;
+  IndicesObjectBuilder({List<int>? data, int? count, IndexType? type})
+    : _data = data,
+      _count = count,
+      _type = type;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? dataOffset =
-        _data == null ? null : fbBuilder.writeListUint8(_data!);
+    final int? dataOffset = _data == null
+        ? null
+        : fbBuilder.writeListUint8(_data!);
     fbBuilder.startTable(3);
     fbBuilder.addOffset(0, dataOffset);
     fbBuilder.addUint32(1, _count);
@@ -1836,12 +2049,16 @@ class MeshPrimitive {
   final int _bcOffset;
 
   VertexBufferTypeId? get verticesType => VertexBufferTypeId._createOrNull(
-      const fb.Uint8Reader().vTableGetNullable(_bc, _bcOffset, 4));
+    const fb.Uint8Reader().vTableGetNullable(_bc, _bcOffset, 4),
+  );
   dynamic get vertices {
     switch (verticesType?.value) {
       case 1:
-        return UnskinnedVertexBuffer.reader
-            .vTableGetNullable(_bc, _bcOffset, 6);
+        return UnskinnedVertexBuffer.reader.vTableGetNullable(
+          _bc,
+          _bcOffset,
+          6,
+        );
       case 2:
         return SkinnedVertexBuffer.reader.vTableGetNullable(_bc, _bcOffset, 6);
       default:
@@ -1853,16 +2070,28 @@ class MeshPrimitive {
   Material? get material =>
       Material.reader.vTableGetNullable(_bc, _bcOffset, 10);
 
+  ///  Local-space (vertex-position-space) bounds of this primitive.
+  ///
+  ///  Optional. When absent, the runtime falls back to scanning the vertex
+  ///  positions on first access, so older `.model` files without bounds
+  ///  still load correctly.
+  Aabb3? get boundsAabb => Aabb3.reader.vTableGetNullable(_bc, _bcOffset, 12);
+  Sphere? get boundsSphere =>
+      Sphere.reader.vTableGetNullable(_bc, _bcOffset, 14);
+
   @override
   String toString() {
-    return 'MeshPrimitive{verticesType: ${verticesType}, vertices: ${vertices}, indices: ${indices}, material: ${material}}';
+    return 'MeshPrimitive{verticesType: ${verticesType}, vertices: ${vertices}, indices: ${indices}, material: ${material}, boundsAabb: ${boundsAabb}, boundsSphere: ${boundsSphere}}';
   }
 
   MeshPrimitiveT unpack() => MeshPrimitiveT(
-      verticesType: verticesType,
-      vertices: vertices,
-      indices: indices?.unpack(),
-      material: material?.unpack());
+    verticesType: verticesType,
+    vertices: vertices,
+    indices: indices?.unpack(),
+    material: material?.unpack(),
+    boundsAabb: boundsAabb?.unpack(),
+    boundsSphere: boundsSphere?.unpack(),
+  );
 
   static int pack(fb.Builder fbBuilder, MeshPrimitiveT? object) {
     if (object == null) return 0;
@@ -1876,25 +2105,45 @@ class MeshPrimitiveT implements fb.Packable {
   IndicesT? indices;
   MaterialT? material;
 
-  MeshPrimitiveT(
-      {this.verticesType, this.vertices, this.indices, this.material});
+  ///  Local-space (vertex-position-space) bounds of this primitive.
+  ///
+  ///  Optional. When absent, the runtime falls back to scanning the vertex
+  ///  positions on first access, so older `.model` files without bounds
+  ///  still load correctly.
+  Aabb3T? boundsAabb;
+  SphereT? boundsSphere;
+
+  MeshPrimitiveT({
+    this.verticesType,
+    this.vertices,
+    this.indices,
+    this.material,
+    this.boundsAabb,
+    this.boundsSphere,
+  });
 
   @override
   int pack(fb.Builder fbBuilder) {
     final int? verticesOffset = vertices?.pack(fbBuilder);
     final int? indicesOffset = indices?.pack(fbBuilder);
     final int? materialOffset = material?.pack(fbBuilder);
-    fbBuilder.startTable(4);
+    fbBuilder.startTable(6);
     fbBuilder.addUint8(0, verticesType?.value);
     fbBuilder.addOffset(1, verticesOffset);
     fbBuilder.addOffset(2, indicesOffset);
     fbBuilder.addOffset(3, materialOffset);
+    if (boundsAabb != null) {
+      fbBuilder.addStruct(4, boundsAabb!.pack(fbBuilder));
+    }
+    if (boundsSphere != null) {
+      fbBuilder.addStruct(5, boundsSphere!.pack(fbBuilder));
+    }
     return fbBuilder.endTable();
   }
 
   @override
   String toString() {
-    return 'MeshPrimitiveT{verticesType: ${verticesType}, vertices: ${vertices}, indices: ${indices}, material: ${material}}';
+    return 'MeshPrimitiveT{verticesType: ${verticesType}, vertices: ${vertices}, indices: ${indices}, material: ${material}, boundsAabb: ${boundsAabb}, boundsSphere: ${boundsSphere}}';
   }
 }
 
@@ -1912,7 +2161,7 @@ class MeshPrimitiveBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable(4);
+    fbBuilder.startTable(6);
   }
 
   int addVerticesType(VertexBufferTypeId? verticesType) {
@@ -1935,6 +2184,16 @@ class MeshPrimitiveBuilder {
     return fbBuilder.offset;
   }
 
+  int addBoundsAabb(int offset) {
+    fbBuilder.addStruct(4, offset);
+    return fbBuilder.offset;
+  }
+
+  int addBoundsSphere(int offset) {
+    fbBuilder.addStruct(5, offset);
+    return fbBuilder.offset;
+  }
+
   int finish() {
     return fbBuilder.endTable();
   }
@@ -1945,16 +2204,22 @@ class MeshPrimitiveObjectBuilder extends fb.ObjectBuilder {
   final dynamic _vertices;
   final IndicesObjectBuilder? _indices;
   final MaterialObjectBuilder? _material;
+  final Aabb3ObjectBuilder? _boundsAabb;
+  final SphereObjectBuilder? _boundsSphere;
 
   MeshPrimitiveObjectBuilder({
     VertexBufferTypeId? verticesType,
     dynamic vertices,
     IndicesObjectBuilder? indices,
     MaterialObjectBuilder? material,
-  })  : _verticesType = verticesType,
-        _vertices = vertices,
-        _indices = indices,
-        _material = material;
+    Aabb3ObjectBuilder? boundsAabb,
+    SphereObjectBuilder? boundsSphere,
+  }) : _verticesType = verticesType,
+       _vertices = vertices,
+       _indices = indices,
+       _material = material,
+       _boundsAabb = boundsAabb,
+       _boundsSphere = boundsSphere;
 
   /// Finish building, and store into the [fbBuilder].
   @override
@@ -1962,11 +2227,17 @@ class MeshPrimitiveObjectBuilder extends fb.ObjectBuilder {
     final int? verticesOffset = _vertices?.getOrCreateOffset(fbBuilder);
     final int? indicesOffset = _indices?.getOrCreateOffset(fbBuilder);
     final int? materialOffset = _material?.getOrCreateOffset(fbBuilder);
-    fbBuilder.startTable(4);
+    fbBuilder.startTable(6);
     fbBuilder.addUint8(0, _verticesType?.value);
     fbBuilder.addOffset(1, verticesOffset);
     fbBuilder.addOffset(2, indicesOffset);
     fbBuilder.addOffset(3, materialOffset);
+    if (_boundsAabb != null) {
+      fbBuilder.addStruct(4, _boundsAabb!.finish(fbBuilder));
+    }
+    if (_boundsSphere != null) {
+      fbBuilder.addStruct(5, _boundsSphere!.finish(fbBuilder));
+    }
     return fbBuilder.endTable();
   }
 
@@ -1994,8 +2265,9 @@ class TranslationKeyframes {
   final fb.BufferContext _bc;
   final int _bcOffset;
 
-  List<Vec3>? get values => const fb.ListReader<Vec3>(Vec3.reader)
-      .vTableGetNullable(_bc, _bcOffset, 4);
+  List<Vec3>? get values => const fb.ListReader<Vec3>(
+    Vec3.reader,
+  ).vTableGetNullable(_bc, _bcOffset, 4);
 
   @override
   String toString() {
@@ -2068,15 +2340,15 @@ class TranslationKeyframesBuilder {
 class TranslationKeyframesObjectBuilder extends fb.ObjectBuilder {
   final List<Vec3ObjectBuilder>? _values;
 
-  TranslationKeyframesObjectBuilder({
-    List<Vec3ObjectBuilder>? values,
-  }) : _values = values;
+  TranslationKeyframesObjectBuilder({List<Vec3ObjectBuilder>? values})
+    : _values = values;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? valuesOffset =
-        _values == null ? null : fbBuilder.writeListOfStructs(_values!);
+    final int? valuesOffset = _values == null
+        ? null
+        : fbBuilder.writeListOfStructs(_values!);
     fbBuilder.startTable(1);
     fbBuilder.addOffset(0, valuesOffset);
     return fbBuilder.endTable();
@@ -2103,8 +2375,9 @@ class RotationKeyframes {
   final fb.BufferContext _bc;
   final int _bcOffset;
 
-  List<Vec4>? get values => const fb.ListReader<Vec4>(Vec4.reader)
-      .vTableGetNullable(_bc, _bcOffset, 4);
+  List<Vec4>? get values => const fb.ListReader<Vec4>(
+    Vec4.reader,
+  ).vTableGetNullable(_bc, _bcOffset, 4);
 
   @override
   String toString() {
@@ -2175,15 +2448,15 @@ class RotationKeyframesBuilder {
 class RotationKeyframesObjectBuilder extends fb.ObjectBuilder {
   final List<Vec4ObjectBuilder>? _values;
 
-  RotationKeyframesObjectBuilder({
-    List<Vec4ObjectBuilder>? values,
-  }) : _values = values;
+  RotationKeyframesObjectBuilder({List<Vec4ObjectBuilder>? values})
+    : _values = values;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? valuesOffset =
-        _values == null ? null : fbBuilder.writeListOfStructs(_values!);
+    final int? valuesOffset = _values == null
+        ? null
+        : fbBuilder.writeListOfStructs(_values!);
     fbBuilder.startTable(1);
     fbBuilder.addOffset(0, valuesOffset);
     return fbBuilder.endTable();
@@ -2210,8 +2483,9 @@ class ScaleKeyframes {
   final fb.BufferContext _bc;
   final int _bcOffset;
 
-  List<Vec3>? get values => const fb.ListReader<Vec3>(Vec3.reader)
-      .vTableGetNullable(_bc, _bcOffset, 4);
+  List<Vec3>? get values => const fb.ListReader<Vec3>(
+    Vec3.reader,
+  ).vTableGetNullable(_bc, _bcOffset, 4);
 
   @override
   String toString() {
@@ -2282,15 +2556,15 @@ class ScaleKeyframesBuilder {
 class ScaleKeyframesObjectBuilder extends fb.ObjectBuilder {
   final List<Vec3ObjectBuilder>? _values;
 
-  ScaleKeyframesObjectBuilder({
-    List<Vec3ObjectBuilder>? values,
-  }) : _values = values;
+  ScaleKeyframesObjectBuilder({List<Vec3ObjectBuilder>? values})
+    : _values = values;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? valuesOffset =
-        _values == null ? null : fbBuilder.writeListOfStructs(_values!);
+    final int? valuesOffset = _values == null
+        ? null
+        : fbBuilder.writeListOfStructs(_values!);
     fbBuilder.startTable(1);
     fbBuilder.addOffset(0, valuesOffset);
     return fbBuilder.endTable();
@@ -2318,15 +2592,20 @@ class Channel {
   final int _bcOffset;
 
   int get node => const fb.Int32Reader().vTableGet(_bc, _bcOffset, 4, 0);
-  List<double>? get timeline => const fb.ListReader<double>(fb.Float32Reader())
-      .vTableGetNullable(_bc, _bcOffset, 6);
+  List<double>? get timeline => const fb.ListReader<double>(
+    fb.Float32Reader(),
+  ).vTableGetNullable(_bc, _bcOffset, 6);
   KeyframesTypeId? get keyframesType => KeyframesTypeId._createOrNull(
-      const fb.Uint8Reader().vTableGetNullable(_bc, _bcOffset, 8));
+    const fb.Uint8Reader().vTableGetNullable(_bc, _bcOffset, 8),
+  );
   dynamic get keyframes {
     switch (keyframesType?.value) {
       case 1:
-        return TranslationKeyframes.reader
-            .vTableGetNullable(_bc, _bcOffset, 10);
+        return TranslationKeyframes.reader.vTableGetNullable(
+          _bc,
+          _bcOffset,
+          10,
+        );
       case 2:
         return RotationKeyframes.reader.vTableGetNullable(_bc, _bcOffset, 10);
       case 3:
@@ -2342,11 +2621,14 @@ class Channel {
   }
 
   ChannelT unpack() => ChannelT(
-      node: node,
-      timeline: const fb.ListReader<double>(fb.Float32Reader(), lazy: false)
-          .vTableGetNullable(_bc, _bcOffset, 6),
-      keyframesType: keyframesType,
-      keyframes: keyframes);
+    node: node,
+    timeline: const fb.ListReader<double>(
+      fb.Float32Reader(),
+      lazy: false,
+    ).vTableGetNullable(_bc, _bcOffset, 6),
+    keyframesType: keyframesType,
+    keyframes: keyframes,
+  );
 
   static int pack(fb.Builder fbBuilder, ChannelT? object) {
     if (object == null) return 0;
@@ -2364,8 +2646,9 @@ class ChannelT implements fb.Packable {
 
   @override
   int pack(fb.Builder fbBuilder) {
-    final int? timelineOffset =
-        timeline == null ? null : fbBuilder.writeListFloat32(timeline!);
+    final int? timelineOffset = timeline == null
+        ? null
+        : fbBuilder.writeListFloat32(timeline!);
     final int? keyframesOffset = keyframes?.pack(fbBuilder);
     fbBuilder.startTable(4);
     fbBuilder.addInt32(0, node);
@@ -2434,16 +2717,17 @@ class ChannelObjectBuilder extends fb.ObjectBuilder {
     List<double>? timeline,
     KeyframesTypeId? keyframesType,
     dynamic keyframes,
-  })  : _node = node,
-        _timeline = timeline,
-        _keyframesType = keyframesType,
-        _keyframes = keyframes;
+  }) : _node = node,
+       _timeline = timeline,
+       _keyframesType = keyframesType,
+       _keyframes = keyframes;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? timelineOffset =
-        _timeline == null ? null : fbBuilder.writeListFloat32(_timeline!);
+    final int? timelineOffset = _timeline == null
+        ? null
+        : fbBuilder.writeListFloat32(_timeline!);
     final int? keyframesOffset = _keyframes?.getOrCreateOffset(fbBuilder);
     fbBuilder.startTable(4);
     fbBuilder.addInt32(0, _node);
@@ -2476,8 +2760,9 @@ class Animation {
 
   String? get name =>
       const fb.StringReader().vTableGetNullable(_bc, _bcOffset, 4);
-  List<Channel>? get channels => const fb.ListReader<Channel>(Channel.reader)
-      .vTableGetNullable(_bc, _bcOffset, 6);
+  List<Channel>? get channels => const fb.ListReader<Channel>(
+    Channel.reader,
+  ).vTableGetNullable(_bc, _bcOffset, 6);
 
   @override
   String toString() {
@@ -2485,7 +2770,9 @@ class Animation {
   }
 
   AnimationT unpack() => AnimationT(
-      name: name, channels: channels?.map((e) => e.unpack()).toList());
+    name: name,
+    channels: channels?.map((e) => e.unpack()).toList(),
+  );
 
   static int pack(fb.Builder fbBuilder, AnimationT? object) {
     if (object == null) return 0;
@@ -2553,21 +2840,21 @@ class AnimationObjectBuilder extends fb.ObjectBuilder {
   final String? _name;
   final List<ChannelObjectBuilder>? _channels;
 
-  AnimationObjectBuilder({
-    String? name,
-    List<ChannelObjectBuilder>? channels,
-  })  : _name = name,
-        _channels = channels;
+  AnimationObjectBuilder({String? name, List<ChannelObjectBuilder>? channels})
+    : _name = name,
+      _channels = channels;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? nameOffset =
-        _name == null ? null : fbBuilder.writeString(_name!);
+    final int? nameOffset = _name == null
+        ? null
+        : fbBuilder.writeString(_name!);
     final int? channelsOffset = _channels == null
         ? null
         : fbBuilder.writeList(
-            _channels!.map((b) => b.getOrCreateOffset(fbBuilder)).toList());
+            _channels!.map((b) => b.getOrCreateOffset(fbBuilder)).toList(),
+          );
     fbBuilder.startTable(2);
     fbBuilder.addOffset(0, nameOffset);
     fbBuilder.addOffset(1, channelsOffset);
@@ -2595,11 +2882,12 @@ class Skin {
   final fb.BufferContext _bc;
   final int _bcOffset;
 
-  List<int>? get joints => const fb.ListReader<int>(fb.Int32Reader())
-      .vTableGetNullable(_bc, _bcOffset, 4);
-  List<Matrix>? get inverseBindMatrices =>
-      const fb.ListReader<Matrix>(Matrix.reader)
-          .vTableGetNullable(_bc, _bcOffset, 6);
+  List<int>? get joints => const fb.ListReader<int>(
+    fb.Int32Reader(),
+  ).vTableGetNullable(_bc, _bcOffset, 4);
+  List<Matrix>? get inverseBindMatrices => const fb.ListReader<Matrix>(
+    Matrix.reader,
+  ).vTableGetNullable(_bc, _bcOffset, 6);
 
   ///  The root joint of the skeleton.
   int get skeleton => const fb.Int32Reader().vTableGet(_bc, _bcOffset, 8, 0);
@@ -2610,10 +2898,13 @@ class Skin {
   }
 
   SkinT unpack() => SkinT(
-      joints: const fb.ListReader<int>(fb.Int32Reader(), lazy: false)
-          .vTableGetNullable(_bc, _bcOffset, 4),
-      inverseBindMatrices: inverseBindMatrices?.map((e) => e.unpack()).toList(),
-      skeleton: skeleton);
+    joints: const fb.ListReader<int>(
+      fb.Int32Reader(),
+      lazy: false,
+    ).vTableGetNullable(_bc, _bcOffset, 4),
+    inverseBindMatrices: inverseBindMatrices?.map((e) => e.unpack()).toList(),
+    skeleton: skeleton,
+  );
 
   static int pack(fb.Builder fbBuilder, SkinT? object) {
     if (object == null) return 0;
@@ -2632,15 +2923,17 @@ class SkinT implements fb.Packable {
 
   @override
   int pack(fb.Builder fbBuilder) {
-    final int? jointsOffset =
-        joints == null ? null : fbBuilder.writeListInt32(joints!);
+    final int? jointsOffset = joints == null
+        ? null
+        : fbBuilder.writeListInt32(joints!);
     int? inverseBindMatricesOffset;
     if (inverseBindMatrices != null) {
       for (var e in inverseBindMatrices!) {
         e.pack(fbBuilder);
       }
-      inverseBindMatricesOffset =
-          fbBuilder.endStructVector(inverseBindMatrices!.length);
+      inverseBindMatricesOffset = fbBuilder.endStructVector(
+        inverseBindMatrices!.length,
+      );
     }
     fbBuilder.startTable(3);
     fbBuilder.addOffset(0, jointsOffset);
@@ -2700,15 +2993,16 @@ class SkinObjectBuilder extends fb.ObjectBuilder {
     List<int>? joints,
     List<MatrixObjectBuilder>? inverseBindMatrices,
     int? skeleton,
-  })  : _joints = joints,
-        _inverseBindMatrices = inverseBindMatrices,
-        _skeleton = skeleton;
+  }) : _joints = joints,
+       _inverseBindMatrices = inverseBindMatrices,
+       _skeleton = skeleton;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? jointsOffset =
-        _joints == null ? null : fbBuilder.writeListInt32(_joints!);
+    final int? jointsOffset = _joints == null
+        ? null
+        : fbBuilder.writeListInt32(_joints!);
     final int? inverseBindMatricesOffset = _inverseBindMatrices == null
         ? null
         : fbBuilder.writeListOfStructs(_inverseBindMatrices!);
@@ -2761,22 +3055,23 @@ class Matrix {
   }
 
   MatrixT unpack() => MatrixT(
-      m0: m0,
-      m1: m1,
-      m2: m2,
-      m3: m3,
-      m4: m4,
-      m5: m5,
-      m6: m6,
-      m7: m7,
-      m8: m8,
-      m9: m9,
-      m10: m10,
-      m11: m11,
-      m12: m12,
-      m13: m13,
-      m14: m14,
-      m15: m15);
+    m0: m0,
+    m1: m1,
+    m2: m2,
+    m3: m3,
+    m4: m4,
+    m5: m5,
+    m6: m6,
+    m7: m7,
+    m8: m8,
+    m9: m9,
+    m10: m10,
+    m11: m11,
+    m12: m12,
+    m13: m13,
+    m14: m14,
+    m15: m15,
+  );
 
   static int pack(fb.Builder fbBuilder, MatrixT? object) {
     if (object == null) return 0;
@@ -2804,23 +3099,24 @@ class MatrixT implements fb.Packable {
   double m14;
   double m15;
 
-  MatrixT(
-      {required this.m0,
-      required this.m1,
-      required this.m2,
-      required this.m3,
-      required this.m4,
-      required this.m5,
-      required this.m6,
-      required this.m7,
-      required this.m8,
-      required this.m9,
-      required this.m10,
-      required this.m11,
-      required this.m12,
-      required this.m13,
-      required this.m14,
-      required this.m15});
+  MatrixT({
+    required this.m0,
+    required this.m1,
+    required this.m2,
+    required this.m3,
+    required this.m4,
+    required this.m5,
+    required this.m6,
+    required this.m7,
+    required this.m8,
+    required this.m9,
+    required this.m10,
+    required this.m11,
+    required this.m12,
+    required this.m13,
+    required this.m14,
+    required this.m15,
+  });
 
   @override
   int pack(fb.Builder fbBuilder) {
@@ -2865,22 +3161,23 @@ class MatrixBuilder {
   final fb.Builder fbBuilder;
 
   int finish(
-      double m0,
-      double m1,
-      double m2,
-      double m3,
-      double m4,
-      double m5,
-      double m6,
-      double m7,
-      double m8,
-      double m9,
-      double m10,
-      double m11,
-      double m12,
-      double m13,
-      double m14,
-      double m15) {
+    double m0,
+    double m1,
+    double m2,
+    double m3,
+    double m4,
+    double m5,
+    double m6,
+    double m7,
+    double m8,
+    double m9,
+    double m10,
+    double m11,
+    double m12,
+    double m13,
+    double m14,
+    double m15,
+  ) {
     fbBuilder.putFloat32(m15);
     fbBuilder.putFloat32(m14);
     fbBuilder.putFloat32(m13);
@@ -2936,22 +3233,22 @@ class MatrixObjectBuilder extends fb.ObjectBuilder {
     required double m13,
     required double m14,
     required double m15,
-  })  : _m0 = m0,
-        _m1 = m1,
-        _m2 = m2,
-        _m3 = m3,
-        _m4 = m4,
-        _m5 = m5,
-        _m6 = m6,
-        _m7 = m7,
-        _m8 = m8,
-        _m9 = m9,
-        _m10 = m10,
-        _m11 = m11,
-        _m12 = m12,
-        _m13 = m13,
-        _m14 = m14,
-        _m15 = m15;
+  }) : _m0 = m0,
+       _m1 = m1,
+       _m2 = m2,
+       _m3 = m3,
+       _m4 = m4,
+       _m5 = m5,
+       _m6 = m6,
+       _m7 = m7,
+       _m8 = m8,
+       _m9 = m9,
+       _m10 = m10,
+       _m11 = m11,
+       _m12 = m12,
+       _m13 = m13,
+       _m14 = m14,
+       _m15 = m15;
 
   /// Finish building, and store into the [fbBuilder].
   @override
@@ -2998,26 +3295,41 @@ class Node {
 
   String? get name =>
       const fb.StringReader().vTableGetNullable(_bc, _bcOffset, 4);
-  List<int>? get children => const fb.ListReader<int>(fb.Int32Reader())
-      .vTableGetNullable(_bc, _bcOffset, 6);
+  List<int>? get children => const fb.ListReader<int>(
+    fb.Int32Reader(),
+  ).vTableGetNullable(_bc, _bcOffset, 6);
   Matrix? get transform => Matrix.reader.vTableGetNullable(_bc, _bcOffset, 8);
-  List<MeshPrimitive>? get meshPrimitives =>
-      const fb.ListReader<MeshPrimitive>(MeshPrimitive.reader)
-          .vTableGetNullable(_bc, _bcOffset, 10);
+  List<MeshPrimitive>? get meshPrimitives => const fb.ListReader<MeshPrimitive>(
+    MeshPrimitive.reader,
+  ).vTableGetNullable(_bc, _bcOffset, 10);
   Skin? get skin => Skin.reader.vTableGetNullable(_bc, _bcOffset, 12);
+
+  ///  Union of this node's mesh primitive AABBs together with each
+  ///  descendant node's `combined_local_aabb` transformed by the
+  ///  descendant's local transform. Expressed in this node's local space.
+  ///
+  ///  Lets the runtime cull entire subtrees with a single AABB-vs-frustum
+  ///  test instead of recomputing the union every frame. Optional for
+  ///  backwards compatibility.
+  Aabb3? get combinedLocalAabb =>
+      Aabb3.reader.vTableGetNullable(_bc, _bcOffset, 14);
 
   @override
   String toString() {
-    return 'Node{name: ${name}, children: ${children}, transform: ${transform}, meshPrimitives: ${meshPrimitives}, skin: ${skin}}';
+    return 'Node{name: ${name}, children: ${children}, transform: ${transform}, meshPrimitives: ${meshPrimitives}, skin: ${skin}, combinedLocalAabb: ${combinedLocalAabb}}';
   }
 
   NodeT unpack() => NodeT(
-      name: name,
-      children: const fb.ListReader<int>(fb.Int32Reader(), lazy: false)
-          .vTableGetNullable(_bc, _bcOffset, 6),
-      transform: transform?.unpack(),
-      meshPrimitives: meshPrimitives?.map((e) => e.unpack()).toList(),
-      skin: skin?.unpack());
+    name: name,
+    children: const fb.ListReader<int>(
+      fb.Int32Reader(),
+      lazy: false,
+    ).vTableGetNullable(_bc, _bcOffset, 6),
+    transform: transform?.unpack(),
+    meshPrimitives: meshPrimitives?.map((e) => e.unpack()).toList(),
+    skin: skin?.unpack(),
+    combinedLocalAabb: combinedLocalAabb?.unpack(),
+  );
 
   static int pack(fb.Builder fbBuilder, NodeT? object) {
     if (object == null) return 0;
@@ -3032,24 +3344,37 @@ class NodeT implements fb.Packable {
   List<MeshPrimitiveT>? meshPrimitives;
   SkinT? skin;
 
-  NodeT(
-      {this.name,
-      this.children,
-      this.transform,
-      this.meshPrimitives,
-      this.skin});
+  ///  Union of this node's mesh primitive AABBs together with each
+  ///  descendant node's `combined_local_aabb` transformed by the
+  ///  descendant's local transform. Expressed in this node's local space.
+  ///
+  ///  Lets the runtime cull entire subtrees with a single AABB-vs-frustum
+  ///  test instead of recomputing the union every frame. Optional for
+  ///  backwards compatibility.
+  Aabb3T? combinedLocalAabb;
+
+  NodeT({
+    this.name,
+    this.children,
+    this.transform,
+    this.meshPrimitives,
+    this.skin,
+    this.combinedLocalAabb,
+  });
 
   @override
   int pack(fb.Builder fbBuilder) {
     final int? nameOffset = name == null ? null : fbBuilder.writeString(name!);
-    final int? childrenOffset =
-        children == null ? null : fbBuilder.writeListInt32(children!);
+    final int? childrenOffset = children == null
+        ? null
+        : fbBuilder.writeListInt32(children!);
     final int? meshPrimitivesOffset = meshPrimitives == null
         ? null
-        : fbBuilder
-            .writeList(meshPrimitives!.map((b) => b.pack(fbBuilder)).toList());
+        : fbBuilder.writeList(
+            meshPrimitives!.map((b) => b.pack(fbBuilder)).toList(),
+          );
     final int? skinOffset = skin?.pack(fbBuilder);
-    fbBuilder.startTable(5);
+    fbBuilder.startTable(6);
     fbBuilder.addOffset(0, nameOffset);
     fbBuilder.addOffset(1, childrenOffset);
     if (transform != null) {
@@ -3057,12 +3382,15 @@ class NodeT implements fb.Packable {
     }
     fbBuilder.addOffset(3, meshPrimitivesOffset);
     fbBuilder.addOffset(4, skinOffset);
+    if (combinedLocalAabb != null) {
+      fbBuilder.addStruct(5, combinedLocalAabb!.pack(fbBuilder));
+    }
     return fbBuilder.endTable();
   }
 
   @override
   String toString() {
-    return 'NodeT{name: ${name}, children: ${children}, transform: ${transform}, meshPrimitives: ${meshPrimitives}, skin: ${skin}}';
+    return 'NodeT{name: ${name}, children: ${children}, transform: ${transform}, meshPrimitives: ${meshPrimitives}, skin: ${skin}, combinedLocalAabb: ${combinedLocalAabb}}';
   }
 }
 
@@ -3079,7 +3407,7 @@ class NodeBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable(5);
+    fbBuilder.startTable(6);
   }
 
   int addNameOffset(int? offset) {
@@ -3107,6 +3435,11 @@ class NodeBuilder {
     return fbBuilder.offset;
   }
 
+  int addCombinedLocalAabb(int offset) {
+    fbBuilder.addStruct(5, offset);
+    return fbBuilder.offset;
+  }
+
   int finish() {
     return fbBuilder.endTable();
   }
@@ -3118,6 +3451,7 @@ class NodeObjectBuilder extends fb.ObjectBuilder {
   final MatrixObjectBuilder? _transform;
   final List<MeshPrimitiveObjectBuilder>? _meshPrimitives;
   final SkinObjectBuilder? _skin;
+  final Aabb3ObjectBuilder? _combinedLocalAabb;
 
   NodeObjectBuilder({
     String? name,
@@ -3125,26 +3459,32 @@ class NodeObjectBuilder extends fb.ObjectBuilder {
     MatrixObjectBuilder? transform,
     List<MeshPrimitiveObjectBuilder>? meshPrimitives,
     SkinObjectBuilder? skin,
-  })  : _name = name,
-        _children = children,
-        _transform = transform,
-        _meshPrimitives = meshPrimitives,
-        _skin = skin;
+    Aabb3ObjectBuilder? combinedLocalAabb,
+  }) : _name = name,
+       _children = children,
+       _transform = transform,
+       _meshPrimitives = meshPrimitives,
+       _skin = skin,
+       _combinedLocalAabb = combinedLocalAabb;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? nameOffset =
-        _name == null ? null : fbBuilder.writeString(_name!);
-    final int? childrenOffset =
-        _children == null ? null : fbBuilder.writeListInt32(_children!);
+    final int? nameOffset = _name == null
+        ? null
+        : fbBuilder.writeString(_name!);
+    final int? childrenOffset = _children == null
+        ? null
+        : fbBuilder.writeListInt32(_children!);
     final int? meshPrimitivesOffset = _meshPrimitives == null
         ? null
-        : fbBuilder.writeList(_meshPrimitives!
-            .map((b) => b.getOrCreateOffset(fbBuilder))
-            .toList());
+        : fbBuilder.writeList(
+            _meshPrimitives!
+                .map((b) => b.getOrCreateOffset(fbBuilder))
+                .toList(),
+          );
     final int? skinOffset = _skin?.getOrCreateOffset(fbBuilder);
-    fbBuilder.startTable(5);
+    fbBuilder.startTable(6);
     fbBuilder.addOffset(0, nameOffset);
     fbBuilder.addOffset(1, childrenOffset);
     if (_transform != null) {
@@ -3152,6 +3492,9 @@ class NodeObjectBuilder extends fb.ObjectBuilder {
     }
     fbBuilder.addOffset(3, meshPrimitivesOffset);
     fbBuilder.addOffset(4, skinOffset);
+    if (_combinedLocalAabb != null) {
+      fbBuilder.addStruct(5, _combinedLocalAabb!.finish(fbBuilder));
+    }
     return fbBuilder.endTable();
   }
 
@@ -3176,16 +3519,19 @@ class Scene {
   final fb.BufferContext _bc;
   final int _bcOffset;
 
-  List<int>? get children => const fb.ListReader<int>(fb.Int32Reader())
-      .vTableGetNullable(_bc, _bcOffset, 4);
+  List<int>? get children => const fb.ListReader<int>(
+    fb.Int32Reader(),
+  ).vTableGetNullable(_bc, _bcOffset, 4);
   Matrix? get transform => Matrix.reader.vTableGetNullable(_bc, _bcOffset, 6);
-  List<Node>? get nodes => const fb.ListReader<Node>(Node.reader)
-      .vTableGetNullable(_bc, _bcOffset, 8);
-  List<Texture>? get textures => const fb.ListReader<Texture>(Texture.reader)
-      .vTableGetNullable(_bc, _bcOffset, 10);
-  List<Animation>? get animations =>
-      const fb.ListReader<Animation>(Animation.reader)
-          .vTableGetNullable(_bc, _bcOffset, 12);
+  List<Node>? get nodes => const fb.ListReader<Node>(
+    Node.reader,
+  ).vTableGetNullable(_bc, _bcOffset, 8);
+  List<Texture>? get textures => const fb.ListReader<Texture>(
+    Texture.reader,
+  ).vTableGetNullable(_bc, _bcOffset, 10);
+  List<Animation>? get animations => const fb.ListReader<Animation>(
+    Animation.reader,
+  ).vTableGetNullable(_bc, _bcOffset, 12);
 
   @override
   String toString() {
@@ -3193,12 +3539,15 @@ class Scene {
   }
 
   SceneT unpack() => SceneT(
-      children: const fb.ListReader<int>(fb.Int32Reader(), lazy: false)
-          .vTableGetNullable(_bc, _bcOffset, 4),
-      transform: transform?.unpack(),
-      nodes: nodes?.map((e) => e.unpack()).toList(),
-      textures: textures?.map((e) => e.unpack()).toList(),
-      animations: animations?.map((e) => e.unpack()).toList());
+    children: const fb.ListReader<int>(
+      fb.Int32Reader(),
+      lazy: false,
+    ).vTableGetNullable(_bc, _bcOffset, 4),
+    transform: transform?.unpack(),
+    nodes: nodes?.map((e) => e.unpack()).toList(),
+    textures: textures?.map((e) => e.unpack()).toList(),
+    animations: animations?.map((e) => e.unpack()).toList(),
+  );
 
   static int pack(fb.Builder fbBuilder, SceneT? object) {
     if (object == null) return 0;
@@ -3213,17 +3562,19 @@ class SceneT implements fb.Packable {
   List<TextureT>? textures;
   List<AnimationT>? animations;
 
-  SceneT(
-      {this.children,
-      this.transform,
-      this.nodes,
-      this.textures,
-      this.animations});
+  SceneT({
+    this.children,
+    this.transform,
+    this.nodes,
+    this.textures,
+    this.animations,
+  });
 
   @override
   int pack(fb.Builder fbBuilder) {
-    final int? childrenOffset =
-        children == null ? null : fbBuilder.writeListInt32(children!);
+    final int? childrenOffset = children == null
+        ? null
+        : fbBuilder.writeListInt32(children!);
     final int? nodesOffset = nodes == null
         ? null
         : fbBuilder.writeList(nodes!.map((b) => b.pack(fbBuilder)).toList());
@@ -3232,8 +3583,9 @@ class SceneT implements fb.Packable {
         : fbBuilder.writeList(textures!.map((b) => b.pack(fbBuilder)).toList());
     final int? animationsOffset = animations == null
         ? null
-        : fbBuilder
-            .writeList(animations!.map((b) => b.pack(fbBuilder)).toList());
+        : fbBuilder.writeList(
+            animations!.map((b) => b.pack(fbBuilder)).toList(),
+          );
     fbBuilder.startTable(5);
     fbBuilder.addOffset(0, childrenOffset);
     if (transform != null) {
@@ -3310,29 +3662,33 @@ class SceneObjectBuilder extends fb.ObjectBuilder {
     List<NodeObjectBuilder>? nodes,
     List<TextureObjectBuilder>? textures,
     List<AnimationObjectBuilder>? animations,
-  })  : _children = children,
-        _transform = transform,
-        _nodes = nodes,
-        _textures = textures,
-        _animations = animations;
+  }) : _children = children,
+       _transform = transform,
+       _nodes = nodes,
+       _textures = textures,
+       _animations = animations;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? childrenOffset =
-        _children == null ? null : fbBuilder.writeListInt32(_children!);
+    final int? childrenOffset = _children == null
+        ? null
+        : fbBuilder.writeListInt32(_children!);
     final int? nodesOffset = _nodes == null
         ? null
         : fbBuilder.writeList(
-            _nodes!.map((b) => b.getOrCreateOffset(fbBuilder)).toList());
+            _nodes!.map((b) => b.getOrCreateOffset(fbBuilder)).toList(),
+          );
     final int? texturesOffset = _textures == null
         ? null
         : fbBuilder.writeList(
-            _textures!.map((b) => b.getOrCreateOffset(fbBuilder)).toList());
+            _textures!.map((b) => b.getOrCreateOffset(fbBuilder)).toList(),
+          );
     final int? animationsOffset = _animations == null
         ? null
         : fbBuilder.writeList(
-            _animations!.map((b) => b.getOrCreateOffset(fbBuilder)).toList());
+            _animations!.map((b) => b.getOrCreateOffset(fbBuilder)).toList(),
+          );
     fbBuilder.startTable(5);
     fbBuilder.addOffset(0, childrenOffset);
     if (_transform != null) {

--- a/packages/flutter_scene_importer/lib/src/fb_emitter/model_emitter.dart
+++ b/packages/flutter_scene_importer/lib/src/fb_emitter/model_emitter.dart
@@ -6,6 +6,7 @@
 /// for byte-level parity coverage against the C++ output.
 library;
 
+import 'dart:math' show sqrt;
 import 'dart:typed_data';
 
 import 'package:image/image.dart' as img;
@@ -55,12 +56,143 @@ fb.SceneT _buildScene(GltfDocument doc, Uint8List bufferData) {
       _buildNode(doc.nodes[i], doc, bufferData),
   ];
 
+  // Post-pass: bake each node's combined local-space AABB so the
+  // runtime can cull entire subtrees with a single AABB-vs-frustum
+  // test. Skinned subtrees opt out of this (see _bakeCombinedAabbs).
+  _bakeCombinedAabbs(scene.nodes!, doc);
+
   // Animations.
   scene.animations = [
     for (final a in doc.animations) _buildAnimation(a, doc, bufferData),
   ];
 
   return scene;
+}
+
+/// Walks the node forest in post-order and assigns
+/// `combined_local_aabb` to each node where it can be computed
+/// soundly. Subtrees that contain any skinned primitive are left
+/// without a baked AABB; the runtime treats absent bounds as
+/// "always visible" so animated meshes don't disappear when posed
+/// outside their bind-pose extent.
+void _bakeCombinedAabbs(List<fb.NodeT> nodes, GltfDocument doc) {
+  // Memoize: null when the subtree is unbounded (skinned), an
+  // `_AabbBox` otherwise. `_AabbBox.empty` represents a soundly
+  // computed but empty subtree (no geometry at all), which still
+  // serializes as a degenerate AABB so we can tell it apart from
+  // "unbounded" at runtime.
+  final memo = List<_AabbBox?>.filled(nodes.length, null);
+  final computed = List<bool>.filled(nodes.length, false);
+
+  _AabbBox? walk(int idx) {
+    if (computed[idx]) return memo[idx];
+    computed[idx] = true;
+
+    final node = nodes[idx];
+    final glNode = doc.nodes[idx];
+
+    // Skinned content makes the static AABB meaningless.
+    if (glNode.skin != null) {
+      memo[idx] = null;
+      return null;
+    }
+
+    final box = _AabbBox.empty();
+    for (final prim in node.meshPrimitives ?? const <fb.MeshPrimitiveT>[]) {
+      final aabb = prim.boundsAabb;
+      if (aabb != null) box.expandToAabb(aabb);
+    }
+
+    bool subtreeBounded = true;
+    for (final childIdx in node.children ?? const <int>[]) {
+      if (childIdx < 0 || childIdx >= nodes.length) continue;
+      final childBox = walk(childIdx);
+      if (childBox == null) {
+        subtreeBounded = false;
+        continue;
+      }
+      if (childBox.isEmpty) continue;
+      // Transform the child's combined AABB into this node's local
+      // space using the child's local transform.
+      final childLocal = _localTransformFor(doc.nodes[childIdx]);
+      box.expandToTransformedBox(childBox, childLocal);
+    }
+
+    if (!subtreeBounded) {
+      memo[idx] = null;
+      return null;
+    }
+
+    memo[idx] = box;
+    if (!box.isEmpty) {
+      node.combinedLocalAabb = fb.Aabb3T(
+        min: fb.Vec3T(x: box.minX, y: box.minY, z: box.minZ),
+        max: fb.Vec3T(x: box.maxX, y: box.maxY, z: box.maxZ),
+      );
+    }
+    return box;
+  }
+
+  for (int i = 0; i < nodes.length; i++) {
+    walk(i);
+  }
+}
+
+/// Mutable AABB used during the bake post-pass. Tracks emptiness
+/// explicitly so a node with no geometry stays distinguishable from
+/// a node whose AABB happens to include the origin.
+class _AabbBox {
+  _AabbBox(
+    this.minX,
+    this.minY,
+    this.minZ,
+    this.maxX,
+    this.maxY,
+    this.maxZ,
+    this.isEmpty,
+  );
+
+  factory _AabbBox.empty() => _AabbBox(0, 0, 0, 0, 0, 0, true);
+
+  double minX, minY, minZ, maxX, maxY, maxZ;
+  bool isEmpty;
+
+  void _includePoint(double x, double y, double z) {
+    if (isEmpty) {
+      minX = maxX = x;
+      minY = maxY = y;
+      minZ = maxZ = z;
+      isEmpty = false;
+      return;
+    }
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (z < minZ) minZ = z;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+    if (z > maxZ) maxZ = z;
+  }
+
+  void expandToAabb(fb.Aabb3T a) {
+    final mn = a.min, mx = a.max;
+    _includePoint(mn.x, mn.y, mn.z);
+    _includePoint(mx.x, mx.y, mx.z);
+  }
+
+  /// Transform every corner of [other] by [transform] and union the
+  /// result into this box. Eight-corner expansion is used (rather
+  /// than the cheaper centre-plus-extents trick) because this runs
+  /// offline and tightness matters more than throughput.
+  void expandToTransformedBox(_AabbBox other, Matrix4 transform) {
+    if (other.isEmpty) return;
+    for (int i = 0; i < 8; i++) {
+      final x = (i & 1) == 0 ? other.minX : other.maxX;
+      final y = (i & 2) == 0 ? other.minY : other.maxY;
+      final z = (i & 4) == 0 ? other.minZ : other.maxZ;
+      final p = transform.transformed3(Vector3(x, y, z));
+      _includePoint(p.x, p.y, p.z);
+    }
+  }
 }
 
 // ───── Nodes ─────
@@ -105,8 +237,20 @@ fb.MeshPrimitiveT _buildMeshPrimitive(
       p.attributes.containsKey('JOINTS_0') &&
       p.attributes.containsKey('WEIGHTS_0');
 
+  // Position attribute is mandatory in glTF and (separately) required by
+  // flutter_scene. Read it once and reuse for both vertex packing and
+  // bounds.
+  final positionAccessor = doc.accessors[p.attributes['POSITION']!];
+  final positions = _readVec3(p.attributes['POSITION']!, doc, bufferData);
+
   // Pack vertex bytes using the same layout as flutter_scene's vertex shaders.
-  final vertexBytes = _packVertices(p, doc, bufferData, hasJoints: hasJoints);
+  final vertexBytes = _packVertices(
+    p,
+    doc,
+    bufferData,
+    positions: positions,
+    hasJoints: hasJoints,
+  );
   final vertexCount =
       vertexBytes.length ~/
       (hasJoints ? kSkinnedPerVertexSize : kUnskinnedPerVertexSize);
@@ -131,6 +275,15 @@ fb.MeshPrimitiveT _buildMeshPrimitive(
   if (p.material != null && p.material! < doc.materials.length) {
     out.material = _buildMaterial(doc.materials[p.material!]);
   }
+
+  // Bounds. Prefer the accessor's spec-provided min/max for the AABB so
+  // we don't redo work the asset already encodes; the sphere always
+  // requires a vertex pass.
+  if (vertexCount > 0) {
+    final aabb = _aabbFromAccessorOrPositions(positionAccessor, positions);
+    out.boundsAabb = aabb;
+    out.boundsSphere = _sphereFromPositions(positions);
+  }
   return out;
 }
 
@@ -138,9 +291,9 @@ Uint8List _packVertices(
   GltfMeshPrimitive p,
   GltfDocument doc,
   Uint8List bufferData, {
+  required Float32List positions,
   required bool hasJoints,
 }) {
-  final positions = _readVec3(p.attributes['POSITION']!, doc, bufferData);
   final vertexCount = positions.length ~/ 3;
   final normals = _readOptionalVec3('NORMAL', p, doc, bufferData, vertexCount);
   final tex = _readOptionalVec2('TEXCOORD_0', p, doc, bufferData, vertexCount);
@@ -400,6 +553,117 @@ List<fb.Vec4T> _vec4List(Float32List values, bool isCubic) {
         w: values[i + off + 3],
       ),
   ].reversed.toList();
+}
+
+// ───── Bounds ─────
+
+/// Build a local-space AABB for a primitive. Uses the accessor's
+/// spec-provided `min`/`max` when present (the glTF spec requires them
+/// on POSITION accessors but consumers occasionally omit them); falls
+/// back to a vertex scan otherwise.
+fb.Aabb3T _aabbFromAccessorOrPositions(
+  GltfAccessor accessor,
+  Float32List positions,
+) {
+  final min = accessor.min;
+  final max = accessor.max;
+  if (min != null && min.length >= 3 && max != null && max.length >= 3) {
+    return fb.Aabb3T(
+      min: fb.Vec3T(x: min[0], y: min[1], z: min[2]),
+      max: fb.Vec3T(x: max[0], y: max[1], z: max[2]),
+    );
+  }
+  return _aabbFromPositions(positions);
+}
+
+fb.Aabb3T _aabbFromPositions(Float32List positions) {
+  double minX = double.infinity, minY = double.infinity, minZ = double.infinity;
+  double maxX = double.negativeInfinity,
+      maxY = double.negativeInfinity,
+      maxZ = double.negativeInfinity;
+  for (int i = 0; i + 2 < positions.length; i += 3) {
+    final x = positions[i];
+    final y = positions[i + 1];
+    final z = positions[i + 2];
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (z < minZ) minZ = z;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+    if (z > maxZ) maxZ = z;
+  }
+  return fb.Aabb3T(
+    min: fb.Vec3T(x: minX, y: minY, z: minZ),
+    max: fb.Vec3T(x: maxX, y: maxY, z: maxZ),
+  );
+}
+
+/// Bounding sphere via Ritter's two-pass approximation: pick the most
+/// distant pair along an arbitrary first vertex, seed with their
+/// midpoint, then expand to cover any remaining outliers. Tighter than
+/// the AABB-circumscribed sphere for elongated meshes while still being
+/// O(n).
+fb.SphereT _sphereFromPositions(Float32List positions) {
+  final vertexCount = positions.length ~/ 3;
+  if (vertexCount == 0) {
+    return fb.SphereT(center: fb.Vec3T(x: 0, y: 0, z: 0), radius: 0);
+  }
+  if (vertexCount == 1) {
+    return fb.SphereT(
+      center: fb.Vec3T(x: positions[0], y: positions[1], z: positions[2]),
+      radius: 0,
+    );
+  }
+
+  // Pass 1: pick vertex farthest from positions[0], then farthest from
+  // that. The pair seeds the initial diameter.
+  Vector3 readAt(int i) =>
+      Vector3(positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2]);
+
+  final p0 = readAt(0);
+  int bestA = 0;
+  double bestDist = 0;
+  for (int i = 1; i < vertexCount; i++) {
+    final d = readAt(i).distanceToSquared(p0);
+    if (d > bestDist) {
+      bestDist = d;
+      bestA = i;
+    }
+  }
+  final a = readAt(bestA);
+  int bestB = bestA;
+  bestDist = 0;
+  for (int i = 0; i < vertexCount; i++) {
+    final d = readAt(i).distanceToSquared(a);
+    if (d > bestDist) {
+      bestDist = d;
+      bestB = i;
+    }
+  }
+  final b = readAt(bestB);
+
+  Vector3 center = (a + b) * 0.5;
+  double radius = a.distanceTo(b) * 0.5;
+  double radiusSq = radius * radius;
+
+  // Pass 2: expand to cover any vertex outside the seed sphere.
+  for (int i = 0; i < vertexCount; i++) {
+    final v = readAt(i);
+    final dSq = v.distanceToSquared(center);
+    if (dSq > radiusSq) {
+      final d = sqrt(dSq);
+      final newRadius = (radius + d) * 0.5;
+      final shift = (newRadius - radius) / d;
+      center = center + (v - center) * shift;
+      radius = newRadius;
+      radiusSq = radius * radius;
+    }
+  }
+
+  return fb.SphereT(
+    center: fb.Vec3T(x: center.x, y: center.y, z: center.z),
+    radius: radius,
+  );
 }
 
 // ───── Helpers ─────

--- a/packages/flutter_scene_importer/lib/src/gltf/parser.dart
+++ b/packages/flutter_scene_importer/lib/src/gltf/parser.dart
@@ -99,7 +99,14 @@ GltfAccessor _parseAccessor(Map<String, Object?> j) {
     bufferView: j['bufferView'] as int?,
     byteOffset: (j['byteOffset'] as int?) ?? 0,
     normalized: (j['normalized'] as bool?) ?? false,
+    min: _numList(j['min']),
+    max: _numList(j['max']),
   );
+}
+
+List<double>? _numList(Object? raw) {
+  if (raw is! List) return null;
+  return [for (final v in raw) (v as num).toDouble()];
 }
 
 GltfBufferView _parseBufferView(Map<String, Object?> j) {

--- a/packages/flutter_scene_importer/lib/src/gltf/types.dart
+++ b/packages/flutter_scene_importer/lib/src/gltf/types.dart
@@ -142,6 +142,8 @@ class GltfAccessor {
     this.bufferView,
     this.byteOffset = 0,
     this.normalized = false,
+    this.min,
+    this.max,
   });
 
   final GltfComponentType componentType;
@@ -150,6 +152,12 @@ class GltfAccessor {
   final int? bufferView;
   final int byteOffset;
   final bool normalized;
+
+  /// Componentwise min/max bounds, when supplied by the glTF asset. The
+  /// spec requires these on POSITION accessors, so consumers can use them
+  /// to skip a vertex scan when computing bounding volumes.
+  final List<double>? min;
+  final List<double>? max;
 }
 
 class GltfBufferView {

--- a/packages/flutter_scene_importer/scene.fbs
+++ b/packages/flutter_scene_importer/scene.fbs
@@ -91,6 +91,19 @@ struct Vec4 {
   w: float;
 }
 
+/// Axis-aligned bounding box in some local space (typically the space of
+/// the vertex positions on a primitive, or the local space of a node).
+struct Aabb3 {
+  min: Vec3;
+  max: Vec3;
+}
+
+/// Bounding sphere in the same space as an associated `Aabb3`.
+struct Sphere {
+  center: Vec3;
+  radius: float;
+}
+
 // This attribute layout is expected to be identical to that within
 // `shaders/flutter_scene_unskinned.vert`.
 //
@@ -148,6 +161,14 @@ table MeshPrimitive {
   vertices: VertexBuffer;
   indices: Indices;
   material: Material;
+
+  /// Local-space (vertex-position-space) bounds of this primitive.
+  ///
+  /// Optional. When absent, the runtime falls back to scanning the vertex
+  /// positions on first access, so older `.model` files without bounds
+  /// still load correctly.
+  bounds_aabb: Aabb3;
+  bounds_sphere: Sphere;
 }
 
 //-----------------------------------------------------------------------------
@@ -216,6 +237,15 @@ table Node {
   transform: Matrix;
   mesh_primitives: [MeshPrimitive];
   skin: Skin;
+
+  /// Union of this node's mesh primitive AABBs together with each
+  /// descendant node's `combined_local_aabb` transformed by the
+  /// descendant's local transform. Expressed in this node's local space.
+  ///
+  /// Lets the runtime cull entire subtrees with a single AABB-vs-frustum
+  /// test instead of recomputing the union every frame. Optional for
+  /// backwards compatibility.
+  combined_local_aabb: Aabb3;
 }
 
 table Scene {

--- a/packages/flutter_scene_importer/test/bounds_bake_test.dart
+++ b/packages/flutter_scene_importer/test/bounds_bake_test.dart
@@ -16,73 +16,76 @@ import 'package:flutter_scene_importer/src/fb_emitter/model_emitter.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('fcar.glb: every primitive has tight bounds, every node has a combined AABB', () {
-    final scene = _emitAndDecode('examples/assets_src/fcar.glb');
-    if (scene == null) {
-      print('fcar.glb missing — skipping.');
-      return;
-    }
-
-    int primCount = 0;
-    for (final node in scene.nodes ?? const <fb.Node>[]) {
-      for (final p in node.meshPrimitives ?? const <fb.MeshPrimitive>[]) {
-        primCount++;
-        final aabb = p.boundsAabb;
-        expect(aabb, isNotNull, reason: 'primitive missing AABB');
-        // AABB must be non-degenerate on at least one axis (every fcar
-        // primitive is a real mesh).
-        final extentX = aabb!.max.x - aabb.min.x;
-        final extentY = aabb.max.y - aabb.min.y;
-        final extentZ = aabb.max.z - aabb.min.z;
-        expect(extentX + extentY + extentZ, greaterThan(0));
-
-        final sphere = p.boundsSphere;
-        expect(sphere, isNotNull, reason: 'primitive missing sphere');
-        expect(sphere!.radius, greaterThan(0));
-        // Sphere centre lies inside the AABB (a Ritter sphere centre is
-        // the midpoint of two vertices, both of which are inside the
-        // AABB, so the midpoint must be too).
-        final eps = 1e-4;
-        expect(sphere.center.x, greaterThanOrEqualTo(aabb.min.x - eps));
-        expect(sphere.center.y, greaterThanOrEqualTo(aabb.min.y - eps));
-        expect(sphere.center.z, greaterThanOrEqualTo(aabb.min.z - eps));
-        expect(sphere.center.x, lessThanOrEqualTo(aabb.max.x + eps));
-        expect(sphere.center.y, lessThanOrEqualTo(aabb.max.y + eps));
-        expect(sphere.center.z, lessThanOrEqualTo(aabb.max.z + eps));
-        // Sphere radius should at least cover the AABB centre-to-min
-        // distance from the sphere centre. (This is a vertex-free
-        // sanity check that fails on a clearly-bogus radius.)
-        final cdx = sphere.center.x - (aabb.min.x + aabb.max.x) * 0.5;
-        final cdy = sphere.center.y - (aabb.min.y + aabb.max.y) * 0.5;
-        final cdz = sphere.center.z - (aabb.min.z + aabb.max.z) * 0.5;
-        final centreOffset = _len3(cdx, cdy, cdz);
-        expect(
-          sphere.radius,
-          greaterThanOrEqualTo(centreOffset - eps),
-          reason: 'sphere radius is smaller than the AABB centre offset',
-        );
+  test(
+    'fcar.glb: every primitive has tight bounds, every node has a combined AABB',
+    () {
+      final scene = _emitAndDecode('examples/assets_src/fcar.glb');
+      if (scene == null) {
+        print('fcar.glb missing — skipping.');
+        return;
       }
-    }
-    expect(primCount, greaterThan(0));
 
-    // Every node in fcar (no skin anywhere) should get a combined AABB.
-    int nodesWithCombined = 0;
-    int nodesWithoutCombined = 0;
-    for (final node in scene.nodes ?? const <fb.Node>[]) {
-      if (node.combinedLocalAabb != null) {
-        nodesWithCombined++;
-      } else {
-        nodesWithoutCombined++;
+      int primCount = 0;
+      for (final node in scene.nodes ?? const <fb.Node>[]) {
+        for (final p in node.meshPrimitives ?? const <fb.MeshPrimitive>[]) {
+          primCount++;
+          final aabb = p.boundsAabb;
+          expect(aabb, isNotNull, reason: 'primitive missing AABB');
+          // AABB must be non-degenerate on at least one axis (every fcar
+          // primitive is a real mesh).
+          final extentX = aabb!.max.x - aabb.min.x;
+          final extentY = aabb.max.y - aabb.min.y;
+          final extentZ = aabb.max.z - aabb.min.z;
+          expect(extentX + extentY + extentZ, greaterThan(0));
+
+          final sphere = p.boundsSphere;
+          expect(sphere, isNotNull, reason: 'primitive missing sphere');
+          expect(sphere!.radius, greaterThan(0));
+          // Sphere centre lies inside the AABB (a Ritter sphere centre is
+          // the midpoint of two vertices, both of which are inside the
+          // AABB, so the midpoint must be too).
+          final eps = 1e-4;
+          expect(sphere.center.x, greaterThanOrEqualTo(aabb.min.x - eps));
+          expect(sphere.center.y, greaterThanOrEqualTo(aabb.min.y - eps));
+          expect(sphere.center.z, greaterThanOrEqualTo(aabb.min.z - eps));
+          expect(sphere.center.x, lessThanOrEqualTo(aabb.max.x + eps));
+          expect(sphere.center.y, lessThanOrEqualTo(aabb.max.y + eps));
+          expect(sphere.center.z, lessThanOrEqualTo(aabb.max.z + eps));
+          // Sphere radius should at least cover the AABB centre-to-min
+          // distance from the sphere centre. (This is a vertex-free
+          // sanity check that fails on a clearly-bogus radius.)
+          final cdx = sphere.center.x - (aabb.min.x + aabb.max.x) * 0.5;
+          final cdy = sphere.center.y - (aabb.min.y + aabb.max.y) * 0.5;
+          final cdz = sphere.center.z - (aabb.min.z + aabb.max.z) * 0.5;
+          final centreOffset = _len3(cdx, cdy, cdz);
+          expect(
+            sphere.radius,
+            greaterThanOrEqualTo(centreOffset - eps),
+            reason: 'sphere radius is smaller than the AABB centre offset',
+          );
+        }
       }
-    }
-    expect(nodesWithCombined, greaterThan(0));
-    // fcar has nodes that are pure transform groups (no own mesh, no
-    // children with meshes) — those are allowed to omit the AABB.
-    print(
-      '  fcar nodes with combined AABB: $nodesWithCombined / '
-      '${nodesWithCombined + nodesWithoutCombined}',
-    );
-  });
+      expect(primCount, greaterThan(0));
+
+      // Every node in fcar (no skin anywhere) should get a combined AABB.
+      int nodesWithCombined = 0;
+      int nodesWithoutCombined = 0;
+      for (final node in scene.nodes ?? const <fb.Node>[]) {
+        if (node.combinedLocalAabb != null) {
+          nodesWithCombined++;
+        } else {
+          nodesWithoutCombined++;
+        }
+      }
+      expect(nodesWithCombined, greaterThan(0));
+      // fcar has nodes that are pure transform groups (no own mesh, no
+      // children with meshes) — those are allowed to omit the AABB.
+      print(
+        '  fcar nodes with combined AABB: $nodesWithCombined / '
+        '${nodesWithCombined + nodesWithoutCombined}',
+      );
+    },
+  );
 
   test('dash.glb: skinned subtree opts out of combined AABB', () {
     final scene = _emitAndDecode('examples/assets_src/dash.glb');
@@ -104,7 +107,11 @@ void main() {
         );
       }
     }
-    expect(foundSkinnedNode, isTrue, reason: 'dash should contain a skinned node');
+    expect(
+      foundSkinnedNode,
+      isTrue,
+      reason: 'dash should contain a skinned node',
+    );
 
     // Primitive-level bounds are still baked even for skinned vertex
     // buffers (they describe bind-pose extents, which are useful for
@@ -155,7 +162,9 @@ void main() {
 
     final modelBytes = emitModel(doc, container.binaryChunk);
     final scene =
-        ImportedScene.fromFlatbuffer(ByteData.sublistView(modelBytes)).flatbuffer;
+        ImportedScene.fromFlatbuffer(
+          ByteData.sublistView(modelBytes),
+        ).flatbuffer;
 
     // Find the matching emitted primitive (by vertex count, since names
     // may have collisions).
@@ -164,9 +173,10 @@ void main() {
     fb.MeshPrimitive? match;
     for (final node in scene.nodes ?? const <fb.Node>[]) {
       for (final p in node.meshPrimitives ?? const <fb.MeshPrimitive>[]) {
-        final vbCount = (p.vertices is fb.UnskinnedVertexBuffer)
-            ? (p.vertices as fb.UnskinnedVertexBuffer).vertexCount
-            : (p.vertices as fb.SkinnedVertexBuffer).vertexCount;
+        final vbCount =
+            (p.vertices is fb.UnskinnedVertexBuffer)
+                ? (p.vertices as fb.UnskinnedVertexBuffer).vertexCount
+                : (p.vertices as fb.SkinnedVertexBuffer).vertexCount;
         if (vbCount == exemplarVertCount) {
           match = p;
           break;

--- a/packages/flutter_scene_importer/test/bounds_bake_test.dart
+++ b/packages/flutter_scene_importer/test/bounds_bake_test.dart
@@ -1,0 +1,210 @@
+// ignore_for_file: avoid_print
+
+/// Verifies that the model emitter bakes per-primitive AABB / bounding
+/// sphere data and per-node combined AABBs, and that the values it
+/// writes are tight enough to be useful for runtime culling.
+library;
+
+import 'dart:io';
+import 'dart:math' show sqrt;
+import 'dart:typed_data';
+
+import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
+import 'package:flutter_scene_importer/gltf.dart';
+import 'package:flutter_scene_importer/importer.dart';
+import 'package:flutter_scene_importer/src/fb_emitter/model_emitter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('fcar.glb: every primitive has tight bounds, every node has a combined AABB', () {
+    final scene = _emitAndDecode('examples/assets_src/fcar.glb');
+    if (scene == null) {
+      print('fcar.glb missing — skipping.');
+      return;
+    }
+
+    int primCount = 0;
+    for (final node in scene.nodes ?? const <fb.Node>[]) {
+      for (final p in node.meshPrimitives ?? const <fb.MeshPrimitive>[]) {
+        primCount++;
+        final aabb = p.boundsAabb;
+        expect(aabb, isNotNull, reason: 'primitive missing AABB');
+        // AABB must be non-degenerate on at least one axis (every fcar
+        // primitive is a real mesh).
+        final extentX = aabb!.max.x - aabb.min.x;
+        final extentY = aabb.max.y - aabb.min.y;
+        final extentZ = aabb.max.z - aabb.min.z;
+        expect(extentX + extentY + extentZ, greaterThan(0));
+
+        final sphere = p.boundsSphere;
+        expect(sphere, isNotNull, reason: 'primitive missing sphere');
+        expect(sphere!.radius, greaterThan(0));
+        // Sphere centre lies inside the AABB (a Ritter sphere centre is
+        // the midpoint of two vertices, both of which are inside the
+        // AABB, so the midpoint must be too).
+        final eps = 1e-4;
+        expect(sphere.center.x, greaterThanOrEqualTo(aabb.min.x - eps));
+        expect(sphere.center.y, greaterThanOrEqualTo(aabb.min.y - eps));
+        expect(sphere.center.z, greaterThanOrEqualTo(aabb.min.z - eps));
+        expect(sphere.center.x, lessThanOrEqualTo(aabb.max.x + eps));
+        expect(sphere.center.y, lessThanOrEqualTo(aabb.max.y + eps));
+        expect(sphere.center.z, lessThanOrEqualTo(aabb.max.z + eps));
+        // Sphere radius should at least cover the AABB centre-to-min
+        // distance from the sphere centre. (This is a vertex-free
+        // sanity check that fails on a clearly-bogus radius.)
+        final cdx = sphere.center.x - (aabb.min.x + aabb.max.x) * 0.5;
+        final cdy = sphere.center.y - (aabb.min.y + aabb.max.y) * 0.5;
+        final cdz = sphere.center.z - (aabb.min.z + aabb.max.z) * 0.5;
+        final centreOffset = _len3(cdx, cdy, cdz);
+        expect(
+          sphere.radius,
+          greaterThanOrEqualTo(centreOffset - eps),
+          reason: 'sphere radius is smaller than the AABB centre offset',
+        );
+      }
+    }
+    expect(primCount, greaterThan(0));
+
+    // Every node in fcar (no skin anywhere) should get a combined AABB.
+    int nodesWithCombined = 0;
+    int nodesWithoutCombined = 0;
+    for (final node in scene.nodes ?? const <fb.Node>[]) {
+      if (node.combinedLocalAabb != null) {
+        nodesWithCombined++;
+      } else {
+        nodesWithoutCombined++;
+      }
+    }
+    expect(nodesWithCombined, greaterThan(0));
+    // fcar has nodes that are pure transform groups (no own mesh, no
+    // children with meshes) — those are allowed to omit the AABB.
+    print(
+      '  fcar nodes with combined AABB: $nodesWithCombined / '
+      '${nodesWithCombined + nodesWithoutCombined}',
+    );
+  });
+
+  test('dash.glb: skinned subtree opts out of combined AABB', () {
+    final scene = _emitAndDecode('examples/assets_src/dash.glb');
+    if (scene == null) {
+      print('dash.glb missing — skipping.');
+      return;
+    }
+
+    // Dash has a skin; the importer must omit combined_local_aabb on
+    // every ancestor of any skinned node, all the way to root.
+    bool foundSkinnedNode = false;
+    for (final node in scene.nodes ?? const <fb.Node>[]) {
+      if (node.skin != null) {
+        foundSkinnedNode = true;
+        expect(
+          node.combinedLocalAabb,
+          isNull,
+          reason: 'skinned node ${node.name} should not have a combined AABB',
+        );
+      }
+    }
+    expect(foundSkinnedNode, isTrue, reason: 'dash should contain a skinned node');
+
+    // Primitive-level bounds are still baked even for skinned vertex
+    // buffers (they describe bind-pose extents, which are useful for
+    // editor/UI work even if not for cull).
+    int primCount = 0;
+    for (final node in scene.nodes ?? const <fb.Node>[]) {
+      for (final p in node.meshPrimitives ?? const <fb.MeshPrimitive>[]) {
+        primCount++;
+        expect(p.boundsAabb, isNotNull);
+        expect(p.boundsSphere, isNotNull);
+      }
+    }
+    expect(primCount, greaterThan(0));
+  });
+
+  test('AABB matches glTF accessor min/max when present', () {
+    // fcar's CarBody primitive has POSITION accessor min/max set in the
+    // source glTF. The baked AABB should equal those values exactly,
+    // without going through a float-imprecise vertex scan.
+    final glbPath = _resolve('examples/assets_src/fcar.glb');
+    if (!File(glbPath).existsSync()) {
+      print('fcar.glb missing — skipping.');
+      return;
+    }
+    final glbBytes = File(glbPath).readAsBytesSync();
+    final container = parseGlb(glbBytes);
+    final doc = parseGltfJson(container.json);
+
+    // Scan all primitives, find one with both accessor min/max present.
+    GltfMeshPrimitive? exemplar;
+    GltfAccessor? exemplarPos;
+    for (final mesh in doc.meshes) {
+      for (final p in mesh.primitives) {
+        final pos = doc.accessors[p.attributes['POSITION']!];
+        if (pos.min != null && pos.max != null) {
+          exemplar = p;
+          exemplarPos = pos;
+          break;
+        }
+      }
+      if (exemplar != null) break;
+    }
+    expect(
+      exemplar,
+      isNotNull,
+      reason: 'fcar should have at least one primitive with min/max',
+    );
+
+    final modelBytes = emitModel(doc, container.binaryChunk);
+    final scene =
+        ImportedScene.fromFlatbuffer(ByteData.sublistView(modelBytes)).flatbuffer;
+
+    // Find the matching emitted primitive (by vertex count, since names
+    // may have collisions).
+    final exemplarVertCount =
+        doc.accessors[exemplar!.attributes['POSITION']!].count;
+    fb.MeshPrimitive? match;
+    for (final node in scene.nodes ?? const <fb.Node>[]) {
+      for (final p in node.meshPrimitives ?? const <fb.MeshPrimitive>[]) {
+        final vbCount = (p.vertices is fb.UnskinnedVertexBuffer)
+            ? (p.vertices as fb.UnskinnedVertexBuffer).vertexCount
+            : (p.vertices as fb.SkinnedVertexBuffer).vertexCount;
+        if (vbCount == exemplarVertCount) {
+          match = p;
+          break;
+        }
+      }
+      if (match != null) break;
+    }
+    expect(match, isNotNull);
+    final aabb = match!.boundsAabb!;
+    expect(aabb.min.x, closeTo(exemplarPos!.min![0], 1e-6));
+    expect(aabb.min.y, closeTo(exemplarPos.min![1], 1e-6));
+    expect(aabb.min.z, closeTo(exemplarPos.min![2], 1e-6));
+    expect(aabb.max.x, closeTo(exemplarPos.max![0], 1e-6));
+    expect(aabb.max.y, closeTo(exemplarPos.max![1], 1e-6));
+    expect(aabb.max.z, closeTo(exemplarPos.max![2], 1e-6));
+  });
+}
+
+fb.Scene? _emitAndDecode(String relativePath) {
+  final glbPath = _resolve(relativePath);
+  if (!File(glbPath).existsSync()) return null;
+  final glbBytes = File(glbPath).readAsBytesSync();
+  final container = parseGlb(glbBytes);
+  final doc = parseGltfJson(container.json);
+  final modelBytes = emitModel(doc, container.binaryChunk);
+  return ImportedScene.fromFlatbuffer(
+    ByteData.sublistView(modelBytes),
+  ).flatbuffer;
+}
+
+double _len3(double x, double y, double z) => sqrt(x * x + y * y + z * z);
+
+String _resolve(String relative) {
+  for (final prefix in ['', '../../', '../../../']) {
+    final candidate = '$prefix$relative';
+    if (File(candidate).existsSync() || Directory(candidate).existsSync()) {
+      return candidate;
+    }
+  }
+  return relative;
+}


### PR DESCRIPTION
## Summary

Adds bounding volume infrastructure across the importer and runtime, with no behavior change yet. This is the foundation for a frustum-cull pass in a follow-up PR (issue #69).

### Schema (`scene.fbs`)
- New optional `Aabb3` and `Sphere` structs.
- `MeshPrimitive.bounds_aabb`, `MeshPrimitive.bounds_sphere`: per-primitive local-space bounds.
- `Node.combined_local_aabb`: union of own primitive AABBs and every descendant's combined AABB transformed into this node's local space. Lets the runtime cull entire subtrees with a single test.

All fields are optional, so existing `.model` files continue to load.

### Offline importer (`flutter_scene_importer`)
- glTF parser now reads accessor `min`/`max`. The spec requires these on POSITION accessors, so the bake skips a vertex scan whenever the asset already encodes the AABB.
- Each `MeshPrimitive` gets a baked AABB (from accessor `min`/`max` when present, else a vertex scan) and a Ritter-fit bounding sphere.
- A post-pass walks the node graph and bakes `combined_local_aabb` on every node where the subtree is statically bounded.
- Skinned subtrees deliberately opt out: any node with a `skin` (or that has a skinned descendant) is left without a baked combined AABB. The runtime treats absent bounds as always-visible. A follow-up PR will replace this with a baked pose-union AABB derived from animation keyframes.

### Runtime (`flutter_scene`)
- `Geometry.localBounds` / `localBoundingSphere`: populated from the flatbuffer on import, scanned from the position attribute in `uploadVertexData` for procedural geometry, or set explicitly via `Geometry.setLocalBounds(aabb, sphere)` for callers managing their own GPU buffers.
- `Mesh.localBounds`: cached union of primitive bounds; `markLocalBoundsDirty()` to invalidate.
- `Node.combinedLocalBounds`: cached, walks children with their local transforms; returns `null` for skinned subtrees so cull treats them as always visible.
- `Node.markBoundsDirty()` walks the parent chain. `add` / `remove` / `mesh =` invalidate automatically. In-place transform mutations require an explicit call (documented on the getter).

## Test plan
- [x] `flutter test packages/flutter_scene/test` passes (56 tests, including 16 new bounds tests).
- [x] `flutter test packages/flutter_scene_importer/test` passes (8 tests, including 3 new bake tests).
- [x] Existing `model_emitter_test` byte-parity coverage against the C++ baseline still passes (bounds are purely additive in the flatbuffer).
- [x] `dart analyze` is clean across both packages.
- [x] Formatted with `dart_style:format` for CI parity.
- [ ] Manual smoke run of the example app on macOS (no behavioral changes expected).