### PR TITLE
Reference README media via raw.githubusercontent.com

### DIFF
--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/bdero/flutter_scene">
-    <img alt="Flutter Scene" width="200px" src="https://bdero.me/flutter_scene_media/DashColorTransparent.svg">
+    <img alt="Flutter Scene" width="200px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/DashColorTransparent.svg">
   </a>
 </p>
 
@@ -24,23 +24,23 @@ The primary goal of this project is to make performant cross platform 3D easy in
 ---
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://bdero.me/flutter_scene_media/dashgameported2.gif">
+  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/dashgameported2.gif">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://bdero.me/flutter_scene_media/hexagons3.gif">
+  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/hexagons3.gif">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://bdero.me/flutter_scene_media/DamagedHelmet.gif">
+  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/DamagedHelmet.gif">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://bdero.me/flutter_scene_media/car_example.gif">
+  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/car_example.gif">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://bdero.me/flutter_scene_media/cloning.gif">
+  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/cloning.gif">
 </p>
 
 ## Early preview! ⚠️


### PR DESCRIPTION
## Summary

#113 pointed the README images at the `flutter_scene_media` GitHub Pages site (`bdero.me/flutter_scene_media/`), which broke the GIFs on the GitHub README. GitHub proxies images served from non-`githubusercontent.com` domains through Camo (`camo.githubusercontent.com`), and Camo refuses to proxy images above ~5 MB. The five demo GIFs are 15-45 MB each, so Camo returned errors and the GIFs didn't render. The SVG logo (9 KB) was unaffected, which matches the reported symptom.

This switches the six image URLs to `https://raw.githubusercontent.com/bdero/flutter_scene_media/main/<file>`. `raw.githubusercontent.com` is not Camo-proxied, so the GitHub README serves these directly and the browser content-sniffs the GIFs (GitHub serves large files with `Content-Type: application/octet-stream`, which browsers render fine via sniffing — this is exactly how the original gist URLs worked). The assets still live in the dedicated [`bdero/flutter_scene_media`](https://github.com/bdero/flutter_scene_media) repo, so nothing is added to this repo's history.

## Known limitation

pub.dev's image proxy (`external-images.pub.dev`) validates `Content-Type` and rejects `application/octet-stream`, so the GIFs still won't render on the pub.dev package page or the dartdoc site. There is no hosting configuration where 15-45 MB GIFs render on both surfaces:

- GitHub README needs `*.githubusercontent.com` URLs (avoids Camo's size limit), but `raw.githubusercontent.com` serves large files as `application/octet-stream`.
- pub.dev needs an image `Content-Type`, which a generic static host (e.g. GitHub Pages) provides — but then GitHub Camo-proxies it and rejects it for size.

Rendering the animations on pub.dev would require shrinking the assets (animated WebP downscaled to ~1080px at ~20 fps brings the set from ~155 MB to ~15-25 MB and serves with `image/webp` everywhere). The `flutter_scene_media` README notes this as a future option; for now the GitHub README is restored and pub.dev shows the SVG logo (which it already did).

## Test plan

- [x] `curl -sI https://raw.githubusercontent.com/bdero/flutter_scene_media/main/dashgameported2.gif` returns 200 (`application/octet-stream`, which browsers sniff and render).
- [x] SVG URL serves `image/svg+xml`.
- [ ] After merge, confirm all five GIFs and the logo render on https://github.com/bdero/flutter_scene.