### PR TITLE
Generate normals for glTF primitives that omit them, and share one primitive packer

### DIFF
--- a/packages/flutter_scene/lib/src/runtime_importer/geometry_builder.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/geometry_builder.dart
@@ -1,3 +1,4 @@
+import 'dart:math' show sqrt;
 import 'dart:typed_data';
 
 import 'package:flutter_gpu/gpu.dart' as gpu;
@@ -74,14 +75,43 @@ PackedPrimitiveData packPrimitive({
   final positions = _readVec3(positionIdx, accessors, bufferViews, bufferData);
   final vertexCount = positions.length ~/ 3;
 
-  final normals = _readOptionalVec3(
-    'NORMAL',
-    primitive,
-    accessors,
-    bufferViews,
-    bufferData,
-    vertexCount,
-  );
+  // Read (or synthesize) the triangle index list up front: it's needed
+  // both to build the index buffer and to compute normals when the
+  // glTF primitive omits them.
+  final Uint32List indexList;
+  final bool indices32Bit;
+  if (primitive.indices != null) {
+    final accessor = accessors[primitive.indices!];
+    indexList = readAccessorAsUint32(
+      accessor,
+      bufferViews[accessor.bufferView!],
+      bufferData,
+    );
+    indices32Bit = accessor.componentType == GltfComponentType.unsignedInt;
+  } else {
+    // No indices: a sequential triangle list.
+    indexList = Uint32List(vertexCount);
+    for (int i = 0; i < vertexCount; i++) {
+      indexList[i] = i;
+    }
+    indices32Bit = false;
+  }
+
+  // glTF requires the client to generate normals when a primitive
+  // omits them. The Khronos Fox sample, for one, ships no NORMAL
+  // attribute; without this it would render with zero normals and lose
+  // all shading.
+  final Float32List normals;
+  if (primitive.attributes.containsKey('NORMAL')) {
+    normals = _readVec3(
+      primitive.attributes['NORMAL']!,
+      accessors,
+      bufferViews,
+      bufferData,
+    );
+  } else {
+    normals = _computeNormals(positions, indexList, vertexCount);
+  }
   final texCoords = _readOptionalVec2(
     'TEXCOORD_0',
     primitive,
@@ -149,36 +179,20 @@ PackedPrimitiveData packPrimitive({
     }
   }
 
-  // Indices: glTF uses optional unsigned 8/16/32 bit. flutter_gpu wants 16 or
-  // 32. Widen byte indices to 16, otherwise pass through.
+  // flutter_gpu wants 16- or 32-bit indices. Pass 32-bit through;
+  // narrow everything else to 16-bit.
   final Uint8List indexBytes;
   final gpu.IndexType indexType;
-  if (primitive.indices != null) {
-    final accessor = accessors[primitive.indices!];
-    final bufferView = bufferViews[accessor.bufferView!];
-    final list = readAccessorAsUint32(accessor, bufferView, bufferData);
-    if (accessor.componentType == GltfComponentType.unsignedInt) {
-      indexBytes = list.buffer.asUint8List(
-        list.offsetInBytes,
-        list.lengthInBytes,
-      );
-      indexType = gpu.IndexType.int32;
-    } else {
-      final widened = Uint16List(list.length);
-      for (int i = 0; i < list.length; i++) {
-        widened[i] = list[i];
-      }
-      indexBytes = widened.buffer.asUint8List(
-        widened.offsetInBytes,
-        widened.lengthInBytes,
-      );
-      indexType = gpu.IndexType.int16;
-    }
+  if (indices32Bit) {
+    indexBytes = indexList.buffer.asUint8List(
+      indexList.offsetInBytes,
+      indexList.lengthInBytes,
+    );
+    indexType = gpu.IndexType.int32;
   } else {
-    // No indices: synthesize a sequential 16-bit index buffer.
-    final widened = Uint16List(vertexCount);
-    for (int i = 0; i < vertexCount; i++) {
-      widened[i] = i;
+    final widened = Uint16List(indexList.length);
+    for (int i = 0; i < indexList.length; i++) {
+      widened[i] = indexList[i];
     }
     indexBytes = widened.buffer.asUint8List(
       widened.offsetInBytes,
@@ -224,17 +238,59 @@ Float32List _readVec4(
   );
 }
 
-Float32List _readOptionalVec3(
-  String name,
-  GltfMeshPrimitive primitive,
-  List<GltfAccessor> accessors,
-  List<GltfBufferView> bufferViews,
-  Uint8List bufferData,
+/// Generates per-vertex normals from a triangle list, used when a glTF
+/// primitive omits the NORMAL attribute (the spec requires the client
+/// to generate them).
+///
+/// Each triangle's face normal (the unnormalized cross product, so
+/// larger triangles contribute proportionally) is added to its three
+/// vertices, then every vertex normal is normalized. This produces
+/// smoothed normals, which is what common glTF loaders do and which
+/// the engine's bind-pose / skinning paths handle uniformly with
+/// authored normals.
+Float32List _computeNormals(
+  Float32List positions,
+  Uint32List indices,
   int vertexCount,
 ) {
-  final idx = primitive.attributes[name];
-  if (idx == null) return Float32List(vertexCount * 3); // zero-initialized
-  return _readVec3(idx, accessors, bufferViews, bufferData);
+  final normals = Float32List(vertexCount * 3);
+  for (int t = 0; t + 2 < indices.length; t += 3) {
+    final i0 = indices[t];
+    final i1 = indices[t + 1];
+    final i2 = indices[t + 2];
+    final ax = positions[i0 * 3];
+    final ay = positions[i0 * 3 + 1];
+    final az = positions[i0 * 3 + 2];
+    final e1x = positions[i1 * 3] - ax;
+    final e1y = positions[i1 * 3 + 1] - ay;
+    final e1z = positions[i1 * 3 + 2] - az;
+    final e2x = positions[i2 * 3] - ax;
+    final e2y = positions[i2 * 3 + 1] - ay;
+    final e2z = positions[i2 * 3 + 2] - az;
+    final nx = e1y * e2z - e1z * e2y;
+    final ny = e1z * e2x - e1x * e2z;
+    final nz = e1x * e2y - e1y * e2x;
+    for (final i in [i0, i1, i2]) {
+      normals[i * 3] += nx;
+      normals[i * 3 + 1] += ny;
+      normals[i * 3 + 2] += nz;
+    }
+  }
+  for (int i = 0; i < vertexCount; i++) {
+    final x = normals[i * 3];
+    final y = normals[i * 3 + 1];
+    final z = normals[i * 3 + 2];
+    final len = sqrt(x * x + y * y + z * z);
+    if (len > 1e-12) {
+      normals[i * 3] = x / len;
+      normals[i * 3 + 1] = y / len;
+      normals[i * 3 + 2] = z / len;
+    } else {
+      // Degenerate vertex (only touched by zero-area triangles).
+      normals[i * 3 + 1] = 1.0;
+    }
+  }
+  return normals;
 }
 
 Float32List _readOptionalVec2(

--- a/packages/flutter_scene/lib/src/runtime_importer/geometry_builder.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/geometry_builder.dart
@@ -1,51 +1,32 @@
-import 'dart:math' show sqrt;
 import 'dart:typed_data';
 
 import 'package:flutter_gpu/gpu.dart' as gpu;
-import 'package:flutter_scene_importer/constants.dart';
 import 'package:flutter_scene_importer/gltf.dart';
 
 import '../geometry/geometry.dart';
 
-/// Builds an engine [Geometry] from a glTF mesh primitive.
-///
-/// Vertex layout produced here must match what
-/// `shaders/flutter_scene_(un)skinned.vert` expects:
-///
-/// - **Unskinned** (48 bytes/vertex): position(3 f32), normal(3 f32),
-///   texture_coords(2 f32), color(4 f32).
-/// - **Skinned** (80 bytes/vertex): unskinned + joints(4 f32) + weights(4 f32).
+/// An engine [Geometry] built from a glTF mesh primitive, paired with
+/// its vertex count.
 class BuiltGeometry {
   BuiltGeometry({required this.geometry, required this.vertexCount});
   final Geometry geometry;
   final int vertexCount;
 }
 
-/// Pure-data result of packing a primitive into the engine's vertex layout,
-/// without uploading to the GPU. Useful for unit testing and byte-level
-/// comparisons against the offline `.model` import path.
-class PackedPrimitiveData {
-  PackedPrimitiveData({
-    required this.vertexBytes,
-    required this.vertexCount,
-    required this.indexBytes,
-    required this.indexType,
-    required this.isSkinned,
-  });
-  final Uint8List vertexBytes;
-  final int vertexCount;
-  final Uint8List indexBytes;
-  final gpu.IndexType indexType;
-  final bool isSkinned;
-}
-
+/// Builds and GPU-uploads an engine [Geometry] from a glTF mesh
+/// primitive.
+///
+/// The pure-data packing (vertex layout, index handling, normal
+/// generation) is done by [packGltfPrimitive] in flutter_scene_importer
+/// so the runtime GLB importer and the offline `.model` emitter share
+/// one implementation.
 BuiltGeometry buildGeometry({
   required GltfMeshPrimitive primitive,
   required List<GltfAccessor> accessors,
   required List<GltfBufferView> bufferViews,
   required Uint8List bufferData,
 }) {
-  final packed = packPrimitive(
+  final packed = packGltfPrimitive(
     primitive: primitive,
     accessors: accessors,
     bufferViews: bufferViews,
@@ -57,303 +38,7 @@ BuiltGeometry buildGeometry({
     ByteData.sublistView(packed.vertexBytes),
     packed.vertexCount,
     ByteData.sublistView(packed.indexBytes),
-    indexType: packed.indexType,
+    indexType: packed.indices32Bit ? gpu.IndexType.int32 : gpu.IndexType.int16,
   );
   return BuiltGeometry(geometry: geometry, vertexCount: packed.vertexCount);
-}
-
-PackedPrimitiveData packPrimitive({
-  required GltfMeshPrimitive primitive,
-  required List<GltfAccessor> accessors,
-  required List<GltfBufferView> bufferViews,
-  required Uint8List bufferData,
-}) {
-  final positionIdx = primitive.attributes['POSITION'];
-  if (positionIdx == null) {
-    throw const FormatException('Mesh primitive is missing POSITION attribute');
-  }
-  final positions = _readVec3(positionIdx, accessors, bufferViews, bufferData);
-  final vertexCount = positions.length ~/ 3;
-
-  // Read (or synthesize) the triangle index list up front: it's needed
-  // both to build the index buffer and to compute normals when the
-  // glTF primitive omits them.
-  final Uint32List indexList;
-  final bool indices32Bit;
-  if (primitive.indices != null) {
-    final accessor = accessors[primitive.indices!];
-    indexList = readAccessorAsUint32(
-      accessor,
-      bufferViews[accessor.bufferView!],
-      bufferData,
-    );
-    indices32Bit = accessor.componentType == GltfComponentType.unsignedInt;
-  } else {
-    // No indices: a sequential triangle list.
-    indexList = Uint32List(vertexCount);
-    for (int i = 0; i < vertexCount; i++) {
-      indexList[i] = i;
-    }
-    indices32Bit = false;
-  }
-
-  // Source attribute arrays, indexed by original glTF vertex index.
-  final texCoords = _readOptionalVec2(
-    'TEXCOORD_0',
-    primitive,
-    accessors,
-    bufferViews,
-    bufferData,
-    vertexCount,
-  );
-  final colors = _readOptionalColor(
-    'COLOR_0',
-    primitive,
-    accessors,
-    bufferViews,
-    bufferData,
-    vertexCount,
-  );
-  final hasJoints =
-      primitive.attributes.containsKey('JOINTS_0') &&
-      primitive.attributes.containsKey('WEIGHTS_0');
-  final joints =
-      hasJoints
-          ? _readVec4(
-            primitive.attributes['JOINTS_0']!,
-            accessors,
-            bufferViews,
-            bufferData,
-          )
-          : null;
-  final weights =
-      hasJoints
-          ? _readVec4(
-            primitive.attributes['WEIGHTS_0']!,
-            accessors,
-            bufferViews,
-            bufferData,
-          )
-          : null;
-
-  // Determine the output vertex set.
-  //
-  // When the primitive authors normals, the mesh is kept as-is:
-  // `srcOf` is the identity and the glTF index buffer is reused.
-  //
-  // When normals are absent, glTF requires the client to generate
-  // flat normals -- each triangle gets its own face normal. Shared
-  // vertices can't carry per-triangle normals, so the mesh is
-  // de-indexed: every triangle is expanded to three unique vertices
-  // and a sequential index buffer is emitted. The Khronos Fox and
-  // RecursiveSkeletons samples both ship without normals.
-  final List<int> srcOf; // output vertex index -> source vertex index
-  final Float32List normals; // output-vertex normals (3 per vertex)
-  final Uint32List outIndexList;
-  final bool outIndices32Bit;
-
-  if (primitive.attributes.containsKey('NORMAL')) {
-    normals = _readVec3(
-      primitive.attributes['NORMAL']!,
-      accessors,
-      bufferViews,
-      bufferData,
-    );
-    srcOf = List<int>.generate(vertexCount, (i) => i);
-    outIndexList = indexList;
-    outIndices32Bit = indices32Bit;
-  } else {
-    final triCount = indexList.length ~/ 3;
-    final outCount = triCount * 3;
-    srcOf = List<int>.filled(outCount, 0);
-    normals = Float32List(outCount * 3);
-    for (int t = 0; t < triCount; t++) {
-      final i0 = indexList[t * 3];
-      final i1 = indexList[t * 3 + 1];
-      final i2 = indexList[t * 3 + 2];
-      final ax = positions[i0 * 3];
-      final ay = positions[i0 * 3 + 1];
-      final az = positions[i0 * 3 + 2];
-      final e1x = positions[i1 * 3] - ax;
-      final e1y = positions[i1 * 3 + 1] - ay;
-      final e1z = positions[i1 * 3 + 2] - az;
-      final e2x = positions[i2 * 3] - ax;
-      final e2y = positions[i2 * 3 + 1] - ay;
-      final e2z = positions[i2 * 3 + 2] - az;
-      var nx = e1y * e2z - e1z * e2y;
-      var ny = e1z * e2x - e1x * e2z;
-      var nz = e1x * e2y - e1y * e2x;
-      final len = sqrt(nx * nx + ny * ny + nz * nz);
-      if (len > 1e-12) {
-        nx /= len;
-        ny /= len;
-        nz /= len;
-      } else {
-        // Degenerate (zero-area) triangle: pick an arbitrary normal.
-        nx = 0;
-        ny = 1;
-        nz = 0;
-      }
-      for (int c = 0; c < 3; c++) {
-        final k = t * 3 + c;
-        srcOf[k] = indexList[t * 3 + c];
-        normals[k * 3] = nx;
-        normals[k * 3 + 1] = ny;
-        normals[k * 3 + 2] = nz;
-      }
-    }
-    outIndexList = Uint32List(outCount);
-    for (int k = 0; k < outCount; k++) {
-      outIndexList[k] = k;
-    }
-    // 16-bit indices address 0..65535.
-    outIndices32Bit = outCount > 0x10000;
-  }
-
-  final outVertexCount = srcOf.length;
-  final perVertex = hasJoints ? kSkinnedPerVertexSize : kUnskinnedPerVertexSize;
-  final stride = perVertex ~/ 4; // floats per vertex
-  final out = Float32List(outVertexCount * stride);
-
-  for (int k = 0; k < outVertexCount; k++) {
-    final o = k * stride;
-    final s = srcOf[k];
-    out[o + 0] = positions[s * 3 + 0];
-    out[o + 1] = positions[s * 3 + 1];
-    out[o + 2] = positions[s * 3 + 2];
-    out[o + 3] = normals[k * 3 + 0];
-    out[o + 4] = normals[k * 3 + 1];
-    out[o + 5] = normals[k * 3 + 2];
-    out[o + 6] = texCoords[s * 2 + 0];
-    out[o + 7] = texCoords[s * 2 + 1];
-    out[o + 8] = colors[s * 4 + 0];
-    out[o + 9] = colors[s * 4 + 1];
-    out[o + 10] = colors[s * 4 + 2];
-    out[o + 11] = colors[s * 4 + 3];
-    if (hasJoints) {
-      final j = o + 12;
-      out[j + 0] = joints![s * 4 + 0];
-      out[j + 1] = joints[s * 4 + 1];
-      out[j + 2] = joints[s * 4 + 2];
-      out[j + 3] = joints[s * 4 + 3];
-      out[j + 4] = weights![s * 4 + 0];
-      out[j + 5] = weights[s * 4 + 1];
-      out[j + 6] = weights[s * 4 + 2];
-      out[j + 7] = weights[s * 4 + 3];
-    }
-  }
-
-  // flutter_gpu wants 16- or 32-bit indices. Pass 32-bit through;
-  // narrow everything else to 16-bit.
-  final Uint8List indexBytes;
-  final gpu.IndexType indexType;
-  if (outIndices32Bit) {
-    indexBytes = outIndexList.buffer.asUint8List(
-      outIndexList.offsetInBytes,
-      outIndexList.lengthInBytes,
-    );
-    indexType = gpu.IndexType.int32;
-  } else {
-    final widened = Uint16List(outIndexList.length);
-    for (int i = 0; i < outIndexList.length; i++) {
-      widened[i] = outIndexList[i];
-    }
-    indexBytes = widened.buffer.asUint8List(
-      widened.offsetInBytes,
-      widened.lengthInBytes,
-    );
-    indexType = gpu.IndexType.int16;
-  }
-
-  return PackedPrimitiveData(
-    vertexBytes: out.buffer.asUint8List(out.offsetInBytes, out.lengthInBytes),
-    vertexCount: outVertexCount,
-    indexBytes: indexBytes,
-    indexType: indexType,
-    isSkinned: hasJoints,
-  );
-}
-
-Float32List _readVec3(
-  int idx,
-  List<GltfAccessor> accessors,
-  List<GltfBufferView> bufferViews,
-  Uint8List bufferData,
-) {
-  final accessor = accessors[idx];
-  return readAccessorAsFloat32(
-    accessor,
-    bufferViews[accessor.bufferView!],
-    bufferData,
-  );
-}
-
-Float32List _readVec4(
-  int idx,
-  List<GltfAccessor> accessors,
-  List<GltfBufferView> bufferViews,
-  Uint8List bufferData,
-) {
-  final accessor = accessors[idx];
-  return readAccessorAsFloat32(
-    accessor,
-    bufferViews[accessor.bufferView!],
-    bufferData,
-  );
-}
-
-Float32List _readOptionalVec2(
-  String name,
-  GltfMeshPrimitive primitive,
-  List<GltfAccessor> accessors,
-  List<GltfBufferView> bufferViews,
-  Uint8List bufferData,
-  int vertexCount,
-) {
-  final idx = primitive.attributes[name];
-  if (idx == null) return Float32List(vertexCount * 2);
-  final accessor = accessors[idx];
-  return readAccessorAsFloat32(
-    accessor,
-    bufferViews[accessor.bufferView!],
-    bufferData,
-  );
-}
-
-Float32List _readOptionalColor(
-  String name,
-  GltfMeshPrimitive primitive,
-  List<GltfAccessor> accessors,
-  List<GltfBufferView> bufferViews,
-  Uint8List bufferData,
-  int vertexCount,
-) {
-  final idx = primitive.attributes[name];
-  if (idx == null) {
-    // Default vertex color = opaque white.
-    final out = Float32List(vertexCount * 4);
-    for (int i = 0; i < vertexCount; i++) {
-      out[i * 4 + 0] = 1.0;
-      out[i * 4 + 1] = 1.0;
-      out[i * 4 + 2] = 1.0;
-      out[i * 4 + 3] = 1.0;
-    }
-    return out;
-  }
-  final accessor = accessors[idx];
-  final raw = readAccessorAsFloat32(
-    accessor,
-    bufferViews[accessor.bufferView!],
-    bufferData,
-  );
-  if (accessor.type == GltfAccessorType.vec4) return raw;
-  // Promote vec3 colors to vec4 with alpha=1.
-  final out = Float32List(vertexCount * 4);
-  for (int i = 0; i < vertexCount; i++) {
-    out[i * 4 + 0] = raw[i * 3 + 0];
-    out[i * 4 + 1] = raw[i * 3 + 1];
-    out[i * 4 + 2] = raw[i * 3 + 2];
-    out[i * 4 + 3] = 1.0;
-  }
-  return out;
 }

--- a/packages/flutter_scene/lib/src/runtime_importer/geometry_builder.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/geometry_builder.dart
@@ -97,21 +97,7 @@ PackedPrimitiveData packPrimitive({
     indices32Bit = false;
   }
 
-  // glTF requires the client to generate normals when a primitive
-  // omits them. The Khronos Fox sample, for one, ships no NORMAL
-  // attribute; without this it would render with zero normals and lose
-  // all shading.
-  final Float32List normals;
-  if (primitive.attributes.containsKey('NORMAL')) {
-    normals = _readVec3(
-      primitive.attributes['NORMAL']!,
-      accessors,
-      bufferViews,
-      bufferData,
-    );
-  } else {
-    normals = _computeNormals(positions, indexList, vertexCount);
-  }
+  // Source attribute arrays, indexed by original glTF vertex index.
   final texCoords = _readOptionalVec2(
     'TEXCOORD_0',
     primitive,
@@ -128,54 +114,132 @@ PackedPrimitiveData packPrimitive({
     bufferData,
     vertexCount,
   );
-
   final hasJoints =
       primitive.attributes.containsKey('JOINTS_0') &&
       primitive.attributes.containsKey('WEIGHTS_0');
+  final joints =
+      hasJoints
+          ? _readVec4(
+            primitive.attributes['JOINTS_0']!,
+            accessors,
+            bufferViews,
+            bufferData,
+          )
+          : null;
+  final weights =
+      hasJoints
+          ? _readVec4(
+            primitive.attributes['WEIGHTS_0']!,
+            accessors,
+            bufferViews,
+            bufferData,
+          )
+          : null;
 
-  final perVertex = hasJoints ? kSkinnedPerVertexSize : kUnskinnedPerVertexSize;
-  final stride = perVertex ~/ 4; // floats per vertex
-  final out = Float32List(vertexCount * stride);
+  // Determine the output vertex set.
+  //
+  // When the primitive authors normals, the mesh is kept as-is:
+  // `srcOf` is the identity and the glTF index buffer is reused.
+  //
+  // When normals are absent, glTF requires the client to generate
+  // flat normals -- each triangle gets its own face normal. Shared
+  // vertices can't carry per-triangle normals, so the mesh is
+  // de-indexed: every triangle is expanded to three unique vertices
+  // and a sequential index buffer is emitted. The Khronos Fox and
+  // RecursiveSkeletons samples both ship without normals.
+  final List<int> srcOf; // output vertex index -> source vertex index
+  final Float32List normals; // output-vertex normals (3 per vertex)
+  final Uint32List outIndexList;
+  final bool outIndices32Bit;
 
-  for (int i = 0; i < vertexCount; i++) {
-    final o = i * stride;
-    out[o + 0] = positions[i * 3 + 0];
-    out[o + 1] = positions[i * 3 + 1];
-    out[o + 2] = positions[i * 3 + 2];
-    out[o + 3] = normals[i * 3 + 0];
-    out[o + 4] = normals[i * 3 + 1];
-    out[o + 5] = normals[i * 3 + 2];
-    out[o + 6] = texCoords[i * 2 + 0];
-    out[o + 7] = texCoords[i * 2 + 1];
-    out[o + 8] = colors[i * 4 + 0];
-    out[o + 9] = colors[i * 4 + 1];
-    out[o + 10] = colors[i * 4 + 2];
-    out[o + 11] = colors[i * 4 + 3];
+  if (primitive.attributes.containsKey('NORMAL')) {
+    normals = _readVec3(
+      primitive.attributes['NORMAL']!,
+      accessors,
+      bufferViews,
+      bufferData,
+    );
+    srcOf = List<int>.generate(vertexCount, (i) => i);
+    outIndexList = indexList;
+    outIndices32Bit = indices32Bit;
+  } else {
+    final triCount = indexList.length ~/ 3;
+    final outCount = triCount * 3;
+    srcOf = List<int>.filled(outCount, 0);
+    normals = Float32List(outCount * 3);
+    for (int t = 0; t < triCount; t++) {
+      final i0 = indexList[t * 3];
+      final i1 = indexList[t * 3 + 1];
+      final i2 = indexList[t * 3 + 2];
+      final ax = positions[i0 * 3];
+      final ay = positions[i0 * 3 + 1];
+      final az = positions[i0 * 3 + 2];
+      final e1x = positions[i1 * 3] - ax;
+      final e1y = positions[i1 * 3 + 1] - ay;
+      final e1z = positions[i1 * 3 + 2] - az;
+      final e2x = positions[i2 * 3] - ax;
+      final e2y = positions[i2 * 3 + 1] - ay;
+      final e2z = positions[i2 * 3 + 2] - az;
+      var nx = e1y * e2z - e1z * e2y;
+      var ny = e1z * e2x - e1x * e2z;
+      var nz = e1x * e2y - e1y * e2x;
+      final len = sqrt(nx * nx + ny * ny + nz * nz);
+      if (len > 1e-12) {
+        nx /= len;
+        ny /= len;
+        nz /= len;
+      } else {
+        // Degenerate (zero-area) triangle: pick an arbitrary normal.
+        nx = 0;
+        ny = 1;
+        nz = 0;
+      }
+      for (int c = 0; c < 3; c++) {
+        final k = t * 3 + c;
+        srcOf[k] = indexList[t * 3 + c];
+        normals[k * 3] = nx;
+        normals[k * 3 + 1] = ny;
+        normals[k * 3 + 2] = nz;
+      }
+    }
+    outIndexList = Uint32List(outCount);
+    for (int k = 0; k < outCount; k++) {
+      outIndexList[k] = k;
+    }
+    // 16-bit indices address 0..65535.
+    outIndices32Bit = outCount > 0x10000;
   }
 
-  if (hasJoints) {
-    final joints = _readVec4(
-      primitive.attributes['JOINTS_0']!,
-      accessors,
-      bufferViews,
-      bufferData,
-    );
-    final weights = _readVec4(
-      primitive.attributes['WEIGHTS_0']!,
-      accessors,
-      bufferViews,
-      bufferData,
-    );
-    for (int i = 0; i < vertexCount; i++) {
-      final o = i * stride + 12;
-      out[o + 0] = joints[i * 4 + 0];
-      out[o + 1] = joints[i * 4 + 1];
-      out[o + 2] = joints[i * 4 + 2];
-      out[o + 3] = joints[i * 4 + 3];
-      out[o + 4] = weights[i * 4 + 0];
-      out[o + 5] = weights[i * 4 + 1];
-      out[o + 6] = weights[i * 4 + 2];
-      out[o + 7] = weights[i * 4 + 3];
+  final outVertexCount = srcOf.length;
+  final perVertex = hasJoints ? kSkinnedPerVertexSize : kUnskinnedPerVertexSize;
+  final stride = perVertex ~/ 4; // floats per vertex
+  final out = Float32List(outVertexCount * stride);
+
+  for (int k = 0; k < outVertexCount; k++) {
+    final o = k * stride;
+    final s = srcOf[k];
+    out[o + 0] = positions[s * 3 + 0];
+    out[o + 1] = positions[s * 3 + 1];
+    out[o + 2] = positions[s * 3 + 2];
+    out[o + 3] = normals[k * 3 + 0];
+    out[o + 4] = normals[k * 3 + 1];
+    out[o + 5] = normals[k * 3 + 2];
+    out[o + 6] = texCoords[s * 2 + 0];
+    out[o + 7] = texCoords[s * 2 + 1];
+    out[o + 8] = colors[s * 4 + 0];
+    out[o + 9] = colors[s * 4 + 1];
+    out[o + 10] = colors[s * 4 + 2];
+    out[o + 11] = colors[s * 4 + 3];
+    if (hasJoints) {
+      final j = o + 12;
+      out[j + 0] = joints![s * 4 + 0];
+      out[j + 1] = joints[s * 4 + 1];
+      out[j + 2] = joints[s * 4 + 2];
+      out[j + 3] = joints[s * 4 + 3];
+      out[j + 4] = weights![s * 4 + 0];
+      out[j + 5] = weights[s * 4 + 1];
+      out[j + 6] = weights[s * 4 + 2];
+      out[j + 7] = weights[s * 4 + 3];
     }
   }
 
@@ -183,16 +247,16 @@ PackedPrimitiveData packPrimitive({
   // narrow everything else to 16-bit.
   final Uint8List indexBytes;
   final gpu.IndexType indexType;
-  if (indices32Bit) {
-    indexBytes = indexList.buffer.asUint8List(
-      indexList.offsetInBytes,
-      indexList.lengthInBytes,
+  if (outIndices32Bit) {
+    indexBytes = outIndexList.buffer.asUint8List(
+      outIndexList.offsetInBytes,
+      outIndexList.lengthInBytes,
     );
     indexType = gpu.IndexType.int32;
   } else {
-    final widened = Uint16List(indexList.length);
-    for (int i = 0; i < indexList.length; i++) {
-      widened[i] = indexList[i];
+    final widened = Uint16List(outIndexList.length);
+    for (int i = 0; i < outIndexList.length; i++) {
+      widened[i] = outIndexList[i];
     }
     indexBytes = widened.buffer.asUint8List(
       widened.offsetInBytes,
@@ -203,7 +267,7 @@ PackedPrimitiveData packPrimitive({
 
   return PackedPrimitiveData(
     vertexBytes: out.buffer.asUint8List(out.offsetInBytes, out.lengthInBytes),
-    vertexCount: vertexCount,
+    vertexCount: outVertexCount,
     indexBytes: indexBytes,
     indexType: indexType,
     isSkinned: hasJoints,
@@ -236,61 +300,6 @@ Float32List _readVec4(
     bufferViews[accessor.bufferView!],
     bufferData,
   );
-}
-
-/// Generates per-vertex normals from a triangle list, used when a glTF
-/// primitive omits the NORMAL attribute (the spec requires the client
-/// to generate them).
-///
-/// Each triangle's face normal (the unnormalized cross product, so
-/// larger triangles contribute proportionally) is added to its three
-/// vertices, then every vertex normal is normalized. This produces
-/// smoothed normals, which is what common glTF loaders do and which
-/// the engine's bind-pose / skinning paths handle uniformly with
-/// authored normals.
-Float32List _computeNormals(
-  Float32List positions,
-  Uint32List indices,
-  int vertexCount,
-) {
-  final normals = Float32List(vertexCount * 3);
-  for (int t = 0; t + 2 < indices.length; t += 3) {
-    final i0 = indices[t];
-    final i1 = indices[t + 1];
-    final i2 = indices[t + 2];
-    final ax = positions[i0 * 3];
-    final ay = positions[i0 * 3 + 1];
-    final az = positions[i0 * 3 + 2];
-    final e1x = positions[i1 * 3] - ax;
-    final e1y = positions[i1 * 3 + 1] - ay;
-    final e1z = positions[i1 * 3 + 2] - az;
-    final e2x = positions[i2 * 3] - ax;
-    final e2y = positions[i2 * 3 + 1] - ay;
-    final e2z = positions[i2 * 3 + 2] - az;
-    final nx = e1y * e2z - e1z * e2y;
-    final ny = e1z * e2x - e1x * e2z;
-    final nz = e1x * e2y - e1y * e2x;
-    for (final i in [i0, i1, i2]) {
-      normals[i * 3] += nx;
-      normals[i * 3 + 1] += ny;
-      normals[i * 3 + 2] += nz;
-    }
-  }
-  for (int i = 0; i < vertexCount; i++) {
-    final x = normals[i * 3];
-    final y = normals[i * 3 + 1];
-    final z = normals[i * 3 + 2];
-    final len = sqrt(x * x + y * y + z * z);
-    if (len > 1e-12) {
-      normals[i * 3] = x / len;
-      normals[i * 3 + 1] = y / len;
-      normals[i * 3 + 2] = z / len;
-    } else {
-      // Degenerate vertex (only touched by zero-area triangles).
-      normals[i * 3 + 1] = 1.0;
-    }
-  }
-  return normals;
 }
 
 Float32List _readOptionalVec2(

--- a/packages/flutter_scene/test/geometry_builder_test.dart
+++ b/packages/flutter_scene/test/geometry_builder_test.dart
@@ -1,0 +1,125 @@
+/// Covers packPrimitive's handling of the NORMAL attribute: authored
+/// normals are passed through, and absent normals are generated from
+/// the triangle geometry (glTF requires the client to do this; the
+/// Khronos Fox sample ships no normals).
+library;
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/runtime_importer/geometry_builder.dart';
+import 'package:flutter_scene_importer/gltf.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Reads vertex `v`'s normal (floats 3..5 of the 12-float unskinned
+/// vertex layout) out of packed vertex bytes.
+List<double> _normalOf(PackedPrimitiveData packed, int v) {
+  final floats = Float32List.sublistView(packed.vertexBytes);
+  const stride = 12;
+  return [
+    floats[v * stride + 3],
+    floats[v * stride + 4],
+    floats[v * stride + 5],
+  ];
+}
+
+void main() {
+  test('generates +Z normals for a CCW triangle with no NORMAL', () {
+    // Triangle (0,0,0), (1,0,0), (0,1,0): face normal is +Z.
+    final buffer = Uint8List(36 + 6);
+    final bd = ByteData.sublistView(buffer);
+    const positions = <double>[0, 0, 0, 1, 0, 0, 0, 1, 0];
+    for (var i = 0; i < positions.length; i++) {
+      bd.setFloat32(i * 4, positions[i], Endian.little);
+    }
+    for (var i = 0; i < 3; i++) {
+      bd.setUint16(36 + i * 2, i, Endian.little);
+    }
+
+    final packed = packPrimitive(
+      primitive: GltfMeshPrimitive(attributes: {'POSITION': 0}, indices: 1),
+      accessors: [
+        GltfAccessor(
+          componentType: GltfComponentType.float,
+          count: 3,
+          type: GltfAccessorType.vec3,
+          bufferView: 0,
+        ),
+        GltfAccessor(
+          componentType: GltfComponentType.unsignedShort,
+          count: 3,
+          type: GltfAccessorType.scalar,
+          bufferView: 1,
+        ),
+      ],
+      bufferViews: [
+        GltfBufferView(buffer: 0, byteLength: 36, byteOffset: 0),
+        GltfBufferView(buffer: 0, byteLength: 6, byteOffset: 36),
+      ],
+      bufferData: buffer,
+    );
+
+    expect(packed.vertexCount, 3);
+    for (var v = 0; v < 3; v++) {
+      expect(_normalOf(packed, v)[0], closeTo(0.0, 1e-6));
+      expect(_normalOf(packed, v)[1], closeTo(0.0, 1e-6));
+      expect(_normalOf(packed, v)[2], closeTo(1.0, 1e-6));
+    }
+  });
+
+  test('passes authored normals through unchanged', () {
+    // positions (36 bytes) + normals (36 bytes) + indices (6 bytes).
+    final buffer = Uint8List(36 + 36 + 6);
+    final bd = ByteData.sublistView(buffer);
+    const positions = <double>[0, 0, 0, 1, 0, 0, 0, 1, 0];
+    for (var i = 0; i < positions.length; i++) {
+      bd.setFloat32(i * 4, positions[i], Endian.little);
+    }
+    // Authored normals all point +Y, which is deliberately not the
+    // triangle's +Z face normal so a regression to generation shows.
+    for (var v = 0; v < 3; v++) {
+      bd.setFloat32(36 + v * 12 + 0, 0, Endian.little);
+      bd.setFloat32(36 + v * 12 + 4, 1, Endian.little);
+      bd.setFloat32(36 + v * 12 + 8, 0, Endian.little);
+    }
+    for (var i = 0; i < 3; i++) {
+      bd.setUint16(72 + i * 2, i, Endian.little);
+    }
+
+    final packed = packPrimitive(
+      primitive: GltfMeshPrimitive(
+        attributes: {'POSITION': 0, 'NORMAL': 1},
+        indices: 2,
+      ),
+      accessors: [
+        GltfAccessor(
+          componentType: GltfComponentType.float,
+          count: 3,
+          type: GltfAccessorType.vec3,
+          bufferView: 0,
+        ),
+        GltfAccessor(
+          componentType: GltfComponentType.float,
+          count: 3,
+          type: GltfAccessorType.vec3,
+          bufferView: 1,
+        ),
+        GltfAccessor(
+          componentType: GltfComponentType.unsignedShort,
+          count: 3,
+          type: GltfAccessorType.scalar,
+          bufferView: 2,
+        ),
+      ],
+      bufferViews: [
+        GltfBufferView(buffer: 0, byteLength: 36, byteOffset: 0),
+        GltfBufferView(buffer: 0, byteLength: 36, byteOffset: 36),
+        GltfBufferView(buffer: 0, byteLength: 6, byteOffset: 72),
+      ],
+      bufferData: buffer,
+    );
+
+    for (var v = 0; v < 3; v++) {
+      expect(_normalOf(packed, v), [0.0, 1.0, 0.0]);
+    }
+  });
+}

--- a/packages/flutter_scene/test/geometry_builder_test.dart
+++ b/packages/flutter_scene/test/geometry_builder_test.dart
@@ -1,18 +1,17 @@
-/// Covers packPrimitive's handling of the NORMAL attribute: authored
-/// normals are passed through, and absent normals are generated from
-/// the triangle geometry (glTF requires the client to do this; the
-/// Khronos Fox sample ships no normals).
+/// Covers packGltfPrimitive's handling of the NORMAL attribute:
+/// authored normals are passed through, and absent normals are
+/// generated from the triangle geometry (glTF requires the client to
+/// do this; the Khronos Fox sample ships no normals).
 library;
 
 import 'dart:typed_data';
 
-import 'package:flutter_scene/src/runtime_importer/geometry_builder.dart';
 import 'package:flutter_scene_importer/gltf.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Reads vertex `v`'s normal (floats 3..5 of the 12-float unskinned
 /// vertex layout) out of packed vertex bytes.
-List<double> _normalOf(PackedPrimitiveData packed, int v) {
+List<double> _normalOf(PackedPrimitive packed, int v) {
   final floats = Float32List.sublistView(packed.vertexBytes);
   const stride = 12;
   return [
@@ -35,7 +34,7 @@ void main() {
       bd.setUint16(36 + i * 2, i, Endian.little);
     }
 
-    final packed = packPrimitive(
+    final packed = packGltfPrimitive(
       primitive: GltfMeshPrimitive(attributes: {'POSITION': 0}, indices: 1),
       accessors: [
         GltfAccessor(
@@ -88,7 +87,7 @@ void main() {
       bd.setUint16(48 + i * 2, indices[i], Endian.little);
     }
 
-    final packed = packPrimitive(
+    final packed = packGltfPrimitive(
       primitive: GltfMeshPrimitive(attributes: {'POSITION': 0}, indices: 1),
       accessors: [
         GltfAccessor(
@@ -144,7 +143,7 @@ void main() {
       bd.setUint16(72 + i * 2, i, Endian.little);
     }
 
-    final packed = packPrimitive(
+    final packed = packGltfPrimitive(
       primitive: GltfMeshPrimitive(
         attributes: {'POSITION': 0, 'NORMAL': 1},
         indices: 2,

--- a/packages/flutter_scene/test/geometry_builder_test.dart
+++ b/packages/flutter_scene/test/geometry_builder_test.dart
@@ -66,6 +66,65 @@ void main() {
     }
   });
 
+  test('de-indexes a shared-vertex mesh for flat normals', () {
+    // Two triangles sharing edge v0-v1 but in different planes:
+    //   A = (v0, v1, v2): face normal +Z
+    //   B = (v0, v1, v3): face normal -Y
+    // De-indexing must expand the 4 shared vertices to 6, each
+    // carrying its own triangle's face normal (no averaging).
+    final buffer = Uint8List(48 + 12);
+    final bd = ByteData.sublistView(buffer);
+    const positions = <double>[
+      0, 0, 0, // v0
+      1, 0, 0, // v1
+      1, 1, 0, // v2
+      1, 0, 1, // v3
+    ];
+    for (var i = 0; i < positions.length; i++) {
+      bd.setFloat32(i * 4, positions[i], Endian.little);
+    }
+    const indices = <int>[0, 1, 2, 0, 1, 3];
+    for (var i = 0; i < indices.length; i++) {
+      bd.setUint16(48 + i * 2, indices[i], Endian.little);
+    }
+
+    final packed = packPrimitive(
+      primitive: GltfMeshPrimitive(attributes: {'POSITION': 0}, indices: 1),
+      accessors: [
+        GltfAccessor(
+          componentType: GltfComponentType.float,
+          count: 4,
+          type: GltfAccessorType.vec3,
+          bufferView: 0,
+        ),
+        GltfAccessor(
+          componentType: GltfComponentType.unsignedShort,
+          count: 6,
+          type: GltfAccessorType.scalar,
+          bufferView: 1,
+        ),
+      ],
+      bufferViews: [
+        GltfBufferView(buffer: 0, byteLength: 48, byteOffset: 0),
+        GltfBufferView(buffer: 0, byteLength: 12, byteOffset: 48),
+      ],
+      bufferData: buffer,
+    );
+
+    // 2 triangles -> 6 unique vertices after de-indexing.
+    expect(packed.vertexCount, 6);
+    for (var v = 0; v < 3; v++) {
+      expect(_normalOf(packed, v)[0], closeTo(0.0, 1e-6));
+      expect(_normalOf(packed, v)[1], closeTo(0.0, 1e-6));
+      expect(_normalOf(packed, v)[2], closeTo(1.0, 1e-6));
+    }
+    for (var v = 3; v < 6; v++) {
+      expect(_normalOf(packed, v)[0], closeTo(0.0, 1e-6));
+      expect(_normalOf(packed, v)[1], closeTo(-1.0, 1e-6));
+      expect(_normalOf(packed, v)[2], closeTo(0.0, 1e-6));
+    }
+  });
+
   test('passes authored normals through unchanged', () {
     // positions (36 bytes) + normals (36 bytes) + indices (6 bytes).
     final buffer = Uint8List(36 + 36 + 6);

--- a/packages/flutter_scene/test/runtime_importer_byte_comparison_test.dart
+++ b/packages/flutter_scene/test/runtime_importer_byte_comparison_test.dart
@@ -3,7 +3,6 @@
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:flutter_scene/src/runtime_importer/geometry_builder.dart';
 import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
 import 'package:flutter_scene_importer/importer.dart';
 import 'package:flutter_scene_importer/gltf.dart';
@@ -29,7 +28,7 @@ void main() {
     // Use mesh index 1, primitive 0 (CarBody) — the first primitive that
     // exercises the full unskinned vertex layout in this file.
     final myPrimitive = doc.meshes[1].primitives[0];
-    final mine = packPrimitive(
+    final mine = packGltfPrimitive(
       primitive: myPrimitive,
       accessors: doc.accessors,
       bufferViews: doc.bufferViews,
@@ -77,7 +76,7 @@ void main() {
 
     print('--- Index bytes ---');
     print(
-      '  mine.length=${mine.indexBytes.length} bytes, type=${mine.indexType}',
+      '  mine.length=${mine.indexBytes.length} bytes, indices32Bit=${mine.indices32Bit}',
     );
     print(
       '  theirs.length=${theirIndexBytes.length} bytes, type=${theirIndices.type}',
@@ -189,7 +188,7 @@ void main() {
     final glbBytes = File(glbPath).readAsBytesSync();
     final container = parseGlb(glbBytes);
     final doc = parseGltfJson(container.json);
-    final mine = packPrimitive(
+    final mine = packGltfPrimitive(
       primitive: doc.meshes.first.primitives.first,
       accessors: doc.accessors,
       bufferViews: doc.bufferViews,
@@ -266,7 +265,7 @@ void main() {
       if (theirPrim == null) continue;
       final myPrims = doc.meshes[gn.mesh!].primitives;
       if (myPrims.isEmpty) continue;
-      final mine = packPrimitive(
+      final mine = packGltfPrimitive(
         primitive: myPrims.first,
         accessors: doc.accessors,
         bufferViews: doc.bufferViews,
@@ -321,7 +320,7 @@ void _comparePrimitiveBytes(
     }
   }
   expect(myPrim, isNotNull);
-  final mine = packPrimitive(
+  final mine = packGltfPrimitive(
     primitive: myPrim!,
     accessors: doc.accessors,
     bufferViews: doc.bufferViews,

--- a/packages/flutter_scene_importer/lib/gltf.dart
+++ b/packages/flutter_scene_importer/lib/gltf.dart
@@ -9,4 +9,5 @@ library;
 export 'src/gltf/accessor.dart';
 export 'src/gltf/glb.dart';
 export 'src/gltf/parser.dart';
+export 'src/gltf/primitive_packer.dart';
 export 'src/gltf/types.dart';

--- a/packages/flutter_scene_importer/lib/src/fb_emitter/model_emitter.dart
+++ b/packages/flutter_scene_importer/lib/src/fb_emitter/model_emitter.dart
@@ -12,7 +12,6 @@ import 'dart:typed_data';
 import 'package:image/image.dart' as img;
 import 'package:vector_math/vector_math.dart';
 
-import '../../constants.dart';
 // Import the generated flatbuffer types directly rather than going through
 // flatbuffer.dart, which transitively pulls in `flutter_gpu/gpu.dart` and
 // `dart:ui` — both unavailable in the build-hook isolate.
@@ -291,43 +290,36 @@ fb.MeshPrimitiveT _buildMeshPrimitive(
   Uint8List bufferData,
 ) {
   final out = fb.MeshPrimitiveT();
-  final hasJoints =
-      p.attributes.containsKey('JOINTS_0') &&
-      p.attributes.containsKey('WEIGHTS_0');
 
-  // Position attribute is mandatory in glTF and (separately) required by
-  // flutter_scene. Read it once and reuse for both vertex packing and
-  // bounds.
-  final positionAccessor = doc.accessors[p.attributes['POSITION']!];
-  final positions = _readVec3(p.attributes['POSITION']!, doc, bufferData);
-
-  // Pack vertex bytes using the same layout as flutter_scene's vertex shaders.
-  final vertexBytes = _packVertices(
-    p,
-    doc,
-    bufferData,
-    positions: positions,
-    hasJoints: hasJoints,
+  // Pack vertices and indices with the shared packer (vertex layout,
+  // index handling, normal generation, de-indexing). The runtime GLB
+  // importer uses the same code, so the offline .model output matches
+  // it byte-for-byte.
+  final packed = packGltfPrimitive(
+    primitive: p,
+    accessors: doc.accessors,
+    bufferViews: doc.bufferViews,
+    bufferData: bufferData,
   );
-  final vertexCount =
-      vertexBytes.length ~/
-      (hasJoints ? kSkinnedPerVertexSize : kUnskinnedPerVertexSize);
-  if (hasJoints) {
+  if (packed.isSkinned) {
     out.verticesType = fb.VertexBufferTypeId.SkinnedVertexBuffer;
     out.vertices = fb.SkinnedVertexBufferT(
-      vertices: vertexBytes,
-      vertexCount: vertexCount,
+      vertices: packed.vertexBytes,
+      vertexCount: packed.vertexCount,
     );
   } else {
     out.verticesType = fb.VertexBufferTypeId.UnskinnedVertexBuffer;
     out.vertices = fb.UnskinnedVertexBufferT(
-      vertices: vertexBytes,
-      vertexCount: vertexCount,
+      vertices: packed.vertexBytes,
+      vertexCount: packed.vertexCount,
     );
   }
-
-  // Indices (preserve glTF order — no winding flip).
-  out.indices = _buildIndices(p, doc, bufferData);
+  out.indices =
+      fb.IndicesT()
+        ..data = packed.indexBytes
+        ..count = packed.indexCount
+        ..type =
+            packed.indices32Bit ? fb.IndexType.k32Bit : fb.IndexType.k16Bit;
 
   // Material.
   if (p.material != null && p.material! < doc.materials.length) {
@@ -336,99 +328,13 @@ fb.MeshPrimitiveT _buildMeshPrimitive(
 
   // Bounds. Prefer the accessor's spec-provided min/max for the AABB so
   // we don't redo work the asset already encodes; the sphere always
-  // requires a vertex pass.
-  if (vertexCount > 0) {
-    final aabb = _aabbFromAccessorOrPositions(positionAccessor, positions);
-    out.boundsAabb = aabb;
+  // requires a vertex pass. De-indexing duplicates points without
+  // adding new ones, so the original positions cover the same extent.
+  final positionAccessor = doc.accessors[p.attributes['POSITION']!];
+  final positions = _readVec3(p.attributes['POSITION']!, doc, bufferData);
+  if (positions.isNotEmpty) {
+    out.boundsAabb = _aabbFromAccessorOrPositions(positionAccessor, positions);
     out.boundsSphere = _sphereFromPositions(positions);
-  }
-  return out;
-}
-
-Uint8List _packVertices(
-  GltfMeshPrimitive p,
-  GltfDocument doc,
-  Uint8List bufferData, {
-  required Float32List positions,
-  required bool hasJoints,
-}) {
-  final vertexCount = positions.length ~/ 3;
-  final normals = _readOptionalVec3('NORMAL', p, doc, bufferData, vertexCount);
-  final tex = _readOptionalVec2('TEXCOORD_0', p, doc, bufferData, vertexCount);
-  final colors = _readOptionalColor('COLOR_0', p, doc, bufferData, vertexCount);
-
-  final stride =
-      (hasJoints ? kSkinnedPerVertexSize : kUnskinnedPerVertexSize) ~/ 4;
-  final out = Float32List(vertexCount * stride);
-  for (int i = 0; i < vertexCount; i++) {
-    final o = i * stride;
-    out[o + 0] = positions[i * 3 + 0];
-    out[o + 1] = positions[i * 3 + 1];
-    out[o + 2] = positions[i * 3 + 2];
-    out[o + 3] = normals[i * 3 + 0];
-    out[o + 4] = normals[i * 3 + 1];
-    out[o + 5] = normals[i * 3 + 2];
-    out[o + 6] = tex[i * 2 + 0];
-    out[o + 7] = tex[i * 2 + 1];
-    out[o + 8] = colors[i * 4 + 0];
-    out[o + 9] = colors[i * 4 + 1];
-    out[o + 10] = colors[i * 4 + 2];
-    out[o + 11] = colors[i * 4 + 3];
-  }
-  if (hasJoints) {
-    final joints = _readVec4(p.attributes['JOINTS_0']!, doc, bufferData);
-    final weights = _readVec4(p.attributes['WEIGHTS_0']!, doc, bufferData);
-    for (int i = 0; i < vertexCount; i++) {
-      final o = i * stride + 12;
-      for (int c = 0; c < 4; c++) {
-        out[o + c] = joints[i * 4 + c];
-        out[o + 4 + c] = weights[i * 4 + c];
-      }
-    }
-  }
-  return out.buffer.asUint8List(out.offsetInBytes, out.lengthInBytes);
-}
-
-fb.IndicesT _buildIndices(
-  GltfMeshPrimitive p,
-  GltfDocument doc,
-  Uint8List bufferData,
-) {
-  final out = fb.IndicesT();
-  if (p.indices == null) {
-    // Synthesize a sequential 16-bit index list.
-    final positionAccessor = doc.accessors[p.attributes['POSITION']!];
-    final count = positionAccessor.count;
-    final widened = Uint16List(count);
-    for (int i = 0; i < count; i++) {
-      widened[i] = i;
-    }
-    out.data = widened.buffer.asUint8List(
-      widened.offsetInBytes,
-      widened.lengthInBytes,
-    );
-    out.count = count;
-    out.type = fb.IndexType.k16Bit;
-    return out;
-  }
-  final accessor = doc.accessors[p.indices!];
-  final view = doc.bufferViews[accessor.bufferView!];
-  final list = readAccessorAsUint32(accessor, view, bufferData);
-  if (accessor.componentType == GltfComponentType.unsignedInt) {
-    out.data = list.buffer.asUint8List(list.offsetInBytes, list.lengthInBytes);
-    out.count = accessor.count;
-    out.type = fb.IndexType.k32Bit;
-  } else {
-    final widened = Uint16List(list.length);
-    for (int i = 0; i < list.length; i++) {
-      widened[i] = list[i];
-    }
-    out.data = widened.buffer.asUint8List(
-      widened.offsetInBytes,
-      widened.lengthInBytes,
-    );
-    out.count = accessor.count;
-    out.type = fb.IndexType.k16Bit;
   }
   return out;
 }
@@ -1285,65 +1191,4 @@ Float32List _readVec3(int idx, GltfDocument doc, Uint8List bufferData) {
 Float32List _readVec4(int idx, GltfDocument doc, Uint8List bufferData) {
   final a = doc.accessors[idx];
   return readAccessorAsFloat32(a, doc.bufferViews[a.bufferView!], bufferData);
-}
-
-Float32List _readOptionalVec3(
-  String name,
-  GltfMeshPrimitive p,
-  GltfDocument doc,
-  Uint8List bufferData,
-  int vertexCount,
-) {
-  final i = p.attributes[name];
-  if (i == null) return Float32List(vertexCount * 3);
-  return _readVec3(i, doc, bufferData);
-}
-
-Float32List _readOptionalVec2(
-  String name,
-  GltfMeshPrimitive p,
-  GltfDocument doc,
-  Uint8List bufferData,
-  int vertexCount,
-) {
-  final i = p.attributes[name];
-  if (i == null) return Float32List(vertexCount * 2);
-  final a = doc.accessors[i];
-  return readAccessorAsFloat32(a, doc.bufferViews[a.bufferView!], bufferData);
-}
-
-Float32List _readOptionalColor(
-  String name,
-  GltfMeshPrimitive p,
-  GltfDocument doc,
-  Uint8List bufferData,
-  int vertexCount,
-) {
-  final i = p.attributes[name];
-  if (i == null) {
-    final out = Float32List(vertexCount * 4);
-    for (int v = 0; v < vertexCount; v++) {
-      out[v * 4 + 0] = 1.0;
-      out[v * 4 + 1] = 1.0;
-      out[v * 4 + 2] = 1.0;
-      out[v * 4 + 3] = 1.0;
-    }
-    return out;
-  }
-  final a = doc.accessors[i];
-  final raw = readAccessorAsFloat32(
-    a,
-    doc.bufferViews[a.bufferView!],
-    bufferData,
-  );
-  if (a.type == GltfAccessorType.vec4) return raw;
-  // Promote vec3 to vec4 with alpha=1.
-  final out = Float32List(vertexCount * 4);
-  for (int v = 0; v < vertexCount; v++) {
-    out[v * 4 + 0] = raw[v * 3 + 0];
-    out[v * 4 + 1] = raw[v * 3 + 1];
-    out[v * 4 + 2] = raw[v * 3 + 2];
-    out[v * 4 + 3] = 1.0;
-  }
-  return out;
 }

--- a/packages/flutter_scene_importer/lib/src/gltf/primitive_packer.dart
+++ b/packages/flutter_scene_importer/lib/src/gltf/primitive_packer.dart
@@ -1,0 +1,344 @@
+import 'dart:math' show sqrt;
+import 'dart:typed_data';
+
+import '../../constants.dart';
+import 'accessor.dart';
+import 'types.dart';
+
+/// Pure-data result of packing a glTF mesh primitive into
+/// flutter_scene's vertex layout.
+///
+/// Shared by the runtime GLB importer and the offline `.model` emitter
+/// so a model packs identically whichever path imported it. Backend-
+/// neutral: [indices32Bit] is reported as a flag, and each caller maps
+/// it to its own index-type representation.
+class PackedPrimitive {
+  PackedPrimitive({
+    required this.vertexBytes,
+    required this.vertexCount,
+    required this.indexBytes,
+    required this.indexCount,
+    required this.indices32Bit,
+    required this.isSkinned,
+  });
+
+  /// Packed vertex buffer in the engine's vertex layout (48 bytes per
+  /// unskinned vertex, 80 per skinned).
+  final Uint8List vertexBytes;
+
+  /// Number of vertices in [vertexBytes].
+  final int vertexCount;
+
+  /// Packed index buffer, either 16- or 32-bit per [indices32Bit].
+  final Uint8List indexBytes;
+
+  /// Number of indices in [indexBytes].
+  final int indexCount;
+
+  /// Whether [indexBytes] holds 32-bit (`true`) or 16-bit indices.
+  final bool indices32Bit;
+
+  /// Whether the vertex layout includes joints and weights.
+  final bool isSkinned;
+}
+
+/// Packs a glTF mesh primitive into the engine's vertex/index layout.
+///
+/// The vertex layout matches `shaders/flutter_scene_(un)skinned.vert`:
+///
+/// - Unskinned (48 bytes/vertex): position(3 f32), normal(3 f32),
+///   texture_coords(2 f32), color(4 f32).
+/// - Skinned (80 bytes/vertex): unskinned + joints(4 f32) +
+///   weights(4 f32).
+///
+/// When the primitive omits the NORMAL attribute, glTF requires the
+/// client to generate flat normals. A vertex shared by several
+/// triangles can't carry a single per-face normal, so the primitive is
+/// de-indexed (every triangle expanded to three unique vertices, each
+/// carrying that triangle's face normal) with a sequential index
+/// buffer. Primitives that author normals are kept as-is.
+PackedPrimitive packGltfPrimitive({
+  required GltfMeshPrimitive primitive,
+  required List<GltfAccessor> accessors,
+  required List<GltfBufferView> bufferViews,
+  required Uint8List bufferData,
+}) {
+  final positionIdx = primitive.attributes['POSITION'];
+  if (positionIdx == null) {
+    throw const FormatException('Mesh primitive is missing POSITION attribute');
+  }
+  final positions = _readVec3(positionIdx, accessors, bufferViews, bufferData);
+  final vertexCount = positions.length ~/ 3;
+
+  // Read (or synthesize) the triangle index list up front: it's needed
+  // both to build the index buffer and to generate normals when the
+  // glTF primitive omits them.
+  final Uint32List indexList;
+  final bool indices32Bit;
+  if (primitive.indices != null) {
+    final accessor = accessors[primitive.indices!];
+    indexList = readAccessorAsUint32(
+      accessor,
+      bufferViews[accessor.bufferView!],
+      bufferData,
+    );
+    indices32Bit = accessor.componentType == GltfComponentType.unsignedInt;
+  } else {
+    // No indices: a sequential triangle list.
+    indexList = Uint32List(vertexCount);
+    for (int i = 0; i < vertexCount; i++) {
+      indexList[i] = i;
+    }
+    indices32Bit = false;
+  }
+
+  // Source attribute arrays, indexed by original glTF vertex index.
+  final texCoords = _readOptionalVec2(
+    'TEXCOORD_0',
+    primitive,
+    accessors,
+    bufferViews,
+    bufferData,
+    vertexCount,
+  );
+  final colors = _readOptionalColor(
+    'COLOR_0',
+    primitive,
+    accessors,
+    bufferViews,
+    bufferData,
+    vertexCount,
+  );
+  final hasJoints =
+      primitive.attributes.containsKey('JOINTS_0') &&
+      primitive.attributes.containsKey('WEIGHTS_0');
+  final joints =
+      hasJoints
+          ? _readVec4(
+            primitive.attributes['JOINTS_0']!,
+            accessors,
+            bufferViews,
+            bufferData,
+          )
+          : null;
+  final weights =
+      hasJoints
+          ? _readVec4(
+            primitive.attributes['WEIGHTS_0']!,
+            accessors,
+            bufferViews,
+            bufferData,
+          )
+          : null;
+
+  // Determine the output vertex set. With authored normals the mesh is
+  // kept as-is; without them it is de-indexed for flat normals (see the
+  // function doc).
+  final List<int> srcOf; // output vertex index -> source vertex index
+  final Float32List normals; // output-vertex normals (3 per vertex)
+  final Uint32List outIndexList;
+  final bool outIndices32Bit;
+
+  if (primitive.attributes.containsKey('NORMAL')) {
+    normals = _readVec3(
+      primitive.attributes['NORMAL']!,
+      accessors,
+      bufferViews,
+      bufferData,
+    );
+    srcOf = List<int>.generate(vertexCount, (i) => i);
+    outIndexList = indexList;
+    outIndices32Bit = indices32Bit;
+  } else {
+    final triCount = indexList.length ~/ 3;
+    final outCount = triCount * 3;
+    srcOf = List<int>.filled(outCount, 0);
+    normals = Float32List(outCount * 3);
+    for (int t = 0; t < triCount; t++) {
+      final i0 = indexList[t * 3];
+      final i1 = indexList[t * 3 + 1];
+      final i2 = indexList[t * 3 + 2];
+      final ax = positions[i0 * 3];
+      final ay = positions[i0 * 3 + 1];
+      final az = positions[i0 * 3 + 2];
+      final e1x = positions[i1 * 3] - ax;
+      final e1y = positions[i1 * 3 + 1] - ay;
+      final e1z = positions[i1 * 3 + 2] - az;
+      final e2x = positions[i2 * 3] - ax;
+      final e2y = positions[i2 * 3 + 1] - ay;
+      final e2z = positions[i2 * 3 + 2] - az;
+      var nx = e1y * e2z - e1z * e2y;
+      var ny = e1z * e2x - e1x * e2z;
+      var nz = e1x * e2y - e1y * e2x;
+      final len = sqrt(nx * nx + ny * ny + nz * nz);
+      if (len > 1e-12) {
+        nx /= len;
+        ny /= len;
+        nz /= len;
+      } else {
+        // Degenerate (zero-area) triangle: pick an arbitrary normal.
+        nx = 0;
+        ny = 1;
+        nz = 0;
+      }
+      for (int c = 0; c < 3; c++) {
+        final k = t * 3 + c;
+        srcOf[k] = indexList[t * 3 + c];
+        normals[k * 3] = nx;
+        normals[k * 3 + 1] = ny;
+        normals[k * 3 + 2] = nz;
+      }
+    }
+    outIndexList = Uint32List(outCount);
+    for (int k = 0; k < outCount; k++) {
+      outIndexList[k] = k;
+    }
+    // 16-bit indices address 0..65535.
+    outIndices32Bit = outCount > 0x10000;
+  }
+
+  final outVertexCount = srcOf.length;
+  final perVertex = hasJoints ? kSkinnedPerVertexSize : kUnskinnedPerVertexSize;
+  final stride = perVertex ~/ 4; // floats per vertex
+  final out = Float32List(outVertexCount * stride);
+
+  for (int k = 0; k < outVertexCount; k++) {
+    final o = k * stride;
+    final s = srcOf[k];
+    out[o + 0] = positions[s * 3 + 0];
+    out[o + 1] = positions[s * 3 + 1];
+    out[o + 2] = positions[s * 3 + 2];
+    out[o + 3] = normals[k * 3 + 0];
+    out[o + 4] = normals[k * 3 + 1];
+    out[o + 5] = normals[k * 3 + 2];
+    out[o + 6] = texCoords[s * 2 + 0];
+    out[o + 7] = texCoords[s * 2 + 1];
+    out[o + 8] = colors[s * 4 + 0];
+    out[o + 9] = colors[s * 4 + 1];
+    out[o + 10] = colors[s * 4 + 2];
+    out[o + 11] = colors[s * 4 + 3];
+    if (hasJoints) {
+      final j = o + 12;
+      out[j + 0] = joints![s * 4 + 0];
+      out[j + 1] = joints[s * 4 + 1];
+      out[j + 2] = joints[s * 4 + 2];
+      out[j + 3] = joints[s * 4 + 3];
+      out[j + 4] = weights![s * 4 + 0];
+      out[j + 5] = weights[s * 4 + 1];
+      out[j + 6] = weights[s * 4 + 2];
+      out[j + 7] = weights[s * 4 + 3];
+    }
+  }
+
+  // The engine wants 16- or 32-bit indices. Pass 32-bit through; narrow
+  // everything else to 16-bit.
+  final Uint8List indexBytes;
+  if (outIndices32Bit) {
+    indexBytes = outIndexList.buffer.asUint8List(
+      outIndexList.offsetInBytes,
+      outIndexList.lengthInBytes,
+    );
+  } else {
+    final widened = Uint16List(outIndexList.length);
+    for (int i = 0; i < outIndexList.length; i++) {
+      widened[i] = outIndexList[i];
+    }
+    indexBytes = widened.buffer.asUint8List(
+      widened.offsetInBytes,
+      widened.lengthInBytes,
+    );
+  }
+
+  return PackedPrimitive(
+    vertexBytes: out.buffer.asUint8List(out.offsetInBytes, out.lengthInBytes),
+    vertexCount: outVertexCount,
+    indexBytes: indexBytes,
+    indexCount: outIndexList.length,
+    indices32Bit: outIndices32Bit,
+    isSkinned: hasJoints,
+  );
+}
+
+Float32List _readVec3(
+  int idx,
+  List<GltfAccessor> accessors,
+  List<GltfBufferView> bufferViews,
+  Uint8List bufferData,
+) {
+  final accessor = accessors[idx];
+  return readAccessorAsFloat32(
+    accessor,
+    bufferViews[accessor.bufferView!],
+    bufferData,
+  );
+}
+
+Float32List _readVec4(
+  int idx,
+  List<GltfAccessor> accessors,
+  List<GltfBufferView> bufferViews,
+  Uint8List bufferData,
+) {
+  final accessor = accessors[idx];
+  return readAccessorAsFloat32(
+    accessor,
+    bufferViews[accessor.bufferView!],
+    bufferData,
+  );
+}
+
+Float32List _readOptionalVec2(
+  String name,
+  GltfMeshPrimitive primitive,
+  List<GltfAccessor> accessors,
+  List<GltfBufferView> bufferViews,
+  Uint8List bufferData,
+  int vertexCount,
+) {
+  final idx = primitive.attributes[name];
+  if (idx == null) return Float32List(vertexCount * 2);
+  final accessor = accessors[idx];
+  return readAccessorAsFloat32(
+    accessor,
+    bufferViews[accessor.bufferView!],
+    bufferData,
+  );
+}
+
+Float32List _readOptionalColor(
+  String name,
+  GltfMeshPrimitive primitive,
+  List<GltfAccessor> accessors,
+  List<GltfBufferView> bufferViews,
+  Uint8List bufferData,
+  int vertexCount,
+) {
+  final idx = primitive.attributes[name];
+  if (idx == null) {
+    // Default vertex color = opaque white.
+    final out = Float32List(vertexCount * 4);
+    for (int i = 0; i < vertexCount; i++) {
+      out[i * 4 + 0] = 1.0;
+      out[i * 4 + 1] = 1.0;
+      out[i * 4 + 2] = 1.0;
+      out[i * 4 + 3] = 1.0;
+    }
+    return out;
+  }
+  final accessor = accessors[idx];
+  final raw = readAccessorAsFloat32(
+    accessor,
+    bufferViews[accessor.bufferView!],
+    bufferData,
+  );
+  if (accessor.type == GltfAccessorType.vec4) return raw;
+  // Promote vec3 colors to vec4 with alpha=1.
+  final out = Float32List(vertexCount * 4);
+  for (int i = 0; i < vertexCount; i++) {
+    out[i * 4 + 0] = raw[i * 3 + 0];
+    out[i * 4 + 1] = raw[i * 3 + 1];
+    out[i * 4 + 2] = raw[i * 3 + 2];
+    out[i * 4 + 3] = 1.0;
+  }
+  return out;
+}


### PR DESCRIPTION
Fixes skinned glTF models that ship without vertex normals, and unifies the two primitive-packing code paths. Found while testing the Khronos sample assets in the Stress Tests example.

## Generated normals for primitives with no NORMAL

glTF lets a mesh primitive omit the NORMAL attribute, and the spec requires the client to generate normals in that case. The runtime importer instead zero-filled the attribute, so every vertex got a `(0,0,0)` normal. `normalize()` of that is NaN/zero in the shader, collapsing all lighting to a flat constant. The Khronos Fox sample ships no normals and rendered as a flat gray silhouette.

The packer now generates normals when NORMAL is absent. Per the spec, these are flat (faceted): each triangle gets its own face normal. A vertex shared by several triangles can't carry a per-face normal, so such a primitive is de-indexed (every triangle expanded to three unique vertices) with a sequential index buffer. Primitives that author normals are untouched.

This fixes Fox (rendered flat gray, now lit and textured) and RecursiveSkeletons (rendered smooth, now faceted to match reference renderers).

## Shared primitive packer

The runtime GLB importer and the offline `.model` emitter each had their own copy of the vertex/index packing logic, hand-synced and verified byte-for-byte by a test. Rather than duplicate the normal-generation work into both, they now call a single `packGltfPrimitive` in `flutter_scene_importer`. It returns a backend-neutral `PackedPrimitive` (a `bool indices32Bit` flag rather than a `flutter_gpu` `IndexType`, so the importer package keeps no `flutter_gpu` dependency); each caller maps that to its own index-type representation.

This deletes the offline emitter's `_packVertices` / `_buildIndices` and the duplicated attribute-read helpers, and the runtime importer's `packPrimitive` / `PackedPrimitiveData`. Net change is about 130 fewer lines, and the offline path now also gets normal generation and de-indexing.

## Test plan

- [x] New `packGltfPrimitive` tests (normal generation, de-indexing, authored-normal passthrough); flutter_scene (73) and flutter_scene_importer (14) suites pass, including the runtime-vs-offline byte comparison and the `model_emitter` parity tests.
- [x] macOS Impeller: Fox lit and textured, RecursiveSkeletons faceted, Car/Animation (offline `.model`) unchanged.
- [ ] Verify on Pixel 10 Vulkan + Impeller GLES.
- [ ] Verify on iOS Metal.