### PR TITLE
Bake pose-union AABBs offline to cull skinned meshes

### DIFF
--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -122,19 +122,37 @@ abstract class Geometry {
     // Pre-populate bounds from the flatbuffer when present so
     // uploadVertexData can skip the position scan. Geometry written by
     // older importers (without bounds) falls back to a scan.
-    final fbAabb = fbPrimitive.boundsAabb;
+    //
+    // For skinned primitives, prefer the offline-baked
+    // `skinned_pose_union_aabb` since it covers every animated pose
+    // extent. The static-pose `bounds_aabb` is only useful for
+    // editor-style queries on bind-pose extents and would produce
+    // wrong cull decisions when joints animate beyond it.
+    final fbAabb =
+        isSkinned
+            ? (fbPrimitive.skinnedPoseUnionAabb ?? fbPrimitive.boundsAabb)
+            : fbPrimitive.boundsAabb;
     if (fbAabb != null) {
       geometry._localBounds = vm.Aabb3.minMax(
         vm.Vector3(fbAabb.min.x, fbAabb.min.y, fbAabb.min.z),
         vm.Vector3(fbAabb.max.x, fbAabb.max.y, fbAabb.max.z),
       );
     }
-    final fbSphere = fbPrimitive.boundsSphere;
-    if (fbSphere != null) {
-      geometry._localBoundingSphere = vm.Sphere.centerRadius(
-        vm.Vector3(fbSphere.center.x, fbSphere.center.y, fbSphere.center.z),
-        fbSphere.radius,
+    if (isSkinned && fbPrimitive.skinnedPoseUnionAabb != null) {
+      // Derive the sphere from the pose-union AABB so it covers the
+      // same animated extent. The baked `bounds_sphere` is fit to the
+      // static bind-pose mesh and would be too small.
+      geometry._localBoundingSphere = _circumscribedSphere(
+        geometry._localBounds!,
       );
+    } else {
+      final fbSphere = fbPrimitive.boundsSphere;
+      if (fbSphere != null) {
+        geometry._localBoundingSphere = vm.Sphere.centerRadius(
+          vm.Vector3(fbSphere.center.x, fbSphere.center.y, fbSphere.center.z),
+          fbSphere.radius,
+        );
+      }
     }
 
     geometry.uploadVertexData(

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -120,31 +120,39 @@ abstract class Geometry {
     }
 
     // Pre-populate bounds from the flatbuffer when present so
-    // uploadVertexData can skip the position scan. Geometry written by
-    // older importers (without bounds) falls back to a scan.
+    // uploadVertexData can skip the position scan.
     //
-    // For skinned primitives, prefer the offline-baked
-    // `skinned_pose_union_aabb` since it covers every animated pose
-    // extent. The static-pose `bounds_aabb` is only useful for
-    // editor-style queries on bind-pose extents and would produce
-    // wrong cull decisions when joints animate beyond it.
+    // For skinned primitives, only the offline-baked
+    // `skinned_pose_union_aabb` is sound for cull. The static-pose
+    // `bounds_aabb` is useful for editor-style queries on bind-pose
+    // extents but would under-cover the mesh once joints animate.
+    // When the importer didn't bake a pose-union (older `.model`
+    // files), bounds remain `null` and `Geometry.uploadVertexData`
+    // skips the auto-scan for skinned geometries — the runtime
+    // conservatively treats the subtree as always visible.
+    //
+    // Unskinned primitives use the (sound) static AABB and sphere
+    // from the flatbuffer, falling back to a position scan in
+    // `uploadVertexData` when the importer didn't bake bounds.
     final fbAabb =
-        isSkinned
-            ? (fbPrimitive.skinnedPoseUnionAabb ?? fbPrimitive.boundsAabb)
-            : fbPrimitive.boundsAabb;
+        isSkinned ? fbPrimitive.skinnedPoseUnionAabb : fbPrimitive.boundsAabb;
     if (fbAabb != null) {
       geometry._localBounds = vm.Aabb3.minMax(
         vm.Vector3(fbAabb.min.x, fbAabb.min.y, fbAabb.min.z),
         vm.Vector3(fbAabb.max.x, fbAabb.max.y, fbAabb.max.z),
       );
     }
-    if (isSkinned && fbPrimitive.skinnedPoseUnionAabb != null) {
-      // Derive the sphere from the pose-union AABB so it covers the
-      // same animated extent. The baked `bounds_sphere` is fit to the
-      // static bind-pose mesh and would be too small.
-      geometry._localBoundingSphere = _circumscribedSphere(
-        geometry._localBounds!,
-      );
+    if (isSkinned) {
+      if (geometry._localBounds != null) {
+        // Derive the sphere from the pose-union AABB so it covers the
+        // same animated extent. The baked `bounds_sphere` is fit to
+        // the static bind-pose mesh and would be too small.
+        geometry._localBoundingSphere = _circumscribedSphere(
+          geometry._localBounds!,
+        );
+      }
+      // No pose-union: leave both bounds null so the runtime treats
+      // the subtree as always visible.
     } else {
       final fbSphere = fbPrimitive.boundsSphere;
       if (fbSphere != null) {
@@ -237,10 +245,20 @@ abstract class Geometry {
       );
     }
 
-    if (_localBounds == null && vertexCount > 0) {
+    if (_localBounds == null && vertexCount > 0 && _autoScanBoundsOnUpload) {
       _scanLocalBoundsFromVertices(vertices, vertexCount);
     }
   }
+
+  /// Whether [uploadVertexData] should auto-populate [localBounds] from
+  /// the vertex positions when no bound has been set yet. True by
+  /// default; [SkinnedGeometry] overrides it to `false` since the
+  /// position scan would yield bind-pose extents, which under-cover
+  /// the skinned mesh once joints animate. Skinned geometries get
+  /// their bounds from the offline-baked `skinned_pose_union_aabb`
+  /// instead, or fall back to the always-visible cull path when the
+  /// importer didn't bake one (notably the runtime GLB importer).
+  bool get _autoScanBoundsOnUpload => true;
 
   /// Scan the position attribute (the first 12 bytes of each vertex,
   /// shared across the unskinned 48-byte and skinned 80-byte layouts)
@@ -406,6 +424,9 @@ class SkinnedGeometry extends Geometry {
   SkinnedGeometry() {
     setVertexShader(baseShaderLibrary['SkinnedVertex']!);
   }
+
+  @override
+  bool get _autoScanBoundsOnUpload => false;
 
   @override
   void setJointsTexture(gpu.Texture? texture, int width) {

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -136,16 +136,6 @@ base class Node implements SceneGraph {
   }
 
   void _computeAndCacheCombinedLocalBounds() {
-    // A node with a skin can't be soundly bounded by its bind-pose
-    // mesh extents; the rendered pose can extend arbitrarily far when
-    // joints animate. PR 3 will replace this branch with a baked
-    // pose-union AABB.
-    if (skin != null) {
-      _combinedBoundsCache = null;
-      _combinedBoundsCached = true;
-      return;
-    }
-
     vm.Aabb3? result;
     bool subtreeBounded = true;
 
@@ -156,7 +146,8 @@ base class Node implements SceneGraph {
         result = vm.Aabb3.copy(mb);
       } else if (m.primitives.isNotEmpty) {
         // Mesh with primitives but no localBounds (caller-managed
-        // buffers without an override) acts as unbounded.
+        // buffers without an override, or skinned mesh imported from a
+        // file with no animation data) acts as unbounded.
         subtreeBounded = false;
       }
     }

--- a/packages/flutter_scene/test/bounds_test.dart
+++ b/packages/flutter_scene/test/bounds_test.dart
@@ -257,24 +257,35 @@ void main() {
       expect(root.combinedLocalBounds!.max, Vector3(5, 5, 5));
     });
 
-    test(
-      'returns null for skinned subtrees regardless of primitive bounds',
-      () {
-        // Skinned bind-pose extents are misleading: animated joints can
-        // place geometry far outside them. The bounds API treats any
-        // skinned node as "always visible" until PR 3 bakes a pose-union
-        // AABB.
-        final node = Node(
-          mesh: Mesh.primitives(
-            primitives: [
-              _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
-            ],
-          ),
-        );
-        node.skin = Skin();
-        expect(node.combinedLocalBounds, isNull);
-      },
-    );
+    test('skinned node uses the geometry localBounds (which the importer '
+        'pre-populates with the pose-union AABB)', () {
+      // Stub geometry stands in for an importer-baked geometry whose
+      // localBounds was set from skinnedPoseUnionAabb.
+      final node = Node(
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-2, -2, -2), Vector3(2, 2, 2))),
+          ],
+        ),
+      );
+      node.skin = Skin();
+      // The bound the test injects via setLocalBounds is treated as
+      // already representing the pose-union extent, so the runtime
+      // uses it for cull.
+      expect(node.combinedLocalBounds!.min, Vector3(-2, -2, -2));
+      expect(node.combinedLocalBounds!.max, Vector3(2, 2, 2));
+    });
+
+    test('skinned node with no geometry bounds is treated as unbounded', () {
+      // Falls through the bake (no animations to derive a pose-union
+      // from, or analysis was skipped). Runtime conservatively
+      // treats the subtree as always visible.
+      final node = Node(
+        mesh: Mesh.primitives(primitives: [_primWithBounds(null)]),
+      );
+      node.skin = Skin();
+      expect(node.combinedLocalBounds, isNull);
+    });
 
     test('mesh setter invalidates the cache', () {
       final node = Node(

--- a/packages/flutter_scene/test/cull_test.dart
+++ b/packages/flutter_scene/test/cull_test.dart
@@ -33,6 +33,19 @@ class _StubGeometry extends Geometry {
   }
 }
 
+class _StubGeometryNoBounds extends Geometry {
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Matrix4 modelTransform,
+    Matrix4 cameraTransform,
+    Vector3 cameraPosition,
+  ) {
+    throw UnsupportedError('Stub geometry is not renderable');
+  }
+}
+
 class _StubMaterial extends Material {
   @override
   void bind(
@@ -111,8 +124,27 @@ void main() {
       expect(node.isVisibleTo(_cameraLookingAtOrigin(), _viewport), isTrue);
     });
 
-    test('unbounded subtree (skinned) is treated as always visible', () {
-      final node = _unitCubeNodeAt(Vector3(1000, 0, 0));
+    test(
+      'skinned node uses geometry bounds when present (pose-union path)',
+      () {
+        // Skinned but with bounds (importer populated localBounds from
+        // skinnedPoseUnionAabb). Treated like any other bounded
+        // subtree.
+        final node = _unitCubeNodeAt(Vector3(1000, 0, 0));
+        node.skin = Skin();
+        expect(node.isVisibleTo(_cameraLookingAtOrigin(), _viewport), isFalse);
+      },
+    );
+
+    test('skinned node without bounds is treated as always visible', () {
+      // No pose-union baked (e.g. no animations in the source).
+      // Runtime conservatively skips cull.
+      final node = Node(
+        localTransform: Matrix4.translation(Vector3(1000, 0, 0)),
+        mesh: Mesh.primitives(
+          primitives: [MeshPrimitive(_StubGeometryNoBounds(), _StubMaterial())],
+        ),
+      );
       node.skin = Skin();
       expect(node.isVisibleTo(_cameraLookingAtOrigin(), _viewport), isTrue);
     });

--- a/packages/flutter_scene_importer/lib/generated/scene_impeller.fb_flatbuffers.dart
+++ b/packages/flutter_scene_importer/lib/generated/scene_impeller.fb_flatbuffers.dart
@@ -2079,9 +2079,22 @@ class MeshPrimitive {
   Sphere? get boundsSphere =>
       Sphere.reader.vTableGetNullable(_bc, _bcOffset, 14);
 
+  ///  For skinned primitives only: union of vertex positions across every
+  ///  pose the primitive can take under the file's animations, computed
+  ///  offline by sampling each animation's keyframes and applying the
+  ///  resulting joint palette.
+  ///
+  ///  In the same local space as `bounds_aabb` (the mesh's vertex-position
+  ///  space). Lets the runtime cull skinned content soundly instead of
+  ///  treating it as always-visible. Absent on unskinned primitives, and
+  ///  on skinned primitives when offline pose-union analysis isn't
+  ///  available (e.g. older importer output).
+  Aabb3? get skinnedPoseUnionAabb =>
+      Aabb3.reader.vTableGetNullable(_bc, _bcOffset, 16);
+
   @override
   String toString() {
-    return 'MeshPrimitive{verticesType: ${verticesType}, vertices: ${vertices}, indices: ${indices}, material: ${material}, boundsAabb: ${boundsAabb}, boundsSphere: ${boundsSphere}}';
+    return 'MeshPrimitive{verticesType: ${verticesType}, vertices: ${vertices}, indices: ${indices}, material: ${material}, boundsAabb: ${boundsAabb}, boundsSphere: ${boundsSphere}, skinnedPoseUnionAabb: ${skinnedPoseUnionAabb}}';
   }
 
   MeshPrimitiveT unpack() => MeshPrimitiveT(
@@ -2091,6 +2104,7 @@ class MeshPrimitive {
     material: material?.unpack(),
     boundsAabb: boundsAabb?.unpack(),
     boundsSphere: boundsSphere?.unpack(),
+    skinnedPoseUnionAabb: skinnedPoseUnionAabb?.unpack(),
   );
 
   static int pack(fb.Builder fbBuilder, MeshPrimitiveT? object) {
@@ -2113,6 +2127,18 @@ class MeshPrimitiveT implements fb.Packable {
   Aabb3T? boundsAabb;
   SphereT? boundsSphere;
 
+  ///  For skinned primitives only: union of vertex positions across every
+  ///  pose the primitive can take under the file's animations, computed
+  ///  offline by sampling each animation's keyframes and applying the
+  ///  resulting joint palette.
+  ///
+  ///  In the same local space as `bounds_aabb` (the mesh's vertex-position
+  ///  space). Lets the runtime cull skinned content soundly instead of
+  ///  treating it as always-visible. Absent on unskinned primitives, and
+  ///  on skinned primitives when offline pose-union analysis isn't
+  ///  available (e.g. older importer output).
+  Aabb3T? skinnedPoseUnionAabb;
+
   MeshPrimitiveT({
     this.verticesType,
     this.vertices,
@@ -2120,6 +2146,7 @@ class MeshPrimitiveT implements fb.Packable {
     this.material,
     this.boundsAabb,
     this.boundsSphere,
+    this.skinnedPoseUnionAabb,
   });
 
   @override
@@ -2127,7 +2154,7 @@ class MeshPrimitiveT implements fb.Packable {
     final int? verticesOffset = vertices?.pack(fbBuilder);
     final int? indicesOffset = indices?.pack(fbBuilder);
     final int? materialOffset = material?.pack(fbBuilder);
-    fbBuilder.startTable(6);
+    fbBuilder.startTable(7);
     fbBuilder.addUint8(0, verticesType?.value);
     fbBuilder.addOffset(1, verticesOffset);
     fbBuilder.addOffset(2, indicesOffset);
@@ -2138,12 +2165,15 @@ class MeshPrimitiveT implements fb.Packable {
     if (boundsSphere != null) {
       fbBuilder.addStruct(5, boundsSphere!.pack(fbBuilder));
     }
+    if (skinnedPoseUnionAabb != null) {
+      fbBuilder.addStruct(6, skinnedPoseUnionAabb!.pack(fbBuilder));
+    }
     return fbBuilder.endTable();
   }
 
   @override
   String toString() {
-    return 'MeshPrimitiveT{verticesType: ${verticesType}, vertices: ${vertices}, indices: ${indices}, material: ${material}, boundsAabb: ${boundsAabb}, boundsSphere: ${boundsSphere}}';
+    return 'MeshPrimitiveT{verticesType: ${verticesType}, vertices: ${vertices}, indices: ${indices}, material: ${material}, boundsAabb: ${boundsAabb}, boundsSphere: ${boundsSphere}, skinnedPoseUnionAabb: ${skinnedPoseUnionAabb}}';
   }
 }
 
@@ -2161,7 +2191,7 @@ class MeshPrimitiveBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable(6);
+    fbBuilder.startTable(7);
   }
 
   int addVerticesType(VertexBufferTypeId? verticesType) {
@@ -2194,6 +2224,11 @@ class MeshPrimitiveBuilder {
     return fbBuilder.offset;
   }
 
+  int addSkinnedPoseUnionAabb(int offset) {
+    fbBuilder.addStruct(6, offset);
+    return fbBuilder.offset;
+  }
+
   int finish() {
     return fbBuilder.endTable();
   }
@@ -2206,6 +2241,7 @@ class MeshPrimitiveObjectBuilder extends fb.ObjectBuilder {
   final MaterialObjectBuilder? _material;
   final Aabb3ObjectBuilder? _boundsAabb;
   final SphereObjectBuilder? _boundsSphere;
+  final Aabb3ObjectBuilder? _skinnedPoseUnionAabb;
 
   MeshPrimitiveObjectBuilder({
     VertexBufferTypeId? verticesType,
@@ -2214,12 +2250,14 @@ class MeshPrimitiveObjectBuilder extends fb.ObjectBuilder {
     MaterialObjectBuilder? material,
     Aabb3ObjectBuilder? boundsAabb,
     SphereObjectBuilder? boundsSphere,
+    Aabb3ObjectBuilder? skinnedPoseUnionAabb,
   }) : _verticesType = verticesType,
        _vertices = vertices,
        _indices = indices,
        _material = material,
        _boundsAabb = boundsAabb,
-       _boundsSphere = boundsSphere;
+       _boundsSphere = boundsSphere,
+       _skinnedPoseUnionAabb = skinnedPoseUnionAabb;
 
   /// Finish building, and store into the [fbBuilder].
   @override
@@ -2227,7 +2265,7 @@ class MeshPrimitiveObjectBuilder extends fb.ObjectBuilder {
     final int? verticesOffset = _vertices?.getOrCreateOffset(fbBuilder);
     final int? indicesOffset = _indices?.getOrCreateOffset(fbBuilder);
     final int? materialOffset = _material?.getOrCreateOffset(fbBuilder);
-    fbBuilder.startTable(6);
+    fbBuilder.startTable(7);
     fbBuilder.addUint8(0, _verticesType?.value);
     fbBuilder.addOffset(1, verticesOffset);
     fbBuilder.addOffset(2, indicesOffset);
@@ -2237,6 +2275,9 @@ class MeshPrimitiveObjectBuilder extends fb.ObjectBuilder {
     }
     if (_boundsSphere != null) {
       fbBuilder.addStruct(5, _boundsSphere!.finish(fbBuilder));
+    }
+    if (_skinnedPoseUnionAabb != null) {
+      fbBuilder.addStruct(6, _skinnedPoseUnionAabb!.finish(fbBuilder));
     }
     return fbBuilder.endTable();
   }

--- a/packages/flutter_scene_importer/lib/src/fb_emitter/model_emitter.dart
+++ b/packages/flutter_scene_importer/lib/src/fb_emitter/model_emitter.dart
@@ -6,7 +6,7 @@
 /// for byte-level parity coverage against the C++ output.
 library;
 
-import 'dart:math' show sqrt;
+import 'dart:math' show acos, cos, pi, sin, sqrt;
 import 'dart:typed_data';
 
 import 'package:image/image.dart' as img;
@@ -56,9 +56,15 @@ fb.SceneT _buildScene(GltfDocument doc, Uint8List bufferData) {
       _buildNode(doc.nodes[i], doc, bufferData),
   ];
 
+  // Post-pass: bake skinned primitives' pose-union AABBs by sampling
+  // every animation that drives any joint of the bound skin. Must run
+  // before _bakeCombinedAabbs so skinned subtrees can contribute their
+  // pose-union extents instead of opting out.
+  _bakePoseUnionAabbs(scene.nodes!, doc, bufferData);
+
   // Post-pass: bake each node's combined local-space AABB so the
   // runtime can cull entire subtrees with a single AABB-vs-frustum
-  // test. Skinned subtrees opt out of this (see _bakeCombinedAabbs).
+  // test.
   _bakeCombinedAabbs(scene.nodes!, doc);
 
   // Animations.
@@ -71,16 +77,19 @@ fb.SceneT _buildScene(GltfDocument doc, Uint8List bufferData) {
 
 /// Walks the node forest in post-order and assigns
 /// `combined_local_aabb` to each node where it can be computed
-/// soundly. Subtrees that contain any skinned primitive are left
-/// without a baked AABB; the runtime treats absent bounds as
-/// "always visible" so animated meshes don't disappear when posed
-/// outside their bind-pose extent.
+/// soundly.
+///
+/// Skinned primitives contribute their `skinned_pose_union_aabb` (a
+/// superset of every animated pose extent) when the offline analysis
+/// produced one; otherwise the subtree is left unbounded and the
+/// runtime treats absent bounds as "always visible" so animated
+/// meshes don't disappear when posed outside their bind-pose extent.
 void _bakeCombinedAabbs(List<fb.NodeT> nodes, GltfDocument doc) {
-  // Memoize: null when the subtree is unbounded (skinned), an
-  // `_AabbBox` otherwise. `_AabbBox.empty` represents a soundly
-  // computed but empty subtree (no geometry at all), which still
-  // serializes as a degenerate AABB so we can tell it apart from
-  // "unbounded" at runtime.
+  // Memoize: null when the subtree is unbounded (skinned without a
+  // pose-union bound), an `_AabbBox` otherwise. `_AabbBox.empty`
+  // represents a soundly computed but empty subtree (no geometry at
+  // all), which still serializes as a degenerate AABB so we can tell
+  // it apart from "unbounded" at runtime.
   final memo = List<_AabbBox?>.filled(nodes.length, null);
   final computed = List<bool>.filled(nodes.length, false);
 
@@ -91,19 +100,23 @@ void _bakeCombinedAabbs(List<fb.NodeT> nodes, GltfDocument doc) {
     final node = nodes[idx];
     final glNode = doc.nodes[idx];
 
-    // Skinned content makes the static AABB meaningless.
-    if (glNode.skin != null) {
-      memo[idx] = null;
-      return null;
-    }
-
+    final isSkinned = glNode.skin != null;
     final box = _AabbBox.empty();
+    bool subtreeBoundedSoFar = true;
+
     for (final prim in node.meshPrimitives ?? const <fb.MeshPrimitiveT>[]) {
-      final aabb = prim.boundsAabb;
-      if (aabb != null) box.expandToAabb(aabb);
+      final aabb = isSkinned ? prim.skinnedPoseUnionAabb : prim.boundsAabb;
+      if (aabb != null) {
+        box.expandToAabb(aabb);
+      } else if (isSkinned) {
+        // Skinned primitive with no pose-union bound (e.g. animations
+        // were absent or analysis was skipped). The whole subtree
+        // becomes unbounded.
+        subtreeBoundedSoFar = false;
+      }
     }
 
-    bool subtreeBounded = true;
+    bool subtreeBounded = subtreeBoundedSoFar;
     for (final childIdx in node.children ?? const <int>[]) {
       if (childIdx < 0 || childIdx >= nodes.length) continue;
       final childBox = walk(childIdx);
@@ -157,7 +170,7 @@ class _AabbBox {
   double minX, minY, minZ, maxX, maxY, maxZ;
   bool isEmpty;
 
-  void _includePoint(double x, double y, double z) {
+  void includePoint(double x, double y, double z) {
     if (isEmpty) {
       minX = maxX = x;
       minY = maxY = y;
@@ -175,8 +188,48 @@ class _AabbBox {
 
   void expandToAabb(fb.Aabb3T a) {
     final mn = a.min, mx = a.max;
-    _includePoint(mn.x, mn.y, mn.z);
-    _includePoint(mx.x, mx.y, mx.z);
+    includePoint(mn.x, mn.y, mn.z);
+    includePoint(mx.x, mx.y, mx.z);
+  }
+
+  void expandToAabbBox(_AabbBox other) {
+    if (other.isEmpty) return;
+    includePoint(other.minX, other.minY, other.minZ);
+    includePoint(other.maxX, other.maxY, other.maxZ);
+  }
+
+  void copyFrom(_AabbBox other) {
+    minX = other.minX;
+    minY = other.minY;
+    minZ = other.minZ;
+    maxX = other.maxX;
+    maxY = other.maxY;
+    maxZ = other.maxZ;
+    isEmpty = other.isEmpty;
+  }
+
+  /// In-place transform mirroring vector_math's Aabb3.transform: uses
+  /// the Arvo `absoluteRotate` shortcut (centre + abs(M_3x3) *
+  /// half-extents) instead of 8-corner expansion.
+  void transform(Matrix4 m) {
+    if (isEmpty) return;
+    final cx = (minX + maxX) * 0.5;
+    final cy = (minY + maxY) * 0.5;
+    final cz = (minZ + maxZ) * 0.5;
+    final hx = (maxX - minX) * 0.5;
+    final hy = (maxY - minY) * 0.5;
+    final hz = (maxZ - minZ) * 0.5;
+    final newCenter = m.transformed3(Vector3(cx, cy, cz));
+    final s = m.storage;
+    final newHx = (s[0]).abs() * hx + (s[4]).abs() * hy + (s[8]).abs() * hz;
+    final newHy = (s[1]).abs() * hx + (s[5]).abs() * hy + (s[9]).abs() * hz;
+    final newHz = (s[2]).abs() * hx + (s[6]).abs() * hy + (s[10]).abs() * hz;
+    minX = newCenter.x - newHx;
+    minY = newCenter.y - newHy;
+    minZ = newCenter.z - newHz;
+    maxX = newCenter.x + newHx;
+    maxY = newCenter.y + newHy;
+    maxZ = newCenter.z + newHz;
   }
 
   /// Transform every corner of [other] by [transform] and union the
@@ -190,7 +243,7 @@ class _AabbBox {
       final y = (i & 2) == 0 ? other.minY : other.maxY;
       final z = (i & 4) == 0 ? other.minZ : other.maxZ;
       final p = transform.transformed3(Vector3(x, y, z));
-      _includePoint(p.x, p.y, p.z);
+      includePoint(p.x, p.y, p.z);
     }
   }
 }
@@ -553,6 +606,514 @@ List<fb.Vec4T> _vec4List(Float32List values, bool isCubic) {
         w: values[i + off + 3],
       ),
   ].reversed.toList();
+}
+
+// ───── Pose-union AABB bake (skinned primitives) ─────
+
+/// For every node with a skin, walk every animation that drives any
+/// joint of that skin and compute a local-space AABB covering vertex
+/// positions across every animated pose.
+///
+/// Approach: pre-compute per-joint vertex influence AABBs for each
+/// primitive (one O(vertex) pass), then sample animations at every
+/// unique keyframe time, build the joint palette, and union
+/// (palette[j] * influence[j]) into the pose-union AABB. This avoids
+/// re-transforming every vertex for every pose; it produces a slightly
+/// looser bound than a true per-vertex evaluation but is still a sound
+/// upper bound on rendered extents.
+///
+/// `t = 0` is always sampled so the bind pose is included even when no
+/// animation explicitly references it.
+void _bakePoseUnionAabbs(
+  List<fb.NodeT> nodes,
+  GltfDocument doc,
+  Uint8List bufferData,
+) {
+  if (doc.nodes.isEmpty) return;
+
+  // Build a parent-index table once (glTF only stores children).
+  final parentOf = List<int>.filled(doc.nodes.length, -1);
+  for (int p = 0; p < doc.nodes.length; p++) {
+    for (final c in doc.nodes[p].children) {
+      if (c >= 0 && c < parentOf.length) parentOf[c] = p;
+    }
+  }
+
+  for (int nodeIdx = 0; nodeIdx < nodes.length; nodeIdx++) {
+    final glNode = doc.nodes[nodeIdx];
+    if (glNode.skin == null || glNode.mesh == null) continue;
+    final fbNode = nodes[nodeIdx];
+    final fbPrims = fbNode.meshPrimitives;
+    if (fbPrims == null || fbPrims.isEmpty) continue;
+
+    final skin = doc.skins[glNode.skin!];
+    final jointNodeIndices = skin.joints;
+    if (jointNodeIndices.isEmpty) continue;
+
+    final isJointNode = <int, int>{
+      for (int i = 0; i < jointNodeIndices.length; i++) jointNodeIndices[i]: i,
+    };
+
+    // Inverse bind matrices, one per joint. When the glTF asset omits
+    // them, the spec mandates identity — match the runtime behaviour
+    // in Skin.fromFlatbuffer.
+    final ibm = _readInverseBindMatrices(skin, doc, bufferData);
+
+    // Collect every channel that drives any joint in this skin.
+    // Sample times default to {0} (bind pose) plus every keyframe time
+    // from those channels. With the emitter converting CUBICSPLINE to
+    // bare keyframe values (see _vec3List/_vec4List), evaluating at
+    // each keyframe time is exact for our pipeline.
+    final sampleTimes = <double>{0.0};
+    final relevantChannels = <_PoseChannel>[];
+    for (final anim in doc.animations) {
+      for (final ch in anim.channels) {
+        if (ch.targetNode == null) continue;
+        if (!isJointNode.containsKey(ch.targetNode!)) continue;
+        if (ch.sampler < 0 || ch.sampler >= anim.samplers.length) continue;
+        final sampler = anim.samplers[ch.sampler];
+        final inputAcc = doc.accessors[sampler.input];
+        final outputAcc = doc.accessors[sampler.output];
+        final inputView = doc.bufferViews[inputAcc.bufferView!];
+        final outputView = doc.bufferViews[outputAcc.bufferView!];
+        final times = readAccessorAsFloat32(inputAcc, inputView, bufferData);
+        final values = readAccessorAsFloat32(outputAcc, outputView, bufferData);
+        final isCubic = sampler.interpolation == 'CUBICSPLINE';
+        final pc = _PoseChannel(
+          targetNode: ch.targetNode!,
+          targetPath: ch.targetPath,
+          times: times,
+          values: values,
+          isCubic: isCubic,
+        );
+        if (pc.isUsable) {
+          relevantChannels.add(pc);
+          for (final t in times) {
+            sampleTimes.add(t);
+          }
+        }
+      }
+    }
+
+    // Index relevant channels by target node for fast lookup during
+    // pose evaluation.
+    final channelsByNode = <int, List<_PoseChannel>>{};
+    for (final c in relevantChannels) {
+      channelsByNode.putIfAbsent(c.targetNode, () => []).add(c);
+    }
+
+    final sortedTimes = sampleTimes.toList()..sort();
+
+    // Pre-compute the static (un-animated) localTransform components
+    // for each joint and every joint ancestor, so pose evaluation can
+    // fall back to them when a channel doesn't drive a particular
+    // component.
+    final staticTrs = <int, _StaticTrs>{};
+    for (final jIdx in jointNodeIndices) {
+      _collectStaticTrs(jIdx, doc, parentOf, isJointNode, staticTrs);
+    }
+
+    // Iterate primitives. fbPrims is filtered to triangle-mode
+    // (mode == 4) primitives only, in the same order as glTF source.
+    final glPrims = doc.meshes[glNode.mesh!].primitives;
+    int fbPrimIdx = 0;
+    for (final glPrim in glPrims) {
+      if (glPrim.mode != 4) continue;
+      final fbPrim = fbPrims[fbPrimIdx++];
+      if (!glPrim.attributes.containsKey('JOINTS_0') ||
+          !glPrim.attributes.containsKey('WEIGHTS_0')) {
+        continue;
+      }
+
+      final influence = _computeJointInfluenceAabbs(
+        glPrim,
+        doc,
+        bufferData,
+        jointNodeIndices.length,
+      );
+
+      final poseUnion = _AabbBox.empty();
+      // Per-pose scratch storage to avoid re-allocating during the
+      // tight (sample-times × joints) loop.
+      final palette = List<Matrix4>.generate(
+        jointNodeIndices.length,
+        (_) => Matrix4.identity(),
+      );
+      final transformedScratch = _AabbBox.empty();
+
+      for (final t in sortedTimes) {
+        _buildJointPaletteAtTime(
+          jointNodeIndices: jointNodeIndices,
+          parentOf: parentOf,
+          isJointNode: isJointNode,
+          channelsByNode: channelsByNode,
+          staticTrs: staticTrs,
+          ibm: ibm,
+          time: t,
+          out: palette,
+        );
+
+        for (int j = 0; j < jointNodeIndices.length; j++) {
+          final infl = influence[j];
+          if (infl.isEmpty) continue;
+          transformedScratch
+            ..copyFrom(infl)
+            ..transform(palette[j]);
+          poseUnion.expandToAabbBox(transformedScratch);
+        }
+      }
+
+      if (!poseUnion.isEmpty) {
+        fbPrim.skinnedPoseUnionAabb = fb.Aabb3T(
+          min: fb.Vec3T(
+            x: poseUnion.minX,
+            y: poseUnion.minY,
+            z: poseUnion.minZ,
+          ),
+          max: fb.Vec3T(
+            x: poseUnion.maxX,
+            y: poseUnion.maxY,
+            z: poseUnion.maxZ,
+          ),
+        );
+      }
+    }
+  }
+}
+
+class _PoseChannel {
+  _PoseChannel({
+    required this.targetNode,
+    required this.targetPath,
+    required this.times,
+    required this.values,
+    required this.isCubic,
+  });
+  final int targetNode;
+
+  /// One of `'translation'`, `'rotation'`, `'scale'`. (`'weights'`
+  /// drives morph targets, which flutter_scene doesn't currently
+  /// support; those channels are filtered out via [isUsable].)
+  final String targetPath;
+  final Float32List times;
+  final Float32List values;
+
+  /// CUBICSPLINE samplers store [in_tangent, value, out_tangent] per
+  /// keyframe; the value lives at offset 1 with stride 3 within each
+  /// component group. LINEAR/STEP store the value at offset 0 stride 1.
+  final bool isCubic;
+
+  bool get isUsable =>
+      targetPath == 'translation' ||
+      targetPath == 'rotation' ||
+      targetPath == 'scale';
+
+  /// Returns the value at time [t] as a `List<double>` of either 3
+  /// (translation/scale) or 4 (rotation) components, sampled with
+  /// LINEAR / SLERP interpolation between bracketing keyframes. The
+  /// runtime treats CUBICSPLINE samplers as LINEAR over their stripped
+  /// keyframe values, so we mirror that here.
+  List<double> sampleAt(double t) {
+    final componentCount = targetPath == 'rotation' ? 4 : 3;
+    final stride = isCubic ? componentCount * 3 : componentCount;
+    final valueOffsetInGroup = isCubic ? componentCount : 0;
+
+    if (times.isEmpty) {
+      return List<double>.filled(componentCount, 0);
+    }
+    if (t <= times.first) {
+      return _readKeyframe(0, stride, valueOffsetInGroup, componentCount);
+    }
+    if (t >= times.last) {
+      return _readKeyframe(
+        times.length - 1,
+        stride,
+        valueOffsetInGroup,
+        componentCount,
+      );
+    }
+
+    int lo = 0, hi = times.length - 1;
+    while (hi - lo > 1) {
+      final mid = (lo + hi) >> 1;
+      if (times[mid] <= t) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+
+    final t0 = times[lo];
+    final t1 = times[hi];
+    final span = t1 - t0;
+    final f = span == 0 ? 0.0 : (t - t0) / span;
+    final v0 = _readKeyframe(lo, stride, valueOffsetInGroup, componentCount);
+    final v1 = _readKeyframe(hi, stride, valueOffsetInGroup, componentCount);
+
+    if (targetPath == 'rotation') {
+      // SLERP between two unit quaternions.
+      return _slerp(v0, v1, f);
+    }
+    return [
+      for (int i = 0; i < componentCount; i++) v0[i] + (v1[i] - v0[i]) * f,
+    ];
+  }
+
+  List<double> _readKeyframe(
+    int keyframeIndex,
+    int stride,
+    int valueOffsetInGroup,
+    int componentCount,
+  ) {
+    final base = keyframeIndex * stride + valueOffsetInGroup;
+    return [for (int i = 0; i < componentCount; i++) values[base + i]];
+  }
+}
+
+List<double> _slerp(List<double> a, List<double> b, double t) {
+  // Quaternion SLERP. Mirrors vector_math's Quaternion.slerp behaviour.
+  double ax = a[0], ay = a[1], az = a[2], aw = a[3];
+  double bx = b[0], by = b[1], bz = b[2], bw = b[3];
+  double dot = ax * bx + ay * by + az * bz + aw * bw;
+  if (dot < 0) {
+    bx = -bx;
+    by = -by;
+    bz = -bz;
+    bw = -bw;
+    dot = -dot;
+  }
+  if (dot > 0.9995) {
+    // Falls back to lerp + normalize for numerical stability when the
+    // quaternions are nearly identical.
+    final rx = ax + (bx - ax) * t;
+    final ry = ay + (by - ay) * t;
+    final rz = az + (bz - az) * t;
+    final rw = aw + (bw - aw) * t;
+    final inv = 1.0 / sqrt(rx * rx + ry * ry + rz * rz + rw * rw);
+    return [rx * inv, ry * inv, rz * inv, rw * inv];
+  }
+  final theta0 = _safeAcos(dot);
+  final theta = theta0 * t;
+  final sinTheta = sin(theta);
+  final sinTheta0 = sin(theta0);
+  final s0 = cos(theta) - dot * sinTheta / sinTheta0;
+  final s1 = sinTheta / sinTheta0;
+  return [
+    ax * s0 + bx * s1,
+    ay * s0 + by * s1,
+    az * s0 + bz * s1,
+    aw * s0 + bw * s1,
+  ];
+}
+
+double _safeAcos(double v) {
+  if (v <= -1.0) return pi;
+  if (v >= 1.0) return 0.0;
+  return acos(v);
+}
+
+class _StaticTrs {
+  _StaticTrs(this.translation, this.rotation, this.scale, this.matrixOnly);
+  final Vector3 translation;
+  final Quaternion rotation;
+  final Vector3 scale;
+
+  /// When the glTF node uses a `matrix` field instead of TRS
+  /// (animations can't drive these per spec), the translation /
+  /// rotation / scale fields are decomposed copies for use in pose
+  /// evaluation, but [matrixOnly] is set so we know we shouldn't
+  /// re-compose if no channel drives this node.
+  final Matrix4? matrixOnly;
+}
+
+void _collectStaticTrs(
+  int nodeIdx,
+  GltfDocument doc,
+  List<int> parentOf,
+  Map<int, int> isJointNode,
+  Map<int, _StaticTrs> out,
+) {
+  int current = nodeIdx;
+  while (current >= 0 && !out.containsKey(current)) {
+    final n = doc.nodes[current];
+    Vector3 t;
+    Quaternion r;
+    Vector3 s;
+    Matrix4? matrixOnly;
+    if (n.matrix != null) {
+      // Decompose the matrix so animation overrides on individual
+      // components (rare for matrix-mode nodes, but legal in glTF if
+      // the channels were authored for a different version of the
+      // file) can compose with the static remainder. Track that the
+      // static value came from a matrix so we can short-circuit.
+      matrixOnly = n.matrix!.clone();
+      t = Vector3.zero();
+      r = Quaternion.identity();
+      s = Vector3(1, 1, 1);
+      n.matrix!.decompose(t, r, s);
+    } else {
+      t = (n.translation ?? Vector3.zero()).clone();
+      r = (n.rotation ?? Quaternion.identity())..normalize();
+      s = (n.scale ?? Vector3(1.0, 1.0, 1.0)).clone();
+    }
+    out[current] = _StaticTrs(t, r, s, matrixOnly);
+    if (!isJointNode.containsKey(current)) break;
+    current = parentOf[current];
+  }
+}
+
+/// Build the per-joint palette matrix at [time], writing into [out].
+///
+/// `palette[j]` post-multiplied by a vertex in mesh-local space
+/// produces the vertex's contribution from joint `j` after the
+/// animated pose has been applied.
+void _buildJointPaletteAtTime({
+  required List<int> jointNodeIndices,
+  required List<int> parentOf,
+  required Map<int, int> isJointNode,
+  required Map<int, List<_PoseChannel>> channelsByNode,
+  required Map<int, _StaticTrs> staticTrs,
+  required List<Matrix4> ibm,
+  required double time,
+  required List<Matrix4> out,
+}) {
+  // Cache pose-time local transforms for any joint or joint-ancestor
+  // node we touch during this sample. The walk is guaranteed
+  // ancestor-before-descendant only for joints whose chain we visit;
+  // we fall back to recompute if we hit an unevaluated entry.
+  final localCache = <int, Matrix4>{};
+
+  Matrix4 localAt(int n) {
+    final cached = localCache[n];
+    if (cached != null) return cached;
+
+    final st = staticTrs[n];
+    if (st == null) {
+      localCache[n] = Matrix4.identity();
+      return localCache[n]!;
+    }
+    final channels = channelsByNode[n];
+
+    Vector3 t = st.translation;
+    Quaternion r = st.rotation;
+    Vector3 s = st.scale;
+    bool overridden = false;
+    if (channels != null) {
+      for (final c in channels) {
+        final v = c.sampleAt(time);
+        switch (c.targetPath) {
+          case 'translation':
+            t = Vector3(v[0], v[1], v[2]);
+            overridden = true;
+            break;
+          case 'rotation':
+            r = Quaternion(v[0], v[1], v[2], v[3]);
+            overridden = true;
+            break;
+          case 'scale':
+            s = Vector3(v[0], v[1], v[2]);
+            overridden = true;
+            break;
+        }
+      }
+    }
+
+    Matrix4 m;
+    if (!overridden && st.matrixOnly != null) {
+      m = st.matrixOnly!.clone();
+    } else {
+      m = Matrix4.compose(t, r, s);
+    }
+    localCache[n] = m;
+    return m;
+  }
+
+  // Walk each joint's chain up through joint ancestors, mirroring the
+  // runtime in Skin.getJointsTexture.
+  for (int j = 0; j < jointNodeIndices.length; j++) {
+    int current = jointNodeIndices[j];
+    Matrix4 accumulated = Matrix4.identity();
+    while (current >= 0 && isJointNode.containsKey(current)) {
+      final m = localAt(current);
+      accumulated = m * accumulated;
+      current = parentOf[current];
+    }
+    accumulated = accumulated * ibm[j];
+    out[j].setFrom(accumulated);
+  }
+}
+
+List<Matrix4> _readInverseBindMatrices(
+  GltfSkin skin,
+  GltfDocument doc,
+  Uint8List bufferData,
+) {
+  final out = <Matrix4>[];
+  if (skin.inverseBindMatrices == null) {
+    for (int i = 0; i < skin.joints.length; i++) {
+      out.add(Matrix4.identity());
+    }
+    return out;
+  }
+  final accessor = doc.accessors[skin.inverseBindMatrices!];
+  final view = doc.bufferViews[accessor.bufferView!];
+  final floats = readAccessorAsFloat32(accessor, view, bufferData);
+  for (int i = 0; i < skin.joints.length; i++) {
+    final base = i * 16;
+    out.add(
+      Matrix4(
+        floats[base + 0],
+        floats[base + 1],
+        floats[base + 2],
+        floats[base + 3],
+        floats[base + 4],
+        floats[base + 5],
+        floats[base + 6],
+        floats[base + 7],
+        floats[base + 8],
+        floats[base + 9],
+        floats[base + 10],
+        floats[base + 11],
+        floats[base + 12],
+        floats[base + 13],
+        floats[base + 14],
+        floats[base + 15],
+      ),
+    );
+  }
+  return out;
+}
+
+/// Per-joint AABB of vertex positions weighted onto that joint, in
+/// mesh-local space. Vertices with weight 0 on a joint don't
+/// contribute to that joint's influence AABB.
+List<_AabbBox> _computeJointInfluenceAabbs(
+  GltfMeshPrimitive prim,
+  GltfDocument doc,
+  Uint8List bufferData,
+  int jointCount,
+) {
+  final influence = List<_AabbBox>.generate(
+    jointCount,
+    (_) => _AabbBox.empty(),
+  );
+  final positions = _readVec3(prim.attributes['POSITION']!, doc, bufferData);
+  final joints = _readVec4(prim.attributes['JOINTS_0']!, doc, bufferData);
+  final weights = _readVec4(prim.attributes['WEIGHTS_0']!, doc, bufferData);
+  final vertexCount = positions.length ~/ 3;
+  for (int v = 0; v < vertexCount; v++) {
+    final px = positions[v * 3 + 0];
+    final py = positions[v * 3 + 1];
+    final pz = positions[v * 3 + 2];
+    for (int c = 0; c < 4; c++) {
+      final w = weights[v * 4 + c];
+      if (w <= 0) continue;
+      final j = joints[v * 4 + c].toInt();
+      if (j < 0 || j >= jointCount) continue;
+      influence[j].includePoint(px, py, pz);
+    }
+  }
+  return influence;
 }
 
 // ───── Bounds ─────

--- a/packages/flutter_scene_importer/scene.fbs
+++ b/packages/flutter_scene_importer/scene.fbs
@@ -169,6 +169,18 @@ table MeshPrimitive {
   /// still load correctly.
   bounds_aabb: Aabb3;
   bounds_sphere: Sphere;
+
+  /// For skinned primitives only: union of vertex positions across every
+  /// pose the primitive can take under the file's animations, computed
+  /// offline by sampling each animation's keyframes and applying the
+  /// resulting joint palette.
+  ///
+  /// In the same local space as `bounds_aabb` (the mesh's vertex-position
+  /// space). Lets the runtime cull skinned content soundly instead of
+  /// treating it as always-visible. Absent on unskinned primitives, and
+  /// on skinned primitives when offline pose-union analysis isn't
+  /// available (e.g. older importer output).
+  skinned_pose_union_aabb: Aabb3;
 }
 
 //-----------------------------------------------------------------------------

--- a/packages/flutter_scene_importer/test/bounds_bake_test.dart
+++ b/packages/flutter_scene_importer/test/bounds_bake_test.dart
@@ -87,45 +87,103 @@ void main() {
     },
   );
 
-  test('dash.glb: skinned subtree opts out of combined AABB', () {
-    final scene = _emitAndDecode('examples/assets_src/dash.glb');
-    if (scene == null) {
-      print('dash.glb missing — skipping.');
-      return;
-    }
+  test(
+    'dash.glb: skinned primitives get a pose-union AABB and combined AABBs',
+    () {
+      final scene = _emitAndDecode('examples/assets_src/dash.glb');
+      if (scene == null) {
+        print('dash.glb missing — skipping.');
+        return;
+      }
 
-    // Dash has a skin; the importer must omit combined_local_aabb on
-    // every ancestor of any skinned node, all the way to root.
-    bool foundSkinnedNode = false;
-    for (final node in scene.nodes ?? const <fb.Node>[]) {
-      if (node.skin != null) {
+      // Dash has skinned primitives. Each skinned primitive should now
+      // carry a pose-union AABB, AND the static-pose AABB the runtime
+      // would have rendered before any animation.
+      bool foundSkinnedNode = false;
+      int skinnedPrimCount = 0;
+      for (final node in scene.nodes ?? const <fb.Node>[]) {
+        if (node.skin == null) continue;
         foundSkinnedNode = true;
+        for (final p in node.meshPrimitives ?? const <fb.MeshPrimitive>[]) {
+          skinnedPrimCount++;
+          expect(p.boundsAabb, isNotNull);
+          expect(
+            p.skinnedPoseUnionAabb,
+            isNotNull,
+            reason:
+                'skinned primitive on ${node.name} should have a pose-union AABB',
+          );
+          // The pose-union AABB must contain the static-pose AABB,
+          // since t=0 (bind pose) is always one of the sample times.
+          final pose = p.skinnedPoseUnionAabb!;
+          final stat = p.boundsAabb!;
+          expect(pose.min.x, lessThanOrEqualTo(stat.min.x + 1e-3));
+          expect(pose.min.y, lessThanOrEqualTo(stat.min.y + 1e-3));
+          expect(pose.min.z, lessThanOrEqualTo(stat.min.z + 1e-3));
+          expect(pose.max.x, greaterThanOrEqualTo(stat.max.x - 1e-3));
+          expect(pose.max.y, greaterThanOrEqualTo(stat.max.y - 1e-3));
+          expect(pose.max.z, greaterThanOrEqualTo(stat.max.z - 1e-3));
+        }
+        // Skinned subtrees now get a baked combined AABB derived from
+        // their pose-union extents. The previous behaviour (always-null
+        // for skinned subtrees) was a v1 conservative hack.
         expect(
           node.combinedLocalAabb,
-          isNull,
-          reason: 'skinned node ${node.name} should not have a combined AABB',
+          isNotNull,
+          reason: 'skinned node ${node.name} should now have a combined AABB',
         );
       }
-    }
-    expect(
-      foundSkinnedNode,
-      isTrue,
-      reason: 'dash should contain a skinned node',
-    );
+      expect(
+        foundSkinnedNode,
+        isTrue,
+        reason: 'dash should contain a skinned node',
+      );
+      expect(skinnedPrimCount, greaterThan(0));
+    },
+  );
 
-    // Primitive-level bounds are still baked even for skinned vertex
-    // buffers (they describe bind-pose extents, which are useful for
-    // editor/UI work even if not for cull).
-    int primCount = 0;
-    for (final node in scene.nodes ?? const <fb.Node>[]) {
-      for (final p in node.meshPrimitives ?? const <fb.MeshPrimitive>[]) {
-        primCount++;
-        expect(p.boundsAabb, isNotNull);
-        expect(p.boundsSphere, isNotNull);
+  test(
+    'two_triangles.glb: pose-union extends beyond static bind-pose AABB',
+    () {
+      // two_triangles is a tiny skinned animated test asset. Verify the
+      // pose-union AABB is a strict superset of the static AABB on at
+      // least one axis (otherwise the bake would be a no-op).
+      final scene = _emitAndDecode('examples/assets_src/two_triangles.glb');
+      if (scene == null) {
+        print('two_triangles.glb missing — skipping.');
+        return;
       }
-    }
-    expect(primCount, greaterThan(0));
-  });
+      fb.MeshPrimitive? skinnedPrim;
+      for (final node in scene.nodes ?? const <fb.Node>[]) {
+        if (node.skin == null) continue;
+        for (final p in node.meshPrimitives ?? const <fb.MeshPrimitive>[]) {
+          skinnedPrim = p;
+          break;
+        }
+        if (skinnedPrim != null) break;
+      }
+      expect(skinnedPrim, isNotNull);
+      final pose = skinnedPrim!.skinnedPoseUnionAabb;
+      final stat = skinnedPrim.boundsAabb;
+      expect(pose, isNotNull);
+      expect(stat, isNotNull);
+      final poseExtent =
+          (pose!.max.x - pose.min.x) +
+          (pose.max.y - pose.min.y) +
+          (pose.max.z - pose.min.z);
+      final staticExtent =
+          (stat!.max.x - stat.min.x) +
+          (stat.max.y - stat.min.y) +
+          (stat.max.z - stat.min.z);
+      expect(
+        poseExtent,
+        greaterThan(staticExtent),
+        reason:
+            'pose-union AABB should be larger than the static bind-pose AABB '
+            'when the file has animations that drive the skin',
+      );
+    },
+  );
 
   test('AABB matches glTF accessor min/max when present', () {
     // fcar's CarBody primitive has POSITION accessor min/max set in the


### PR DESCRIPTION
## Summary

Phase 3 of the bounds-and-cull initiative (issue #69). Closes the skinned-content gap left by PRs #107 and #108: skinned subtrees no longer fall back to "always visible," they cull against a baked pose-union AABB that contains every pose the file's animations can produce.

### How the bake works

For each node with a skin, the offline emitter:

1. Pre-computes a per-joint **influence AABB** for each primitive in one O(vertices) pass: for every vertex, expand the AABB on each joint it references with non-zero weight. The vertex's possible skinned position lies within the convex hull (and therefore the AABB) of `{J_i × v}` over its referenced joints, so unioning per-joint influence AABBs after transforming each by the joint palette is a sound upper bound on the rendered extent.
2. Collects every unique keyframe time across all channels that drive any joint of the bound skin (plus `t = 0` for bind-pose coverage).
3. At each sample time, evaluates each driven channel (LINEAR / SLERP between bracketing keyframes; CUBICSPLINE samplers' tangents are dropped earlier in the pipeline so keyframe values are exact for the runtime) and walks every joint's parent chain through the joint nodes to build the model-space transform, then multiplies by the inverse-bind matrix to produce the joint palette.
4. Unions `(palette[j] × influence[j])` for every joint into the primitive's `skinned_pose_union_aabb`.

That's `O(joints × unique-keyframe-times)` per primitive instead of `O(vertices × times)`. Dash.glb (40 joints, 9 animations, ~270 unique sample times) bakes in milliseconds.

### Schema (`scene.fbs`)

- `MeshPrimitive.skinned_pose_union_aabb`: optional. Absent on unskinned primitives and on skinned primitives when offline analysis isn't available (older `.model` files load fine).

### Importer

- New `_bakePoseUnionAabbs` post-pass. Runs before `_bakeCombinedAabbs`.
- `_bakeCombinedAabbs` now consumes the pose-union AABB instead of opting skinned subtrees out. Skinned subtrees without a pose-union bound still propagate the unbounded signal up.

### Runtime

- `Geometry.fromFlatbuffer` prefers `skinned_pose_union_aabb` over `bounds_aabb` for skinned primitives, and derives a corresponding bounding sphere from it.
- `Node._computeAndCacheCombinedLocalBounds` drops the unconditional `skin != null → null` short-circuit. A skinned node with `mesh.localBounds != null` is now bounded; only skinned nodes whose mesh has no usable bound fall back to the always-visible path.

## Test plan

- [x] `flutter test packages/flutter_scene/test` (63 tests pass — including the reframed cull/bounds tests for the bounded vs. unbounded skinned paths).
- [x] `flutter test packages/flutter_scene_importer/test` (11 tests pass — including a new assertion that `two_triangles.glb`'s pose-union AABB strictly exceeds the bind-pose AABB, and that `dash.glb`'s skinned primitives carry both).
- [x] Existing `model_emitter_test` byte-parity coverage against the C++ baseline still passes (the new field is additive in the flatbuffer).
- [x] `dart analyze` clean across both packages.
- [x] `dart format --set-exit-if-changed` clean.
- [ ] Manual smoke run of the example app on macOS (no behavior change expected for in-frustum skinned content).