### PR TITLE
Bump flutter_scene and flutter_scene_importer to 0.12.0

### DIFF
--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_scene: ^0.11.0
-  flutter_scene_importer: ^0.11.0
+  flutter_scene: ^0.12.0
+  flutter_scene_importer: ^0.12.0
   hooks: ^1.0.0
   vector_math: ^2.1.4
 

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 0.12.0
+
+* Add bounding-volume and frustum-culling infrastructure. The scene
+  encoder now builds a `Frustum` once per render from the camera's
+  view-projection matrix and skips entire subtrees whose combined
+  local-space AABB lies outside it.
+* Skinned subtrees are culled against an offline-baked pose-union
+  AABB that covers every animated pose. The runtime falls through
+  to the always-visible path for skinned content imported via the
+  runtime GLB importer (`Node.fromGlbBytes` / `Node.fromGlbAsset`)
+  since the pose-union analysis runs only in the offline importer.
+* New public API:
+  - `Geometry.localBounds`, `Geometry.localBoundingSphere`,
+    `Geometry.setLocalBounds(aabb, sphere)`.
+  - `Mesh.localBounds` (cached union of primitive bounds) and
+    `Mesh.markLocalBoundsDirty()`.
+  - `Node.combinedLocalBounds` (cached union including transformed
+    descendants), `Node.frustumCulled` (default `true`),
+    `Node.markBoundsDirty()`, `Node.isVisibleTo(camera, dimensions)`.
+  - `Camera.getFrustum(dimensions)`.
+
 ## 0.0.1-dev.1
 
 * Initial render box.

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_scene
 description: 3D rendering library for Flutter. Currently only supported when Impeller is enabled.
-version: 0.11.1
+version: 0.12.0
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
 platforms:
@@ -23,7 +23,7 @@ dependencies:
   flutter_gpu:
     sdk: flutter
   flutter_gpu_shaders: ^0.4.0
-  flutter_scene_importer: ^0.11.0
+  flutter_scene_importer: ^0.12.0
   hooks: ^1.0.0
   vector_math: ^2.1.4
 

--- a/packages/flutter_scene_importer/CHANGELOG.md
+++ b/packages/flutter_scene_importer/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.12.0
+
+* `.model` flatbuffer now carries `MeshPrimitive.bounds_aabb`,
+  `MeshPrimitive.bounds_sphere`, and `Node.combined_local_aabb` so
+  the runtime can cull subtrees without re-scanning vertex
+  positions on every load. Older `.model` files (without these
+  fields) continue to load.
+* New `MeshPrimitive.skinned_pose_union_aabb` baked offline by
+  sampling every animation that drives any joint of the bound
+  skin, building the joint palette per keyframe, and unioning
+  per-joint vertex influence AABBs transformed by the palette.
+  Lets the runtime cull skinned content soundly instead of
+  treating it as always visible.
+* Read POSITION accessor `min` / `max` from glTF when present so
+  the bake can skip the vertex scan for unskinned primitives.
+
 ## 0.1.0
 
 * Implementation for the offline model importer.

--- a/packages/flutter_scene_importer/pubspec.yaml
+++ b/packages/flutter_scene_importer/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_scene_importer
 description: "An offline 3D model importer for Flutter. Converts glTF files into the Flutter Scene model format."
-version: 0.11.0
+version: 0.12.0
 homepage: https://github.com/bdero/flutter_scene
 platforms:
   linux:


### PR DESCRIPTION
Release for the bounds + cull initiative (PRs #107 #108 #109). CHANGELOGs cover the new public runtime API and the new schema fields. Example app pubspec bumped to keep workspace resolution happy.