### PR TITLE
Point README media at flutter_scene_media WebP assets

### DIFF
--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/bdero/flutter_scene">
-    <img alt="Flutter Scene" width="200px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/086f1b421981733da1182656668b940080c54456/DashColorTransparent.svg">
+    <img alt="Flutter Scene" width="200px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/DashColorTransparent.svg">
   </a>
 </p>
 
@@ -24,23 +24,23 @@ The primary goal of this project is to make performant cross platform 3D easy in
 ---
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/ff137e3fdd0b1bb8808d5ff08f5c1c94e8a30665/dashgameported2.gif">
+  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/dashgameported2.webp">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/8156b23a0fb446865554d4fda029f28bc659ef07/hexagons3.gif">
+  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/hexagons3.webp">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/ff137e3fdd0b1bb8808d5ff08f5c1c94e8a30665/DamagedHelmet.gif">
+  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/DamagedHelmet.webp">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/8156b23a0fb446865554d4fda029f28bc659ef07/car_example.gif">
+  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/car_example.webp">
 </p>
 
 <p align="center">
-  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/gist/bdero/4f34a4dfe78a4a83d54788bc4f5bcf07/raw/ff137e3fdd0b1bb8808d5ff08f5c1c94e8a30665/cloning.gif">
+  <img alt="Flutter Scene" width="600px" src="https://raw.githubusercontent.com/bdero/flutter_scene_media/main/cloning.webp">
 </p>
 
 ## Early preview! ⚠️


### PR DESCRIPTION
## Summary

Restores the README's logo and demo animations on pub.dev (and fixes them on the GitHub README too), by hosting them as animated WebP in the dedicated [`bdero/flutter_scene_media`](https://github.com/bdero/flutter_scene_media) repo.

### The problem

The images were hotlinked from a GitHub gist (`raw.githubusercontent.com/gist/bdero/<gist_id>/raw/<commit>/<file>`). GitHub serves gist raw content — and any multi-megabyte raw file — with `Content-Type: application/octet-stream` and `X-Content-Type-Options: nosniff`. So:

- pub.dev's image proxy (`external-images.pub.dev`) validates the upstream content type and 404s anything that isn't `image/*` → the GIFs never rendered on the pub.dev package page or the dartdoc site.
- Browsers can't MIME-sniff a `nosniff` response, so they also won't render an `octet-stream` `<img>` as a GIF → the GIFs weren't reliably rendering on the GitHub README either.

(Previous attempts: GitHub Pages URLs render with the right content type for pub.dev's proxy, but GitHub Camo-proxies non-`githubusercontent.com` images and rejects anything over ~5 MB, so the 15-45 MB GIFs broke the GitHub README. `raw.githubusercontent.com/<repo>/<file>.gif` URLs hit the same `octet-stream`/`nosniff` issue. No hosting config works for 15-45 MB GIFs on both surfaces.)

### The fix

The five demo GIFs are converted to animated WebP (`gif2webp`, lossy q64-75, downscaled to 720px wide — slightly above the README's 600px display size — with the **original frame rate preserved**, since for these 3D-rendered animations frame rate matters far more than resolution). The result is 2.6-6.7 MB per file. The original full-resolution GIFs are kept in `flutter_scene_media` as archival sources.

The README now points at `https://raw.githubusercontent.com/bdero/flutter_scene_media/main/<file>.webp`. WebP files serve with an `image/webp` content type (verified: `curl -sI` returns `content-type: image/webp` for all five, even the 6.7 MB one), which browsers render directly and pub.dev's proxy accepts. `raw.githubusercontent.com` is not Camo-proxied (confirmed: the gist URLs in the README HTML stay un-proxied while `img.shields.io` gets a `camo.githubusercontent.com` rewrite), so there's no size cap on the GitHub-README side. Nothing is added to this repo's git history — the assets live entirely in `flutter_scene_media`.

## Notes

- The repo-root `README.md` is a symlink to `packages/flutter_scene/README.md`, so this is one file edit.
- pub.dev re-renders the package README on each version publish; the currently published `flutter_scene` still references the old gist URLs, so pub.dev picks up the fix after the next release. The GitHub README updates immediately on merge.

## Test plan

- [x] All five `.webp` files validate via `webpinfo` (correct ANMF frame counts matching the source GIFs: 142 / 102 / 122 / 278 / 77 — original frame rate intact).
- [x] `curl -sI https://raw.githubusercontent.com/bdero/flutter_scene_media/main/<file>.webp` returns `content-type: image/webp` for all five.
- [x] Confirmed `raw.githubusercontent.com` README image URLs are not Camo-proxied (so no size limit on GitHub).
- [ ] After merge, confirm the logo and all five animations render on https://github.com/bdero/flutter_scene.
- [ ] After the next `flutter_scene` publish, confirm they render on https://pub.dev/packages/flutter_scene and https://pub.dev/documentation/flutter_scene/latest/.