### PR TITLE
Work around Impeller GLES UBO-instance-name bug in the Toon example shader

### DIFF
--- a/examples/flutter_app/shaders/example_toon.frag
+++ b/examples/flutter_app/shaders/example_toon.frag
@@ -21,7 +21,10 @@ uniform ToonInfo {
   // Ambient lighting contribution.
   float ambient;
 }
-toon;
+// NOTE: the instance name has to fold (case- and underscore-insensitive)
+// to the block name `ToonInfo` so Impeller's GLES backend can resolve
+// the decomposed struct members. See flutter/flutter#186394.
+toon_info;
 
 uniform sampler2D base_color_texture;
 
@@ -35,25 +38,25 @@ out vec4 frag_color;
 
 void main() {
   vec3 normal = normalize(v_normal);
-  vec3 light_dir = normalize(toon.light_direction.xyz);
+  vec3 light_dir = normalize(toon_info.light_direction.xyz);
   vec3 view_dir = normalize(v_viewvector);
 
   // Banded N dot L. floor() quantizes the diffuse term into bands.
   float n_dot_l = max(dot(normal, light_dir), 0.0);
-  float bands = max(toon.band_count, 1.0);
+  float bands = max(toon_info.band_count, 1.0);
   float banded = floor(n_dot_l * bands + 0.001) / bands;
 
   // Rim term: bright when the surface is grazing.
   float n_dot_v = max(dot(normal, view_dir), 0.0);
   float rim = 1.0 - n_dot_v;
-  rim = smoothstep(1.0 - toon.rim_width, 1.0, rim) * toon.rim_strength;
+  rim = smoothstep(1.0 - toon_info.rim_width, 1.0, rim) * toon_info.rim_strength;
 
   vec4 albedo_sample = texture(base_color_texture, v_texture_coords);
-  vec3 albedo = toon.base_color.rgb * albedo_sample.rgb * v_color.rgb;
+  vec3 albedo = toon_info.base_color.rgb * albedo_sample.rgb * v_color.rgb;
 
-  vec3 lit = albedo * (toon.ambient + banded * (1.0 - toon.ambient));
-  vec3 final_color = lit + toon.rim_color.rgb * rim;
+  vec3 lit = albedo * (toon_info.ambient + banded * (1.0 - toon_info.ambient));
+  vec3 final_color = lit + toon_info.rim_color.rgb * rim;
 
-  float alpha = toon.base_color.a * albedo_sample.a * v_color.a;
+  float alpha = toon_info.base_color.a * albedo_sample.a * v_color.a;
   frag_color = vec4(final_color, 1.0) * alpha;
 }


### PR DESCRIPTION
The Toon example renders correctly on Metal and Vulkan but is invisible on Impeller's GLES backend. Bisected on a Pixel 10 Pro by hardcoding the fragment output to each input in turn — textures, varyings, and `v_color` all bind correctly; only the user-supplied `ToonInfo` uniform block silently reads back as zero, which collapses the toon math (`alpha = base_color.a * tex.a * v_color.a` = `0 * 1 * 1` = 0 → premultiplied alpha-0 → invisible).

Root cause is upstream: [flutter/flutter#186394](https://github.com/flutter/flutter/pull/186394). On pre-\`#version 140\` GL targets SPIRV-Cross lowers \`uniform Block { ... } instance;\` to \`struct Block { ... }; uniform Block instance;\`, and Impeller's \`BufferBindingsGLES\` resolves members by the **block** name under a case- and underscore-insensitive fold. \`toon\` folds to \`toon\`, not \`tooninfo\`, so every member of \`ToonInfo\` binds to GL location \`-1\` and reads as 0. The standard \`PhysicallyBasedMaterial\` shader is unaffected because its instance names follow the conforming \`frag_info\` / \`frame_info\` convention.

Until #186394 lands this PR renames the instance to \`toon_info\`, which folds to \`tooninfo\` and matches the block name \`ToonInfo\` after the same fold. The Dart side binds the block by **block** name (\`ShaderMaterial.setUniformBlock('ToonInfo', ...)\`), so this is a one-shader change with no Dart or API surface impact.

## Test plan

- [ ] Run \`examples/flutter_app\` on a Pixel-class device with the Impeller GLES backend (\`ImpellerBackend=opengles\` in \`AndroidManifest.xml\`), navigate to **Toon**, confirm Dash renders with the toon shading rather than as an invisible silhouette.
- [ ] Sanity-check that **Toon** still renders correctly on Impeller Metal (macOS / iOS) and Vulkan (default Android).