### PR TITLE
Add ShaderMaterial for user-authored custom fragment shaders

### DIFF
--- a/MATERIALS.md
+++ b/MATERIALS.md
@@ -1,0 +1,331 @@
+# Custom materials in flutter_scene
+
+This doc walks through writing a custom material for flutter_scene by
+authoring a fragment shader. The 0.12 release ships the foundation
+for this workflow as `ShaderMaterial`; a more ergonomic declarative
+material format is planned and tracked in [issue #22][issue22].
+
+If you've worked with Three.js's `ShaderMaterial`, Bevy's `Material`
+trait, or Filament's `.mat` files, the underlying mental model will
+be familiar. flutter_scene's v1 surface is the most permissive of the
+three: you write a complete GLSL fragment shader, declare the uniform
+blocks and samplers you want, and bind them by name from Dart.
+
+## Authoring workflow at a glance
+
+1. Add `flutter_gpu_shaders` to your app and create a shader bundle
+   manifest plus a `hook/build.dart` that compiles it.
+2. Write a fragment shader. Consume the standard vertex outputs the
+   engine provides; declare your own uniform blocks and textures.
+3. Load the compiled bundle at runtime with
+   `gpu.ShaderLibrary.fromAsset(...)` and pull out your fragment
+   shader entry by name.
+4. Construct a `ShaderMaterial` wrapping the shader; set its uniform
+   blocks and textures by name; attach it to the `MeshPrimitive`s
+   that should use it.
+
+The toon example under `examples/flutter_app/` is a complete worked
+case. Read along with this doc.
+
+## The engine contract
+
+flutter_scene's engine vertex shaders (`UnskinnedVertex` and
+`SkinnedVertex`, both in the bundle exposed as
+`baseShaderLibrary`) emit the same five outputs in both layouts.
+Your fragment shader receives them as `in` declarations:
+
+```glsl
+in vec3 v_position;        // world space
+in vec3 v_normal;          // world space, not necessarily unit length
+in vec3 v_viewvector;      // camera_position - vertex_position
+in vec2 v_texture_coords;
+in vec4 v_color;           // per-vertex color, white when the model has none
+```
+
+You must write to `out vec4 frag_color;` (the location-0 fragment
+output is fixed by the engine). Everything else is up to you.
+
+The engine binds a vertex uniform block named `FrameInfo` containing
+the model, camera, and camera-position matrices. You do not see this
+in your fragment shader directly; the vertex outputs above are
+already in world space.
+
+When you set `ShaderMaterial.useEnvironment = true`, the engine also
+binds the active `Scene`'s IBL textures to these standard sampler
+names if your fragment shader declares them:
+
+```glsl
+uniform sampler2D radiance_texture;
+uniform sampler2D irradiance_texture;
+uniform sampler2D brdf_lut;
+```
+
+Use them if you want image-based lighting from a custom material.
+Leave them undeclared if you don't.
+
+## Writing the fragment shader
+
+Here's the smallest possible useful shader, which renders the
+per-vertex color modulated by a single uniform tint:
+
+```glsl
+// shaders/vertex_color.frag
+uniform FragInfo {
+  vec4 tint;
+}
+frag_info;
+
+in vec2 v_texture_coords;
+in vec4 v_color;
+
+out vec4 frag_color;
+
+void main() {
+  frag_color = v_color * frag_info.tint;
+}
+```
+
+Save the file under your app's shader directory, then add a manifest
+entry alongside the engine's built-in shaders:
+
+```json
+{
+  "VertexColorFragment": {
+    "type": "fragment",
+    "file": "shaders/vertex_color.frag"
+  }
+}
+```
+
+`flutter_gpu_shaders` compiles each entry through `impellerc` into a
+single `.shaderbundle` packaged with your app.
+
+## Building the shader bundle
+
+In your `hook/build.dart`:
+
+```dart
+import 'package:hooks/hooks.dart';
+import 'package:flutter_gpu_shaders/build.dart';
+
+void main(List<String> args) {
+  build(args, (config, output) async {
+    await buildShaderBundleJson(
+      buildInput: config,
+      buildOutput: output,
+      manifestFileName: 'shaders/my_bundle.shaderbundle.json',
+    );
+  });
+}
+```
+
+In your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_gpu:
+    sdk: flutter
+  flutter_gpu_shaders: ^0.4.0
+  flutter_scene: ^0.12.0
+
+flutter:
+  assets:
+    - build/shaderbundles/my_bundle.shaderbundle
+```
+
+The bundle is written to `build/shaderbundles/<name>.shaderbundle`,
+relative to your package root. It's the same workflow flutter_scene
+uses for its own shaders.
+
+## Wiring it up in Dart
+
+```dart
+import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/scene.dart';
+
+// If you also `import 'package:flutter/material.dart'`, hide its
+// `Material` widget to avoid a clash with flutter_scene's:
+//
+//   import 'package:flutter/material.dart' hide Material;
+//
+// (flutter_scene's Material is the rendering material; Flutter
+// Material is the design system widget.)
+
+// 1. Load the bundle and pull out the fragment shader.
+final library = gpu.ShaderLibrary.fromAsset(
+  'build/shaderbundles/my_bundle.shaderbundle',
+)!;
+final fragmentShader = library['VertexColorFragment']!;
+
+// 2. Build a ShaderMaterial.
+final material = ShaderMaterial(fragmentShader: fragmentShader);
+
+// 3. Set parameters by name.
+material.setUniformBlockFromFloats('FragInfo', [
+  1.0, 0.8, 0.4, 1.0, // tint
+]);
+
+// 4. Attach to a mesh primitive.
+node.mesh!.primitives[0].material = material;
+```
+
+The runtime resolves uniform-block and sampler names against the
+shader's reflection metadata. If you misspell a name, Flutter GPU
+throws at draw time with a clear message naming the slot that
+couldn't be found.
+
+## Uniform block packing
+
+This is the largest footgun in v1. Flutter GPU resolves a uniform
+*block* by name and gives you a single byte buffer to fill. The
+contents of that buffer follow the GLSL std140 layout rules, which
+your packing code on the Dart side has to match exactly. The most
+common rules:
+
+| Type            | Size  | Alignment | Notes |
+| --------------- | ----- | --------- | ----- |
+| `bool`, `int`, `float` | 4 | 4 | |
+| `vec2`          | 8     | 8         | |
+| `vec3`          | 12    | **16**    | Pads up to 16 bytes |
+| `vec4`          | 16    | 16        | |
+| `mat3`          | 48    | 16        | Three `vec4` columns, 4 bytes padding each |
+| `mat4`          | 64    | 16        | |
+| Array element   | varies | **16**   | Every array element strides to the next 16-byte boundary |
+| Struct          | varies | 16       | Same alignment as `vec4` |
+
+The two cases that bite most often: declare a `vec3` followed by a
+`float` and the float occupies the 4 bytes of trailing pad on the
+`vec3`, not a fresh 16-byte slot. Declare a `float` followed by a
+`vec3` and the `vec3` jumps to the next 16-byte boundary, leaving 12
+bytes of padding before it. **When in doubt, declare your block with
+`vec4`s and `float`s rounded up to multiples of four, and you'll be
+right.**
+
+A worked example: this GLSL block
+
+```glsl
+uniform ToonInfo {
+  vec4 base_color;
+  vec4 rim_color;
+  vec4 light_direction;
+  float band_count;
+  float rim_strength;
+  float rim_width;
+  float ambient;
+}
+toon;
+```
+
+packs as 16 floats (64 bytes total), one `vec4` per row, with the
+four trailing scalars filling the final row. Construct it in Dart
+as:
+
+```dart
+material.setUniformBlock(
+  'ToonInfo',
+  ByteData.sublistView(
+    Float32List.fromList([
+      // base_color
+      1, 1, 1, 1,
+      // rim_color
+      0.6, 0.8, 1.0, 1.0,
+      // light_direction (vec4 with w=0)
+      0.4, 0.8, -0.5, 0,
+      // band_count, rim_strength, rim_width, ambient
+      3, 1.0, 0.6, 0.3,
+    ]),
+  ),
+);
+```
+
+The v2 preprocessor planned in issue #22 will generate this packing
+code from the `.mat` source so you never write it by hand. Until
+then, follow the std140 rules and document your block layouts in a
+comment near the GLSL declaration.
+
+## Render-state knobs
+
+`ShaderMaterial` exposes a small set of render-state fields you can
+configure in the constructor or mutate later:
+
+- `cullingMode` (default `gpu.CullMode.backFace`): which faces to
+  cull before rasterization.
+- `windingOrder` (default `gpu.WindingOrder.counterClockwise`):
+  triangle winding convention. Match this to your model's
+  authoring; glTF uses counter-clockwise.
+- `isOpaqueOverride` (default `true`): whether the encoder treats
+  this material as opaque (depth-write enabled, drawn in submission
+  order) or translucent (deferred to a back-to-front pass with
+  alpha blending).
+
+Set `cullingMode: gpu.CullMode.none` to render double-sided. Set
+`isOpaqueOverride: false` to render translucent materials with
+alpha blending. There are no other render-state knobs in v1;
+authoring the full PSO is on the v2 roadmap.
+
+## What's not in v1
+
+- **No shader hot reload.** Editing a `.frag` requires a full
+  restart (hot reload doesn't touch the `flutter_gpu_shaders` build
+  hook). This is the single largest authoring-friction gap and is
+  the top item on the v3 roadmap.
+- **No engine PBR helpers exposed to your shaders.** If you want
+  PBR-style shading with image-based lighting, you have to either
+  inline the math in your fragment shader or extend
+  `PhysicallyBasedMaterial`. The internal GLSL chunks
+  (`pbr.glsl`, `normals.glsl`, etc.) are not packaged for external
+  consumption yet; v2 will solve cross-package `#include`
+  distribution.
+- **No declarative material format.** You write GLSL plus a
+  `MaterialT` subclass; v2 will introduce a `.mat`-style format
+  that drives both shader source and Dart bindings from one file.
+- **No inspector / hint annotations.** v2 will parse Godot-style
+  uniform hints (`hint_range`, `source_color`) and surface them
+  for tooling.
+- **No vertex-shader customization.** Use `UnskinnedVertex` or
+  `SkinnedVertex` from `baseShaderLibrary` (or whichever the
+  geometry was built with). Custom vertex shaders are a v2 item.
+
+See issue #22 for the full v2 design discussion.
+
+## Troubleshooting
+
+**"`gpu.ShaderLibrary.fromAsset` returns null."** The bundle wasn't
+built into your app's asset directory. Check that
+`build/shaderbundles/<name>.shaderbundle` is listed under
+`flutter.assets` in your `pubspec.yaml`, and that your `hook/build.dart`
+ran (`flutter run` should rerun the hook on each build; if it doesn't,
+follow CLAUDE.md Trap #3's reset recipe).
+
+**"Failed to find uniform slot X."** Flutter GPU couldn't find a
+uniform block or sampler with the name you passed to `setUniformBlock`
+or `setTexture`. Most common cause: the shader declares it under a
+different name (the variable name, not the type name). For
+`uniform FragInfo { ... } frag_info;` the block is bound by the
+type name `FragInfo`, not the variable name `frag_info`.
+
+**Wrong colors / black geometry.** Almost always a std140 packing
+mismatch. Add a `vec3` test to your block to verify the layout: if
+you read back something other than what you wrote, you have a
+padding bug. The simplest defense is to declare uniform blocks with
+no `vec3` members, just `vec4` and `float`/`vec2`/`vec4` aligned to
+4-float boundaries.
+
+**Black model.** Check `useEnvironment` and your sampler bindings.
+Unbound samplers can read garbage on some backends.
+
+## See also
+
+- [Issue #22][issue22]: the v2 declarative material format and
+  preprocessor design.
+- `examples/flutter_app/lib/example_toon.dart`: the worked toon
+  shader the v1 ships with.
+- `packages/flutter_scene/shaders/flutter_scene_standard.frag`: the
+  engine's PBR fragment shader, useful as a reference for what a
+  full custom material can do.
+- `flutter_gpu_shaders` on pub.dev: the build-hook helper that
+  drives `impellerc`.
+
+[issue22]: https://github.com/bdero/flutter_scene/issues/22

--- a/MATERIALS.md
+++ b/MATERIALS.md
@@ -1,13 +1,13 @@
 # Custom materials in flutter_scene
 
 This doc walks through writing a custom material for flutter_scene by
-authoring a fragment shader. The 0.12 release ships the foundation
-for this workflow as `ShaderMaterial`; a more ergonomic declarative
-material format is planned and tracked in [issue #22][issue22].
+authoring a fragment shader. The current surface is `ShaderMaterial`;
+a more ergonomic declarative material format is planned and tracked
+in [issue #22][issue22].
 
 If you've worked with Three.js's `ShaderMaterial`, Bevy's `Material`
 trait, or Filament's `.mat` files, the underlying mental model will
-be familiar. flutter_scene's v1 surface is the most permissive of the
+be familiar. flutter_scene's surface is the most permissive of the
 three: you write a complete GLSL fragment shader, declare the uniform
 blocks and samplers you want, and bind them by name from Dart.
 
@@ -178,7 +178,7 @@ couldn't be found.
 
 ## Uniform block packing
 
-This is the largest footgun in v1. Flutter GPU resolves a uniform
+This is the largest footgun today. Flutter GPU resolves a uniform
 *block* by name and gives you a single byte buffer to fill. The
 contents of that buffer follow the GLSL std140 layout rules, which
 your packing code on the Dart side has to match exactly. The most
@@ -240,10 +240,10 @@ material.setUniformBlock(
 );
 ```
 
-The v2 preprocessor planned in issue #22 will generate this packing
-code from the `.mat` source so you never write it by hand. Until
-then, follow the std140 rules and document your block layouts in a
-comment near the GLSL declaration.
+TODO ([#22][issue22]): the planned preprocessor will generate this
+packing code from a declarative material source so you never write
+it by hand. Until then, follow the std140 rules and document your
+block layouts in a comment near the GLSL declaration.
 
 ## Render-state knobs
 
@@ -262,33 +262,35 @@ configure in the constructor or mutate later:
 
 Set `cullingMode: gpu.CullMode.none` to render double-sided. Set
 `isOpaqueOverride: false` to render translucent materials with
-alpha blending. There are no other render-state knobs in v1;
-authoring the full PSO is on the v2 roadmap.
+alpha blending. There are no other render-state knobs today.
 
-## What's not in v1
+TODO ([#22][issue22]): expose the full pipeline-state surface
+declaratively (blend modes, depth modes, polygon mode) once the
+preprocessor lands.
+
+## Known limitations
+
+Each of these is tracked in [issue #22][issue22], which has the full
+design discussion for where the custom-materials surface is going.
 
 - **No shader hot reload.** Editing a `.frag` requires a full
-  restart (hot reload doesn't touch the `flutter_gpu_shaders` build
-  hook). This is the single largest authoring-friction gap and is
-  the top item on the v3 roadmap.
+  restart; hot reload doesn't touch the `flutter_gpu_shaders` build
+  hook. This is the single largest authoring-friction gap today.
 - **No engine PBR helpers exposed to your shaders.** If you want
   PBR-style shading with image-based lighting, you have to either
   inline the math in your fragment shader or extend
   `PhysicallyBasedMaterial`. The internal GLSL chunks
   (`pbr.glsl`, `normals.glsl`, etc.) are not packaged for external
-  consumption yet; v2 will solve cross-package `#include`
-  distribution.
-- **No declarative material format.** You write GLSL plus a
-  `MaterialT` subclass; v2 will introduce a `.mat`-style format
-  that drives both shader source and Dart bindings from one file.
-- **No inspector / hint annotations.** v2 will parse Godot-style
-  uniform hints (`hint_range`, `source_color`) and surface them
-  for tooling.
+  `#include` consumption yet.
+- **No declarative material format.** You write GLSL plus call
+  into `ShaderMaterial` from Dart. A planned `.mat`-style format
+  will drive both shader source and Dart bindings from one file.
+- **No inspector / hint annotations.** A planned preprocessor pass
+  will parse Godot-style uniform hints (`hint_range`,
+  `source_color`) and surface them for tooling.
 - **No vertex-shader customization.** Use `UnskinnedVertex` or
   `SkinnedVertex` from `baseShaderLibrary` (or whichever the
-  geometry was built with). Custom vertex shaders are a v2 item.
-
-See issue #22 for the full v2 design discussion.
+  geometry was built with).
 
 ## Troubleshooting
 
@@ -318,10 +320,10 @@ Unbound samplers can read garbage on some backends.
 
 ## See also
 
-- [Issue #22][issue22]: the v2 declarative material format and
-  preprocessor design.
+- [Issue #22][issue22]: the declarative material format and
+  preprocessor design discussion.
 - `examples/flutter_app/lib/example_toon.dart`: the worked toon
-  shader the v1 ships with.
+  shader that ships with the example app.
 - `packages/flutter_scene/shaders/flutter_scene_standard.frag`: the
   engine's PBR fragment shader, useful as a reference for what a
   full custom material can do.

--- a/examples/flutter_app/hook/build.dart
+++ b/examples/flutter_app/hook/build.dart
@@ -1,4 +1,5 @@
 import 'package:hooks/hooks.dart';
+import 'package:flutter_gpu_shaders/build.dart';
 import 'package:flutter_scene_importer/build_hooks.dart';
 
 void main(List<String> args) {
@@ -11,6 +12,11 @@ void main(List<String> args) {
         '../assets_src/dash.glb',
         '../assets_src/fcar.glb',
       ],
+    );
+    await buildShaderBundleJson(
+      buildInput: config,
+      buildOutput: output,
+      manifestFileName: 'shaders/example.shaderbundle.json',
     );
   });
 }

--- a/examples/flutter_app/lib/example_toon.dart
+++ b/examples/flutter_app/lib/example_toon.dart
@@ -1,0 +1,287 @@
+// Toon-shader example: loads a glTF model and renders it through a
+// caller-authored fragment shader bound by name.
+//
+// Demonstrates the v1 ShaderMaterial workflow end-to-end:
+//   1. Author a fragment shader (shaders/example_toon.frag) that
+//      consumes the engine's standard vertex outputs.
+//   2. Compile it offline through `flutter_gpu_shaders` build hook
+//      into `build/shaderbundles/example.shaderbundle`.
+//   3. Load the bundle at runtime and pull out the fragment shader.
+//   4. Construct a ShaderMaterial, set its uniform block + texture by
+//      name, attach it to the model's mesh primitives.
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' hide Material;
+import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+class ExampleToon extends StatefulWidget {
+  const ExampleToon({super.key, this.elapsedSeconds = 0});
+  final double elapsedSeconds;
+
+  @override
+  State<ExampleToon> createState() => _ExampleToonState();
+}
+
+class _ExampleToonState extends State<ExampleToon> {
+  Scene scene = Scene();
+  bool loaded = false;
+
+  // Wrapper around the loaded Dash node. Spinning this instead of the
+  // camera keeps the world-space light direction (which we use for
+  // shading) stable relative to the viewer.
+  final Node _dashGroup = Node();
+
+  // Shader parameters surfaced as UI sliders below. The base color is
+  // a saturated cool blue with a brighter sky-blue rim, so the toon
+  // bands read clearly as a cohesive blue palette.
+  double bandCount = 3;
+  double rimStrength = 0.9;
+  double rimWidth = 0.55;
+  double ambient = 0.25;
+  vm.Vector4 baseColor = vm.Vector4(0.32, 0.55, 0.95, 1.0);
+  vm.Vector4 rimColor = vm.Vector4(0.55, 0.85, 1.0, 1.0);
+
+  ShaderMaterial? _toonMaterial;
+
+  @override
+  void initState() {
+    // Load the toon shader bundle the example app's build hook
+    // produces.
+    final shaderLibrary = gpu.ShaderLibrary.fromAsset(
+      'build/shaderbundles/example.shaderbundle',
+    );
+    final toonShader = shaderLibrary?['ToonFragment'];
+    if (toonShader == null) {
+      throw StateError(
+        'Toon shader missing from example.shaderbundle. The build hook '
+        'should have produced it; rerun `flutter run` with a clean build.',
+      );
+    }
+
+    Node.fromAsset('build/models/dash.model').then((dash) {
+      dash.name = 'Dash';
+
+      // Build one ShaderMaterial; every skinned primitive on the model
+      // shares it so parameter tweaks are reflected everywhere.
+      final material = ShaderMaterial(fragmentShader: toonShader);
+      _refreshUniforms(material);
+      // Default white placeholder so the texture sampler is bound even
+      // when the model itself doesn't carry a base color texture.
+      material.setTexture(
+        'base_color_texture',
+        Material.getWhitePlaceholderTexture(),
+      );
+      _toonMaterial = material;
+
+      _applyMaterialToAllPrimitives(dash, material);
+
+      // Start the Walk animation looping. Dash walks in place, so the
+      // root transform doesn't drift; we drive the visible rotation
+      // via `_dashGroup.localTransform` in build() instead.
+      dash
+          .createAnimationClip(dash.findAnimationByName('Walk')!)
+        ..loop = true
+        ..play();
+
+      _dashGroup.add(dash);
+      scene.add(_dashGroup);
+      scene.environment.exposure = 1.5;
+      setState(() {
+        loaded = true;
+      });
+    });
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    scene.removeAll();
+    super.dispose();
+  }
+
+  void _applyMaterialToAllPrimitives(Node node, Material material) {
+    final mesh = node.mesh;
+    if (mesh != null) {
+      for (final p in mesh.primitives) {
+        p.material = material;
+      }
+    }
+    for (final child in node.children) {
+      _applyMaterialToAllPrimitives(child, material);
+    }
+  }
+
+  void _refreshUniforms(ShaderMaterial material) {
+    // Layout must match the `ToonInfo` uniform block in
+    // example_toon.frag, packed std140:
+    //   vec4 base_color           (offset 0,  16 bytes)
+    //   vec4 rim_color            (offset 16, 16 bytes)
+    //   vec4 light_direction      (offset 32, 16 bytes; w padded)
+    //   float band_count          (offset 48, 4 bytes)
+    //   float rim_strength        (offset 52, 4 bytes)
+    //   float rim_width           (offset 56, 4 bytes)
+    //   float ambient             (offset 60, 4 bytes)
+    final light = vm.Vector3(0.4, 0.8, -0.5).normalized();
+    material.setUniformBlock(
+      'ToonInfo',
+      ByteData.sublistView(
+        Float32List.fromList([
+          // base_color
+          baseColor.r, baseColor.g, baseColor.b, baseColor.a,
+          // rim_color
+          rimColor.r, rimColor.g, rimColor.b, rimColor.a,
+          // light_direction (vec4 with w=0)
+          light.x, light.y, light.z, 0,
+          // band_count, rim_strength, rim_width, ambient
+          bandCount, rimStrength, rimWidth, ambient,
+        ]),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!loaded) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    // Rotate Dash in place. Keeping the camera fixed and the world-
+    // space light direction constant means the toon bands stay
+    // anchored to the viewer's perspective: the bright side of Dash
+    // sweeps around her body as she turns, the way a real character
+    // under a stable spotlight would look.
+    _dashGroup.localTransform = vm.Matrix4.rotationY(
+      widget.elapsedSeconds * 0.6,
+    );
+    _dashGroup.markBoundsDirty();
+
+    return Stack(
+      children: [
+        SizedBox.expand(
+          child: CustomPaint(
+            painter: _ScenePainter(scene, widget.elapsedSeconds),
+          ),
+        ),
+        Positioned(
+          left: 16,
+          right: 16,
+          bottom: 16,
+          child: Card(
+            color: Colors.black54,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _SliderRow(
+                    label: 'Band count',
+                    value: bandCount,
+                    min: 1,
+                    max: 8,
+                    onChanged:
+                        (v) => setState(() {
+                          bandCount = v.roundToDouble();
+                          _refreshUniforms(_toonMaterial!);
+                        }),
+                  ),
+                  _SliderRow(
+                    label: 'Rim strength',
+                    value: rimStrength,
+                    min: 0,
+                    max: 2,
+                    onChanged:
+                        (v) => setState(() {
+                          rimStrength = v;
+                          _refreshUniforms(_toonMaterial!);
+                        }),
+                  ),
+                  _SliderRow(
+                    label: 'Rim width',
+                    value: rimWidth,
+                    min: 0,
+                    max: 1,
+                    onChanged:
+                        (v) => setState(() {
+                          rimWidth = v;
+                          _refreshUniforms(_toonMaterial!);
+                        }),
+                  ),
+                  _SliderRow(
+                    label: 'Ambient',
+                    value: ambient,
+                    min: 0,
+                    max: 1,
+                    onChanged:
+                        (v) => setState(() {
+                          ambient = v;
+                          _refreshUniforms(_toonMaterial!);
+                        }),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SliderRow extends StatelessWidget {
+  const _SliderRow({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 110,
+          child: Text(
+            '$label: ${value.toStringAsFixed(2)}',
+            style: const TextStyle(color: Colors.white),
+          ),
+        ),
+        Expanded(
+          child: Slider(value: value, min: min, max: max, onChanged: onChanged),
+        ),
+      ],
+    );
+  }
+}
+
+class _ScenePainter extends CustomPainter {
+  _ScenePainter(this.scene, this.elapsedTime);
+  Scene scene;
+  double elapsedTime;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Camera is fixed so the toon shader's world-space light stays
+    // stable from the viewer's perspective. Dash spins in place
+    // instead (see `_ExampleToonState.build`). Distance matches the
+    // animation example.
+    final camera = PerspectiveCamera(
+      position: vm.Vector3(0, 2, -6),
+      target: vm.Vector3(0, 1.5, 0),
+    );
+    scene.render(camera, canvas, viewport: Offset.zero & size);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}

--- a/examples/flutter_app/lib/example_toon.dart
+++ b/examples/flutter_app/lib/example_toon.dart
@@ -1,7 +1,7 @@
 // Toon-shader example: loads a glTF model and renders it through a
 // caller-authored fragment shader bound by name.
 //
-// Demonstrates the v1 ShaderMaterial workflow end-to-end:
+// Demonstrates the ShaderMaterial workflow end-to-end:
 //   1. Author a fragment shader (shaders/example_toon.frag) that
 //      consumes the engine's standard vertex outputs.
 //   2. Compile it offline through `flutter_gpu_shaders` build hook
@@ -81,8 +81,7 @@ class _ExampleToonState extends State<ExampleToon> {
       // Start the Walk animation looping. Dash walks in place, so the
       // root transform doesn't drift; we drive the visible rotation
       // via `_dashGroup.localTransform` in build() instead.
-      dash
-          .createAnimationClip(dash.findAnimationByName('Walk')!)
+      dash.createAnimationClip(dash.findAnimationByName('Walk')!)
         ..loop = true
         ..play();
 

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:example_app/example_animation.dart';
 
 import 'example_cuboid.dart';
 import 'example_logo.dart';
+import 'example_toon.dart';
 
 void main() {
   runApp(const MyApp());
@@ -39,6 +40,7 @@ class _MyAppState extends State<MyApp> {
       'Imported Model':
           (context) => ExampleLogo(elapsedSeconds: elapsedSeconds),
       'Cuboid': (context) => ExampleCuboid(elapsedSeconds: elapsedSeconds),
+      'Toon': (context) => ExampleToon(elapsedSeconds: elapsedSeconds),
     };
     selectedExample = examples.keys.first;
 

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -12,6 +12,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_gpu:
+    sdk: flutter
+  flutter_gpu_shaders: ^0.4.0
   flutter_scene: ^0.12.0
   flutter_scene_importer: ^0.12.0
   hooks: ^1.0.0
@@ -30,3 +33,5 @@ flutter:
     - build/models/
     # Source .glb files for the runtime importer demo.
     - assets_src/
+    # Custom shader bundle for the toon example.
+    - build/shaderbundles/example.shaderbundle

--- a/examples/flutter_app/shaders/example.shaderbundle.json
+++ b/examples/flutter_app/shaders/example.shaderbundle.json
@@ -1,0 +1,6 @@
+{
+    "ToonFragment": {
+        "type": "fragment",
+        "file": "shaders/example_toon.frag"
+    }
+}

--- a/examples/flutter_app/shaders/example_toon.frag
+++ b/examples/flutter_app/shaders/example_toon.frag
@@ -1,0 +1,59 @@
+// Toon fragment shader for the flutter_scene example app.
+//
+// Consumes the engine's standard vertex outputs (see MATERIALS.md)
+// and produces banded N.L diffuse plus a Fresnel-style rim term.
+// Drives every parameter from a single uniform block bound by name
+// from the Dart side as `ToonInfo`.
+
+uniform ToonInfo {
+  // Tint multiplied with the texture sample. Alpha drives output alpha.
+  vec4 base_color;
+  // Color of the rim term. Alpha unused but kept for std140 alignment.
+  vec4 rim_color;
+  // World-space light direction (xyz). w is unused padding.
+  vec4 light_direction;
+  // Number of bands in the N.L term (1 = unlit, higher = more steps).
+  float band_count;
+  // Strength of the rim term.
+  float rim_strength;
+  // Rim falloff: smaller = thinner rim.
+  float rim_width;
+  // Ambient lighting contribution.
+  float ambient;
+}
+toon;
+
+uniform sampler2D base_color_texture;
+
+in vec3 v_position;
+in vec3 v_normal;
+in vec3 v_viewvector;
+in vec2 v_texture_coords;
+in vec4 v_color;
+
+out vec4 frag_color;
+
+void main() {
+  vec3 normal = normalize(v_normal);
+  vec3 light_dir = normalize(toon.light_direction.xyz);
+  vec3 view_dir = normalize(v_viewvector);
+
+  // Banded N dot L. floor() quantizes the diffuse term into bands.
+  float n_dot_l = max(dot(normal, light_dir), 0.0);
+  float bands = max(toon.band_count, 1.0);
+  float banded = floor(n_dot_l * bands + 0.001) / bands;
+
+  // Rim term: bright when the surface is grazing.
+  float n_dot_v = max(dot(normal, view_dir), 0.0);
+  float rim = 1.0 - n_dot_v;
+  rim = smoothstep(1.0 - toon.rim_width, 1.0, rim) * toon.rim_strength;
+
+  vec4 albedo_sample = texture(base_color_texture, v_texture_coords);
+  vec3 albedo = toon.base_color.rgb * albedo_sample.rgb * v_color.rgb;
+
+  vec3 lit = albedo * (toon.ambient + banded * (1.0 - toon.ambient));
+  vec3 final_color = lit + toon.rim_color.rgb * rim;
+
+  float alpha = toon.base_color.a * albedo_sample.a * v_color.a;
+  frag_color = vec4(final_color, 1.0) * alpha;
+}

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -27,6 +27,7 @@ export 'src/geometry/geometry.dart';
 export 'src/material/environment.dart';
 export 'src/material/material.dart';
 export 'src/material/physically_based_material.dart';
+export 'src/material/shader_material.dart';
 export 'src/material/unlit_material.dart';
 
 export 'src/asset_helpers.dart';

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -1,0 +1,226 @@
+import 'dart:typed_data';
+
+import 'package:flutter_gpu/gpu.dart' as gpu;
+
+import 'package:flutter_scene/src/material/environment.dart';
+import 'package:flutter_scene/src/material/material.dart';
+
+/// A [Material] backed by a caller-supplied fragment shader.
+///
+/// `ShaderMaterial` is the foundation for writing custom materials in
+/// flutter_scene. Use it when [UnlitMaterial] and
+/// [PhysicallyBasedMaterial] don't cover what you need: stylized
+/// shading, custom alpha modes, screen-space effects, vertex-painted
+/// looks, and so on.
+///
+/// ## Authoring a custom material
+///
+/// 1. Write a fragment shader. It should consume the engine's
+///    standard vertex outputs and declare its own uniform blocks /
+///    samplers for any parameters. See `MATERIALS.md` for the full
+///    contract.
+/// 2. Compile the shader through the `flutter_gpu_shaders` build
+///    hook into a `.shaderbundle` packaged with your app.
+/// 3. Load the bundle at runtime with
+///    `gpu.ShaderLibrary.fromAsset('path/to/your.shaderbundle')` and
+///    pull out the fragment shader entry.
+/// 4. Construct a `ShaderMaterial` pointing at the shader, populate
+///    its uniform blocks and textures by name, and attach it to a
+///    [MeshPrimitive].
+///
+/// ## Engine-bound resources available to your fragment shader
+///
+/// These vertex outputs are written by the engine's standard vertex
+/// shader and are always available as `in` declarations in your
+/// fragment shader (the names are part of the engine contract):
+///
+/// ```glsl
+/// in vec3 v_position;        // world space
+/// in vec3 v_normal;          // world space (not necessarily unit)
+/// in vec3 v_viewvector;      // camera_position - vertex_position, world space
+/// in vec2 v_texture_coords;
+/// in vec4 v_color;           // per-vertex color, white when absent
+/// ```
+///
+/// Setting [useEnvironment] to `true` makes the engine bind the
+/// active [Environment]'s IBL textures by their standard names when
+/// your fragment shader declares them: `radiance_texture`,
+/// `irradiance_texture`, and `brdf_lut` (all as `sampler2D`). Useful
+/// when your custom shader still wants the engine's image-based
+/// lighting.
+///
+/// ## Uniform block packing
+///
+/// Flutter GPU resolves uniform blocks by name (via
+/// [gpu.Shader.getUniformSlot]) but the block's contents are a flat
+/// byte buffer that your code packs and the GPU interprets according
+/// to the shader's std140 layout. flutter_scene v0.12 leaves this
+/// packing to you. Common rules:
+///
+/// * `float`, `int`, `bool` occupy 4 bytes.
+/// * `vec2` occupies 8 bytes aligned to 8.
+/// * `vec3`, `vec4` occupy 16 bytes aligned to 16.
+/// * `mat4` occupies 64 bytes; `mat3` occupies 48 bytes laid out as
+///   three `vec4` columns (12 bytes of padding).
+/// * Array elements stride to the next 16 bytes.
+///
+/// Put a `Float32List` together that matches the block's declared
+/// member order (including padding) and pass it via
+/// [setUniformBlock]. The v2 preprocessor described in issue #22 will
+/// generate this packing code at build time.
+class ShaderMaterial extends Material {
+  /// Creates a [ShaderMaterial] wrapping [fragmentShader].
+  ///
+  /// The shader is typically loaded from a `.shaderbundle` produced
+  /// by `flutter_gpu_shaders`. May be omitted at construction and
+  /// assigned later via [setFragmentShader]; rendering throws until a
+  /// shader is set. Set [useEnvironment] to `true` to have the engine
+  /// bind the scene environment's IBL textures by their standard
+  /// names.
+  ShaderMaterial({
+    gpu.Shader? fragmentShader,
+    this.useEnvironment = false,
+    this.cullingMode = gpu.CullMode.backFace,
+    this.windingOrder = gpu.WindingOrder.counterClockwise,
+    this.isOpaqueOverride = true,
+  }) {
+    if (fragmentShader != null) {
+      setFragmentShader(fragmentShader);
+    }
+  }
+
+  /// Whether the engine should bind the active [Environment]'s IBL
+  /// textures (`radiance_texture`, `irradiance_texture`, `brdf_lut`)
+  /// when the fragment shader declares them. Defaults to `false`.
+  bool useEnvironment;
+
+  /// Backface culling mode applied before drawing. Defaults to
+  /// [gpu.CullMode.backFace] to match the standard materials.
+  gpu.CullMode cullingMode;
+
+  /// Triangle winding order. Defaults to
+  /// [gpu.WindingOrder.counterClockwise] to match the glTF
+  /// convention and the standard materials.
+  gpu.WindingOrder windingOrder;
+
+  /// Whether this material participates in the opaque pass.
+  ///
+  /// Returned from [isOpaque]. Set to `false` for translucent
+  /// materials, which the encoder defers to the back-to-front
+  /// translucent pass with alpha blending.
+  bool isOpaqueOverride;
+
+  final Map<String, ByteData> _uniformBlocks = {};
+  final Map<String, _BoundTexture> _textures = {};
+
+  /// Assign the byte contents of a uniform block by name.
+  ///
+  /// [bytes] must already match the block's std140 layout. Replacing
+  /// an existing assignment overrides the previous value. Pass `null`
+  /// to clear the binding.
+  void setUniformBlock(String name, ByteData? bytes) {
+    if (bytes == null) {
+      _uniformBlocks.remove(name);
+    } else {
+      _uniformBlocks[name] = bytes;
+    }
+  }
+
+  /// Convenience wrapper around [setUniformBlock] that packs a list
+  /// of float values. The caller is still responsible for std140
+  /// padding; see the class doc.
+  void setUniformBlockFromFloats(String name, List<double> floats) {
+    setUniformBlock(name, ByteData.sublistView(Float32List.fromList(floats)));
+  }
+
+  /// Read back a previously-set uniform block, or `null` when none
+  /// has been set.
+  ByteData? getUniformBlock(String name) => _uniformBlocks[name];
+
+  /// All currently-bound uniform block names. Order is insertion order.
+  Iterable<String> get uniformBlockNames => _uniformBlocks.keys;
+
+  /// Assign a texture to a sampler uniform by name.
+  ///
+  /// Pass `null` for [texture] to clear the binding.
+  void setTexture(
+    String name,
+    gpu.Texture? texture, {
+    gpu.SamplerOptions? sampler,
+  }) {
+    if (texture == null) {
+      _textures.remove(name);
+    } else {
+      _textures[name] = _BoundTexture(texture, sampler);
+    }
+  }
+
+  /// Read back a previously-set texture binding, or `null` when none
+  /// has been set.
+  gpu.Texture? getTexture(String name) => _textures[name]?.texture;
+
+  /// All currently-bound sampler names. Order is insertion order.
+  Iterable<String> get textureNames => _textures.keys;
+
+  @override
+  bool isOpaque() => isOpaqueOverride;
+
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Environment environment,
+  ) {
+    pass.setCullMode(cullingMode);
+    pass.setWindingOrder(windingOrder);
+
+    for (final entry in _uniformBlocks.entries) {
+      pass.bindUniform(
+        fragmentShader.getUniformSlot(entry.key),
+        transientsBuffer.emplace(entry.value),
+      );
+    }
+
+    for (final entry in _textures.entries) {
+      pass.bindTexture(
+        fragmentShader.getUniformSlot(entry.key),
+        entry.value.texture,
+        sampler: entry.value.sampler ?? gpu.SamplerOptions(),
+      );
+    }
+
+    if (useEnvironment) {
+      _bindEnvironmentTextures(pass, environment);
+    }
+  }
+
+  void _bindEnvironmentTextures(gpu.RenderPass pass, Environment environment) {
+    final samplerOptions = gpu.SamplerOptions(
+      minFilter: gpu.MinMagFilter.linear,
+      magFilter: gpu.MinMagFilter.linear,
+      widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+      heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+    );
+    pass.bindTexture(
+      fragmentShader.getUniformSlot('radiance_texture'),
+      environment.environmentMap.radianceTexture,
+      sampler: samplerOptions,
+    );
+    pass.bindTexture(
+      fragmentShader.getUniformSlot('irradiance_texture'),
+      environment.environmentMap.irradianceTexture,
+      sampler: samplerOptions,
+    );
+    pass.bindTexture(
+      fragmentShader.getUniformSlot('brdf_lut'),
+      Material.getBrdfLutTexture(),
+      sampler: samplerOptions,
+    );
+  }
+}
+
+class _BoundTexture {
+  _BoundTexture(this.texture, this.sampler);
+  final gpu.Texture texture;
+  final gpu.SamplerOptions? sampler;
+}

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -54,8 +54,7 @@ import 'package:flutter_scene/src/material/material.dart';
 /// Flutter GPU resolves uniform blocks by name (via
 /// [gpu.Shader.getUniformSlot]) but the block's contents are a flat
 /// byte buffer that your code packs and the GPU interprets according
-/// to the shader's std140 layout. flutter_scene v0.12 leaves this
-/// packing to you. Common rules:
+/// to the shader's std140 layout. Common rules:
 ///
 /// * `float`, `int`, `bool` occupy 4 bytes.
 /// * `vec2` occupies 8 bytes aligned to 8.
@@ -66,8 +65,11 @@ import 'package:flutter_scene/src/material/material.dart';
 ///
 /// Put a `Float32List` together that matches the block's declared
 /// member order (including padding) and pass it via
-/// [setUniformBlock]. The v2 preprocessor described in issue #22 will
-/// generate this packing code at build time.
+/// [setUniformBlock].
+///
+/// TODO(https://github.com/bdero/flutter_scene/issues/22): generate
+/// this packing code at build time from a declarative material
+/// source so callers don't write it by hand.
 class ShaderMaterial extends Material {
   /// Creates a [ShaderMaterial] wrapping [fragmentShader].
   ///

--- a/packages/flutter_scene/test/shader_material_test.dart
+++ b/packages/flutter_scene/test/shader_material_test.dart
@@ -1,0 +1,71 @@
+// ShaderMaterial accessor and storage tests. The actual GPU bind
+// path (RenderPass binding via getUniformSlot) requires a real
+// Flutter GPU context and is exercised by the example app smoke test,
+// not by unit tests.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ShaderMaterial uniform block storage', () {
+    test('setUniformBlock round-trips ByteData', () {
+      final material = ShaderMaterial();
+      final bytes = ByteData.sublistView(Float32List.fromList([1, 2, 3]));
+      material.setUniformBlock('FragInfo', bytes);
+      expect(material.getUniformBlock('FragInfo'), same(bytes));
+      expect(material.uniformBlockNames, contains('FragInfo'));
+    });
+
+    test('setUniformBlock(null) clears the binding', () {
+      final material = ShaderMaterial();
+      material.setUniformBlock(
+        'FragInfo',
+        ByteData.sublistView(Float32List.fromList([1])),
+      );
+      material.setUniformBlock('FragInfo', null);
+      expect(material.getUniformBlock('FragInfo'), isNull);
+      expect(material.uniformBlockNames, isNot(contains('FragInfo')));
+    });
+
+    test('setUniformBlockFromFloats packs as Float32List', () {
+      final material = ShaderMaterial();
+      material.setUniformBlockFromFloats('FragInfo', [0.5, 1.0, 1.5, 2.0]);
+      final bytes = material.getUniformBlock('FragInfo');
+      expect(bytes, isNotNull);
+      expect(bytes!.lengthInBytes, 16);
+      expect(bytes.getFloat32(0, Endian.host), 0.5);
+      expect(bytes.getFloat32(4, Endian.host), 1.0);
+      expect(bytes.getFloat32(8, Endian.host), 1.5);
+      expect(bytes.getFloat32(12, Endian.host), 2.0);
+    });
+
+    test('multiple uniform blocks remain independently addressable', () {
+      final material = ShaderMaterial();
+      material.setUniformBlockFromFloats('FragInfo', [1]);
+      material.setUniformBlockFromFloats('ExtraInfo', [9, 9]);
+      expect(
+        material.uniformBlockNames,
+        containsAll(['FragInfo', 'ExtraInfo']),
+      );
+      expect(material.getUniformBlock('FragInfo')!.lengthInBytes, 4);
+      expect(material.getUniformBlock('ExtraInfo')!.lengthInBytes, 8);
+    });
+  });
+
+  // Texture storage uses the same Map-backed pattern as uniform blocks
+  // and shares an implementation path. Constructing a real
+  // `gpu.Texture` requires a Flutter GPU context, so binding behavior
+  // for textures is covered by the integration smoke test (the toon
+  // example) rather than unit tests.
+
+  group('ShaderMaterial render-state flags', () {
+    test('isOpaque mirrors isOpaqueOverride', () {
+      final opaque = ShaderMaterial();
+      expect(opaque.isOpaque(), isTrue);
+      opaque.isOpaqueOverride = false;
+      expect(opaque.isOpaque(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
First step of the v1 plan posted on issue #22. Lets users supply their own fragment shader (compiled offline via `flutter_gpu_shaders` / `impellerc`) and bind uniform blocks plus textures by name through a new public `ShaderMaterial` class.

```dart
ShaderMaterial(fragmentShader: shader)
  ..setUniformBlockFromFloats('FragInfo', [...])
  ..setTexture('base_color_texture', texture);
node.mesh!.primitives[0].material = material;
```

Bindings are entirely name-based, leveraging Flutter GPU's existing `getUniformSlot` reflection (no slot bookkeeping required). The opt-in `useEnvironment` flag auto-binds the scene's IBL textures (`radiance_texture`, `irradiance_texture`, `brdf_lut`) when the user's shader declares them, so custom materials can still participate in the engine's image-based lighting.

This is intentionally the smallest useful surface area, not the final design. The declarative `.fs_mat` format with a Dart-side preprocessor (v2) and shader hot-reload (v3) are described in detail in the design comment on issue #22 and will follow as separate PRs.

## What's included

* `ShaderMaterial` in `packages/flutter_scene/lib/src/material/shader_material.dart`, exported from `scene.dart`.
* Unit tests covering uniform-block storage, the `setUniformBlock(null)` clear path, `setUniformBlockFromFloats` packing, multiple independently-addressable blocks, and the `isOpaqueOverride` flag.
* `MATERIALS.md` at the repo root: end-to-end authoring walkthrough covering the engine uniform / varying contract, std140 packing rules and footguns, build-hook setup, name-based binding, and an honest list of what's not yet supported in v1.
* Worked toon-shader example in `examples/flutter_app/lib/example_toon.dart`: a custom fragment shader with banded N.L diffuse and a Fresnel rim term, driven by a uniform block exposed as live sliders. Dash plays her `Walk` animation and spins in place under a fixed camera, so the world-space light direction stays anchored to the viewer's perspective regardless of her orientation.
* Build-hook integration: extended `examples/flutter_app/hook/build.dart` to compile a shader bundle alongside the model imports; updated `pubspec.yaml` to depend on `flutter_gpu_shaders` and ship the resulting `example.shaderbundle` as a Flutter asset.

## Test plan

- [x] `flutter test packages/flutter_scene/test` passes (78 tests including 5 new `shader_material_test.dart` cases).
- [x] `flutter test packages/flutter_scene_importer/test` passes (8 tests).
- [x] `dart analyze packages/flutter_scene packages/flutter_scene_importer examples/flutter_app` clean (one pre-existing warning on `test/widget_test.dart` unrelated to this PR).
- [x] `dart format --set-exit-if-changed` clean.
- [x] End-to-end smoke test on macOS: the toon shader compiles via `impellerc`, the bundle ships into the app, `gpu.ShaderLibrary.fromAsset` loads it, `ShaderMaterial` binds the uniform block and sampler by name, and Dash renders with the toon shader through the engine's frustum cull pipeline. Sliders update the uniform block live; the rim and band parameters respond correctly.

## What's not in v1

These limitations are called out explicitly in `MATERIALS.md` and tracked under issue #22:

* No declarative material file format (the v2 preprocessor will solve this).
* No cross-package distribution of the engine's shader chunks (`pbr.glsl`, etc.). Users who want PBR math in custom shaders inline it for now.
* No vertex-shader customization. `UnskinnedVertex` / `SkinnedVertex` from `baseShaderLibrary` are the only options.
* No shader hot reload. Editing a `.frag` requires a full restart. This is the v3 top priority.
* No Godot-style uniform hint annotations (the v2 preprocessor will surface these).