### PR TITLE
Cull subtrees against the camera frustum during render

### DIFF
--- a/packages/flutter_scene/lib/src/camera.dart
+++ b/packages/flutter_scene/lib/src/camera.dart
@@ -22,6 +22,15 @@ abstract class Camera {
   /// [dimensions] (typically to compute aspect ratio) and any subclass
   /// configuration to build the matrix.
   Matrix4 getViewTransform(ui.Size dimensions);
+
+  /// Returns the view frustum (six normalized clip planes) for a render
+  /// target of the given [dimensions].
+  ///
+  /// Built from [getViewTransform] using the standard Gribb-Hartmann
+  /// extraction. Useful for [Node.isVisibleTo] queries and any other
+  /// caller-driven culling.
+  Frustum getFrustum(ui.Size dimensions) =>
+      Frustum.matrix(getViewTransform(dimensions));
 }
 
 Matrix4 _matrix4LookAt(Vector3 position, Vector3 target, Vector3 up) {

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' hide Matrix4;
 import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/runtime_importer/runtime_importer.dart';
 import 'package:flutter_scene/src/scene.dart';
 import 'package:flutter_scene/src/animation.dart';
@@ -38,6 +39,18 @@ base class Node implements SceneGraph {
 
   /// Whether this node is visible in the scene. If false, the node and its children will not be rendered.
   bool visible = true;
+
+  /// Whether this node and its descendants should be tested against the
+  /// camera frustum each frame. When `true` (the default), subtrees
+  /// whose [combinedLocalBounds] don't intersect the frustum are
+  /// skipped entirely. Set to `false` for procedural geometry, large
+  /// terrain pieces, or anything else where the cached bound is
+  /// known-stale or known-misleading.
+  ///
+  /// Subtrees that report no bound (skinned content, geometry without
+  /// computable bounds) are treated as always visible regardless of
+  /// this flag.
+  bool frustumCulled = true;
 
   /// The transformation matrix representing the node's position, rotation, and scale relative to the parent node.
   ///
@@ -165,6 +178,27 @@ base class Node implements SceneGraph {
 
     _combinedBoundsCache = subtreeBounded ? result : null;
     _combinedBoundsCached = true;
+  }
+
+  /// Whether this node's subtree would survive frustum culling against
+  /// [camera] for a render target of the given [dimensions].
+  ///
+  /// Returns `true` when the node is configured to opt out of culling
+  /// ([frustumCulled] is `false`), when the subtree is unbounded
+  /// (skinned content, or geometry without computable bounds, both of
+  /// which the renderer conservatively treats as always visible), or
+  /// when the world-space AABB intersects the camera frustum. Returns
+  /// `false` only when there is a sound bound and it lies entirely
+  /// outside the frustum.
+  ///
+  /// Uses [globalTransform] to place the subtree's local-space AABB
+  /// into world space.
+  bool isVisibleTo(Camera camera, Size dimensions) {
+    if (!frustumCulled) return true;
+    final bounds = combinedLocalBounds;
+    if (bounds == null) return true;
+    final worldAabb = vm.Aabb3.copy(bounds)..transform(globalTransform);
+    return camera.getFrustum(dimensions).intersectsWithAabb3(worldAabb);
   }
 
   /// Mark this node's [combinedLocalBounds] cache (and every ancestor's)
@@ -699,6 +733,22 @@ base class Node implements SceneGraph {
     }
 
     final worldTransform = parentWorldTransform * localTransform;
+
+    // Subtree-level frustum cull. Skipped when the user opted out
+    // (frustumCulled = false) or when the subtree reports no bound
+    // (skinned content, or geometry without computable bounds — both
+    // of which conservatively pass through to the render path).
+    if (frustumCulled) {
+      final localBounds = combinedLocalBounds;
+      if (localBounds != null) {
+        encoder.cullScratchAabb.copyFrom(localBounds);
+        encoder.cullScratchAabb.transform(worldTransform);
+        if (!encoder.frustum.intersectsWithAabb3(encoder.cullScratchAabb)) {
+          return;
+        }
+      }
+    }
+
     if (mesh != null) {
       mesh!.render(
         encoder,

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -48,6 +48,7 @@ base class SceneEncoder {
     this._environment,
   ) {
     _cameraTransform = _camera.getViewTransform(dimensions);
+    frustum = Frustum.matrix(_cameraTransform);
     _commandBuffer = gpu.gpuContext.createCommandBuffer();
     _transientsBuffer = gpu.gpuContext.createHostBuffer();
 
@@ -65,6 +66,16 @@ base class SceneEncoder {
   late final gpu.HostBuffer _transientsBuffer;
   late final gpu.RenderPass _renderPass;
   final List<_TranslucentRecord> _translucentRecords = [];
+
+  /// View frustum derived from the camera's view-projection matrix at
+  /// the start of this frame. Used by [Node.render] for subtree-level
+  /// culling.
+  late final Frustum frustum;
+
+  /// Reusable AABB owned by this encoder so the per-node cull check can
+  /// transform a local AABB into world space without allocating a new
+  /// [Aabb3] every frame, every node.
+  final Aabb3 cullScratchAabb = Aabb3();
 
   /// Records a draw call for [geometry] with [material] at
   /// [worldTransform].

--- a/packages/flutter_scene/test/cull_test.dart
+++ b/packages/flutter_scene/test/cull_test.dart
@@ -1,0 +1,142 @@
+// Frustum / cull tests. Exercises Camera.getFrustum and
+// Node.isVisibleTo without touching a real GPU context. Uses a stub
+// Geometry / Material so MeshPrimitive can be constructed in pure
+// Dart, same pattern as bounds_test.dart.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+class _StubGeometry extends Geometry {
+  _StubGeometry(Aabb3 aabb) {
+    setLocalBounds(
+      aabb,
+      Sphere.centerRadius(
+        (aabb.min + aabb.max) * 0.5,
+        ((aabb.max - aabb.min) * 0.5).length,
+      ),
+    );
+  }
+
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Matrix4 modelTransform,
+    Matrix4 cameraTransform,
+    Vector3 cameraPosition,
+  ) {
+    throw UnsupportedError('Stub geometry is not renderable');
+  }
+}
+
+class _StubMaterial extends Material {
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Environment environment,
+  ) {
+    throw UnsupportedError('Stub material is not renderable');
+  }
+}
+
+Node _unitCubeNodeAt(Vector3 position) {
+  return Node(
+    localTransform: Matrix4.translation(position),
+    mesh: Mesh.primitives(
+      primitives: [
+        MeshPrimitive(
+          _StubGeometry(Aabb3.minMax(Vector3.all(-1.0), Vector3.all(1.0))),
+          _StubMaterial(),
+        ),
+      ],
+    ),
+  );
+}
+
+const ui.Size _viewport = ui.Size(800, 600);
+
+PerspectiveCamera _cameraLookingAtOrigin() {
+  // Eye at -10z, looking at origin, default 45deg FOV. The default
+  // PerspectiveCamera() is at -5z which sits very close to a unit
+  // cube at the origin; pull back to put cubes safely inside a
+  // canonical frustum.
+  return PerspectiveCamera(
+    position: Vector3(0, 0, -10),
+    target: Vector3.zero(),
+  );
+}
+
+void main() {
+  group('Camera.getFrustum', () {
+    test('contains the camera target and excludes a far-off-axis point', () {
+      final camera = _cameraLookingAtOrigin();
+      final frustum = camera.getFrustum(_viewport);
+      expect(
+        frustum.containsVector3(Vector3.zero()),
+        isTrue,
+        reason: 'origin is on the line of sight, inside the near/far range',
+      );
+      expect(
+        frustum.containsVector3(Vector3(0, 0, -50)),
+        isFalse,
+        reason: 'point behind the camera should be outside',
+      );
+      expect(
+        frustum.containsVector3(Vector3(1000, 0, 0)),
+        isFalse,
+        reason: 'point far off the side should be outside',
+      );
+    });
+  });
+
+  group('Node.isVisibleTo', () {
+    test('cube on the line of sight is visible', () {
+      final node = _unitCubeNodeAt(Vector3.zero());
+      expect(node.isVisibleTo(_cameraLookingAtOrigin(), _viewport), isTrue);
+    });
+
+    test('cube far off-screen is culled', () {
+      final node = _unitCubeNodeAt(Vector3(1000, 0, 0));
+      expect(node.isVisibleTo(_cameraLookingAtOrigin(), _viewport), isFalse);
+    });
+
+    test('frustumCulled = false bypasses the cull test', () {
+      final node = _unitCubeNodeAt(Vector3(1000, 0, 0));
+      node.frustumCulled = false;
+      expect(node.isVisibleTo(_cameraLookingAtOrigin(), _viewport), isTrue);
+    });
+
+    test('unbounded subtree (skinned) is treated as always visible', () {
+      final node = _unitCubeNodeAt(Vector3(1000, 0, 0));
+      node.skin = Skin();
+      expect(node.isVisibleTo(_cameraLookingAtOrigin(), _viewport), isTrue);
+    });
+
+    test('parent transform is honoured when computing world AABB', () {
+      // Cube at the origin is visible. Wrap it in a parent that
+      // translates far off to the side, and visibility flips.
+      final cube = _unitCubeNodeAt(Vector3.zero());
+      final group = Node(
+        localTransform: Matrix4.translation(Vector3(1000, 0, 0)),
+      );
+      group.add(cube);
+      expect(cube.isVisibleTo(_cameraLookingAtOrigin(), _viewport), isFalse);
+    });
+
+    test('negative-determinant world transform still culls correctly', () {
+      // Mirror the cube along Z (the same flip the scene-root uses).
+      // It should still be visible in front of the camera.
+      final cube = _unitCubeNodeAt(Vector3.zero());
+      final flip = Node(
+        localTransform: Matrix4.identity()..setEntry(2, 2, -1.0),
+      );
+      flip.add(cube);
+      expect(cube.isVisibleTo(_cameraLookingAtOrigin(), _viewport), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the rendering-side complement of the bounds infrastructure landed in #107. Closes the implementation half of issue #69 step 3.

Per frame, `SceneEncoder` builds a `Frustum` once from the camera's view-projection matrix and reuses a single scratch `Aabb3` to test every subtree. `Node.render` does an early-out: when the subtree's `combinedLocalBounds` (transformed by the world-transform stack we already maintain) doesn't intersect the frustum, the entire descent is skipped. The win compounds with depth, so deeply nested glTF imports (e.g. `dash.glb` at 37 nodes) get the most benefit.

The implementation deliberately uses `vector_math`'s `Frustum` and `Aabb3` directly:

- `Frustum.matrix(...)` does Gribb-Hartmann extraction with normalized planes.
- `Frustum.intersectsWithAabb3` already uses the p-vertex / n-vertex trick.
- `Aabb3.transform` already uses the Arvo `absoluteRotate` shortcut (no 8-corner expansion).
- `Aabb3.copyFrom` + `transform` writes into a pre-allocated AABB so the cull check allocates nothing per node, per frame.

### API surface

- **`Camera.getFrustum(ui.Size)`** — public frustum factory built on top of `getViewTransform`.
- **`Node.frustumCulled`** — `bool` field, defaults to `true`. Set to `false` for procedural geometry, large terrain pieces, or anything else where the cached bound is known-stale or known-misleading.
- **`Node.isVisibleTo(Camera, ui.Size)`** — caller-driven equivalent of the render-time test, useful for selectively driving expensive update logic only on on-screen nodes.

Subtrees that report no bound (skinned content, or geometry the importer / runtime couldn't compute extents for) pass through the cull conservatively as always visible. PR 3 will replace the skinned case with a baked pose-union AABB.

## Test plan

- [x] `flutter test packages/flutter_scene/test` passes (63 tests, including 7 new cull tests).
- [x] `flutter test packages/flutter_scene_importer/test` still passes (8 tests).
- [x] `dart analyze` clean across both packages.
- [x] `dart format --set-exit-if-changed` clean.
- [ ] Smoke run of the example app on macOS (no behavioral changes expected, since cull is conservative against the existing render output).

The new cull tests cover the cases the survey work flagged as common footguns: opt-out flag, unbounded skinned subtree, parent transform composition, negative-determinant child transform (the scene-root Z-flip case).