### PR TITLE
Fix animation channel binding and skinned-mesh orientation for glTF imports

### DIFF
--- a/examples/flutter_app/lib/example_stress_tests.dart
+++ b/examples/flutter_app/lib/example_stress_tests.dart
@@ -338,11 +338,14 @@ class _StressSceneState extends State<_StressScene> {
       // ~2.4× the bounding radius fills a 60-deg FOV without clipping.
       final double distance = max(radius * 2.4, 0.5);
       final double height = lookAt.y + radius * 0.4;
-      // Initial camera: behind the +Z side of the model, looking back at
-      // it. Yaw=0 / pitch tilted down so the model is centered.
-      _camPos = vm.Vector3(lookAt.x, height, lookAt.z + distance);
+      // Initial camera: on the -Z side looking toward +Z. After the
+      // importer's scene-root Z-flip, glTF models face -Z, so this puts
+      // the camera in front of the model rather than behind it. Yaw=pi
+      // turns the camera around to look back at the model; pitch tilts
+      // down so it stays centered.
+      _camPos = vm.Vector3(lookAt.x, height, lookAt.z - distance);
       final dir = (lookAt - _camPos)..normalize();
-      _yaw = 0;
+      _yaw = pi;
       _pitch = asin(dir.y).clamp(-_pitchLimit, _pitchLimit);
       _moveSpeed = max(radius * 0.5, 0.5);
 

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -38,8 +38,7 @@ class _MyAppState extends State<MyApp> {
       'Car': (context) => ExampleCar(elapsedSeconds: elapsedSeconds),
       'Animation':
           (context) => ExampleAnimation(elapsedSeconds: elapsedSeconds),
-      'Imported Model':
-          (context) => ExampleLogo(elapsedSeconds: elapsedSeconds),
+      'Flutter Logo': (context) => ExampleLogo(elapsedSeconds: elapsedSeconds),
       'Cuboid': (context) => ExampleCuboid(elapsedSeconds: elapsedSeconds),
       'Toon': (context) => ExampleToon(elapsedSeconds: elapsedSeconds),
       'Stress Tests':

--- a/packages/flutter_scene/lib/src/animation/animation_clip.dart
+++ b/packages/flutter_scene/lib/src/animation/animation_clip.dart
@@ -142,19 +142,14 @@ class AnimationClip {
   }
 
   void _bindToTarget(Node target) {
-    final channels = _animation.channels;
     _bindings.clear();
-    for (var channel in channels) {
-      Node channelTarget;
-      if (channel.bindTarget.nodeName == target.name) {
-        channelTarget = target;
-      }
-      Node? result = target.getChildByName(channel.bindTarget.nodeName);
-      if (result != null) {
-        channelTarget = result;
-      } else {
-        continue;
-      }
+    for (final channel in _animation.channels) {
+      final nodeName = channel.bindTarget.nodeName;
+      // A channel may target the bind root itself or one of its
+      // descendants. Resolving descendants first would miss the root.
+      final channelTarget =
+          nodeName == target.name ? target : target.getChildByName(nodeName);
+      if (channelTarget == null) continue;
       _bindings.add(_ChannelBinding(channel, channelTarget));
     }
   }

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -469,25 +469,32 @@ class SkinnedGeometry extends Geometry {
       pass.bindIndexBuffer(_indices!, _indexType, _indexCount);
     }
 
-    // Skinned vertex UBO.
+    // Skinned vertex UBO. The model transform is identity on purpose:
+    // the joint matrices from Skin.getJointsTexture are already full
+    // global transforms (including the scene-root flip), so the shader
+    // applies them directly. Passing the mesh node's own transform here
+    // would double-apply it (and glTF requires a skinned mesh node's
+    // transform to be ignored). `modelTransform` is unused for skinned
+    // geometry as a result.
+    final identityTransform = vm.Matrix4.identity();
     final frameInfoSlot = vertexShader.getUniformSlot('FrameInfo');
     final frameInfoFloats = Float32List.fromList([
-      modelTransform.storage[0],
-      modelTransform.storage[1],
-      modelTransform.storage[2],
-      modelTransform.storage[3],
-      modelTransform.storage[4],
-      modelTransform.storage[5],
-      modelTransform.storage[6],
-      modelTransform.storage[7],
-      modelTransform.storage[8],
-      modelTransform.storage[9],
-      modelTransform.storage[10],
-      modelTransform.storage[11],
-      modelTransform.storage[12],
-      modelTransform.storage[13],
-      modelTransform.storage[14],
-      modelTransform.storage[15],
+      identityTransform.storage[0],
+      identityTransform.storage[1],
+      identityTransform.storage[2],
+      identityTransform.storage[3],
+      identityTransform.storage[4],
+      identityTransform.storage[5],
+      identityTransform.storage[6],
+      identityTransform.storage[7],
+      identityTransform.storage[8],
+      identityTransform.storage[9],
+      identityTransform.storage[10],
+      identityTransform.storage[11],
+      identityTransform.storage[12],
+      identityTransform.storage[13],
+      identityTransform.storage[14],
+      identityTransform.storage[15],
       cameraTransform.storage[0],
       cameraTransform.storage[1],
       cameraTransform.storage[2],

--- a/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
@@ -34,6 +34,7 @@ Future<Node> importGlb(Uint8List bytes) async {
 
   for (int i = 0; i < doc.nodes.length; i++) {
     _populateNode(
+      index: i,
       engineNode: engineNodes[i],
       gltfNode: doc.nodes[i],
       doc: doc,
@@ -106,6 +107,7 @@ Future<Node> importGlb(Uint8List bytes) async {
 }
 
 void _populateNode({
+  required int index,
   required Node engineNode,
   required GltfNode gltfNode,
   required GltfDocument doc,
@@ -113,7 +115,7 @@ void _populateNode({
   required List<Node> engineNodes,
   required List<gpu.Texture> textures,
 }) {
-  engineNode.name = gltfNode.name ?? '';
+  engineNode.name = resolveGltfNodeName(gltfNode.name, index);
   engineNode.localTransform = _localTransformFor(gltfNode);
 
   if (gltfNode.mesh != null) {

--- a/packages/flutter_scene/lib/src/skin.dart
+++ b/packages/flutter_scene/lib/src/skin.dart
@@ -119,40 +119,26 @@ base class Skin {
     }
 
     for (int jointIndex = 0; jointIndex < joints.length; jointIndex++) {
-      Node? joint = joints[jointIndex];
+      final Node? joint = joints[jointIndex];
+      // A null joint (Node.clone couldn't relocate it) keeps the
+      // pre-initialized identity slot.
+      if (joint == null) continue;
 
-      // Compute a model space matrix for the joint by walking up the bones to the
-      // skeleton root.
-      final floatOffset = jointIndex * 16;
-      while (joint != null && joint.isJoint) {
-        final Matrix4 matrix =
-            joint.localTransform *
-            Matrix4.fromFloat32List(
-              jointMatrixFloats.sublist(floatOffset, floatOffset + 16),
-            );
-
-        jointMatrixFloats.setRange(
-          floatOffset,
-          floatOffset + 16,
-          matrix.storage,
-        );
-
-        joint = joint.parent;
-      }
-
-      // Get the joint transform relative to the default pose of the bone by
-      // incorporating the joint's inverse bind matrix. The inverse bind matrix
-      // transforms from model space to the default pose space of the joint. The
-      // result is a model space matrix that only captures the difference between
-      // the joint's default pose and the joint's current pose in the scene. This
-      // is necessary because the skinned model's vertex positions (which _define_
-      // the default pose) are all in model space.
+      // glTF skinning: the joint matrix is the joint's full global
+      // transform times its inverse bind matrix. globalTransform walks
+      // every ancestor, so transforms on non-joint nodes between the
+      // joints and the scene root (e.g. a skeleton root carrying the
+      // model's Z-up-to-Y-up correction) are included, as is the
+      // scene-root flip. The inverse bind matrix takes a vertex from
+      // model space into the joint's rest-pose space; the global
+      // transform then places it by the joint's current pose.
+      //
+      // The shader applies this matrix directly, so the mesh node's own
+      // transform must not be applied again -- SkinnedGeometry.bind
+      // passes an identity model transform.
       final Matrix4 matrix =
-          Matrix4.fromFloat32List(
-            jointMatrixFloats.sublist(floatOffset, floatOffset + 16),
-          ) *
-          inverseBindMatrices[jointIndex];
-
+          joint.globalTransform * inverseBindMatrices[jointIndex];
+      final floatOffset = jointIndex * 16;
       jointMatrixFloats.setRange(floatOffset, floatOffset + 16, matrix.storage);
     }
 

--- a/packages/flutter_scene_importer/lib/src/fb_emitter/model_emitter.dart
+++ b/packages/flutter_scene_importer/lib/src/fb_emitter/model_emitter.dart
@@ -53,7 +53,7 @@ fb.SceneT _buildScene(GltfDocument doc, Uint8List bufferData) {
   // Nodes (flat list).
   scene.nodes = [
     for (int i = 0; i < doc.nodes.length; i++)
-      _buildNode(doc.nodes[i], doc, bufferData),
+      _buildNode(doc.nodes[i], i, doc, bufferData),
   ];
 
   // Post-pass: bake skinned primitives' pose-union AABBs by sampling
@@ -250,9 +250,14 @@ class _AabbBox {
 
 // ───── Nodes ─────
 
-fb.NodeT _buildNode(GltfNode n, GltfDocument doc, Uint8List bufferData) {
+fb.NodeT _buildNode(
+  GltfNode n,
+  int index,
+  GltfDocument doc,
+  Uint8List bufferData,
+) {
   final out = fb.NodeT();
-  out.name = n.name ?? '';
+  out.name = resolveGltfNodeName(n.name, index);
   out.children = n.children.toList();
   out.transform = _matrixT(_localTransformFor(n));
 

--- a/packages/flutter_scene_importer/lib/src/gltf/types.dart
+++ b/packages/flutter_scene_importer/lib/src/gltf/types.dart
@@ -66,6 +66,24 @@ class GltfNode {
   final Vector3? scale;
 }
 
+/// The engine-side name for the glTF node at [index].
+///
+/// glTF lets nodes omit their name, and many real exports leave most
+/// nodes unnamed. Animation channels resolve their target nodes by
+/// name, so every unnamed node sharing the empty string would make all
+/// channels collide on the same node. Synthesizing a unique,
+/// index-derived name keeps channel binding correct. Both the offline
+/// `.model` emitter and the runtime GLB importer must call this so a
+/// model animates identically whichever path imported it.
+///
+/// Named nodes are returned unchanged. The synthetic `node_<index>`
+/// form could in theory collide with an authored name; resolving that
+/// fully would mean index- or path-based channel binding.
+String resolveGltfNodeName(String? gltfName, int index) {
+  if (gltfName != null && gltfName.isNotEmpty) return gltfName;
+  return 'node_$index';
+}
+
 class GltfMesh {
   GltfMesh({this.name, this.primitives = const []});
   final String? name;

--- a/packages/flutter_scene_importer/test/node_naming_test.dart
+++ b/packages/flutter_scene_importer/test/node_naming_test.dart
@@ -1,0 +1,36 @@
+/// Covers [resolveGltfNodeName], the shared rule both the offline
+/// `.model` emitter and the runtime GLB importer use to name nodes.
+/// Animation channels resolve their targets by node name, so unnamed
+/// glTF nodes must get unique synthetic names or every channel collides
+/// on one node.
+library;
+
+import 'package:flutter_scene_importer/gltf.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('keeps an authored name unchanged', () {
+    expect(resolveGltfNodeName('Armature', 0), 'Armature');
+    expect(resolveGltfNodeName('b_Root_00', 12), 'b_Root_00');
+  });
+
+  test('synthesizes a name for a null name', () {
+    expect(resolveGltfNodeName(null, 7), 'node_7');
+  });
+
+  test('synthesizes a name for an empty name', () {
+    expect(resolveGltfNodeName('', 3), 'node_3');
+  });
+
+  test('synthetic names are unique across distinct indices', () {
+    final names = {for (var i = 0; i < 100; i++) resolveGltfNodeName(null, i)};
+    expect(names.length, 100);
+  });
+
+  test('an authored name that looks synthetic is still passed through', () {
+    // The author owns the name even when it collides with the synthetic
+    // form; resolving that fully would need index- or path-based
+    // channel binding.
+    expect(resolveGltfNodeName('node_2', 9), 'node_2');
+  });
+}


### PR DESCRIPTION
Fixes two import bugs that broke skinned/animated glTF models, plus a small camera tweak. Both issues were found while testing the Khronos sample assets in the Stress Tests example.

## Animation channels collided on unnamed nodes (#122)

An `AnimationChannel` resolves its target node by name (`getChildByName`). glTF lets nodes omit their name, and many real exports leave most nodes unnamed. Both importers wrote `name ?? ''`, so every unnamed node shared the empty string and `getChildByName('')` returned the same first node for every channel. The whole animation collapsed onto one node and skinned models with unnamed joints did not visibly animate.

Both importers now route node names through a shared `resolveGltfNodeName` helper: authored names pass through, unnamed nodes get a unique `node_<index>` name. The offline `.model` emitter and the runtime GLB importer use the same helper, so a model animates identically whichever path imported it. Also cleans up a latent `_bindToTarget` bug where a channel targeting the bind root itself was dropped.

## Skinned meshes rendered rotated

`Skin.getJointsTexture` built each joint matrix by walking ancestors only while `isJoint` was true, dropping any transform on a non-joint node between the joints and the scene root. glTF models commonly put the Z-up-to-Y-up correction on the skin's skeleton root, which is not itself a joint (the Khronos BrainStem sample does exactly this), so those models rendered rotated 90 degrees.

Joint matrices now use each joint's full global transform times its inverse bind matrix, the glTF-specified formula. Because the joint matrices are now full global transforms, `SkinnedGeometry.bind` passes an identity model transform so the mesh node's own transform is not applied twice (glTF requires a skinned mesh node's transform to be ignored anyway).

## Stress Tests camera

The stress-test camera opened on the +Z side, which after the scene-root Z-flip is behind the model. It now opens on the -Z side facing the model's front.

## Known limitation

A model that authors a literal `node_<index>` name could still collide with a synthesized name. Fully resolving that needs index- or path-based channel binding, left as a follow-up.

## Test plan

- [x] New `resolveGltfNodeName` unit tests; existing flutter_scene (70) and flutter_scene_importer suites pass.
- [x] macOS Impeller: BrainStem animates and is upright; Dash (offline `.model`) unchanged; stress-test scenes open facing front.
- [ ] Verify on Pixel 10 Vulkan + Impeller GLES.
- [ ] Verify on iOS Metal.