### PR TITLE
Bump flutter_scene to 0.13.0

### DIFF
--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter_gpu:
     sdk: flutter
   flutter_gpu_shaders: ^0.4.0
-  flutter_scene: ^0.12.0
+  flutter_scene: ^0.13.0
   flutter_scene_importer: ^0.12.0
   hooks: ^1.0.0
   vector_math: ^2.1.4

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.13.0
+
+* Add `ShaderMaterial`, the foundation for custom materials. Supply
+  a fragment shader (compiled offline through `flutter_gpu_shaders` /
+  `impellerc` into a `.shaderbundle`), then bind uniform blocks and
+  textures by name with `setUniformBlock` / `setUniformBlockFromFloats`
+  / `setTexture`. Render-state knobs (`cullingMode`, `windingOrder`,
+  `isOpaqueOverride`) are exposed on the material. The opt-in
+  `useEnvironment` flag binds the scene's IBL textures
+  (`radiance_texture`, `irradiance_texture`, `brdf_lut`) when the
+  fragment shader declares them.
+* Add `MATERIALS.md`: an end-to-end guide to the engine uniform /
+  varying contract for custom fragment shaders, std140 uniform-block
+  packing, the `flutter_gpu_shaders` build-hook setup, and the
+  limitations of the current surface (see issue #22 for the planned
+  declarative material format).
+* The example app gains a worked toon-shader demo
+  (`examples/flutter_app/lib/example_toon.dart`).
+
 ## 0.12.0
 
 * Add bounding-volume and frustum-culling infrastructure. The scene

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_scene
 description: 3D rendering library for Flutter. Currently only supported when Impeller is enabled.
-version: 0.12.0
+version: 0.13.0
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
 platforms:


### PR DESCRIPTION
Publishes the ShaderMaterial custom-materials foundation, MATERIALS.md, and the toon-shader example added since 0.12.0, plus the WebP-hosted README media. flutter_scene_importer is unchanged at 0.12.0. Example app pubspec bumped to keep workspace resolution happy.