### PR TITLE
Multi-file glTF import + glTF alpha modes

### DIFF
--- a/examples/flutter_app/lib/example_stress_tests.dart
+++ b/examples/flutter_app/lib/example_stress_tests.dart
@@ -37,6 +37,10 @@ class _StressTest {
   final int sizeBytes;
   // If set, the first matching animation is played on a loop after load.
   final String? animationName;
+
+  /// True when [url] points at a multi-file glTF (a `.gltf` JSON with
+  /// external `.bin` and image files) rather than a single-file `.glb`.
+  bool get isMultiFile => url.endsWith('.gltf');
 }
 
 const _catalog = <_StressTest>[
@@ -61,6 +65,40 @@ const _catalog = <_StressTest>[
         'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/'
         'main/Models/AntiqueCamera/glTF-Binary/AntiqueCamera.glb',
     sizeBytes: 17540348,
+  ),
+  _StressTest(
+    id: 'SciFiHelmet',
+    title: 'Sci-Fi Helmet',
+    description:
+        'High-detail PBR helmet shipped as multi-file glTF: a .gltf plus '
+        'a .bin buffer and four large textures. Exercises external '
+        'resource resolution.',
+    url:
+        'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/'
+        'main/Models/SciFiHelmet/glTF/SciFiHelmet.gltf',
+    sizeBytes: 30286979,
+  ),
+  _StressTest(
+    id: 'FlightHelmet',
+    title: 'Flight Helmet',
+    description:
+        'The Khronos high-fidelity reference: many separate meshes and '
+        'textures. Multi-file glTF.',
+    url:
+        'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/'
+        'main/Models/FlightHelmet/glTF/FlightHelmet.gltf',
+    sizeBytes: 48392569,
+  ),
+  _StressTest(
+    id: 'Sponza',
+    title: 'Sponza',
+    description:
+        'The classic architectural scene: large, many materials and '
+        'textures, lots of draw calls. Multi-file glTF (71 files).',
+    url:
+        'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/'
+        'main/Models/Sponza/glTF/Sponza.gltf',
+    sizeBytes: 52686624,
   ),
   _StressTest(
     id: 'MetalRoughSpheres',
@@ -296,20 +334,19 @@ class _StressSceneState extends State<_StressScene> {
     unawaited(_load());
   }
 
+  // Accumulates downloaded bytes (across every file of a multi-file
+  // model) into the progress display.
+  void _reportChunk(int bytes) {
+    if (!mounted) return;
+    setState(() {
+      _downloaded += bytes;
+      _total = widget.test.sizeBytes;
+    });
+  }
+
   Future<void> _load() async {
     try {
-      final bytes = await _fetchCachedGlb(
-        widget.test,
-        onProgress: (received, total) {
-          if (!mounted) return;
-          setState(() {
-            _downloaded = received;
-            _total = total ?? widget.test.sizeBytes;
-          });
-        },
-      );
-
-      final node = await Node.fromGlbBytes(bytes);
+      final node = await _importTest(widget.test, _reportChunk);
       node.name = widget.test.id;
 
       if (_kDebugDumpScene) {
@@ -697,49 +734,100 @@ class _ScenePainter extends CustomPainter {
   bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
 }
 
-// Fetches `test.url`, streaming through to a cache file in the app's
-// support directory so the second open is instant. Re-downloads on
-// short reads in case a previous run was interrupted.
-Future<Uint8List> _fetchCachedGlb(
-  _StressTest test, {
-  required void Function(int received, int? total) onProgress,
-}) async {
-  final dir = await getApplicationSupportDirectory();
-  final cacheDir = Directory('${dir.path}/stress_tests');
-  if (!await cacheDir.exists()) {
-    await cacheDir.create(recursive: true);
+// Downloads (and caches) the model for `test` and imports it.
+//
+// Single-file `.glb` models go through Node.fromGlbBytes. Multi-file
+// `.gltf` models download the `.gltf` and resolve its `.bin` / image
+// siblings on demand through Node.fromGltfBytes; every sibling is
+// fetched relative to the `.gltf`'s own URL and cached beside it.
+Future<Node> _importTest(_StressTest test, void Function(int) onChunk) async {
+  final supportDir = await getApplicationSupportDirectory();
+  final cacheRoot = Directory('${supportDir.path}/stress_tests');
+
+  if (!test.isMultiFile) {
+    if (!await cacheRoot.exists()) {
+      await cacheRoot.create(recursive: true);
+    }
+    final bytes = await _fetchCached(
+      test.url,
+      File('${cacheRoot.path}/${test.id}.glb'),
+      onChunk: onChunk,
+      expectedSize: test.sizeBytes,
+    );
+    return Node.fromGlbBytes(bytes);
   }
-  final cached = File('${cacheDir.path}/${test.id}.glb');
-  if (await cached.exists()) {
-    final bytes = await cached.readAsBytes();
-    if (bytes.lengthInBytes >= test.sizeBytes * 0.95) {
-      onProgress(bytes.lengthInBytes, bytes.lengthInBytes);
+
+  // Multi-file glTF: the `.gltf` and its siblings share a per-test dir.
+  final dir = Directory('${cacheRoot.path}/${test.id}');
+  if (!await dir.exists()) {
+    await dir.create(recursive: true);
+  }
+  final baseUri = Uri.parse(test.url);
+  final gltfBytes = await _fetchCached(
+    test.url,
+    File('${dir.path}/${_uriBasename(test.url)}'),
+    onChunk: onChunk,
+  );
+  return Node.fromGltfBytes(
+    gltfBytes,
+    resolveUri:
+        (uri) => _fetchCached(
+          baseUri.resolve(uri).toString(),
+          File('${dir.path}/${_uriBasename(uri)}'),
+          onChunk: onChunk,
+        ),
+  );
+}
+
+/// The last path segment of a (possibly percent-encoded) URI, used as
+/// the cache filename for a downloaded resource.
+String _uriBasename(String uri) {
+  final decoded = Uri.decodeComponent(uri);
+  final slash = decoded.lastIndexOf('/');
+  return slash < 0 ? decoded : decoded.substring(slash + 1);
+}
+
+// Downloads `url` into `cacheFile`, skipping the download when a usable
+// cache file is already present, and returns the bytes. `onChunk` is
+// fed each chunk's length while streaming -- and the whole file's
+// length on a cache hit -- so callers can show cumulative progress.
+Future<Uint8List> _fetchCached(
+  String url,
+  File cacheFile, {
+  required void Function(int bytes) onChunk,
+  int? expectedSize,
+}) async {
+  if (await cacheFile.exists()) {
+    final bytes = await cacheFile.readAsBytes();
+    // With a known size, reject a suspiciously short (interrupted)
+    // cache file; otherwise just require it to be non-empty.
+    final usable =
+        expectedSize == null
+            ? bytes.isNotEmpty
+            : bytes.lengthInBytes >= expectedSize * 0.95;
+    if (usable) {
+      onChunk(bytes.lengthInBytes);
       return bytes;
     }
-    // Suspiciously short → re-download.
-    await cached.delete();
+    await cacheFile.delete();
   }
 
   final client = http.Client();
   try {
-    final request = http.Request('GET', Uri.parse(test.url));
-    final response = await client.send(request);
+    final response = await client.send(http.Request('GET', Uri.parse(url)));
     if (response.statusCode != 200) {
-      throw HttpException('GET ${test.url} returned ${response.statusCode}');
+      throw HttpException('GET $url returned ${response.statusCode}');
     }
-    final total = response.contentLength;
-    final sink = cached.openWrite();
-    var received = 0;
+    final sink = cacheFile.openWrite();
     try {
       await for (final chunk in response.stream) {
         sink.add(chunk);
-        received += chunk.length;
-        onProgress(received, total);
+        onChunk(chunk.length);
       }
     } finally {
       await sink.close();
     }
-    return cached.readAsBytes();
+    return cacheFile.readAsBytes();
   } finally {
     client.close();
   }

--- a/examples/flutter_app/macos/Runner/DebugProfile.entitlements
+++ b/examples/flutter_app/macos/Runner/DebugProfile.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -37,6 +37,7 @@ export 'src/math_extensions.dart';
 export 'src/mesh.dart';
 export 'src/node.dart';
 export 'src/render/env_prefilter.dart';
+export 'src/runtime_importer/gltf_resources.dart' show GltfResourceResolver;
 export 'src/scene_encoder.dart';
 export 'src/scene.dart';
 export 'src/shaders.dart';

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -8,6 +8,22 @@ import 'package:flutter_scene/src/shaders.dart';
 import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
 import 'package:vector_math/vector_math.dart';
 
+/// How a [PhysicallyBasedMaterial]'s alpha channel is interpreted,
+/// matching glTF's `alphaMode`.
+enum AlphaMode {
+  /// Alpha is ignored; the material renders fully opaque.
+  opaque,
+
+  /// Alpha-tested: a fragment whose alpha is below
+  /// [PhysicallyBasedMaterial.alphaCutoff] is discarded and the rest
+  /// render fully opaque. Used for cut-out foliage and similar.
+  mask,
+
+  /// Alpha-blended: drawn in the depth-sorted translucent pass with
+  /// source-over blending.
+  blend,
+}
+
 /// A glTF-style metallic-roughness physically based material with
 /// image-based lighting.
 ///
@@ -103,6 +119,11 @@ class PhysicallyBasedMaterial extends Material {
       material.occlusionTexture = textures[fbMaterial.occlusionTexture];
     }
 
+    // Alpha mode.
+
+    material.alphaMode = _alphaModeFromIndex(fbMaterial.alphaMode);
+    material.alphaCutoff = fbMaterial.alphaCutoff;
+
     return material;
   }
 
@@ -176,6 +197,16 @@ class PhysicallyBasedMaterial extends Material {
   /// scene-wide `Scene.environment` when set.
   EnvironmentMap? environment;
 
+  /// How the material's alpha is interpreted; see [AlphaMode].
+  ///
+  /// [AlphaMode.blend] always routes the material through the
+  /// translucent pass regardless of [baseColorFactor]'s alpha.
+  AlphaMode alphaMode = AlphaMode.opaque;
+
+  /// Alpha-test threshold used when [alphaMode] is [AlphaMode.mask]:
+  /// fragments whose alpha falls below this are discarded.
+  double alphaCutoff = 0.5;
+
   @override
   void bind(
     gpu.RenderPass pass,
@@ -210,7 +241,9 @@ class PhysicallyBasedMaterial extends Material {
     //   [78]     float shadow_normal_bias
     //   [79]     float shadow_texel_size
     //   [80]     float render_target_flip_y
-    //   [81..83] padding to a 16-byte multiple
+    //   [81]     float alpha_mode (0 opaque, 1 mask, 2 blend)
+    //   [82]     float alpha_cutoff
+    //   [83]     padding to a 16-byte multiple
     final fragInfo = Float32List(84);
     fragInfo[0] = baseColorFactor.r;
     fragInfo[1] = baseColorFactor.g;
@@ -254,6 +287,8 @@ class PhysicallyBasedMaterial extends Material {
     // Flutter GPU has no backend query; offscreen-MSAA support is a proxy
     // (true on Metal/Vulkan, false on OpenGL ES).
     fragInfo[80] = gpu.gpuContext.doesSupportOffscreenMSAA ? 1.0 : 0.0;
+    fragInfo[81] = alphaMode.index.toDouble();
+    fragInfo[82] = alphaCutoff;
     pass.bindUniform(
       fragmentShader.getUniformSlot("FragInfo"),
       transientsBuffer.emplace(ByteData.sublistView(fragInfo)),
@@ -336,6 +371,24 @@ class PhysicallyBasedMaterial extends Material {
 
   @override
   bool isOpaque() {
-    return baseColorFactor.a == 1;
+    // BLEND always goes through the translucent pass. OPAQUE and MASK
+    // are drawn in the opaque pass (MASK relies on the shader's
+    // alpha-test discard); a sub-1 baseColorFactor alpha still forces
+    // the translucent pass so directly-constructed translucent
+    // materials keep working without an explicit alpha mode.
+    if (alphaMode == AlphaMode.blend) return false;
+    return baseColorFactor.a >= 1.0;
+  }
+}
+
+/// Maps a flatbuffer `alpha_mode` index (0/1/2) to an [AlphaMode].
+AlphaMode _alphaModeFromIndex(int index) {
+  switch (index) {
+    case 1:
+      return AlphaMode.mask;
+    case 2:
+      return AlphaMode.blend;
+    default:
+      return AlphaMode.opaque;
   }
 }

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -311,6 +311,31 @@ base class Node implements SceneGraph {
     );
   }
 
+  /// Load a multi-file glTF model from the raw bytes of its `.gltf`
+  /// (JSON) file.
+  ///
+  /// Multi-file glTF keeps its geometry buffer and images in separate
+  /// files referenced by relative URI. [resolveUri] fetches each of
+  /// those resources by URI — for example downloading them relative to
+  /// the `.gltf`'s own URL, or reading sibling files from disk.
+  /// `data:` URIs are decoded internally and never reach [resolveUri].
+  ///
+  /// For single-file `.glb` models use [fromGlbBytes] instead.
+  ///
+  /// Example:
+  /// ```dart
+  /// final node = await Node.fromGltfBytes(
+  ///   gltfJsonBytes,
+  ///   resolveUri: (uri) => fetchBytes('$baseUrl/$uri'),
+  /// );
+  /// ```
+  static Future<Node> fromGltfBytes(
+    Uint8List gltfJson, {
+    required GltfResourceResolver resolveUri,
+  }) {
+    return importGltf(gltfJson, resolveUri: resolveUri);
+  }
+
   /// Deserialize a model from Flutter Scene's compact model format.
   ///
   /// If you're using [Flutter Scene's offline importer tool](https://pub.dev/packages/flutter_scene_importer),

--- a/packages/flutter_scene/lib/src/runtime_importer/gltf_resources.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/gltf_resources.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Resolves an external resource referenced by a multi-file glTF
+/// document (a `.bin` buffer or an image file).
+///
+/// Given the raw relative URI string from the glTF, returns the
+/// resource's bytes. Supplied by the caller of [Node.fromGltfBytes] /
+/// `importGltf`; `data:` URIs are decoded internally and never reach
+/// the resolver.
+typedef GltfResourceResolver = Future<Uint8List> Function(String uri);
+
+/// Decodes a `data:` URI into its raw bytes.
+///
+/// glTF embeds binary resources as base64 `data:` URIs; that is the
+/// only form expected here. A non-base64 (percent-encoded text) data
+/// URI is decoded as UTF-8 text for completeness.
+Uint8List decodeGltfDataUri(String uri) {
+  final comma = uri.indexOf(',');
+  if (comma < 0) {
+    throw FormatException('Malformed data URI: $uri');
+  }
+  final meta = uri.substring(0, comma);
+  final payload = uri.substring(comma + 1);
+  if (meta.contains(';base64')) {
+    return base64Decode(payload);
+  }
+  return Uint8List.fromList(utf8.encode(Uri.decodeComponent(payload)));
+}

--- a/packages/flutter_scene/lib/src/runtime_importer/material_builder.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/material_builder.dart
@@ -50,7 +50,21 @@ Material buildMaterial(GltfMaterial? gm, List<gpu.Texture> textures) {
     gm.emissiveFactor.length > 2 ? gm.emissiveFactor[2] : 0.0,
     1.0,
   );
+  m.alphaMode = _alphaMode(gm.alphaMode);
+  m.alphaCutoff = gm.alphaCutoff;
   return m;
+}
+
+/// Maps a glTF `alphaMode` string to the engine [AlphaMode].
+AlphaMode _alphaMode(String mode) {
+  switch (mode) {
+    case 'MASK':
+      return AlphaMode.mask;
+    case 'BLEND':
+      return AlphaMode.blend;
+    default:
+      return AlphaMode.opaque;
+  }
 }
 
 gpu.Texture? _resolveTexture(

--- a/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
@@ -9,9 +11,12 @@ import '../node.dart';
 import '../skin.dart';
 import 'animation_builder.dart';
 import 'geometry_builder.dart';
+import 'gltf_resources.dart';
 import 'material_builder.dart';
 import 'skin_builder.dart';
 import 'texture_builder.dart';
+
+export 'gltf_resources.dart' show GltfResourceResolver;
 
 /// Parse a GLB byte stream into a [Node] tree.
 ///
@@ -21,12 +26,48 @@ import 'texture_builder.dart';
 Future<Node> importGlb(Uint8List bytes) async {
   final container = parseGlb(bytes);
   final doc = parseGltfJson(container.json);
+  final bufferData = await _resolveBufferData(
+    doc,
+    glbBinaryChunk: container.binaryChunk,
+    resolveUri: null,
+  );
+  return _buildScene(doc, bufferData, null);
+}
 
-  final bufferData = _resolveBufferData(doc, container.binaryChunk);
+/// Parse a multi-file glTF document into a [Node] tree.
+///
+/// [gltfJson] is the raw bytes of the `.gltf` file. [resolveUri] fetches
+/// each external resource (the `.bin` buffer and image files) the
+/// document references by relative URI; `data:` URIs are decoded
+/// internally and never reach the resolver.
+Future<Node> importGltf(
+  Uint8List gltfJson, {
+  required GltfResourceResolver resolveUri,
+}) async {
+  final json = jsonDecode(utf8.decode(gltfJson)) as Map<String, Object?>;
+  final doc = parseGltfJson(json);
+  final bufferData = await _resolveBufferData(
+    doc,
+    glbBinaryChunk: Uint8List(0),
+    resolveUri: resolveUri,
+  );
+  return _buildScene(doc, bufferData, resolveUri);
+}
 
+/// Builds the [Node] tree from a parsed document and its resolved
+/// buffer. Shared by the GLB and multi-file glTF entry points.
+Future<Node> _buildScene(
+  GltfDocument doc,
+  Uint8List bufferData,
+  GltfResourceResolver? resolveUri,
+) async {
   // Decode all textures up front so material construction can reference
   // them by index without per-material async work.
-  final List<gpu.Texture> textures = await buildTextures(doc, bufferData);
+  final List<gpu.Texture> textures = await buildTextures(
+    doc,
+    bufferData,
+    resolveUri: resolveUri,
+  );
 
   // Pre-allocate engine Node placeholders 1:1 with glTF nodes so children
   // can refer to them by index regardless of the order we visit them in.
@@ -167,22 +208,33 @@ Matrix4 _localTransformFor(GltfNode n) {
 
 /// Returns the binary buffer that backs the document's bufferViews.
 ///
-/// For GLB, the implicit "buffer 0" is the embedded BIN chunk. External buffer
-/// references (data URIs or relative URIs) are not yet supported — they're
-/// part of the .gltf (text) loader path planned as a follow-up.
-Uint8List _resolveBufferData(GltfDocument doc, Uint8List glbBinaryChunk) {
+/// For GLB the implicit "buffer 0" is the embedded BIN chunk. For
+/// multi-file glTF the single buffer is resolved from its URI: a
+/// `data:` URI is decoded inline, an external URI goes through
+/// [resolveUri]. glTF documents with more than one buffer are not yet
+/// supported (none of the engine's target assets need it).
+Future<Uint8List> _resolveBufferData(
+  GltfDocument doc, {
+  required Uint8List glbBinaryChunk,
+  required GltfResourceResolver? resolveUri,
+}) async {
   if (doc.buffers.isEmpty) {
     return glbBinaryChunk;
   }
   if (doc.buffers.length > 1) {
     throw const FormatException(
-      'GLB with multiple buffers is not yet supported by the runtime importer',
+      'glTF with multiple buffers is not yet supported by the runtime '
+      'importer',
     );
   }
-  final b = doc.buffers.first;
-  if (b.uri == null) return glbBinaryChunk; // GLB embedded buffer
-  throw FormatException(
-    'GLB references external buffer URI "${b.uri}". External buffers are not '
-    'yet supported by the runtime importer.',
-  );
+  final uri = doc.buffers.first.uri;
+  if (uri == null) return glbBinaryChunk; // GLB embedded buffer.
+  if (uri.startsWith('data:')) return decodeGltfDataUri(uri);
+  if (resolveUri == null) {
+    throw FormatException(
+      'glTF references external buffer "$uri" but no resource resolver was '
+      'provided. Use importGltf / Node.fromGltfBytes for multi-file glTF.',
+    );
+  }
+  return resolveUri(uri);
 }

--- a/packages/flutter_scene/lib/src/runtime_importer/texture_builder.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/texture_builder.dart
@@ -6,20 +6,22 @@ import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_scene_importer/gltf.dart';
 
 import '../asset_helpers.dart';
+import 'gltf_resources.dart';
 
 /// Decode each glTF texture into a [gpu.Texture]. Each entry in the returned
 /// list corresponds 1:1 to `doc.textures` so material indexes resolve directly.
 ///
-/// Tier 2 supports:
-/// - Images embedded in the GLB binary chunk (referenced via `bufferView`).
-///
-/// Not yet supported:
-/// - Images referenced by URI (data URIs or external files). These will be
-///   handled when text glTF (.gltf) loading is added.
+/// Image data is sourced from the GLB binary chunk (images referenced
+/// via `bufferView`), from a `data:` URI (decoded inline), or from an
+/// external file URI fetched through [resolveUri] when one is given
+/// (multi-file glTF). An image that can't be sourced or decoded falls
+/// back to a 1x1 white placeholder so material binding never sees a
+/// null texture.
 Future<List<gpu.Texture>> buildTextures(
   GltfDocument doc,
-  Uint8List bufferData,
-) async {
+  Uint8List bufferData, {
+  GltfResourceResolver? resolveUri,
+}) async {
   final results = <gpu.Texture>[];
   for (int i = 0; i < doc.textures.length; i++) {
     final tex = doc.textures[i];
@@ -39,14 +41,28 @@ Future<List<gpu.Texture>> buildTextures(
         bv.byteOffset + bv.byteLength,
       );
     } else if (image.uri != null) {
-      // Tier 2 only handles GLB (single embedded buffer). External image URIs
-      // come with text-glTF support later.
-      debugPrint(
-        'glTF image $imageIdx references external URI "${image.uri}" — '
-        'not supported by the runtime importer yet. Using placeholder.',
-      );
-      results.add(_placeholder());
-      continue;
+      final uri = image.uri!;
+      if (uri.startsWith('data:')) {
+        imageBytes = decodeGltfDataUri(uri);
+      } else if (resolveUri != null) {
+        try {
+          imageBytes = await resolveUri(uri);
+        } catch (e) {
+          debugPrint(
+            'Failed to resolve glTF image $imageIdx URI "$uri": $e. '
+            'Using placeholder.',
+          );
+          results.add(_placeholder());
+          continue;
+        }
+      } else {
+        debugPrint(
+          'glTF image $imageIdx references external URI "$uri" but no '
+          'resource resolver was provided. Using placeholder.',
+        );
+        results.add(_placeholder());
+        continue;
+      }
     } else {
       results.add(_placeholder());
       continue;

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -39,6 +39,11 @@ uniform FragInfo {
   // when sampling the shadow map and the prefiltered-radiance atlas; the
   // Dart side fills it (Flutter GPU has no backend macro).
   float render_target_flip_y;
+  // glTF alpha mode: 0 opaque, 1 mask, 2 blend. In mask mode a fragment
+  // whose alpha is below alpha_cutoff is discarded and the rest are
+  // forced fully opaque.
+  float alpha_mode;
+  float alpha_cutoff;
 }
 frag_info;
 
@@ -118,6 +123,14 @@ void main() {
   vec3 albedo = SRGBToLinear(base_color_srgb.rgb) * vertex_color.rgb *
                 frag_info.color.rgb;
   float alpha = base_color_srgb.a * vertex_color.a * frag_info.color.a;
+  // MASK alpha mode: discard fragments below the cutoff, render the
+  // rest fully opaque (glTF treats MASK output as binary).
+  if (frag_info.alpha_mode == 1.0) {
+    if (alpha < frag_info.alpha_cutoff) {
+      discard;
+    }
+    alpha = 1.0;
+  }
   // Note: PerturbNormal needs the non-normalized view vector
   //       (camera_position - vertex_position).
   vec3 normal = normalize(v_normal);

--- a/packages/flutter_scene_importer/lib/generated/scene_impeller.fb_flatbuffers.dart
+++ b/packages/flutter_scene_importer/lib/generated/scene_impeller.fb_flatbuffers.dart
@@ -684,10 +684,13 @@ class Material {
       const fb.Float32Reader().vTableGet(_bc, _bcOffset, 24, 1.0);
   int get occlusionTexture =>
       const fb.Int32Reader().vTableGet(_bc, _bcOffset, 26, -1);
+  int get alphaMode => const fb.Int8Reader().vTableGet(_bc, _bcOffset, 28, 0);
+  double get alphaCutoff =>
+      const fb.Float32Reader().vTableGet(_bc, _bcOffset, 30, 0.5);
 
   @override
   String toString() {
-    return 'Material{type: ${type}, baseColorFactor: ${baseColorFactor}, baseColorTexture: ${baseColorTexture}, metallicFactor: ${metallicFactor}, roughnessFactor: ${roughnessFactor}, metallicRoughnessTexture: ${metallicRoughnessTexture}, normalScale: ${normalScale}, normalTexture: ${normalTexture}, emissiveFactor: ${emissiveFactor}, emissiveTexture: ${emissiveTexture}, occlusionStrength: ${occlusionStrength}, occlusionTexture: ${occlusionTexture}}';
+    return 'Material{type: ${type}, baseColorFactor: ${baseColorFactor}, baseColorTexture: ${baseColorTexture}, metallicFactor: ${metallicFactor}, roughnessFactor: ${roughnessFactor}, metallicRoughnessTexture: ${metallicRoughnessTexture}, normalScale: ${normalScale}, normalTexture: ${normalTexture}, emissiveFactor: ${emissiveFactor}, emissiveTexture: ${emissiveTexture}, occlusionStrength: ${occlusionStrength}, occlusionTexture: ${occlusionTexture}, alphaMode: ${alphaMode}, alphaCutoff: ${alphaCutoff}}';
   }
 
   MaterialT unpack() => MaterialT(
@@ -703,6 +706,8 @@ class Material {
     emissiveTexture: emissiveTexture,
     occlusionStrength: occlusionStrength,
     occlusionTexture: occlusionTexture,
+    alphaMode: alphaMode,
+    alphaCutoff: alphaCutoff,
   );
 
   static int pack(fb.Builder fbBuilder, MaterialT? object) {
@@ -728,6 +733,8 @@ class MaterialT implements fb.Packable {
   int emissiveTexture;
   double occlusionStrength;
   int occlusionTexture;
+  int alphaMode;
+  double alphaCutoff;
 
   MaterialT({
     this.type = MaterialType.kUnlit,
@@ -742,11 +749,13 @@ class MaterialT implements fb.Packable {
     this.emissiveTexture = -1,
     this.occlusionStrength = 1.0,
     this.occlusionTexture = -1,
+    this.alphaMode = 0,
+    this.alphaCutoff = 0.5,
   });
 
   @override
   int pack(fb.Builder fbBuilder) {
-    fbBuilder.startTable(12);
+    fbBuilder.startTable(14);
     fbBuilder.addInt8(0, type.value);
     if (baseColorFactor != null) {
       fbBuilder.addStruct(1, baseColorFactor!.pack(fbBuilder));
@@ -763,12 +772,14 @@ class MaterialT implements fb.Packable {
     fbBuilder.addInt32(9, emissiveTexture);
     fbBuilder.addFloat32(10, occlusionStrength);
     fbBuilder.addInt32(11, occlusionTexture);
+    fbBuilder.addInt8(12, alphaMode);
+    fbBuilder.addFloat32(13, alphaCutoff);
     return fbBuilder.endTable();
   }
 
   @override
   String toString() {
-    return 'MaterialT{type: ${type}, baseColorFactor: ${baseColorFactor}, baseColorTexture: ${baseColorTexture}, metallicFactor: ${metallicFactor}, roughnessFactor: ${roughnessFactor}, metallicRoughnessTexture: ${metallicRoughnessTexture}, normalScale: ${normalScale}, normalTexture: ${normalTexture}, emissiveFactor: ${emissiveFactor}, emissiveTexture: ${emissiveTexture}, occlusionStrength: ${occlusionStrength}, occlusionTexture: ${occlusionTexture}}';
+    return 'MaterialT{type: ${type}, baseColorFactor: ${baseColorFactor}, baseColorTexture: ${baseColorTexture}, metallicFactor: ${metallicFactor}, roughnessFactor: ${roughnessFactor}, metallicRoughnessTexture: ${metallicRoughnessTexture}, normalScale: ${normalScale}, normalTexture: ${normalTexture}, emissiveFactor: ${emissiveFactor}, emissiveTexture: ${emissiveTexture}, occlusionStrength: ${occlusionStrength}, occlusionTexture: ${occlusionTexture}, alphaMode: ${alphaMode}, alphaCutoff: ${alphaCutoff}}';
   }
 }
 
@@ -786,7 +797,7 @@ class MaterialBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable(12);
+    fbBuilder.startTable(14);
   }
 
   int addType(MaterialType? type) {
@@ -849,6 +860,16 @@ class MaterialBuilder {
     return fbBuilder.offset;
   }
 
+  int addAlphaMode(int? alphaMode) {
+    fbBuilder.addInt8(12, alphaMode);
+    return fbBuilder.offset;
+  }
+
+  int addAlphaCutoff(double? alphaCutoff) {
+    fbBuilder.addFloat32(13, alphaCutoff);
+    return fbBuilder.offset;
+  }
+
   int finish() {
     return fbBuilder.endTable();
   }
@@ -867,6 +888,8 @@ class MaterialObjectBuilder extends fb.ObjectBuilder {
   final int? _emissiveTexture;
   final double? _occlusionStrength;
   final int? _occlusionTexture;
+  final int? _alphaMode;
+  final double? _alphaCutoff;
 
   MaterialObjectBuilder({
     MaterialType? type,
@@ -881,6 +904,8 @@ class MaterialObjectBuilder extends fb.ObjectBuilder {
     int? emissiveTexture,
     double? occlusionStrength,
     int? occlusionTexture,
+    int? alphaMode,
+    double? alphaCutoff,
   }) : _type = type,
        _baseColorFactor = baseColorFactor,
        _baseColorTexture = baseColorTexture,
@@ -892,12 +917,14 @@ class MaterialObjectBuilder extends fb.ObjectBuilder {
        _emissiveFactor = emissiveFactor,
        _emissiveTexture = emissiveTexture,
        _occlusionStrength = occlusionStrength,
-       _occlusionTexture = occlusionTexture;
+       _occlusionTexture = occlusionTexture,
+       _alphaMode = alphaMode,
+       _alphaCutoff = alphaCutoff;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    fbBuilder.startTable(12);
+    fbBuilder.startTable(14);
     fbBuilder.addInt8(0, _type?.value);
     if (_baseColorFactor != null) {
       fbBuilder.addStruct(1, _baseColorFactor!.finish(fbBuilder));
@@ -914,6 +941,8 @@ class MaterialObjectBuilder extends fb.ObjectBuilder {
     fbBuilder.addInt32(9, _emissiveTexture);
     fbBuilder.addFloat32(10, _occlusionStrength);
     fbBuilder.addInt32(11, _occlusionTexture);
+    fbBuilder.addInt8(12, _alphaMode);
+    fbBuilder.addFloat32(13, _alphaCutoff);
     return fbBuilder.endTable();
   }
 

--- a/packages/flutter_scene_importer/lib/src/fb_emitter/model_emitter.dart
+++ b/packages/flutter_scene_importer/lib/src/fb_emitter/model_emitter.dart
@@ -367,6 +367,13 @@ fb.MaterialT _buildMaterial(GltfMaterial m) {
     y: _at(m.emissiveFactor, 1, 0.0),
     z: _at(m.emissiveFactor, 2, 0.0),
   );
+  // glTF alpha mode: 0 = OPAQUE, 1 = MASK, 2 = BLEND.
+  out.alphaMode = switch (m.alphaMode) {
+    'MASK' => 1,
+    'BLEND' => 2,
+    _ => 0,
+  };
+  out.alphaCutoff = m.alphaCutoff;
   return out;
 }
 

--- a/packages/flutter_scene_importer/scene.fbs
+++ b/packages/flutter_scene_importer/scene.fbs
@@ -67,6 +67,11 @@ table Material {
 
   occlusion_strength: float = 1.0;
   occlusion_texture: int = -1;
+
+  // glTF alpha mode: 0 = OPAQUE, 1 = MASK, 2 = BLEND.
+  alpha_mode: byte = 0;
+  // Alpha cutoff threshold; used only when alpha_mode is MASK.
+  alpha_cutoff: float = 0.5;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Adds multi-file glTF support to the runtime importer and glTF alpha-mode handling to the renderer. Both came out of testing the Khronos sample assets in the Stress Tests example.

Not the best Sponza I've ever seen, but we'll get there.

<img width="912" height="740" alt="image" src="https://github.com/user-attachments/assets/ded07a45-bf70-449a-960e-8e96506dde10" />

<img width="998" height="764" alt="image" src="https://github.com/user-attachments/assets/ed1c6968-ce61-4a6e-8324-20595dca122e" />


## Multi-file glTF

The runtime importer only handled single-file GLB. Multi-file glTF (a `.gltf` JSON with external `.bin` buffers and image files referenced by relative URI) was rejected, which excluded much of the Khronos corpus.

Adds `importGltf` / `Node.fromGltfBytes`, taking the `.gltf` bytes plus a `GltfResourceResolver` callback that fetches each external resource by URI. `data:` URIs are decoded inline. The GLB and glTF entry points share one scene-building core.

The Stress Tests example gains Sci-Fi Helmet, Flight Helmet, and Sponza (multi-file glTF, 29-50 MB each). A `.gltf` catalog entry downloads the `.gltf` and resolves its siblings on demand relative to the `.gltf` URL, caching every file per-test.

## glTF alpha modes

The importer parsed `alphaMode` / `alphaCutoff` but nothing used them, so every material rendered OPAQUE. MASK materials (cut-out foliage like Sponza's leaves) wrote transparent texels into the opaque pass; BLEND materials rendered solid.

`PhysicallyBasedMaterial` gains an `AlphaMode` and `alphaCutoff`. `isOpaque()` is false for BLEND so it routes through the translucent pass. The standard fragment shader discards MASK fragments below the cutoff and forces the rest opaque. `scene.fbs` gains `alpha_mode` + `alpha_cutoff`; both importers carry it through. The generated flatbuffer code is hand-patched to match (the committed generated file predates the locally available flatc version, so a full regen would rewrite the whole file).

## Notes

- The example app's macOS debug entitlements are now tracked (force-added past the gitignored `macos/` scaffolding) so the Stress Tests screen keeps its network access across checkouts.
- Flight Helmet's goggle lenses still render opaque: they use `KHR_materials_transmission`, an unsupported extension, not alpha blending. Filed as a follow-up.

## Test plan

- [x] flutter_scene (73) and flutter_scene_importer (14) suites pass, including the runtime-vs-offline byte comparison.
- [x] macOS Impeller: SciFiHelmet / FlightHelmet / Sponza download and render; Sponza's MASK foliage renders cut-out; existing single-file stress tests and offline `.model` models unaffected.
- [ ] Verify on Pixel 10 Vulkan + Impeller GLES.
- [ ] Verify on iOS Metal.