### PR TITLE
Point README media at the flutter_scene_media GitHub Pages site

### DIFF
--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/bdero/flutter_scene">
-    <img alt="Flutter Scene" width="200px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/086f1b421981733da1182656668b940080c54456/DashColorTransparent.svg">
+    <img alt="Flutter Scene" width="200px" src="https://bdero.me/flutter_scene_media/DashColorTransparent.svg">
   </a>
 </p>
 
@@ -24,23 +24,23 @@ The primary goal of this project is to make performant cross platform 3D easy in
 ---
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/ff137e3fdd0b1bb8808d5ff08f5c1c94e8a30665/dashgameported2.gif">
+  <img alt="Flutter Scene" width="600px" src="https://bdero.me/flutter_scene_media/dashgameported2.gif">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/8156b23a0fb446865554d4fda029f28bc659ef07/hexagons3.gif">
+  <img alt="Flutter Scene" width="600px" src="https://bdero.me/flutter_scene_media/hexagons3.gif">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/ff137e3fdd0b1bb8808d5ff08f5c1c94e8a30665/DamagedHelmet.gif">
+  <img alt="Flutter Scene" width="600px" src="https://bdero.me/flutter_scene_media/DamagedHelmet.gif">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/8156b23a0fb446865554d4fda029f28bc659ef07/car_example.gif">
+  <img alt="Flutter Scene" width="600px" src="https://bdero.me/flutter_scene_media/car_example.gif">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/ff137e3fdd0b1bb8808d5ff08f5c1c94e8a30665/cloning.gif">
+  <img alt="Flutter Scene" width="600px" src="https://bdero.me/flutter_scene_media/cloning.gif">
 </p>
 
 ## Early preview! ⚠️


### PR DESCRIPTION
## Summary

The README's logo and demo animations don't render on [pub.dev](https://pub.dev/packages/flutter_scene) or the [dartdoc documentation site](https://pub.dev/documentation/flutter_scene/latest/). Both surfaces rewrite every `<img src>` through pub.dev's image proxy at `external-images.pub.dev`, and all of those proxy URLs return 404.

Root cause: the images were hotlinked from a GitHub gist (`raw.githubusercontent.com/gist/bdero/<gist_id>/raw/<commit>/<file>`). GitHub serves gist raw content with `Content-Type: application/octet-stream` regardless of file extension, and pub.dev's proxy rejects any upstream that isn't an image MIME type. github.com's own markdown renderer doesn't use that proxy and is lenient about content types, which is why the images render there but nowhere else.

`raw.githubusercontent.com` also isn't a viable rehost target for the animations: it serves files above a few MB as `application/octet-stream` too (verified: a 43-byte test GIF gets `image/gif`, but every one of the 15-45 MB demo GIFs gets `application/octet-stream`).

## Fix

The assets now live in a dedicated repo, [`bdero/flutter_scene_media`](https://github.com/bdero/flutter_scene_media), published via GitHub Pages at `https://bdero.me/flutter_scene_media/`. Pages serves the files with their correct content types (`image/gif`, `image/svg+xml`), which pub.dev's proxy accepts. Verified:

```
$ curl -sIL https://bdero.me/flutter_scene_media/dashgameported2.gif | grep -i content-type
content-type: image/gif
$ curl -sIL https://bdero.me/flutter_scene_media/DashColorTransparent.svg | grep -i content-type
content-type: image/svg+xml
```

The original GIFs are kept as-is (no re-encoding, no quality loss), and none of those bytes land in this repo's git history. This PR is README-only: it just rewrites the six image URLs to point at the Pages site.

## Notes

- The repo-root `README.md` is a symlink to `packages/flutter_scene/README.md`, so this is one file edit.
- pub.dev re-renders the package README on each version publish, and the dartdoc site regenerates per version. The currently published `flutter_scene` still references the gist URLs, so the fix becomes visible on pub.dev after the next release. The GitHub README updates immediately on merge.

## Test plan

- [x] Confirmed gist proxy URLs 404 and large repo-hosted files serve `application/octet-stream` from `raw.githubusercontent.com`.
- [x] Confirmed GitHub Pages serves all six assets with the correct image content types over HTTPS.
- [ ] After merge + next publish, verify the images render on https://pub.dev/packages/flutter_scene and https://pub.dev/documentation/flutter_scene/latest/.