### PR TITLE
Add a dynamic geometry system

### DIFF
--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -129,11 +129,15 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
       scene.add(Node(mesh: Mesh(line, UnlitMaterial())));
     }
 
-    // A dashed yellow center line.
+    // A dashed yellow center line, each dash rounded at both ends.
     final center = PolylineGeometry(
       _offsetPath(road, 0.0, lift: _markingHeight),
       width: 5,
-      dash: const DashPattern(dashLength: 1.6, gapLength: 1.2),
+      dash: const DashPattern(
+        dashLength: 1.6,
+        gapLength: 1.2,
+        cap: PolylineCap.round,
+      ),
     );
     markings.add(center);
     scene.add(

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -81,6 +81,11 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
   // Rolling wheel-spin angle, advanced from the spin slider each frame.
   double _wheelRotation = 0.0;
 
+  // The animated route line ahead of the car. Its mesh is rebuilt every
+  // frame by the painter; the node and material persist.
+  final Node _navNode = Node();
+  final UnlitMaterial _navMaterial = UnlitMaterial();
+
   @override
   void initState() {
     // A directional "sun" that lights the scene and casts shadows. Its
@@ -105,6 +110,10 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
     );
 
     _addRoad(mainRoad);
+
+    // The route line ahead of the car lives in its own node; the
+    // painter rebuilds its mesh every frame.
+    scene.add(_navNode);
 
     // The example car drives the loop. It is wrapped in a parent node so
     // its imported transform is left intact, and scaled from its bounds.
@@ -245,6 +254,8 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
               carScale: carScale,
               carLift: carLift,
               followCam: _followCam,
+              navNode: _navNode,
+              navMaterial: _navMaterial,
               elapsedSeconds: widget.elapsedSeconds,
             ),
           ),
@@ -291,6 +302,72 @@ List<vm.Vector3> _offsetPath(
   return result;
 }
 
+// Arc length between bright bands in the route line, and how fast (in
+// pattern cycles per second) the bands flow forward along it.
+const double _navWavelength = 7.0;
+const double _navPulseSpeed = 0.8;
+
+// Builds the route line: a thick blue ribbon lying flat just above the
+// car's lane, starting just ahead of the car and reaching forward along
+// the road. A flat ribbon (rather than a camera-facing line) never
+// tilts down into the road surface, and ordinary depth testing then
+// layers it correctly: above the flat road, below the taller car. Each
+// vertex carries a color from a gradient whose bright bands flow away
+// from the car as [elapsedSeconds] advances.
+MeshGeometry _buildNavLine(
+  ScenePath road,
+  double carDistance,
+  double elapsedSeconds,
+) {
+  const samples = 44;
+  const startOffset = 1.6; // begins just past the car's front
+  const aheadLength = 32.0; // how far ahead the route reaches
+  const lift = 0.08; // floats just above the road
+  const halfWidth = 0.55; // a ~1.1 unit wide ribbon
+  final up = vm.Vector3(0, 1, 0);
+  final deep = vm.Vector3(0.05, 0.18, 0.55);
+  final bright = vm.Vector3(0.45, 0.85, 1.5);
+
+  final builder = GeometryBuilder(deduplicate: false)..normal(up);
+  for (var i = 0; i < samples; i++) {
+    final t = i / (samples - 1);
+    final ahead = startOffset + (aheadLength - startOffset) * t;
+    // Ahead of the car is the decreasing-distance direction; wrap so the
+    // line reaches across the loop's seam.
+    final d = (carDistance - ahead) % road.length;
+    final frame = road.frameAtDistance(d);
+    final lateral = _lateral(frame.tangent);
+    final center = frame.position + lateral * (_roadWidth / 4);
+    final y = center.y + lift;
+    final left = center - lateral * halfWidth;
+    final right = center + lateral * halfWidth;
+
+    // Bright bands flow outward, dimming toward the far end.
+    final phase =
+        (ahead - startOffset) / _navWavelength -
+        elapsedSeconds * _navPulseSpeed;
+    final pulse = 0.5 + 0.5 * sin(2 * pi * phase);
+    final fade = 1.0 - 0.5 * t;
+    final c = (deep + (bright - deep) * pulse)..scale(fade);
+
+    builder
+      ..color(vm.Vector4(c.x, c.y, c.z, 1.0))
+      ..addVertex(vm.Vector3(left.x, y, left.z))
+      ..addVertex(vm.Vector3(right.x, y, right.z));
+  }
+  // Stitch consecutive cross-sections into a triangle strip. The line is
+  // sampled in the car's travel direction (decreasing path distance), so
+  // the winding is reversed from a forward-traversed ribbon to keep the
+  // surface facing up.
+  for (var i = 0; i < samples - 1; i++) {
+    final base = i * 2;
+    builder
+      ..addTriangle(base, base + 1, base + 2)
+      ..addTriangle(base + 1, base + 3, base + 2);
+  }
+  return builder.build();
+}
+
 // Mutable smoothing state for the chase camera, carried across frames.
 class _FollowCamState {
   vm.Vector3? anchorPosition;
@@ -307,6 +384,8 @@ class _NavRoutePainter extends CustomPainter {
     required this.carScale,
     required this.carLift,
     required this.followCam,
+    required this.navNode,
+    required this.navMaterial,
     required this.elapsedSeconds,
   });
 
@@ -317,6 +396,8 @@ class _NavRoutePainter extends CustomPainter {
   final double carScale;
   final double carLift;
   final _FollowCamState followCam;
+  final Node navNode;
+  final UnlitMaterial navMaterial;
   final double elapsedSeconds;
 
   @override
@@ -341,6 +422,15 @@ class _NavRoutePainter extends CustomPainter {
     // The camera-facing marking lines are rebuilt for the current view.
     for (final marking in markings) {
       marking.updateForCamera(camera, size);
+    }
+
+    // The route line: a thick blue ribbon along the lane ahead of the
+    // car, rebuilt each frame so its gradient pulses forward.
+    if (carNode != null) {
+      navNode.mesh = Mesh(
+        _buildNavLine(road, distance, elapsedSeconds),
+        navMaterial,
+      );
     }
 
     final car = carNode;

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -126,14 +126,14 @@ class _NavRoutePainter extends CustomPainter {
       target: vm.Vector3(0, 0.3, 0),
     );
 
-    // The camera-facing route line is rebuilt for the current view.
-    routeLine.updateForCamera(camera, size);
-
-    // Drive the marker along the route, looping.
+    // The marker drives the route, looping, and the line draws on up to
+    // it.
     final distance = (elapsedSeconds * 3.5) % route.length;
     markerNode.localTransform = vm.Matrix4.translation(
       route.positionAtDistance(distance)..y = 0.45,
     );
+    routeLine.drawEnd = distance / route.length;
+    routeLine.updateForCamera(camera, size);
 
     scene.render(camera, canvas, viewport: Offset.zero & size);
   }

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -71,6 +71,9 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
   double carScale = 1.0;
   double carLift = 0.0;
 
+  // Smoothing state for the chase camera, carried across frames.
+  final _FollowCamState _followCam = _FollowCamState();
+
   @override
   void initState() {
     // The ground.
@@ -153,6 +156,7 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
         carNode: carNode,
         carScale: carScale,
         carLift: carLift,
+        followCam: _followCam,
         elapsedSeconds: widget.elapsedSeconds,
       ),
     );
@@ -183,6 +187,13 @@ List<vm.Vector3> _offsetPath(
   return result;
 }
 
+// Mutable smoothing state for the chase camera, carried across frames.
+class _FollowCamState {
+  vm.Vector3? anchorPosition;
+  vm.Vector3? anchorDirection;
+  double lastElapsed = 0.0;
+}
+
 class _NavRoutePainter extends CustomPainter {
   _NavRoutePainter({
     required this.scene,
@@ -191,6 +202,7 @@ class _NavRoutePainter extends CustomPainter {
     required this.carNode,
     required this.carScale,
     required this.carLift,
+    required this.followCam,
     required this.elapsedSeconds,
   });
 
@@ -200,43 +212,87 @@ class _NavRoutePainter extends CustomPainter {
   final Node? carNode;
   final double carScale;
   final double carLift;
+  final _FollowCamState followCam;
   final double elapsedSeconds;
 
   @override
   void paint(Canvas canvas, Size size) {
-    final angle = elapsedSeconds * 0.3;
-    final camera = PerspectiveCamera(
-      position: vm.Vector3(sin(angle) * 42, 27, cos(angle) * 42),
-      target: vm.Vector3(0, 0.3, 0),
-    );
+    // The car's pose on the loop. Distance runs backward along the path
+    // so the car travels counterclockwise, and its lane is the
+    // centerline shifted to the opposite side. Querying the smooth
+    // curve directly keeps the heading continuous.
+    final distance = (-elapsedSeconds * 4.0) % road.length;
+    final frame = road.frameAtDistance(distance);
+    final carPosition =
+        frame.position + _lateral(frame.tangent) * (_roadWidth / 4);
+    // The car travels against the path tangent.
+    final travelDirection = -frame.tangent;
+
+    final camera = _followCamera(carPosition, travelDirection);
 
     // The camera-facing marking lines are rebuilt for the current view.
     for (final marking in markings) {
       marking.updateForCamera(camera, size);
     }
 
-    // Drive the car around the loop. Distance runs backward along the
-    // path so the car travels counterclockwise, and its lane is the
-    // centerline shifted to the opposite side. Querying the smooth
-    // curve directly keeps the heading continuous.
     final car = carNode;
     if (car != null) {
-      final distance = (-elapsedSeconds * 9.0) % road.length;
-      final frame = road.frameAtDistance(distance);
-      final position =
-          frame.position + _lateral(frame.tangent) * (_roadWidth / 4);
-      // The car travels against the path tangent.
       final heading =
-          atan2(-frame.tangent.x, -frame.tangent.z) + _carHeadingOffset;
+          atan2(travelDirection.x, travelDirection.z) + _carHeadingOffset;
       car.localTransform =
           vm.Matrix4.translation(
-              vm.Vector3(position.x, position.y + carLift, position.z),
+              vm.Vector3(carPosition.x, carPosition.y + carLift, carPosition.z),
             )
             ..rotateY(heading)
             ..scaleByDouble(carScale, carScale, carScale, 1.0);
     }
 
     scene.render(camera, canvas, viewport: Offset.zero & size);
+  }
+
+  // A chase camera that eases along behind the car and looks down at it
+  // at 45 degrees. The followed anchor lags the car, which smooths the
+  // swing through curves; the camera sits rigidly behind the anchor, so
+  // the downward angle stays a constant 45 degrees.
+  PerspectiveCamera _followCamera(
+    vm.Vector3 carPosition,
+    vm.Vector3 travelDirection,
+  ) {
+    const followDistance = 6.5;
+    const lookLift = 0.2;
+    const stiffness = 5.0;
+
+    // Ease the anchor toward the car by a time-based fraction.
+    final dt = (elapsedSeconds - followCam.lastElapsed).clamp(0.0, 0.05);
+    followCam.lastElapsed = elapsedSeconds;
+    final blend = 1.0 - exp(-stiffness * dt);
+
+    final anchorPosition = followCam.anchorPosition;
+    final anchorDirection = followCam.anchorDirection;
+    if (anchorPosition == null || anchorDirection == null) {
+      followCam.anchorPosition = carPosition.clone();
+      followCam.anchorDirection = travelDirection.clone();
+    } else {
+      followCam.anchorPosition =
+          anchorPosition + (carPosition - anchorPosition) * blend;
+      final direction =
+          anchorDirection + (travelDirection - anchorDirection) * blend;
+      if (direction.length2 > 1e-9) direction.normalize();
+      followCam.anchorDirection = direction;
+    }
+
+    final anchor = followCam.anchorPosition!;
+    final forward = followCam.anchorDirection!;
+    // Behind the anchor, raised by the follow distance above the look
+    // target: equal horizontal and vertical offsets give a 45 degree
+    // downward look.
+    return PerspectiveCamera(
+      position:
+          anchor -
+          forward * followDistance +
+          vm.Vector3(0.0, lookLift + followDistance / 2, 0.0),
+      target: anchor + vm.Vector3(0.0, lookLift + 2, 0.0),
+    );
   }
 
   @override

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -4,12 +4,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
-/// An infotainment-style navigation scene: a ground map, a route
-/// corridor ribbon, a camera-facing route line of constant pixel width,
-/// and a marker travelling the route.
+// Added to the heading derived from the lane tangent, to account for the
+// car model's forward axis. Flip the sign if the car faces backward.
+const double _carHeadingOffset = -pi / 2;
+
+const double _roadWidth = 5.0;
+const double _markingHeight = 0.13;
+
+/// An infotainment-style navigation scene: a long looping road track
+/// with painted edge and center lines, and the example car driving it
+/// indefinitely.
 ///
 /// Exercises the dynamic geometry API: [PlaneGeometry], [CatmullRomPath],
-/// [RibbonGeometry], [PolylineGeometry], and [SphereGeometry].
+/// [RibbonGeometry], and [PolylineGeometry] (solid and dashed).
 class ExampleNavRoute extends StatefulWidget {
   const ExampleNavRoute({super.key, this.elapsedSeconds = 0});
   final double elapsedSeconds;
@@ -21,71 +28,119 @@ class ExampleNavRoute extends StatefulWidget {
 class ExampleNavRouteState extends State<ExampleNavRoute> {
   final Scene scene = Scene();
 
-  // Waypoints of the planned route, smoothed into a curve.
-  static final CatmullRomPath route = CatmullRomPath([
-    vm.Vector3(-8, 0.05, -6),
-    vm.Vector3(-3, 0.05, -8),
-    vm.Vector3(2, 0.05, -3),
-    vm.Vector3(6, 0.05, 3),
-    vm.Vector3(1, 0.05, 7),
-    vm.Vector3(-5, 0.05, 4),
+  // The waypoints of the closed loop. The track runs through them in
+  // order and back to the first. They are spaced widely around a long
+  // elongated circuit that winds gently, so the lap is long while every
+  // curve stays large-radius and smooth. The three around the join,
+  // with the first repeated to close the path, are collinear and evenly
+  // spaced, so the Catmull-Rom tangents match across the seam and the
+  // car's heading does not kink as it loops.
+  static final List<vm.Vector3> _loopWaypoints = [
+    vm.Vector3(0, 0.05, 16), // join
+    vm.Vector3(4, 0.05, 16),
+    vm.Vector3(10, 0.05, 17),
+    vm.Vector3(16, 0.05, 14),
+    vm.Vector3(20, 0.05, 8),
+    vm.Vector3(21, 0.05, 0),
+    vm.Vector3(19, 0.05, -8),
+    vm.Vector3(14, 0.05, -13),
+    vm.Vector3(7, 0.05, -14),
+    vm.Vector3(0, 0.05, -12),
+    vm.Vector3(-7, 0.05, -14),
+    vm.Vector3(-14, 0.05, -13),
+    vm.Vector3(-19, 0.05, -8),
+    vm.Vector3(-21, 0.05, 0),
+    vm.Vector3(-20, 0.05, 8),
+    vm.Vector3(-16, 0.05, 14),
+    vm.Vector3(-10, 0.05, 17),
+    vm.Vector3(-4, 0.05, 16), // collinear with the join and its neighbor
+  ];
+
+  // The looping track the car drives, closed back to the join.
+  static final CatmullRomPath mainRoad = CatmullRomPath([
+    ..._loopWaypoints,
+    _loopWaypoints.first,
   ]);
 
-  late final PolylineGeometry routeLine;
-  late final Node markerNode;
+  // Every camera-facing marking line, rebuilt each frame.
+  final List<PolylineGeometry> markings = [];
+
+  // The car model, loaded asynchronously, with the scale and ground
+  // offset that fit it to the road.
+  Node? carNode;
+  double carScale = 1.0;
+  double carLift = 0.0;
 
   @override
   void initState() {
-    // The ground map.
-    final ground = Node(
-      mesh: Mesh(
-        PlaneGeometry(width: 40, depth: 40),
-        UnlitMaterial()..baseColorFactor = vm.Vector4(0.16, 0.17, 0.2, 1.0),
+    // The ground.
+    scene.add(
+      Node(
+        mesh: Mesh(
+          PlaneGeometry(width: 64, depth: 64),
+          UnlitMaterial()..baseColorFactor = vm.Vector4(0.13, 0.14, 0.16, 1.0),
+        ),
       ),
     );
-    scene.add(ground);
 
-    // A flat corridor ribbon along the route, on the ground.
-    final corridor = Node(
-      mesh: Mesh(
-        RibbonGeometry(route, width: 1.8, stations: 96),
-        UnlitMaterial()..baseColorFactor = vm.Vector4(0.1, 0.2, 0.35, 1.0),
-      ),
-    );
-    scene.add(corridor);
+    _addRoad(mainRoad);
 
-    // The route line: a camera-facing strip of constant pixel width,
-    // sampled from the smooth route and floated above the ground.
-    final samples = route.sample(96, evenlySpaced: true);
-    final linePoints = <vm.Vector3>[
-      for (final p in samples) vm.Vector3(p.x, 0.3, p.z),
-    ];
-    routeLine = PolylineGeometry(
-      linePoints,
-      width: 16,
-      cap: PolylineCap.round,
-      dash: const DashPattern(dashLength: 4.0, gapLength: 2.0),
-      perVertexColor: <vm.Vector4>[
-        for (var i = 0; i < linePoints.length; i++)
-          _lerpColor(
-            vm.Vector4(0.2, 0.85, 1.0, 1.0),
-            vm.Vector4(0.15, 0.35, 1.0, 1.0),
-            i / (linePoints.length - 1),
-          ),
-      ],
-    );
-    scene.add(Node(mesh: Mesh(routeLine, UnlitMaterial())));
-
-    // A marker that drives the route.
-    markerNode = Node(
-      mesh: Mesh(
-        SphereGeometry(radius: 0.45),
-        UnlitMaterial()..baseColorFactor = vm.Vector4(1.0, 0.85, 0.2, 1.0),
-      ),
-    );
-    scene.add(markerNode);
+    // The example car drives the loop. It is wrapped in a parent node so
+    // its imported transform is left intact, and scaled from its bounds.
+    Node.fromAsset('build/models/fcar.model').then((carRoot) {
+      carRoot.name = 'Car';
+      final parent = Node()..add(carRoot);
+      scene.add(parent);
+      final bounds = parent.combinedLocalBounds;
+      if (bounds != null) {
+        final extent = bounds.max - bounds.min;
+        final longest = [extent.x, extent.y, extent.z].reduce(max);
+        carScale = longest > 0 ? 2.5 / longest : 1.0;
+        carLift = -bounds.min.y * carScale;
+      }
+      if (mounted) setState(() => carNode = parent);
+    });
 
     super.initState();
+  }
+
+  // Adds the road's surface ribbon plus its edge and center marking
+  // lines.
+  void _addRoad(ScenePath road) {
+    scene.add(
+      Node(
+        mesh: Mesh(
+          RibbonGeometry(road, width: _roadWidth, stations: 280),
+          UnlitMaterial()..baseColorFactor = vm.Vector4(0.30, 0.31, 0.35, 1.0),
+        ),
+      ),
+    );
+
+    // Solid white edge lines.
+    for (final side in [-_roadWidth / 2, _roadWidth / 2]) {
+      final line = PolylineGeometry(
+        _offsetPath(road, side, lift: _markingHeight),
+        width: 5,
+      );
+      markings.add(line);
+      scene.add(Node(mesh: Mesh(line, UnlitMaterial())));
+    }
+
+    // A dashed yellow center line.
+    final center = PolylineGeometry(
+      _offsetPath(road, 0.0, lift: _markingHeight),
+      width: 5,
+      dash: const DashPattern(dashLength: 1.6, gapLength: 1.2),
+    );
+    markings.add(center);
+    scene.add(
+      Node(
+        mesh: Mesh(
+          center,
+          UnlitMaterial()..baseColorFactor = vm.Vector4(0.95, 0.78, 0.20, 1.0),
+        ),
+      ),
+    );
   }
 
   @override
@@ -93,48 +148,93 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
     return CustomPaint(
       painter: _NavRoutePainter(
         scene: scene,
-        route: route,
-        routeLine: routeLine,
-        markerNode: markerNode,
+        road: mainRoad,
+        markings: markings,
+        carNode: carNode,
+        carScale: carScale,
+        carLift: carLift,
         elapsedSeconds: widget.elapsedSeconds,
       ),
     );
   }
 }
 
-vm.Vector4 _lerpColor(vm.Vector4 a, vm.Vector4 b, double t) => a + (b - a) * t;
+// The horizontal unit vector perpendicular to [tangent].
+vm.Vector3 _lateral(vm.Vector3 tangent) {
+  var lateral = tangent.cross(vm.Vector3(0, 1, 0));
+  if (lateral.length2 < 1e-9) lateral = vm.Vector3(1, 0, 0);
+  return lateral.normalized();
+}
+
+// Samples [path], shifting each point sideways by [offset] along the
+// horizontal perpendicular and up by [lift].
+List<vm.Vector3> _offsetPath(
+  ScenePath path,
+  double offset, {
+  double lift = 0.0,
+}) {
+  const samples = 240;
+  final result = <vm.Vector3>[];
+  for (var i = 0; i < samples; i++) {
+    final frame = path.frameAtDistance(path.length * i / (samples - 1));
+    final p = frame.position + _lateral(frame.tangent) * offset;
+    result.add(vm.Vector3(p.x, p.y + lift, p.z));
+  }
+  return result;
+}
 
 class _NavRoutePainter extends CustomPainter {
   _NavRoutePainter({
     required this.scene,
-    required this.route,
-    required this.routeLine,
-    required this.markerNode,
+    required this.road,
+    required this.markings,
+    required this.carNode,
+    required this.carScale,
+    required this.carLift,
     required this.elapsedSeconds,
   });
 
   final Scene scene;
-  final CatmullRomPath route;
-  final PolylineGeometry routeLine;
-  final Node markerNode;
+  final ScenePath road;
+  final List<PolylineGeometry> markings;
+  final Node? carNode;
+  final double carScale;
+  final double carLift;
   final double elapsedSeconds;
 
   @override
   void paint(Canvas canvas, Size size) {
     final angle = elapsedSeconds * 0.3;
     final camera = PerspectiveCamera(
-      position: vm.Vector3(sin(angle) * 17, 11, cos(angle) * 17),
+      position: vm.Vector3(sin(angle) * 42, 27, cos(angle) * 42),
       target: vm.Vector3(0, 0.3, 0),
     );
 
-    // The marker drives the route, looping, and the line draws on up to
-    // it.
-    final distance = (elapsedSeconds * 3.5) % route.length;
-    markerNode.localTransform = vm.Matrix4.translation(
-      route.positionAtDistance(distance)..y = 0.45,
-    );
-    routeLine.drawEnd = distance / route.length;
-    routeLine.updateForCamera(camera, size);
+    // The camera-facing marking lines are rebuilt for the current view.
+    for (final marking in markings) {
+      marking.updateForCamera(camera, size);
+    }
+
+    // Drive the car around the loop. Distance runs backward along the
+    // path so the car travels counterclockwise, and its lane is the
+    // centerline shifted to the opposite side. Querying the smooth
+    // curve directly keeps the heading continuous.
+    final car = carNode;
+    if (car != null) {
+      final distance = (-elapsedSeconds * 9.0) % road.length;
+      final frame = road.frameAtDistance(distance);
+      final position =
+          frame.position + _lateral(frame.tangent) * (_roadWidth / 4);
+      // The car travels against the path tangent.
+      final heading =
+          atan2(-frame.tangent.x, -frame.tangent.z) + _carHeadingOffset;
+      car.localTransform =
+          vm.Matrix4.translation(
+              vm.Vector3(position.x, position.y + carLift, position.z),
+            )
+            ..rotateY(heading)
+            ..scaleByDouble(carScale, carScale, carScale, 1.0);
+    }
 
     scene.render(camera, canvas, viewport: Offset.zero & size);
   }

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -74,6 +74,13 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
   // Smoothing state for the chase camera, carried across frames.
   final _FollowCamState _followCam = _FollowCamState();
 
+  // The car's animated parts (doors, wheels), keyed by node name.
+  final Map<String, _CarPart> _carParts = {};
+  bool _carPartsReady = false;
+  bool _controlsOpen = false;
+  // Rolling wheel-spin angle, advanced from the spin slider each frame.
+  double _wheelRotation = 0.0;
+
   @override
   void initState() {
     // The ground.
@@ -101,6 +108,17 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
         carScale = longest > 0 ? 2.5 / longest : 1.0;
         carLift = -bounds.min.y * carScale;
       }
+
+      // Capture the doors and wheels so the controls submenu can pose
+      // them; each part remembers its imported transform to pose from.
+      for (final name in _carPartNames) {
+        final node = carRoot.getChildByNamePath([name]);
+        if (node != null) {
+          _carParts[name] = _CarPart(node, node.localTransform.clone());
+        }
+      }
+      _carPartsReady = _carParts.length == _carPartNames.length;
+
       if (mounted) setState(() => carNode = parent);
     });
 
@@ -150,19 +168,85 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
     );
   }
 
+  // Poses the car's doors and wheels from the current control amounts.
+  // Runs every frame so slider changes and the rolling wheels both take
+  // effect. The door and wheel math mirrors the Car example.
+  void _applyCarParts() {
+    if (!_carPartsReady) return;
+
+    // Side doors swing open about their hinge.
+    for (final name in const [
+      'DoorFront.L',
+      'DoorFront.R',
+      'DoorBack.L',
+      'DoorBack.R',
+    ]) {
+      final part = _carParts[name]!;
+      part.node.localTransform =
+          part.startTransform.clone()
+            ..rotate(vm.Vector3(0, -1, 0), part.amount * pi / 2);
+    }
+    final frunk = _carParts['Frunk']!;
+    frunk.node.localTransform =
+        frunk.startTransform.clone()
+          ..rotate(vm.Vector3(0, 0, 1), frunk.amount * pi / 2);
+    final trunk = _carParts['Trunk']!;
+    trunk.node.localTransform =
+        trunk.startTransform.clone()
+          ..rotate(vm.Vector3(0, 0, -1), trunk.amount * pi / 2);
+
+    // The spin slider sets a speed, accumulated into a rolling angle.
+    _wheelRotation += _carParts['WheelBack.L']!.amount / 10;
+    for (final name in const ['WheelBack.L', 'WheelBack.R']) {
+      final wheel = _carParts[name]!;
+      wheel.node.localTransform =
+          wheel.startTransform.clone()
+            ..rotate(vm.Vector3(0, 0, -1), _wheelRotation);
+    }
+    // The front wheels also steer about their vertical axis.
+    final steer = _carParts['WheelFront.L']!.amount;
+    for (final name in const ['WheelFront.L', 'WheelFront.R']) {
+      final wheel = _carParts[name]!;
+      wheel.node.localTransform =
+          wheel.startTransform.clone() *
+          vm.Matrix4.rotationY(-steer / 2) *
+          vm.Matrix4.rotationZ(-_wheelRotation);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return CustomPaint(
-      painter: _NavRoutePainter(
-        scene: scene,
-        road: mainRoad,
-        markings: markings,
-        carNode: carNode,
-        carScale: carScale,
-        carLift: carLift,
-        followCam: _followCam,
-        elapsedSeconds: widget.elapsedSeconds,
-      ),
+    _applyCarParts();
+    return Stack(
+      children: [
+        SizedBox.expand(
+          child: CustomPaint(
+            painter: _NavRoutePainter(
+              scene: scene,
+              road: mainRoad,
+              markings: markings,
+              carNode: carNode,
+              carScale: carScale,
+              carLift: carLift,
+              followCam: _followCam,
+              elapsedSeconds: widget.elapsedSeconds,
+            ),
+          ),
+        ),
+        if (_carPartsReady)
+          Positioned(
+            top: 8,
+            right: 8,
+            child: _CarControlsMenu(
+              open: _controlsOpen,
+              onToggle: () => setState(() => _controlsOpen = !_controlsOpen),
+              parts: _carParts,
+              onControl:
+                  (key, value) =>
+                      setState(() => _carParts[key]!.amount = value),
+            ),
+          ),
+      ],
     );
   }
 }
@@ -301,4 +385,160 @@ class _NavRoutePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}
+
+// The car node names the controls submenu poses.
+const List<String> _carPartNames = [
+  'DoorFront.L',
+  'DoorFront.R',
+  'DoorBack.L',
+  'DoorBack.R',
+  'Frunk',
+  'Trunk',
+  'WheelFront.L',
+  'WheelFront.R',
+  'WheelBack.L',
+  'WheelBack.R',
+];
+
+// One slider each: a label, the car part whose amount it drives, and
+// the slider's range. Back doors and the front-left wheel stand in for
+// their mirrored partners, which follow along.
+const List<(String, String, double, double)> _carControls = [
+  ('Front door L', 'DoorFront.L', 0.0, 1.0),
+  ('Front door R', 'DoorFront.R', 0.0, 1.0),
+  ('Back door L', 'DoorBack.L', 0.0, 1.0),
+  ('Back door R', 'DoorBack.R', 0.0, 1.0),
+  ('Frunk', 'Frunk', 0.0, 1.0),
+  ('Trunk', 'Trunk', 0.0, 1.0),
+  ('Wheel spin', 'WheelBack.L', 0.0, 1.0),
+  ('Wheel steer', 'WheelFront.L', -1.0, 1.0),
+];
+
+// A car node the controls submenu animates, plus its imported
+// transform and the current control amount driving it.
+class _CarPart {
+  _CarPart(this.node, this.startTransform);
+
+  final Node node;
+  final vm.Matrix4 startTransform;
+  double amount = 0.0;
+}
+
+// A collapsible submenu of sliders that pose the car's doors and
+// wheels, styled to match the Toon example's control card.
+class _CarControlsMenu extends StatelessWidget {
+  const _CarControlsMenu({
+    required this.open,
+    required this.onToggle,
+    required this.parts,
+    required this.onControl,
+  });
+
+  final bool open;
+  final VoidCallback onToggle;
+  final Map<String, _CarPart> parts;
+  final void Function(String key, double value) onControl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Colors.black54,
+      child: SizedBox(
+        width: 340,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // The toggle header.
+            InkWell(
+              onTap: onToggle,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(12, 10, 8, 10),
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.directions_car,
+                      color: Colors.white,
+                      size: 20,
+                    ),
+                    const SizedBox(width: 8),
+                    const Expanded(
+                      child: Text(
+                        'Car Controls',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    Icon(
+                      open ? Icons.expand_less : Icons.expand_more,
+                      color: Colors.white,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (open) ...[
+              const Divider(height: 1, color: Colors.white24),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    for (final (label, key, lo, hi) in _carControls)
+                      _SliderRow(
+                        label: label,
+                        value: parts[key]!.amount,
+                        min: lo,
+                        max: hi,
+                        onChanged: (value) => onControl(key, value),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// A labeled slider styled to match the Toon example's controls.
+class _SliderRow extends StatelessWidget {
+  const _SliderRow({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 110,
+          child: Text(
+            '$label: ${value.toStringAsFixed(2)}',
+            style: const TextStyle(color: Colors.white),
+          ),
+        ),
+        Expanded(
+          child: Slider(value: value, min: min, max: max, onChanged: onChanged),
+        ),
+      ],
+    );
+  }
 }

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -63,6 +63,8 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
     routeLine = PolylineGeometry(
       linePoints,
       width: 16,
+      cap: PolylineCap.round,
+      join: PolylineJoin.round,
       perVertexColor: <vm.Vector4>[
         for (var i = 0; i < linePoints.length; i++)
           _lerpColor(

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -64,7 +64,6 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
       linePoints,
       width: 16,
       cap: PolylineCap.round,
-      join: PolylineJoin.round,
       perVertexColor: <vm.Vector4>[
         for (var i = 0; i < linePoints.length; i++)
           _lerpColor(

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -1,0 +1,142 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+/// An infotainment-style navigation scene: a ground map, a route
+/// corridor ribbon, a camera-facing route line of constant pixel width,
+/// and a marker travelling the route.
+///
+/// Exercises the dynamic geometry API: [PlaneGeometry], [CatmullRomPath],
+/// [RibbonGeometry], [PolylineGeometry], and [SphereGeometry].
+class ExampleNavRoute extends StatefulWidget {
+  const ExampleNavRoute({super.key, this.elapsedSeconds = 0});
+  final double elapsedSeconds;
+
+  @override
+  ExampleNavRouteState createState() => ExampleNavRouteState();
+}
+
+class ExampleNavRouteState extends State<ExampleNavRoute> {
+  final Scene scene = Scene();
+
+  // Waypoints of the planned route, smoothed into a curve.
+  static final CatmullRomPath route = CatmullRomPath([
+    vm.Vector3(-8, 0.05, -6),
+    vm.Vector3(-3, 0.05, -8),
+    vm.Vector3(2, 0.05, -3),
+    vm.Vector3(6, 0.05, 3),
+    vm.Vector3(1, 0.05, 7),
+    vm.Vector3(-5, 0.05, 4),
+  ]);
+
+  late final PolylineGeometry routeLine;
+  late final Node markerNode;
+
+  @override
+  void initState() {
+    // The ground map.
+    final ground = Node(
+      mesh: Mesh(
+        PlaneGeometry(width: 40, depth: 40),
+        UnlitMaterial()..baseColorFactor = vm.Vector4(0.16, 0.17, 0.2, 1.0),
+      ),
+    );
+    scene.add(ground);
+
+    // A flat corridor ribbon along the route, on the ground.
+    final corridor = Node(
+      mesh: Mesh(
+        RibbonGeometry(route, width: 1.8, stations: 96),
+        UnlitMaterial()..baseColorFactor = vm.Vector4(0.1, 0.2, 0.35, 1.0),
+      ),
+    );
+    scene.add(corridor);
+
+    // The route line: a camera-facing strip of constant pixel width,
+    // sampled from the smooth route and floated above the ground.
+    final samples = route.sample(96, evenlySpaced: true);
+    final linePoints = <vm.Vector3>[
+      for (final p in samples) vm.Vector3(p.x, 0.3, p.z),
+    ];
+    routeLine = PolylineGeometry(
+      linePoints,
+      width: 16,
+      perVertexColor: <vm.Vector4>[
+        for (var i = 0; i < linePoints.length; i++)
+          _lerpColor(
+            vm.Vector4(0.2, 0.85, 1.0, 1.0),
+            vm.Vector4(0.15, 0.35, 1.0, 1.0),
+            i / (linePoints.length - 1),
+          ),
+      ],
+    );
+    scene.add(Node(mesh: Mesh(routeLine, UnlitMaterial())));
+
+    // A marker that drives the route.
+    markerNode = Node(
+      mesh: Mesh(
+        SphereGeometry(radius: 0.45),
+        UnlitMaterial()..baseColorFactor = vm.Vector4(1.0, 0.85, 0.2, 1.0),
+      ),
+    );
+    scene.add(markerNode);
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _NavRoutePainter(
+        scene: scene,
+        route: route,
+        routeLine: routeLine,
+        markerNode: markerNode,
+        elapsedSeconds: widget.elapsedSeconds,
+      ),
+    );
+  }
+}
+
+vm.Vector4 _lerpColor(vm.Vector4 a, vm.Vector4 b, double t) => a + (b - a) * t;
+
+class _NavRoutePainter extends CustomPainter {
+  _NavRoutePainter({
+    required this.scene,
+    required this.route,
+    required this.routeLine,
+    required this.markerNode,
+    required this.elapsedSeconds,
+  });
+
+  final Scene scene;
+  final CatmullRomPath route;
+  final PolylineGeometry routeLine;
+  final Node markerNode;
+  final double elapsedSeconds;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final angle = elapsedSeconds * 0.3;
+    final camera = PerspectiveCamera(
+      position: vm.Vector3(sin(angle) * 17, 11, cos(angle) * 17),
+      target: vm.Vector3(0, 0.3, 0),
+    );
+
+    // The camera-facing route line is rebuilt for the current view.
+    routeLine.updateForCamera(camera, size);
+
+    // Drive the marker along the route, looping.
+    final distance = (elapsedSeconds * 3.5) % route.length;
+    markerNode.localTransform = vm.Matrix4.translation(
+      route.positionAtDistance(distance)..y = 0.45,
+    );
+
+    scene.render(camera, canvas, viewport: Offset.zero & size);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -9,7 +9,7 @@ import 'package:vector_math/vector_math.dart' as vm;
 const double _carHeadingOffset = -pi / 2;
 
 const double _roadWidth = 5.0;
-const double _markingHeight = 0.13;
+const double _markingHeight = 0.05;
 
 /// An infotainment-style navigation scene: a long looping road track
 /// with painted edge and center lines, and the example car driving it
@@ -83,12 +83,23 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
 
   @override
   void initState() {
-    // The ground.
+    // A directional "sun" that lights the scene and casts shadows. Its
+    // shadow frustum is small; the painter recenters it on the car each
+    // frame so the car's shadow on the road stays crisp.
+    scene.directionalLight = DirectionalLight(
+      direction: vm.Vector3(-0.45, -1.0, -0.35),
+      castsShadow: true,
+    );
+
+    // The ground. A lit material, so it receives the car's shadow.
     scene.add(
       Node(
         mesh: Mesh(
           PlaneGeometry(width: 64, depth: 64),
-          UnlitMaterial()..baseColorFactor = vm.Vector4(0.13, 0.14, 0.16, 1.0),
+          PhysicallyBasedMaterial()
+            ..baseColorFactor = vm.Vector4(0.13, 0.14, 0.16, 1.0)
+            ..metallicFactor = 0.0
+            ..roughnessFactor = 0.95,
         ),
       ),
     );
@@ -128,11 +139,15 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
   // Adds the road's surface ribbon plus its edge and center marking
   // lines.
   void _addRoad(ScenePath road) {
+    // A lit material, so the road receives the car's shadow.
     scene.add(
       Node(
         mesh: Mesh(
           RibbonGeometry(road, width: _roadWidth, stations: 280),
-          UnlitMaterial()..baseColorFactor = vm.Vector4(0.30, 0.31, 0.35, 1.0),
+          PhysicallyBasedMaterial()
+            ..baseColorFactor = vm.Vector4(0.30, 0.31, 0.35, 1.0)
+            ..metallicFactor = 0.0
+            ..roughnessFactor = 0.85,
         ),
       ),
     );
@@ -141,7 +156,7 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
     for (final side in [-_roadWidth / 2, _roadWidth / 2]) {
       final line = PolylineGeometry(
         _offsetPath(road, side, lift: _markingHeight),
-        width: 5,
+        width: 8,
       );
       markings.add(line);
       scene.add(Node(mesh: Mesh(line, UnlitMaterial())));
@@ -150,7 +165,8 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
     // A dashed yellow center line, each dash rounded at both ends.
     final center = PolylineGeometry(
       _offsetPath(road, 0.0, lift: _markingHeight),
-      width: 5,
+      width: 8 * 0.01,
+      widthMode: PolylineWidthMode.worldUnits,
       dash: const DashPattern(
         dashLength: 1.6,
         gapLength: 1.2,
@@ -315,6 +331,10 @@ class _NavRoutePainter extends CustomPainter {
         frame.position + _lateral(frame.tangent) * (_roadWidth / 4);
     // The car travels against the path tangent.
     final travelDirection = -frame.tangent;
+
+    // Keep the shadow frustum centered on the car so its shadow on the
+    // road stays inside the (small, crisp) shadow map.
+    scene.directionalLight?.shadowFocusPoint = carPosition;
 
     final camera = _followCamera(carPosition, travelDirection);
 

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -64,6 +64,7 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
       linePoints,
       width: 16,
       cap: PolylineCap.round,
+      dash: const DashPattern(dashLength: 2.0, gapLength: 1.3),
       perVertexColor: <vm.Vector4>[
         for (var i = 0; i < linePoints.length; i++)
           _lerpColor(

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -64,7 +64,7 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
       linePoints,
       width: 16,
       cap: PolylineCap.round,
-      dash: const DashPattern(dashLength: 2.0, gapLength: 1.3),
+      dash: const DashPattern(dashLength: 4.0, gapLength: 2.0),
       perVertexColor: <vm.Vector4>[
         for (var i = 0; i < linePoints.length; i++)
           _lerpColor(

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:example_app/example_animation.dart';
 import 'example_cuboid.dart';
 import 'example_instancing.dart';
 import 'example_logo.dart';
+import 'example_nav_route.dart';
 import 'example_stress_tests.dart';
 import 'example_toon.dart';
 
@@ -36,6 +37,8 @@ class _MyAppState extends State<MyApp> {
     ticker.start();
 
     examples = {
+      'Navigation Route':
+          (context) => ExampleNavRoute(elapsedSeconds: elapsedSeconds),
       'Car': (context) => ExampleCar(elapsedSeconds: elapsedSeconds),
       'Animation':
           (context) => ExampleAnimation(elapsedSeconds: elapsedSeconds),

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -37,8 +37,6 @@ class _MyAppState extends State<MyApp> {
     ticker.start();
 
     examples = {
-      'Navigation Route':
-          (context) => ExampleNavRoute(elapsedSeconds: elapsedSeconds),
       'Car': (context) => ExampleCar(elapsedSeconds: elapsedSeconds),
       'Animation':
           (context) => ExampleAnimation(elapsedSeconds: elapsedSeconds),
@@ -46,6 +44,8 @@ class _MyAppState extends State<MyApp> {
       'Cuboid': (context) => ExampleCuboid(elapsedSeconds: elapsedSeconds),
       'Instancing':
           (context) => ExampleInstancing(elapsedSeconds: elapsedSeconds),
+      'Navigation Route':
+          (context) => ExampleNavRoute(elapsedSeconds: elapsedSeconds),
       'Toon': (context) => ExampleToon(elapsedSeconds: elapsedSeconds),
       'Stress Tests':
           (context) => ExampleStressTests(elapsedSeconds: elapsedSeconds),

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -28,7 +28,7 @@ export 'src/geometry/mesh_geometry.dart'
 export 'src/geometry/primitives.dart'
     show CuboidGeometry, PlaneGeometry, SphereGeometry;
 export 'src/geometry/swept_geometry.dart'
-    show RibbonAlignment, RibbonGeometry, TubeGeometry;
+    show ExtrudeGeometry, RibbonAlignment, RibbonGeometry, TubeGeometry;
 
 export 'src/material/environment.dart';
 export 'src/material/material.dart';

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -28,7 +28,7 @@ export 'src/geometry/mesh_geometry.dart'
 export 'src/geometry/primitives.dart'
     show CuboidGeometry, PlaneGeometry, SphereGeometry;
 export 'src/geometry/polyline_geometry.dart'
-    show PolylineGeometry, PolylineWidthMode;
+    show PolylineCap, PolylineGeometry, PolylineJoin, PolylineWidthMode;
 export 'src/geometry/swept_geometry.dart'
     show ExtrudeGeometry, RibbonAlignment, RibbonGeometry, TubeGeometry;
 

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -27,6 +27,7 @@ export 'src/geometry/mesh_geometry.dart'
     show GeometryBuilder, GeometryStorage, MeshGeometry;
 export 'src/geometry/primitives.dart'
     show CuboidGeometry, PlaneGeometry, SphereGeometry;
+export 'src/geometry/swept_geometry.dart' show RibbonAlignment, RibbonGeometry;
 
 export 'src/material/environment.dart';
 export 'src/material/material.dart';

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -28,7 +28,7 @@ export 'src/geometry/mesh_geometry.dart'
 export 'src/geometry/primitives.dart'
     show CuboidGeometry, PlaneGeometry, SphereGeometry;
 export 'src/geometry/polyline_geometry.dart'
-    show PolylineCap, PolylineGeometry, PolylineWidthMode;
+    show DashPattern, PolylineCap, PolylineGeometry, PolylineWidthMode;
 export 'src/geometry/swept_geometry.dart'
     show ExtrudeGeometry, RibbonAlignment, RibbonGeometry, TubeGeometry;
 

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -27,7 +27,8 @@ export 'src/geometry/mesh_geometry.dart'
     show GeometryBuilder, GeometryStorage, MeshGeometry;
 export 'src/geometry/primitives.dart'
     show CuboidGeometry, PlaneGeometry, SphereGeometry;
-export 'src/geometry/swept_geometry.dart' show RibbonAlignment, RibbonGeometry;
+export 'src/geometry/swept_geometry.dart'
+    show RibbonAlignment, RibbonGeometry, TubeGeometry;
 
 export 'src/material/environment.dart';
 export 'src/material/material.dart';

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -28,7 +28,7 @@ export 'src/geometry/mesh_geometry.dart'
 export 'src/geometry/primitives.dart'
     show CuboidGeometry, PlaneGeometry, SphereGeometry;
 export 'src/geometry/polyline_geometry.dart'
-    show PolylineCap, PolylineGeometry, PolylineJoin, PolylineWidthMode;
+    show PolylineCap, PolylineGeometry, PolylineWidthMode;
 export 'src/geometry/swept_geometry.dart'
     show ExtrudeGeometry, RibbonAlignment, RibbonGeometry, TubeGeometry;
 

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -23,6 +23,8 @@ library;
 export 'src/animation.dart';
 
 export 'src/geometry/geometry.dart';
+export 'src/geometry/mesh_geometry.dart';
+export 'src/geometry/primitives.dart' show CuboidGeometry;
 
 export 'src/material/environment.dart';
 export 'src/material/material.dart';

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -24,7 +24,8 @@ export 'src/animation.dart';
 
 export 'src/geometry/geometry.dart';
 export 'src/geometry/mesh_geometry.dart';
-export 'src/geometry/primitives.dart' show CuboidGeometry;
+export 'src/geometry/primitives.dart'
+    show CuboidGeometry, PlaneGeometry, SphereGeometry;
 
 export 'src/material/environment.dart';
 export 'src/material/material.dart';

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -23,7 +23,8 @@ library;
 export 'src/animation.dart';
 
 export 'src/geometry/geometry.dart';
-export 'src/geometry/mesh_geometry.dart';
+export 'src/geometry/mesh_geometry.dart'
+    show GeometryBuilder, GeometryStorage, MeshGeometry;
 export 'src/geometry/primitives.dart'
     show CuboidGeometry, PlaneGeometry, SphereGeometry;
 

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -27,6 +27,8 @@ export 'src/geometry/mesh_geometry.dart'
     show GeometryBuilder, GeometryStorage, MeshGeometry;
 export 'src/geometry/primitives.dart'
     show CuboidGeometry, PlaneGeometry, SphereGeometry;
+export 'src/geometry/polyline_geometry.dart'
+    show PolylineGeometry, PolylineWidthMode;
 export 'src/geometry/swept_geometry.dart'
     show ExtrudeGeometry, RibbonAlignment, RibbonGeometry, TubeGeometry;
 

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -47,6 +47,7 @@ export 'src/node.dart';
 export 'src/render/env_prefilter.dart';
 export 'src/runtime_importer/gltf_resources.dart' show GltfResourceResolver;
 export 'src/scene_encoder.dart';
+export 'src/scene_path.dart';
 export 'src/scene.dart';
 export 'src/shaders.dart';
 export 'src/skin.dart';

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -44,6 +44,14 @@ abstract class Geometry {
 
   vm.Aabb3? _localBounds;
   vm.Sphere? _localBoundingSphere;
+  int _localBoundsVersion = 0;
+
+  /// A counter that increments each time [setLocalBounds] changes the
+  /// bounds.
+  ///
+  /// Lets cache holders such as [Mesh] notice that an updatable
+  /// geometry's bounds moved without an explicit invalidation call.
+  int get localBoundsVersion => _localBoundsVersion;
 
   /// Local-space axis-aligned bounding box of this geometry's vertex
   /// positions, or `null` if bounds are unknown. Computed by
@@ -63,6 +71,7 @@ abstract class Geometry {
   void setLocalBounds(vm.Aabb3? aabb, vm.Sphere? sphere) {
     _localBounds = aabb;
     _localBoundingSphere = sphere;
+    _localBoundsVersion++;
   }
 
   /// The vertex shader used when rendering this geometry.

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -33,6 +33,15 @@ abstract class Geometry {
 
   gpu.Shader? _vertexShader;
 
+  /// How the vertex/index data is assembled into primitives when drawn.
+  ///
+  /// Defaults to [gpu.PrimitiveType.triangle]. Set it to
+  /// [gpu.PrimitiveType.lineStrip] or [gpu.PrimitiveType.line] for line
+  /// geometry, or [gpu.PrimitiveType.point] for a point list. Native
+  /// line and point primitives render at a fixed one-pixel size; thick
+  /// styled lines are built as triangle geometry instead.
+  gpu.PrimitiveType primitiveType = gpu.PrimitiveType.triangle;
+
   vm.Aabb3? _localBounds;
   vm.Sphere? _localBoundingSphere;
 

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart' as vm;
@@ -22,8 +20,9 @@ import 'package:flutter_scene_importer/flatbuffer.dart' as fb;
 /// Construct an instance directly and call [uploadVertexData] (or
 /// [setVertices]/[setIndices] with already-uploaded buffer views) to
 /// supply mesh data, or use [Geometry.fromFlatbuffer] when deserializing
-/// a `.model` payload. [CuboidGeometry] is provided as a built-in
-/// example.
+/// a `.model` payload. For procedurally generated meshes, `MeshGeometry`
+/// and `GeometryBuilder` assemble a [Geometry] from vertex attribute
+/// arrays without packing vertex bytes by hand.
 abstract class Geometry {
   gpu.BufferView? _vertices;
   int _vertexCount = 0;
@@ -521,44 +520,5 @@ class SkinnedGeometry extends Geometry {
       frameInfoFloats.buffer.asByteData(),
     );
     pass.bindUniform(frameInfoSlot, frameInfoView);
-  }
-}
-
-/// A unit-cube geometry sized to the supplied extents.
-///
-/// Useful as a quick placeholder or for debugging — pair with any
-/// [Material] to render an axis-aligned box. Each face has unique
-/// vertex colors, which can be visualized with [UnlitMaterial].
-class CuboidGeometry extends UnskinnedGeometry {
-  /// Builds a cuboid spanning `-extents/2` to `+extents/2` on each axis.
-  CuboidGeometry(vm.Vector3 extents) {
-    final e = extents / 2;
-    // Layout: Position, normal, uv, color
-    final vertices = Float32List.fromList(<double>[
-      -e.x, -e.y, -e.z, /* */ 0, 0, -1, /* */ 0, 0, /* */ 1, 0, 0, 1, //
-      e.x, -e.y, -e.z, /*  */ 0, 0, -1, /* */ 1, 0, /* */ 0, 1, 0, 1, //
-      e.x, e.y, -e.z, /*   */ 0, 0, -1, /* */ 1, 1, /* */ 0, 0, 1, 1, //
-      -e.x, e.y, -e.z, /*  */ 0, 0, -1, /* */ 0, 1, /* */ 0, 0, 0, 1, //
-      -e.x, -e.y, e.z, /*  */ 0, 0, -1, /* */ 0, 0, /* */ 0, 1, 1, 1, //
-      e.x, -e.y, e.z, /*   */ 0, 0, -1, /* */ 1, 0, /* */ 1, 0, 1, 1, //
-      e.x, e.y, e.z, /*    */ 0, 0, -1, /* */ 1, 1, /* */ 1, 1, 0, 1, //
-      -e.x, e.y, e.z, /*   */ 0, 0, -1, /* */ 0, 1, /* */ 1, 1, 1, 1, //
-    ]);
-
-    final indices = Uint16List.fromList(<int>[
-      0, 1, 3, 3, 1, 2, //
-      1, 5, 2, 2, 5, 6, //
-      5, 4, 6, 6, 4, 7, //
-      4, 0, 7, 7, 0, 3, //
-      3, 2, 7, 7, 2, 6, //
-      4, 5, 0, 0, 5, 1, //
-    ]);
-
-    uploadVertexData(
-      ByteData.sublistView(vertices),
-      8,
-      ByteData.sublistView(indices),
-      indexType: gpu.IndexType.int16,
-    );
   }
 }

--- a/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
+++ b/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
@@ -1,0 +1,201 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene_importer/constants.dart';
+
+/// Translates structure-of-arrays vertex attributes into the interleaved
+/// unskinned vertex layout.
+///
+/// The interleaved layout packs every attribute of a vertex contiguously:
+/// 12 floats (48 bytes) per vertex, ordered position (3), normal (3),
+/// texture coordinates (2), color (4).
+///
+/// This is the translation layer described in `docs/dynamic_geometry.md`.
+/// The geometry construction API accepts attributes as independent typed
+/// arrays; this adapter packs them into the single interleaved buffer the
+/// built-in pipelines consume. It is intentionally the one place that
+/// depends on the interleaved layout, so the rest of the geometry API can
+/// move to independent attribute buffers later without an API change.
+///
+/// Every method here is pure and free of GPU resources, so the packing
+/// can be exercised without a render context.
+abstract final class InterleavedLayoutAdapter {
+  /// Floats per vertex in the interleaved unskinned layout.
+  static const int floatsPerVertex = kUnskinnedPerVertexSize ~/ 4;
+
+  /// Packs [vertexCount] vertices of structure-of-arrays attributes into
+  /// one interleaved unskinned vertex buffer.
+  ///
+  /// [positions] is required and must hold `3 * vertexCount` floats.
+  /// [normals] (`3 * vertexCount`), [texCoords] (`2 * vertexCount`), and
+  /// [colors] (`4 * vertexCount`) are optional. Absent attributes are
+  /// filled with defaults: normal `(0, 0, 1)`, texture coordinate
+  /// `(0, 0)`, color opaque white.
+  static Uint8List packUnskinned({
+    required Float32List positions,
+    required int vertexCount,
+    Float32List? normals,
+    Float32List? texCoords,
+    Float32List? colors,
+  }) {
+    _checkLength('positions', positions.length, 3 * vertexCount);
+    if (normals != null) {
+      _checkLength('normals', normals.length, 3 * vertexCount);
+    }
+    if (texCoords != null) {
+      _checkLength('texCoords', texCoords.length, 2 * vertexCount);
+    }
+    if (colors != null) {
+      _checkLength('colors', colors.length, 4 * vertexCount);
+    }
+
+    final out = Float32List(vertexCount * floatsPerVertex);
+    for (var v = 0; v < vertexCount; v++) {
+      final o = v * floatsPerVertex;
+      out[o + 0] = positions[v * 3 + 0];
+      out[o + 1] = positions[v * 3 + 1];
+      out[o + 2] = positions[v * 3 + 2];
+      if (normals != null) {
+        out[o + 3] = normals[v * 3 + 0];
+        out[o + 4] = normals[v * 3 + 1];
+        out[o + 5] = normals[v * 3 + 2];
+      } else {
+        out[o + 5] = 1.0;
+      }
+      if (texCoords != null) {
+        out[o + 6] = texCoords[v * 2 + 0];
+        out[o + 7] = texCoords[v * 2 + 1];
+      }
+      if (colors != null) {
+        out[o + 8] = colors[v * 4 + 0];
+        out[o + 9] = colors[v * 4 + 1];
+        out[o + 10] = colors[v * 4 + 2];
+        out[o + 11] = colors[v * 4 + 3];
+      } else {
+        out[o + 8] = 1.0;
+        out[o + 9] = 1.0;
+        out[o + 10] = 1.0;
+        out[o + 11] = 1.0;
+      }
+    }
+    return out.buffer.asUint8List();
+  }
+
+  /// Packs triangle [indices] into the narrowest index buffer that fits.
+  ///
+  /// Returns the packed bytes and whether a 32-bit element width was
+  /// needed; a 16-bit buffer is used when every index is at most
+  /// `0xFFFF`. Throws an [ArgumentError] if any index is negative.
+  static ({Uint8List bytes, bool is32Bit}) packIndices(List<int> indices) {
+    var maxIndex = 0;
+    for (final index in indices) {
+      if (index < 0) {
+        throw ArgumentError.value(
+          index,
+          'indices',
+          'Index must not be negative',
+        );
+      }
+      if (index > maxIndex) maxIndex = index;
+    }
+    if (maxIndex > 0xFFFF) {
+      return (
+        bytes: Uint32List.fromList(indices).buffer.asUint8List(),
+        is32Bit: true,
+      );
+    }
+    return (
+      bytes: Uint16List.fromList(indices).buffer.asUint8List(),
+      is32Bit: false,
+    );
+  }
+
+  /// Computes area-weighted vertex normals for [positions]
+  /// (`3 * vertexCount` floats).
+  ///
+  /// When [indices] is supplied the positions are treated as an indexed
+  /// triangle list; otherwise they are a non-indexed triangle list and
+  /// [vertexCount] must be a multiple of three. Each triangle's
+  /// unnormalized face normal is accumulated onto its three vertices, so
+  /// larger faces contribute proportionally; the result is normalized
+  /// per vertex. Vertices touched by no (or only degenerate) triangles
+  /// receive a default normal of `(0, 0, 1)`.
+  static Float32List generateNormals({
+    required Float32List positions,
+    required int vertexCount,
+    List<int>? indices,
+  }) {
+    _checkLength('positions', positions.length, 3 * vertexCount);
+    final normals = Float32List(3 * vertexCount);
+
+    void accumulate(int a, int b, int c) {
+      final ax = positions[a * 3],
+          ay = positions[a * 3 + 1],
+          az = positions[a * 3 + 2];
+      final bx = positions[b * 3],
+          by = positions[b * 3 + 1],
+          bz = positions[b * 3 + 2];
+      final cx = positions[c * 3],
+          cy = positions[c * 3 + 1],
+          cz = positions[c * 3 + 2];
+      final e1x = bx - ax, e1y = by - ay, e1z = bz - az;
+      final e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
+      // Unnormalized cross product: its magnitude is twice the triangle
+      // area, which weights each face's contribution by its size.
+      final nx = e1y * e2z - e1z * e2y;
+      final ny = e1z * e2x - e1x * e2z;
+      final nz = e1x * e2y - e1y * e2x;
+      for (final v in [a, b, c]) {
+        normals[v * 3] += nx;
+        normals[v * 3 + 1] += ny;
+        normals[v * 3 + 2] += nz;
+      }
+    }
+
+    if (indices != null) {
+      if (indices.length % 3 != 0) {
+        throw ArgumentError(
+          'indices has ${indices.length} entries; a triangle list needs a '
+          'multiple of three',
+        );
+      }
+      for (var t = 0; t < indices.length; t += 3) {
+        accumulate(indices[t], indices[t + 1], indices[t + 2]);
+      }
+    } else {
+      if (vertexCount % 3 != 0) {
+        throw ArgumentError(
+          'A non-indexed triangle list needs a vertex count that is a '
+          'multiple of three; got $vertexCount',
+        );
+      }
+      for (var v = 0; v < vertexCount; v += 3) {
+        accumulate(v, v + 1, v + 2);
+      }
+    }
+
+    for (var v = 0; v < vertexCount; v++) {
+      final x = normals[v * 3], y = normals[v * 3 + 1], z = normals[v * 3 + 2];
+      final length = math.sqrt(x * x + y * y + z * z);
+      if (length > 1e-12) {
+        normals[v * 3] = x / length;
+        normals[v * 3 + 1] = y / length;
+        normals[v * 3 + 2] = z / length;
+      } else {
+        normals[v * 3] = 0.0;
+        normals[v * 3 + 1] = 0.0;
+        normals[v * 3 + 2] = 1.0;
+      }
+    }
+    return normals;
+  }
+
+  static void _checkLength(String name, int actual, int expected) {
+    if (actual != expected) {
+      throw ArgumentError(
+        '$name has $actual floats; expected $expected for the given vertex '
+        'count',
+      );
+    }
+  }
+}

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -27,16 +27,21 @@ class MeshGeometry extends UnskinnedGeometry {
   /// attributes fall back to defaults: texture coordinate `(0, 0)` and
   /// color opaque white.
   ///
-  /// When [normals] is omitted, area-weighted vertex normals are
-  /// generated from the triangle faces. [indices], when supplied, is a
-  /// triangle list; when omitted the mesh is a non-indexed triangle list
-  /// and the vertex count must be a multiple of three.
+  /// When [normals] is omitted and [primitiveType] is a triangle list,
+  /// area-weighted vertex normals are generated from the faces; for line
+  /// and point primitives, absent normals keep their default. [indices],
+  /// when supplied, is an index list; when omitted a triangle mesh must
+  /// have a vertex count that is a multiple of three.
+  ///
+  /// [primitiveType] selects how the vertex/index data is assembled into
+  /// primitives when drawn, and defaults to a triangle list.
   MeshGeometry.fromArrays({
     required Float32List positions,
     Float32List? normals,
     Float32List? texCoords,
     Float32List? colors,
     List<int>? indices,
+    gpu.PrimitiveType primitiveType = gpu.PrimitiveType.triangle,
   }) {
     if (positions.length % 3 != 0) {
       throw ArgumentError(
@@ -45,14 +50,19 @@ class MeshGeometry extends UnskinnedGeometry {
       );
     }
     final vertexCount = positions.length ~/ 3;
+    this.primitiveType = primitiveType;
 
+    // Normals are generated from triangle faces; line and point
+    // geometry has none, so absent normals are left at their default.
     final resolvedNormals =
         normals ??
-        InterleavedLayoutAdapter.generateNormals(
-          positions: positions,
-          vertexCount: vertexCount,
-          indices: indices,
-        );
+        (primitiveType == gpu.PrimitiveType.triangle
+            ? InterleavedLayoutAdapter.generateNormals(
+              positions: positions,
+              vertexCount: vertexCount,
+              indices: indices,
+            )
+            : null);
 
     final vertexBytes = InterleavedLayoutAdapter.packUnskinned(
       positions: positions,

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -1,0 +1,242 @@
+import 'dart:typed_data';
+
+import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/geometry/geometry.dart';
+import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
+
+/// A triangle mesh built at runtime from vertex attribute arrays.
+///
+/// `MeshGeometry` is the general-purpose [Geometry] for procedurally
+/// generated content. Build one directly from attribute arrays with
+/// [MeshGeometry.fromArrays], or assemble it incrementally with a
+/// [GeometryBuilder].
+///
+/// Callers supply attributes as independent typed arrays (positions,
+/// normals, texture coordinates, colors) and never pack vertex bytes by
+/// hand; the arrays are interleaved into the engine vertex layout
+/// internally.
+class MeshGeometry extends UnskinnedGeometry {
+  /// Builds a mesh from structure-of-arrays vertex attributes.
+  ///
+  /// [positions] is required and holds three floats per vertex. The
+  /// optional attributes hold, per vertex, three floats for [normals],
+  /// two for [texCoords], and four for [colors]; each must match the
+  /// vertex count implied by [positions] when supplied. Absent
+  /// attributes fall back to defaults: texture coordinate `(0, 0)` and
+  /// color opaque white.
+  ///
+  /// When [normals] is omitted, area-weighted vertex normals are
+  /// generated from the triangle faces. [indices], when supplied, is a
+  /// triangle list; when omitted the mesh is a non-indexed triangle list
+  /// and the vertex count must be a multiple of three.
+  MeshGeometry.fromArrays({
+    required Float32List positions,
+    Float32List? normals,
+    Float32List? texCoords,
+    Float32List? colors,
+    List<int>? indices,
+  }) {
+    if (positions.length % 3 != 0) {
+      throw ArgumentError(
+        'positions has ${positions.length} floats; expected a multiple of '
+        'three (one vec3 per vertex)',
+      );
+    }
+    final vertexCount = positions.length ~/ 3;
+
+    final resolvedNormals =
+        normals ??
+        InterleavedLayoutAdapter.generateNormals(
+          positions: positions,
+          vertexCount: vertexCount,
+          indices: indices,
+        );
+
+    final vertexBytes = InterleavedLayoutAdapter.packUnskinned(
+      positions: positions,
+      vertexCount: vertexCount,
+      normals: resolvedNormals,
+      texCoords: texCoords,
+      colors: colors,
+    );
+
+    ByteData? indexBytes;
+    var indexType = gpu.IndexType.int16;
+    if (indices != null) {
+      final packed = InterleavedLayoutAdapter.packIndices(indices);
+      indexBytes = ByteData.sublistView(packed.bytes);
+      indexType = packed.is32Bit ? gpu.IndexType.int32 : gpu.IndexType.int16;
+    }
+
+    uploadVertexData(
+      ByteData.sublistView(vertexBytes),
+      vertexCount,
+      indexBytes,
+      indexType: indexType,
+    );
+  }
+}
+
+/// Assembles a [MeshGeometry] one vertex and triangle at a time.
+///
+/// The attribute setters ([normal], [texCoord], [color]) are sticky:
+/// each value applies to every [addVertex] call that follows until it is
+/// changed. [addVertex] returns the index of the added vertex; when
+/// [deduplicate] is set, a vertex equal to one already added is merged
+/// and the existing index is returned instead.
+///
+/// ```dart
+/// final geometry = (GeometryBuilder()
+///       ..color(Vector4(1, 0, 0, 1))
+///       ..addVertex(Vector3(0, 0, 0))
+///       ..addVertex(Vector3(1, 0, 0))
+///       ..addVertex(Vector3(0, 1, 0))
+///       ..addTriangle(0, 1, 2))
+///     .build();
+/// ```
+class GeometryBuilder {
+  /// Creates an empty builder.
+  ///
+  /// When [deduplicate] is `true` (the default), [addVertex] merges a
+  /// vertex equal to one already added.
+  GeometryBuilder({this.deduplicate = true});
+
+  /// Whether [addVertex] merges a vertex equal to one already added.
+  final bool deduplicate;
+
+  final List<double> _positions = [];
+  final List<double> _normals = [];
+  final List<double> _texCoords = [];
+  final List<double> _colors = [];
+  final List<int> _indices = [];
+  final Map<String, int> _vertexLookup = {};
+
+  Vector3 _normal = Vector3(0.0, 0.0, 1.0);
+  Vector2 _texCoord = Vector2.zero();
+  Vector4 _color = Vector4(1.0, 1.0, 1.0, 1.0);
+  bool _normalsAuthored = false;
+
+  /// The number of vertices added so far.
+  int get vertexCount => _positions.length ~/ 3;
+
+  /// The number of triangles added so far.
+  int get triangleCount => _indices.length ~/ 3;
+
+  /// Sets the normal applied to vertices added after this call.
+  ///
+  /// Authoring any normal opts the whole mesh out of generated normals;
+  /// vertices added without an explicit normal keep the default
+  /// `(0, 0, 1)`.
+  GeometryBuilder normal(Vector3 value) {
+    _normal = value.clone();
+    _normalsAuthored = true;
+    return this;
+  }
+
+  /// Sets the texture coordinate applied to vertices added after this
+  /// call.
+  GeometryBuilder texCoord(Vector2 value) {
+    _texCoord = value.clone();
+    return this;
+  }
+
+  /// Sets the color applied to vertices added after this call.
+  GeometryBuilder color(Vector4 value) {
+    _color = value.clone();
+    return this;
+  }
+
+  /// Adds a vertex at [position] carrying the current sticky attributes
+  /// and returns its index.
+  int addVertex(Vector3 position) {
+    if (deduplicate) {
+      final key = _vertexKey(position);
+      final existing = _vertexLookup[key];
+      if (existing != null) return existing;
+      final index = vertexCount;
+      _vertexLookup[key] = index;
+      _appendVertex(position);
+      return index;
+    }
+    final index = vertexCount;
+    _appendVertex(position);
+    return index;
+  }
+
+  /// Adds a triangle referencing three previously added vertex indices.
+  GeometryBuilder addTriangle(int a, int b, int c) {
+    final count = vertexCount;
+    for (final index in [a, b, c]) {
+      if (index < 0 || index >= count) {
+        throw RangeError.range(index, 0, count - 1, 'vertex index');
+      }
+    }
+    _indices
+      ..add(a)
+      ..add(b)
+      ..add(c);
+    return this;
+  }
+
+  /// Packs the accumulated vertices into the interleaved layout.
+  ///
+  /// Pure and free of GPU resources; [build] uses it, and it can be
+  /// exercised directly without a render context.
+  Uint8List packVertices() {
+    return InterleavedLayoutAdapter.packUnskinned(
+      positions: Float32List.fromList(_positions),
+      vertexCount: vertexCount,
+      normals: _resolveNormals(),
+      texCoords: Float32List.fromList(_texCoords),
+      colors: Float32List.fromList(_colors),
+    );
+  }
+
+  /// Builds and GPU-uploads the accumulated mesh.
+  MeshGeometry build() {
+    return MeshGeometry.fromArrays(
+      positions: Float32List.fromList(_positions),
+      normals: _resolveNormals(),
+      texCoords: Float32List.fromList(_texCoords),
+      colors: Float32List.fromList(_colors),
+      indices: _indices.isEmpty ? null : List.of(_indices),
+    );
+  }
+
+  Float32List _resolveNormals() {
+    if (_normalsAuthored) return Float32List.fromList(_normals);
+    return InterleavedLayoutAdapter.generateNormals(
+      positions: Float32List.fromList(_positions),
+      vertexCount: vertexCount,
+      indices: _indices,
+    );
+  }
+
+  void _appendVertex(Vector3 position) {
+    _positions
+      ..add(position.x)
+      ..add(position.y)
+      ..add(position.z);
+    _normals
+      ..add(_normal.x)
+      ..add(_normal.y)
+      ..add(_normal.z);
+    _texCoords
+      ..add(_texCoord.x)
+      ..add(_texCoord.y);
+    _colors
+      ..add(_color.x)
+      ..add(_color.y)
+      ..add(_color.z)
+      ..add(_color.w);
+  }
+
+  String _vertexKey(Vector3 position) {
+    return '${position.x},${position.y},${position.z},'
+        '${_normal.x},${_normal.y},${_normal.z},'
+        '${_texCoord.x},${_texCoord.y},'
+        '${_color.x},${_color.y},${_color.z},${_color.w}';
+  }
+}

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -6,6 +6,25 @@ import 'package:vector_math/vector_math.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 
+/// How a [MeshGeometry] manages its GPU buffers over its lifetime.
+enum GeometryStorage {
+  /// The vertex and index buffers are uploaded once at construction and
+  /// never change. This is the right choice for imported or generated
+  /// meshes that stay still.
+  fixed,
+
+  /// The vertex and index buffers are retained so the mesh can be
+  /// updated in place every frame without reallocating GPU memory. Use
+  /// this for geometry that is regenerated continuously, such as a route
+  /// line that follows a moving vehicle.
+  ///
+  /// An updatable geometry keeps a CPU-side copy of each attribute and
+  /// allocates its buffers with spare capacity, so topology-stable
+  /// updates ([MeshGeometry.updatePositions] and friends) and bounded
+  /// growth ([MeshGeometry.rebuild]) avoid reallocation.
+  updatable,
+}
+
 /// A triangle mesh built at runtime from vertex attribute arrays.
 ///
 /// `MeshGeometry` is the general-purpose [Geometry] for procedurally
@@ -17,6 +36,13 @@ import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 /// normals, texture coordinates, colors) and never pack vertex bytes by
 /// hand; the arrays are interleaved into the engine vertex layout
 /// internally.
+///
+/// Pass [GeometryStorage.updatable] as the storage mode to create a
+/// geometry that can be mutated in place. [updatePositions],
+/// [updateNormals], [updateTexCoords], and [updateColors] replace one
+/// attribute when the vertex count is unchanged; [rebuild] replaces
+/// everything and reallocates only when the data outgrows the spare
+/// capacity.
 class MeshGeometry extends UnskinnedGeometry {
   /// Builds a mesh from structure-of-arrays vertex attributes.
   ///
@@ -35,6 +61,12 @@ class MeshGeometry extends UnskinnedGeometry {
   ///
   /// [primitiveType] selects how the vertex/index data is assembled into
   /// primitives when drawn, and defaults to a triangle list.
+  ///
+  /// [storage] selects whether the mesh can later be updated in place.
+  /// An updatable mesh fixes its indexed-or-not state at construction:
+  /// supplying [indices] makes [rebuild] require indices thereafter, and
+  /// omitting them makes it reject them. To start empty, pass a
+  /// zero-length [positions] array with [GeometryStorage.updatable].
   MeshGeometry.fromArrays({
     required Float32List positions,
     Float32List? normals,
@@ -42,6 +74,7 @@ class MeshGeometry extends UnskinnedGeometry {
     Float32List? colors,
     List<int>? indices,
     gpu.PrimitiveType primitiveType = gpu.PrimitiveType.triangle,
+    this.storage = GeometryStorage.fixed,
   }) {
     if (positions.length % 3 != 0) {
       throw ArgumentError(
@@ -56,7 +89,7 @@ class MeshGeometry extends UnskinnedGeometry {
     // geometry has none, so absent normals are left at their default.
     final resolvedNormals =
         normals ??
-        (primitiveType == gpu.PrimitiveType.triangle
+        (vertexCount > 0 && primitiveType == gpu.PrimitiveType.triangle
             ? InterleavedLayoutAdapter.generateNormals(
               positions: positions,
               vertexCount: vertexCount,
@@ -64,14 +97,181 @@ class MeshGeometry extends UnskinnedGeometry {
             )
             : null);
 
+    if (storage == GeometryStorage.fixed) {
+      _uploadFixed(
+        positions,
+        vertexCount,
+        resolvedNormals,
+        texCoords,
+        colors,
+        indices,
+      );
+    } else {
+      _indexed = indices != null;
+      _setCpuStreams(
+        positions,
+        vertexCount,
+        resolvedNormals,
+        texCoords,
+        colors,
+      );
+      _vertexCapacity = nextBufferCapacity(vertexCount);
+      _vertexBuffer = gpu.gpuContext.createDeviceBuffer(
+        gpu.StorageMode.hostVisible,
+        _vertexCapacity * kInterleavedVertexBytes,
+      );
+      _liveVertexCount = vertexCount;
+      _uploadVertexBytes();
+      if (_indexed) _uploadIndices(indices!);
+      _recomputeBounds();
+    }
+  }
+
+  /// How this geometry's GPU buffers are managed; see [GeometryStorage].
+  final GeometryStorage storage;
+
+  /// Bytes per vertex in the interleaved unskinned layout.
+  static const int kInterleavedVertexBytes =
+      InterleavedLayoutAdapter.floatsPerVertex * 4;
+
+  // --- Updatable-storage state. Unused while [storage] is fixed. ---
+
+  bool _indexed = false;
+  int _liveVertexCount = 0;
+  int _vertexCapacity = 0;
+  int _indexCapacity = 0;
+  gpu.DeviceBuffer? _vertexBuffer;
+  gpu.DeviceBuffer? _indexBuffer;
+  gpu.IndexType _indexType = gpu.IndexType.int16;
+
+  // CPU-side copies of every attribute stream, sized to the live vertex
+  // count. Retained so a single-attribute update can re-pack the
+  // interleaved buffer, which holds every attribute together.
+  Float32List _cpuPositions = Float32List(0);
+  Float32List _cpuNormals = Float32List(0);
+  Float32List _cpuTexCoords = Float32List(0);
+  Float32List _cpuColors = Float32List(0);
+
+  /// The number of vertices currently drawn.
+  int get vertexCount => _liveVertexCount;
+
+  /// Whether this geometry can be updated in place.
+  bool get isUpdatable => storage == GeometryStorage.updatable;
+
+  /// Replaces every vertex position, keeping the vertex count unchanged.
+  ///
+  /// [positions] holds three floats per vertex and must match the
+  /// current [vertexCount]. To change the vertex count, use [rebuild].
+  /// Throws a [StateError] unless this geometry is
+  /// [GeometryStorage.updatable].
+  void updatePositions(Float32List positions) {
+    _ensureUpdatable('updatePositions');
+    _checkAttributeLength('positions', positions.length, 3);
+    _cpuPositions = Float32List.fromList(positions);
+    _uploadVertexBytes();
+    _recomputeBounds();
+  }
+
+  /// Replaces every vertex normal, keeping the vertex count unchanged.
+  void updateNormals(Float32List normals) {
+    _ensureUpdatable('updateNormals');
+    _checkAttributeLength('normals', normals.length, 3);
+    _cpuNormals = Float32List.fromList(normals);
+    _uploadVertexBytes();
+  }
+
+  /// Replaces every texture coordinate, keeping the vertex count
+  /// unchanged.
+  void updateTexCoords(Float32List texCoords) {
+    _ensureUpdatable('updateTexCoords');
+    _checkAttributeLength('texCoords', texCoords.length, 2);
+    _cpuTexCoords = Float32List.fromList(texCoords);
+    _uploadVertexBytes();
+  }
+
+  /// Replaces every vertex color, keeping the vertex count unchanged.
+  void updateColors(Float32List colors) {
+    _ensureUpdatable('updateColors');
+    _checkAttributeLength('colors', colors.length, 4);
+    _cpuColors = Float32List.fromList(colors);
+    _uploadVertexBytes();
+  }
+
+  /// Replaces all of this geometry's data, allowing the vertex and index
+  /// counts to change.
+  ///
+  /// Reuses the existing GPU buffers when the new data fits within their
+  /// spare capacity, and reallocates with headroom only when it does
+  /// not. The indexed-or-not state is fixed at construction: a geometry
+  /// created with indices requires [indices] here, and one created
+  /// without must omit them. Throws a [StateError] unless this geometry
+  /// is [GeometryStorage.updatable].
+  void rebuild({
+    required Float32List positions,
+    Float32List? normals,
+    Float32List? texCoords,
+    Float32List? colors,
+    List<int>? indices,
+  }) {
+    _ensureUpdatable('rebuild');
+    if (positions.length % 3 != 0) {
+      throw ArgumentError(
+        'positions has ${positions.length} floats; expected a multiple of '
+        'three (one vec3 per vertex)',
+      );
+    }
+    if (_indexed && indices == null) {
+      throw ArgumentError(
+        'This geometry was created with indices; rebuild requires them',
+      );
+    }
+    if (!_indexed && indices != null) {
+      throw ArgumentError(
+        'This geometry was created without indices; rebuild must not '
+        'supply them',
+      );
+    }
+    final vertexCount = positions.length ~/ 3;
+    final resolvedNormals =
+        normals ??
+        (vertexCount > 0 && primitiveType == gpu.PrimitiveType.triangle
+            ? InterleavedLayoutAdapter.generateNormals(
+              positions: positions,
+              vertexCount: vertexCount,
+              indices: indices,
+            )
+            : null);
+
+    _setCpuStreams(positions, vertexCount, resolvedNormals, texCoords, colors);
+    if (vertexCount > _vertexCapacity) {
+      _vertexCapacity = nextBufferCapacity(vertexCount);
+      _vertexBuffer = gpu.gpuContext.createDeviceBuffer(
+        gpu.StorageMode.hostVisible,
+        _vertexCapacity * kInterleavedVertexBytes,
+      );
+    }
+    _liveVertexCount = vertexCount;
+    _uploadVertexBytes();
+    if (_indexed) _uploadIndices(indices!);
+    _recomputeBounds();
+  }
+
+  void _uploadFixed(
+    Float32List positions,
+    int vertexCount,
+    Float32List? normals,
+    Float32List? texCoords,
+    Float32List? colors,
+    List<int>? indices,
+  ) {
+    _liveVertexCount = vertexCount;
     final vertexBytes = InterleavedLayoutAdapter.packUnskinned(
       positions: positions,
       vertexCount: vertexCount,
-      normals: resolvedNormals,
+      normals: normals,
       texCoords: texCoords,
       colors: colors,
     );
-
     ByteData? indexBytes;
     var indexType = gpu.IndexType.int16;
     if (indices != null) {
@@ -79,7 +279,6 @@ class MeshGeometry extends UnskinnedGeometry {
       indexBytes = ByteData.sublistView(packed.bytes);
       indexType = packed.is32Bit ? gpu.IndexType.int32 : gpu.IndexType.int16;
     }
-
     uploadVertexData(
       ByteData.sublistView(vertexBytes),
       vertexCount,
@@ -87,6 +286,172 @@ class MeshGeometry extends UnskinnedGeometry {
       indexType: indexType,
     );
   }
+
+  // Re-packs the live CPU streams into the interleaved buffer and binds
+  // it. Reuses the retained DeviceBuffer; no allocation.
+  void _uploadVertexBytes() {
+    final bytes = InterleavedLayoutAdapter.packUnskinned(
+      positions: _cpuPositions,
+      vertexCount: _liveVertexCount,
+      normals: _cpuNormals,
+      texCoords: _cpuTexCoords,
+      colors: _cpuColors,
+    );
+    final buffer = _vertexBuffer!;
+    if (bytes.isNotEmpty) {
+      buffer.overwrite(ByteData.sublistView(bytes));
+      buffer.flush(offsetInBytes: 0, lengthInBytes: bytes.length);
+    }
+    setVertices(
+      gpu.BufferView(buffer, offsetInBytes: 0, lengthInBytes: bytes.length),
+      _liveVertexCount,
+    );
+  }
+
+  void _uploadIndices(List<int> indices) {
+    final packed = InterleavedLayoutAdapter.packIndices(indices);
+    final indexType =
+        packed.is32Bit ? gpu.IndexType.int32 : gpu.IndexType.int16;
+    final elementBytes = packed.is32Bit ? 4 : 2;
+    if (_indexBuffer == null ||
+        indices.length > _indexCapacity ||
+        indexType != _indexType) {
+      _indexCapacity = nextBufferCapacity(indices.length);
+      _indexType = indexType;
+      _indexBuffer = gpu.gpuContext.createDeviceBuffer(
+        gpu.StorageMode.hostVisible,
+        _indexCapacity * elementBytes,
+      );
+    }
+    final buffer = _indexBuffer!;
+    if (packed.bytes.isNotEmpty) {
+      buffer.overwrite(ByteData.sublistView(packed.bytes));
+      buffer.flush(offsetInBytes: 0, lengthInBytes: packed.bytes.length);
+    }
+    setIndices(
+      gpu.BufferView(
+        buffer,
+        offsetInBytes: 0,
+        lengthInBytes: packed.bytes.length,
+      ),
+      indexType,
+    );
+  }
+
+  void _setCpuStreams(
+    Float32List positions,
+    int vertexCount,
+    Float32List? normals,
+    Float32List? texCoords,
+    Float32List? colors,
+  ) {
+    if (normals != null && normals.length != vertexCount * 3) {
+      throw ArgumentError(
+        'normals has ${normals.length} floats; expected ${vertexCount * 3}',
+      );
+    }
+    if (texCoords != null && texCoords.length != vertexCount * 2) {
+      throw ArgumentError(
+        'texCoords has ${texCoords.length} floats; expected '
+        '${vertexCount * 2}',
+      );
+    }
+    if (colors != null && colors.length != vertexCount * 4) {
+      throw ArgumentError(
+        'colors has ${colors.length} floats; expected ${vertexCount * 4}',
+      );
+    }
+    _cpuPositions = Float32List.fromList(positions);
+    _cpuNormals =
+        normals != null
+            ? Float32List.fromList(normals)
+            : _filledStream(vertexCount, 3, const [0.0, 0.0, 1.0]);
+    _cpuTexCoords =
+        texCoords != null
+            ? Float32List.fromList(texCoords)
+            : Float32List(vertexCount * 2);
+    _cpuColors =
+        colors != null
+            ? Float32List.fromList(colors)
+            : _filledStream(vertexCount, 4, const [1.0, 1.0, 1.0, 1.0]);
+  }
+
+  void _recomputeBounds() {
+    if (_liveVertexCount == 0) {
+      setLocalBounds(null, null);
+      return;
+    }
+    var minX = double.infinity, minY = double.infinity, minZ = double.infinity;
+    var maxX = double.negativeInfinity,
+        maxY = double.negativeInfinity,
+        maxZ = double.negativeInfinity;
+    for (var v = 0; v < _liveVertexCount; v++) {
+      final x = _cpuPositions[v * 3];
+      final y = _cpuPositions[v * 3 + 1];
+      final z = _cpuPositions[v * 3 + 2];
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+      if (z > maxZ) maxZ = z;
+    }
+    final min = Vector3(minX, minY, minZ);
+    final max = Vector3(maxX, maxY, maxZ);
+    final center = (min + max) * 0.5;
+    final radius = ((max - min) * 0.5).length;
+    setLocalBounds(Aabb3.minMax(min, max), Sphere.centerRadius(center, radius));
+  }
+
+  void _ensureUpdatable(String operation) {
+    if (storage != GeometryStorage.updatable) {
+      throw StateError(
+        '$operation requires GeometryStorage.updatable; this geometry is '
+        'fixed',
+      );
+    }
+  }
+
+  void _checkAttributeLength(String name, int length, int componentsPerVertex) {
+    final expected = _liveVertexCount * componentsPerVertex;
+    if (length != expected) {
+      throw ArgumentError(
+        '$name has $length floats; a topology-stable update expects '
+        '$expected for $_liveVertexCount vertices. Use rebuild to change '
+        'the vertex count.',
+      );
+    }
+  }
+
+  static Float32List _filledStream(
+    int vertexCount,
+    int componentsPerVertex,
+    List<double> value,
+  ) {
+    final stream = Float32List(vertexCount * componentsPerVertex);
+    for (var v = 0; v < vertexCount; v++) {
+      for (var c = 0; c < componentsPerVertex; c++) {
+        stream[v * componentsPerVertex + c] = value[c];
+      }
+    }
+    return stream;
+  }
+}
+
+/// Rounds [needed] up to a buffer capacity with spare headroom.
+///
+/// Updatable geometry allocates its GPU buffers at the returned size so
+/// that a buffer which grows gradually reallocates only a logarithmic
+/// number of times rather than on every change. The result is the
+/// smallest power of two that is at least [needed] and at least
+/// [minimum].
+int nextBufferCapacity(int needed, {int minimum = 16}) {
+  if (needed <= minimum) return minimum;
+  var capacity = minimum;
+  while (capacity < needed) {
+    capacity <<= 1;
+  }
+  return capacity;
 }
 
 /// Assembles a [MeshGeometry] one vertex and triangle at a time.
@@ -205,13 +570,17 @@ class GeometryBuilder {
   }
 
   /// Builds and GPU-uploads the accumulated mesh.
-  MeshGeometry build() {
+  ///
+  /// Pass [GeometryStorage.updatable] for [storage] to build a mesh that
+  /// can be mutated in place afterwards.
+  MeshGeometry build({GeometryStorage storage = GeometryStorage.fixed}) {
     return MeshGeometry.fromArrays(
       positions: Float32List.fromList(_positions),
       normals: _resolveNormals(),
       texCoords: Float32List.fromList(_texCoords),
       colors: Float32List.fromList(_colors),
       indices: _indices.isEmpty ? null : List.of(_indices),
+      storage: storage,
     );
   }
 

--- a/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
@@ -32,15 +32,22 @@ enum PolylineCap {
 /// in scene units along the line's arc length.
 class DashPattern {
   /// Creates a dash pattern; both lengths must be positive.
-  const DashPattern({required this.dashLength, required this.gapLength})
-    : assert(dashLength > 0, 'dashLength must be positive'),
-      assert(gapLength > 0, 'gapLength must be positive');
+  const DashPattern({
+    required this.dashLength,
+    required this.gapLength,
+    this.cap = PolylineCap.butt,
+  }) : assert(dashLength > 0, 'dashLength must be positive'),
+       assert(gapLength > 0, 'gapLength must be positive');
 
   /// The drawn length of each dash.
   final double dashLength;
 
   /// The undrawn length between dashes.
   final double gapLength;
+
+  /// How each dash's two ends are finished. [PolylineCap.round] caps
+  /// every dash with a camera-facing disk; the default is flat ends.
+  final PolylineCap cap;
 }
 
 // Triangle-fan segments in a round cap disk.
@@ -58,7 +65,8 @@ const int _diskSegments = 16;
 ///
 /// [PolylineCap.round] adds a camera-facing disk at each end point,
 /// [drawStart]/[drawEnd] trim the line or animate it drawing on, and a
-/// [DashPattern] breaks it into dashes. Corners use an averaged
+/// [DashPattern] breaks it into dashes, which its own cap can round.
+/// Corners use an averaged
 /// direction, which stays smooth on a finely sampled curve but can
 /// pinch on a very sharp turn. Rounded corner joins and a GPU
 /// vertex-shader expansion that avoids the per-frame rebuild are
@@ -102,6 +110,7 @@ class PolylineGeometry extends MeshGeometry {
 
     // Dashes resample the line into dash segments joined by zero-width
     // gap points, so the gap regions draw nothing.
+    var dashCapIndices = const <int>[];
     if (dash != null) {
       final dashed = resampleDashed(
         working,
@@ -112,6 +121,7 @@ class PolylineGeometry extends MeshGeometry {
       working = dashed.points;
       workingWidths = dashed.widths;
       workingColors = dashed.colors;
+      dashCapIndices = dashed.dashCapIndices;
     }
 
     final copied = working;
@@ -128,7 +138,13 @@ class PolylineGeometry extends MeshGeometry {
     // Texture coordinates and colors do not depend on the camera, so
     // they are set once here. The placeholder positions collapse the
     // strip onto the points until updateForCamera runs.
-    final diskPoints = diskPointIndices(count, cap);
+    //
+    // Round dash caps put a disk at every dash boundary; otherwise the
+    // disks are just the line's two round ends.
+    final diskPoints =
+        (dash != null && dash.cap == PolylineCap.round)
+            ? dashCapIndices
+            : diskPointIndices(count, cap);
     final stripVertexCount = count * 2;
     final vertexCount =
         stripVertexCount + diskPoints.length * (_diskSegments + 1);
@@ -183,7 +199,7 @@ class PolylineGeometry extends MeshGeometry {
       copied,
       widths,
       widthMode,
-      cap,
+      diskPoints,
       positions: positions,
       normals: normals,
       texCoords: texCoords,
@@ -196,7 +212,7 @@ class PolylineGeometry extends MeshGeometry {
     this._points,
     this._widths,
     this._widthMode,
-    this._cap, {
+    this._diskPoints, {
     required super.positions,
     required super.normals,
     required super.texCoords,
@@ -207,7 +223,9 @@ class PolylineGeometry extends MeshGeometry {
   final List<Vector3> _points;
   final List<double> _widths;
   final PolylineWidthMode _widthMode;
-  final PolylineCap _cap;
+  // The point indices that receive a round cap disk: the line's round
+  // ends, or every dash boundary when the dash pattern is round-capped.
+  final List<int> _diskPoints;
 
   /// The fraction of the line, by arc length, where the visible range
   /// begins. With [drawEnd] this trims the line or animates it drawing
@@ -226,7 +244,7 @@ class PolylineGeometry extends MeshGeometry {
       _points,
       widths: _widths,
       widthMode: _widthMode,
-      cap: _cap,
+      diskPoints: _diskPoints,
       drawStart: drawStart,
       drawEnd: drawEnd,
       viewProjection: camera.getViewTransform(viewportSize),
@@ -254,6 +272,8 @@ List<int> diskPointIndices(int count, PolylineCap cap) {
 /// the visible range: points outside it collapse onto the range
 /// boundary with zero width.
 ///
+/// [diskPoints] lists the point indices that receive a round cap disk.
+///
 /// Pure: it takes the view-projection matrix rather than touching the
 /// GPU, so it can be exercised without a render context. The strip is
 /// two vertices per point; each round cap adds a disk of `1 + 16`
@@ -262,7 +282,7 @@ List<int> diskPointIndices(int count, PolylineCap cap) {
   List<Vector3> points, {
   required List<double> widths,
   required PolylineWidthMode widthMode,
-  required PolylineCap cap,
+  required List<int> diskPoints,
   required double drawStart,
   required double drawEnd,
   required Matrix4 viewProjection,
@@ -338,7 +358,6 @@ List<int> diskPointIndices(int count, PolylineCap cap) {
     }
   }
 
-  final diskPoints = diskPointIndices(count, cap);
   final vertexCount = count * 2 + diskPoints.length * (_diskSegments + 1);
   final positions = Float32List(vertexCount * 3);
   final normals = Float32List(vertexCount * 3);
@@ -426,8 +445,14 @@ Vector3 _pointAtArc(List<Vector3> points, List<double> arc, double target) {
 /// Each dash starts and ends with a full-width point at the exact dash
 /// boundary; consecutive dashes are joined by zero-width gap points so
 /// the gap draws nothing. The overall line keeps its two end points, so
-/// round caps still apply to them.
-({List<Vector3> points, List<double> widths, List<Vector4> colors})
+/// round caps still apply to them. `dashCapIndices` lists the resampled
+/// indices of every dash boundary, for per-dash round caps.
+({
+  List<Vector3> points,
+  List<double> widths,
+  List<Vector4> colors,
+  List<int> dashCapIndices,
+})
 resampleDashed(
   List<Vector3> points,
   List<double> widths,
@@ -440,7 +465,14 @@ resampleDashed(
     arc[i] = arc[i - 1] + points[i].distanceTo(points[i - 1]);
   }
   final total = arc[count - 1];
-  if (total <= 0.0) return (points: points, widths: widths, colors: colors);
+  if (total <= 0.0) {
+    return (
+      points: points,
+      widths: widths,
+      colors: colors,
+      dashCapIndices: const <int>[],
+    );
+  }
 
   // Position, width, and color at an arc-length distance.
   (Vector3, double, Vector4) sampleAt(double distance) {
@@ -469,6 +501,7 @@ resampleDashed(
   final outPoints = <Vector3>[];
   final outWidths = <double>[];
   final outColors = <Vector4>[];
+  final dashCapIndices = <int>[];
   void emit(Vector3 p, double w, Vector4 c) {
     outPoints.add(p);
     outWidths.add(w);
@@ -482,18 +515,30 @@ resampleDashed(
     // A zero-width gap connector before every dash but the first.
     if (k > 0) emit(startPos, 0.0, startColor);
     emit(startPos, startWidth, startColor);
+    dashCapIndices.add(outPoints.length - 1);
     for (var i = 0; i < count; i++) {
       if (arc[i] > a && arc[i] < b) emit(points[i], widths[i], colors[i]);
     }
     emit(endPos, endWidth, endColor);
+    dashCapIndices.add(outPoints.length - 1);
     // A zero-width gap connector after every dash but the last.
     if (k < dashes.length - 1) emit(endPos, 0.0, endColor);
   }
 
   if (outPoints.length < 2) {
-    return (points: points, widths: widths, colors: colors);
+    return (
+      points: points,
+      widths: widths,
+      colors: colors,
+      dashCapIndices: const <int>[],
+    );
   }
-  return (points: outPoints, widths: outWidths, colors: outColors);
+  return (
+    points: outPoints,
+    widths: outWidths,
+    colors: outColors,
+    dashCapIndices: dashCapIndices,
+  );
 }
 
 List<Vector3> _pointTangents(List<Vector3> points) {

--- a/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
@@ -28,17 +28,7 @@ enum PolylineCap {
   round,
 }
 
-/// How a [PolylineGeometry] turns corners.
-enum PolylineJoin {
-  /// The strip bends through a shared averaged direction. Cheap, but it
-  /// can pinch on very sharp turns.
-  miter,
-
-  /// A disk fills each corner, rounding the outside of the bend.
-  round,
-}
-
-// Triangle-fan segments in a round cap or join disk.
+// Triangle-fan segments in a round cap disk.
 const int _diskSegments = 16;
 
 /// A thick, camera-facing line through a list of points.
@@ -51,25 +41,24 @@ const int _diskSegments = 16;
 /// The result is an ordinary triangle mesh: pair it with any material,
 /// and use [perVertexColor] for gradient or distance-fade effects.
 ///
-/// Round caps and joins ([PolylineCap.round], [PolylineJoin.round]) add
-/// camera-facing disks at the end and corner points. Dashes, an animated
-/// draw-on range, and a GPU vertex-shader expansion that avoids the
-/// per-frame rebuild are planned follow-ups; see
-/// `docs/dynamic_geometry.md`.
+/// [PolylineCap.round] adds a camera-facing disk at each end point.
+/// Corners use an averaged direction, which stays smooth on a finely
+/// sampled curve but can pinch on a very sharp turn. Dashes, an animated
+/// draw-on range, rounded corner joins, and a GPU vertex-shader
+/// expansion that avoids the per-frame rebuild are planned follow-ups;
+/// see `docs/dynamic_geometry.md`.
 class PolylineGeometry extends MeshGeometry {
   /// Creates a polyline through [points] (at least two).
   ///
   /// [width] is measured per [widthMode]. [perVertexWidth] overrides it
   /// per point for tapering, and [perVertexColor] sets a color per
-  /// point for gradients. [cap] and [join] select rounded ends and
-  /// corners. The strip is a placeholder until the first
-  /// [updateForCamera] call.
+  /// point for gradients. [cap] selects rounded or flat ends. The strip
+  /// is a placeholder until the first [updateForCamera] call.
   factory PolylineGeometry(
     List<Vector3> points, {
     double width = 8.0,
     PolylineWidthMode widthMode = PolylineWidthMode.screenPixels,
     PolylineCap cap = PolylineCap.butt,
-    PolylineJoin join = PolylineJoin.miter,
     List<double>? perVertexWidth,
     List<Vector4>? perVertexColor,
   }) {
@@ -99,7 +88,7 @@ class PolylineGeometry extends MeshGeometry {
     // Texture coordinates and colors do not depend on the camera, so
     // they are set once here. The placeholder positions collapse the
     // strip onto the points until updateForCamera runs.
-    final diskPoints = diskPointIndices(count, cap, join);
+    final diskPoints = diskPointIndices(count, cap);
     final stripVertexCount = count * 2;
     final vertexCount =
         stripVertexCount + diskPoints.length * (_diskSegments + 1);
@@ -136,7 +125,7 @@ class PolylineGeometry extends MeshGeometry {
         ..addAll([a + 1, a + 2, a + 3]);
     }
 
-    // A triangle-fan disk for each round cap or join point.
+    // A triangle-fan disk for each round cap.
     for (var ord = 0; ord < diskPoints.length; ord++) {
       final point = diskPoints[ord];
       final base = stripVertexCount + ord * (_diskSegments + 1);
@@ -155,7 +144,6 @@ class PolylineGeometry extends MeshGeometry {
       widths,
       widthMode,
       cap,
-      join,
       positions: positions,
       normals: normals,
       texCoords: texCoords,
@@ -168,8 +156,7 @@ class PolylineGeometry extends MeshGeometry {
     this._points,
     this._widths,
     this._widthMode,
-    this._cap,
-    this._join, {
+    this._cap, {
     required super.positions,
     required super.normals,
     required super.texCoords,
@@ -181,7 +168,6 @@ class PolylineGeometry extends MeshGeometry {
   final List<double> _widths;
   final PolylineWidthMode _widthMode;
   final PolylineCap _cap;
-  final PolylineJoin _join;
 
   /// Rebuilds the camera-facing strip for [camera] and [viewportSize].
   ///
@@ -192,7 +178,6 @@ class PolylineGeometry extends MeshGeometry {
       widths: _widths,
       widthMode: _widthMode,
       cap: _cap,
-      join: _join,
       viewProjection: camera.getViewTransform(viewportSize),
       cameraPosition: camera.position,
       viewportSize: viewportSize,
@@ -202,37 +187,27 @@ class PolylineGeometry extends MeshGeometry {
   }
 }
 
-/// The polyline point indices that receive a round cap or join disk, in
-/// the order [expandPolyline] emits them: the two end points first,
-/// then the interior points.
-List<int> diskPointIndices(int count, PolylineCap cap, PolylineJoin join) {
-  final indices = <int>[];
+/// The polyline point indices that receive a round cap disk: the two
+/// end points when [cap] is [PolylineCap.round], otherwise none.
+List<int> diskPointIndices(int count, PolylineCap cap) {
   if (cap == PolylineCap.round) {
-    indices
-      ..add(0)
-      ..add(count - 1);
+    return <int>[0, count - 1];
   }
-  if (join == PolylineJoin.round) {
-    for (var i = 1; i < count - 1; i++) {
-      indices.add(i);
-    }
-  }
-  return indices;
+  return const <int>[];
 }
 
 /// Expands [points] into a camera-facing triangle strip's vertex
-/// positions and normals, including round cap and join disks.
+/// positions and normals, including round cap disks.
 ///
 /// Pure: it takes the view-projection matrix rather than touching the
 /// GPU, so it can be exercised without a render context. The strip is
-/// two vertices per point; each round cap or join adds a disk of
-/// `1 + 16` vertices.
+/// two vertices per point; each round cap adds a disk of `1 + 16`
+/// vertices.
 ({Float32List positions, Float32List normals}) expandPolyline(
   List<Vector3> points, {
   required List<double> widths,
   required PolylineWidthMode widthMode,
   required PolylineCap cap,
-  required PolylineJoin join,
   required Matrix4 viewProjection,
   required Vector3 cameraPosition,
   required ui.Size viewportSize,
@@ -300,7 +275,7 @@ List<int> diskPointIndices(int count, PolylineCap cap, PolylineJoin join) {
     }
   }
 
-  final diskPoints = diskPointIndices(count, cap, join);
+  final diskPoints = diskPointIndices(count, cap);
   final vertexCount = count * 2 + diskPoints.length * (_diskSegments + 1);
   final positions = Float32List(vertexCount * 3);
   final normals = Float32List(vertexCount * 3);

--- a/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
@@ -41,12 +41,13 @@ const int _diskSegments = 16;
 /// The result is an ordinary triangle mesh: pair it with any material,
 /// and use [perVertexColor] for gradient or distance-fade effects.
 ///
-/// [PolylineCap.round] adds a camera-facing disk at each end point.
+/// [PolylineCap.round] adds a camera-facing disk at each end point, and
+/// [drawStart]/[drawEnd] trim the line or animate it drawing on.
 /// Corners use an averaged direction, which stays smooth on a finely
-/// sampled curve but can pinch on a very sharp turn. Dashes, an animated
-/// draw-on range, rounded corner joins, and a GPU vertex-shader
-/// expansion that avoids the per-frame rebuild are planned follow-ups;
-/// see `docs/dynamic_geometry.md`.
+/// sampled curve but can pinch on a very sharp turn. Dashes, rounded
+/// corner joins, and a GPU vertex-shader expansion that avoids the
+/// per-frame rebuild are planned follow-ups; see
+/// `docs/dynamic_geometry.md`.
 class PolylineGeometry extends MeshGeometry {
   /// Creates a polyline through [points] (at least two).
   ///
@@ -169,6 +170,15 @@ class PolylineGeometry extends MeshGeometry {
   final PolylineWidthMode _widthMode;
   final PolylineCap _cap;
 
+  /// The fraction of the line, by arc length, where the visible range
+  /// begins. With [drawEnd] this trims the line or animates it drawing
+  /// on. Clamped to `0..1`; the default is `0`.
+  double drawStart = 0.0;
+
+  /// The fraction of the line, by arc length, where the visible range
+  /// ends. See [drawStart]. The default is `1`.
+  double drawEnd = 1.0;
+
   /// Rebuilds the camera-facing strip for [camera] and [viewportSize].
   ///
   /// Call once per frame before rendering. Reuses the GPU buffers.
@@ -178,6 +188,8 @@ class PolylineGeometry extends MeshGeometry {
       widths: _widths,
       widthMode: _widthMode,
       cap: _cap,
+      drawStart: drawStart,
+      drawEnd: drawEnd,
       viewProjection: camera.getViewTransform(viewportSize),
       cameraPosition: camera.position,
       viewportSize: viewportSize,
@@ -199,6 +211,10 @@ List<int> diskPointIndices(int count, PolylineCap cap) {
 /// Expands [points] into a camera-facing triangle strip's vertex
 /// positions and normals, including round cap disks.
 ///
+/// [drawStart] and [drawEnd] (fractions `0..1` of the arc length) trim
+/// the visible range: points outside it collapse onto the range
+/// boundary with zero width.
+///
 /// Pure: it takes the view-projection matrix rather than touching the
 /// GPU, so it can be exercised without a render context. The strip is
 /// two vertices per point; each round cap adds a disk of `1 + 16`
@@ -208,14 +224,22 @@ List<int> diskPointIndices(int count, PolylineCap cap) {
   required List<double> widths,
   required PolylineWidthMode widthMode,
   required PolylineCap cap,
+  required double drawStart,
+  required double drawEnd,
   required Matrix4 viewProjection,
   required Vector3 cameraPosition,
   required ui.Size viewportSize,
 }) {
   final count = points.length;
-  final tangents = _pointTangents(points);
+  final (drawnPoints, drawnWidths) = _applyDrawRange(
+    points,
+    widths,
+    drawStart,
+    drawEnd,
+  );
+  final tangents = _pointTangents(drawnPoints);
   final viewDirections = <Vector3>[
-    for (final p in points) _towardCamera(cameraPosition, p),
+    for (final p in drawnPoints) _towardCamera(cameraPosition, p),
   ];
 
   // Strip edge vertices, computed per point.
@@ -226,14 +250,14 @@ List<int> diskPointIndices(int count, PolylineCap cap) {
     for (var i = 0; i < count; i++) {
       var across = tangents[i].cross(viewDirections[i]);
       if (across.length2 < 1e-12) across = _anyPerpendicular(tangents[i]);
-      across = across.normalized() * (widths[i] / 2.0);
-      left[i] = points[i] - across;
-      right[i] = points[i] + across;
+      across = across.normalized() * (drawnWidths[i] / 2.0);
+      left[i] = drawnPoints[i] - across;
+      right[i] = drawnPoints[i] + across;
     }
   } else {
     final inverse = Matrix4.inverted(viewProjection);
     final clip = <Vector4>[
-      for (final p in points)
+      for (final p in drawnPoints)
         viewProjection.transformed(Vector4(p.x, p.y, p.z, 1.0)),
     ];
     final width = viewportSize.width;
@@ -255,7 +279,7 @@ List<int> diskPointIndices(int count, PolylineCap cap) {
       screenX /= length;
       screenY /= length;
       // Perpendicular, offset by half the pixel width, expressed in NDC.
-      final half = widths[i] / 2.0;
+      final half = drawnWidths[i] / 2.0;
       final ndcOffsetX = -screenY * half * 2.0 / width;
       final ndcOffsetY = -screenX * half * 2.0 / height;
       left[i] = _unproject(
@@ -287,18 +311,75 @@ List<int> diskPointIndices(int count, PolylineCap cap) {
   var base = count * 2;
   for (final point in diskPoints) {
     // The strip half-width at the point, recovered from its two edges,
-    // works for both world and screen modes.
+    // works for both world and screen modes. It is zero for a point
+    // collapsed by the draw range, hiding that cap.
     final radius = (left[point] - right[point]).length / 2.0;
     base = _emitDisk(
       positions,
       normals,
       base,
-      points[point],
+      drawnPoints[point],
       viewDirections[point],
       radius,
     );
   }
   return (positions: positions, normals: normals);
+}
+
+double _clamp01(double v) => v < 0.0 ? 0.0 : (v > 1.0 ? 1.0 : v);
+
+// Trims the polyline to the [drawStart, drawEnd] arc-length range.
+// Points outside the range collapse onto the boundary position with
+// zero width, so the strip there is degenerate and draws nothing.
+(List<Vector3>, List<double>) _applyDrawRange(
+  List<Vector3> points,
+  List<double> widths,
+  double drawStart,
+  double drawEnd,
+) {
+  final start = _clamp01(drawStart);
+  final end = _clamp01(drawEnd);
+  if (start <= 0.0 && end >= 1.0) return (points, widths);
+
+  final count = points.length;
+  final arc = List<double>.filled(count, 0.0);
+  for (var i = 1; i < count; i++) {
+    arc[i] = arc[i - 1] + points[i].distanceTo(points[i - 1]);
+  }
+  final total = arc[count - 1];
+  if (total <= 0.0) return (points, widths);
+
+  final startPosition = _pointAtArc(points, arc, start * total);
+  final endPosition = _pointAtArc(points, arc, end * total);
+  final drawnPoints = <Vector3>[];
+  final drawnWidths = <double>[];
+  for (var i = 0; i < count; i++) {
+    final fraction = arc[i] / total;
+    if (fraction < start) {
+      drawnPoints.add(startPosition);
+      drawnWidths.add(0.0);
+    } else if (fraction > end) {
+      drawnPoints.add(endPosition);
+      drawnWidths.add(0.0);
+    } else {
+      drawnPoints.add(points[i]);
+      drawnWidths.add(widths[i]);
+    }
+  }
+  return (drawnPoints, drawnWidths);
+}
+
+// The point at arc-length distance [target] along the polyline.
+Vector3 _pointAtArc(List<Vector3> points, List<double> arc, double target) {
+  final clamped = target < 0.0 ? 0.0 : (target > arc.last ? arc.last : target);
+  var hi = 1;
+  while (hi < arc.length - 1 && arc[hi] < clamped) {
+    hi++;
+  }
+  final lo = hi - 1;
+  final span = arc[hi] - arc[lo];
+  final local = span > 1e-12 ? (clamped - arc[lo]) / span : 0.0;
+  return points[lo] + (points[hi] - points[lo]) * local;
 }
 
 List<Vector3> _pointTangents(List<Vector3> points) {

--- a/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
@@ -1,0 +1,293 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
+
+/// How a [PolylineGeometry]'s width is measured.
+enum PolylineWidthMode {
+  /// The width is a constant number of screen pixels at every distance,
+  /// so a route line keeps the same on-screen thickness as the camera
+  /// zooms.
+  screenPixels,
+
+  /// The width is a fixed distance in scene units, so the line looks
+  /// thinner the further it is from the camera.
+  worldUnits,
+}
+
+/// A thick, camera-facing line through a list of points.
+///
+/// `PolylineGeometry` builds a triangle strip that always faces the
+/// camera, which suits navigation routes and other overlay lines. The
+/// strip is regenerated for the current view by [updateForCamera], which
+/// should be called every frame before rendering.
+///
+/// The result is an ordinary triangle mesh: pair it with any material,
+/// and use [perVertexColor] for gradient or distance-fade effects.
+///
+/// Joins use an averaged corner direction, which can spike on very
+/// sharp turns. Caps are flat. Dashes, an animated draw-on range, and a
+/// GPU vertex-shader expansion that avoids the per-frame rebuild are
+/// planned follow-ups; see `docs/dynamic_geometry.md`.
+class PolylineGeometry extends MeshGeometry {
+  /// Creates a polyline through [points] (at least two).
+  ///
+  /// [width] is measured per [widthMode]. [perVertexWidth] overrides it
+  /// per point for tapering, and [perVertexColor] sets a color per
+  /// point for gradients. The strip is a placeholder until the first
+  /// [updateForCamera] call.
+  factory PolylineGeometry(
+    List<Vector3> points, {
+    double width = 8.0,
+    PolylineWidthMode widthMode = PolylineWidthMode.screenPixels,
+    List<double>? perVertexWidth,
+    List<Vector4>? perVertexColor,
+  }) {
+    if (points.length < 2) {
+      throw ArgumentError('A polyline needs at least two points');
+    }
+    final copied = <Vector3>[for (final p in points) p.clone()];
+    final count = copied.length;
+    if (perVertexWidth != null && perVertexWidth.length != count) {
+      throw ArgumentError('perVertexWidth must have one entry per point');
+    }
+    if (perVertexColor != null && perVertexColor.length != count) {
+      throw ArgumentError('perVertexColor must have one entry per point');
+    }
+    final widths =
+        perVertexWidth != null
+            ? List<double>.of(perVertexWidth)
+            : List<double>.filled(count, width);
+
+    // Texture coordinates and colors do not depend on the camera, so
+    // they are set once here. The placeholder positions collapse the
+    // strip onto the points until updateForCamera runs.
+    final texCoords = Float32List(count * 2 * 2);
+    final colors = Float32List(count * 2 * 4);
+    final placeholder = Float32List(count * 2 * 3);
+    final normals = Float32List(count * 2 * 3);
+    var distance = 0.0;
+    for (var i = 0; i < count; i++) {
+      if (i > 0) distance += copied[i].distanceTo(copied[i - 1]);
+      final color = perVertexColor?[i] ?? Vector4(1.0, 1.0, 1.0, 1.0);
+      for (var side = 0; side < 2; side++) {
+        final v = i * 2 + side;
+        placeholder[v * 3] = copied[i].x;
+        placeholder[v * 3 + 1] = copied[i].y;
+        placeholder[v * 3 + 2] = copied[i].z;
+        normals[v * 3 + 2] = 1.0;
+        texCoords[v * 2] = side.toDouble();
+        texCoords[v * 2 + 1] = distance;
+        colors[v * 4] = color.x;
+        colors[v * 4 + 1] = color.y;
+        colors[v * 4 + 2] = color.z;
+        colors[v * 4 + 3] = color.w;
+      }
+    }
+
+    final indices = <int>[];
+    for (var i = 0; i < count - 1; i++) {
+      final a = i * 2;
+      indices
+        ..addAll([a, a + 2, a + 1])
+        ..addAll([a + 1, a + 2, a + 3]);
+    }
+
+    return PolylineGeometry._(
+      copied,
+      widths,
+      widthMode,
+      positions: placeholder,
+      normals: normals,
+      texCoords: texCoords,
+      colors: colors,
+      indices: indices,
+    );
+  }
+
+  PolylineGeometry._(
+    this._points,
+    this._widths,
+    this._widthMode, {
+    required super.positions,
+    required super.normals,
+    required super.texCoords,
+    required super.colors,
+    required super.indices,
+  }) : super.fromArrays(storage: GeometryStorage.updatable);
+
+  final List<Vector3> _points;
+  final List<double> _widths;
+  final PolylineWidthMode _widthMode;
+
+  /// Rebuilds the camera-facing strip for [camera] and [viewportSize].
+  ///
+  /// Call once per frame before rendering. Reuses the GPU buffers.
+  void updateForCamera(Camera camera, ui.Size viewportSize) {
+    final expanded = expandPolyline(
+      _points,
+      widths: _widths,
+      widthMode: _widthMode,
+      viewProjection: camera.getViewTransform(viewportSize),
+      cameraPosition: camera.position,
+      viewportSize: viewportSize,
+    );
+    updatePositions(expanded.positions);
+    updateNormals(expanded.normals);
+  }
+}
+
+/// Expands [points] into a camera-facing triangle-strip's vertex
+/// positions and normals.
+///
+/// Pure: it takes the view-projection matrix rather than touching the
+/// GPU, so it can be exercised without a render context. Returns two
+/// vertices per point (the strip edges), with normals facing the
+/// camera.
+({Float32List positions, Float32List normals}) expandPolyline(
+  List<Vector3> points, {
+  required List<double> widths,
+  required PolylineWidthMode widthMode,
+  required Matrix4 viewProjection,
+  required Vector3 cameraPosition,
+  required ui.Size viewportSize,
+}) {
+  final count = points.length;
+  final positions = Float32List(count * 2 * 3);
+  final normals = Float32List(count * 2 * 3);
+  final tangents = _pointTangents(points);
+
+  if (widthMode == PolylineWidthMode.worldUnits) {
+    for (var i = 0; i < count; i++) {
+      final point = points[i];
+      final viewDirection = _towardCamera(cameraPosition, point);
+      var across = tangents[i].cross(viewDirection);
+      if (across.length2 < 1e-12) across = _anyPerpendicular(tangents[i]);
+      across = across.normalized() * (widths[i] / 2.0);
+      _writePair(
+        positions,
+        normals,
+        i,
+        point - across,
+        point + across,
+        viewDirection,
+      );
+    }
+    return (positions: positions, normals: normals);
+  }
+
+  final inverse = Matrix4.inverted(viewProjection);
+  final clip = <Vector4>[
+    for (final p in points)
+      viewProjection.transformed(Vector4(p.x, p.y, p.z, 1.0)),
+  ];
+  final width = viewportSize.width;
+  final height = viewportSize.height;
+  for (var i = 0; i < count; i++) {
+    final here = clip[i];
+    final w = here.w.abs() < 1e-6 ? 1e-6 : here.w;
+    final previous = clip[i == 0 ? 0 : i - 1];
+    final next = clip[i == count - 1 ? count - 1 : i + 1];
+    // Screen-space direction between the neighbors.
+    var screenX = (_ndcX(next) - _ndcX(previous)) * width;
+    var screenY = -(_ndcY(next) - _ndcY(previous)) * height;
+    var length = math.sqrt(screenX * screenX + screenY * screenY);
+    if (length < 1e-9) {
+      screenX = 1.0;
+      screenY = 0.0;
+      length = 1.0;
+    }
+    screenX /= length;
+    screenY /= length;
+    // Perpendicular, offset by half the pixel width, expressed in NDC.
+    final half = widths[i] / 2.0;
+    final ndcOffsetX = -screenY * half * 2.0 / width;
+    final ndcOffsetY = -screenX * half * 2.0 / height;
+    final viewDirection = _towardCamera(cameraPosition, points[i]);
+    final left = _unproject(
+      inverse,
+      here.x + ndcOffsetX * w,
+      here.y + ndcOffsetY * w,
+      here.z,
+      w,
+    );
+    final right = _unproject(
+      inverse,
+      here.x - ndcOffsetX * w,
+      here.y - ndcOffsetY * w,
+      here.z,
+      w,
+    );
+    _writePair(positions, normals, i, left, right, viewDirection);
+  }
+  return (positions: positions, normals: normals);
+}
+
+List<Vector3> _pointTangents(List<Vector3> points) {
+  final count = points.length;
+  return <Vector3>[
+    for (var i = 0; i < count; i++)
+      () {
+        final Vector3 delta;
+        if (i == 0) {
+          delta = points[1] - points[0];
+        } else if (i == count - 1) {
+          delta = points[count - 1] - points[count - 2];
+        } else {
+          delta = points[i + 1] - points[i - 1];
+        }
+        return delta.length2 < 1e-12
+            ? Vector3(1.0, 0.0, 0.0)
+            : delta.normalized();
+      }(),
+  ];
+}
+
+double _ndcX(Vector4 clip) => clip.x / (clip.w.abs() < 1e-6 ? 1e-6 : clip.w);
+
+double _ndcY(Vector4 clip) => clip.y / (clip.w.abs() < 1e-6 ? 1e-6 : clip.w);
+
+Vector3 _unproject(Matrix4 inverse, double x, double y, double z, double w) {
+  final world = inverse.transformed(Vector4(x, y, z, w));
+  final iw = world.w.abs() < 1e-9 ? 1e-9 : world.w;
+  return Vector3(world.x / iw, world.y / iw, world.z / iw);
+}
+
+Vector3 _towardCamera(Vector3 cameraPosition, Vector3 point) {
+  final direction = cameraPosition - point;
+  return direction.length2 < 1e-12
+      ? Vector3(0.0, 0.0, 1.0)
+      : direction.normalized();
+}
+
+Vector3 _anyPerpendicular(Vector3 direction) {
+  final reference =
+      direction.x.abs() < 0.9 ? Vector3(1.0, 0.0, 0.0) : Vector3(0.0, 1.0, 0.0);
+  return direction.cross(reference).normalized();
+}
+
+void _writePair(
+  Float32List positions,
+  Float32List normals,
+  int point,
+  Vector3 left,
+  Vector3 right,
+  Vector3 normal,
+) {
+  final base = point * 2 * 3;
+  positions[base] = left.x;
+  positions[base + 1] = left.y;
+  positions[base + 2] = left.z;
+  positions[base + 3] = right.x;
+  positions[base + 4] = right.y;
+  positions[base + 5] = right.z;
+  for (var v = 0; v < 6; v += 3) {
+    normals[base + v] = normal.x;
+    normals[base + v + 1] = normal.y;
+    normals[base + v + 2] = normal.z;
+  }
+}

--- a/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
@@ -19,6 +19,28 @@ enum PolylineWidthMode {
   worldUnits,
 }
 
+/// How a [PolylineGeometry] finishes its two end points.
+enum PolylineCap {
+  /// The strip ends flat at the end point.
+  butt,
+
+  /// A half-disk rounds the end off to the line's half-width.
+  round,
+}
+
+/// How a [PolylineGeometry] turns corners.
+enum PolylineJoin {
+  /// The strip bends through a shared averaged direction. Cheap, but it
+  /// can pinch on very sharp turns.
+  miter,
+
+  /// A disk fills each corner, rounding the outside of the bend.
+  round,
+}
+
+// Triangle-fan segments in a round cap or join disk.
+const int _diskSegments = 16;
+
 /// A thick, camera-facing line through a list of points.
 ///
 /// `PolylineGeometry` builds a triangle strip that always faces the
@@ -29,21 +51,25 @@ enum PolylineWidthMode {
 /// The result is an ordinary triangle mesh: pair it with any material,
 /// and use [perVertexColor] for gradient or distance-fade effects.
 ///
-/// Joins use an averaged corner direction, which can spike on very
-/// sharp turns. Caps are flat. Dashes, an animated draw-on range, and a
-/// GPU vertex-shader expansion that avoids the per-frame rebuild are
-/// planned follow-ups; see `docs/dynamic_geometry.md`.
+/// Round caps and joins ([PolylineCap.round], [PolylineJoin.round]) add
+/// camera-facing disks at the end and corner points. Dashes, an animated
+/// draw-on range, and a GPU vertex-shader expansion that avoids the
+/// per-frame rebuild are planned follow-ups; see
+/// `docs/dynamic_geometry.md`.
 class PolylineGeometry extends MeshGeometry {
   /// Creates a polyline through [points] (at least two).
   ///
   /// [width] is measured per [widthMode]. [perVertexWidth] overrides it
   /// per point for tapering, and [perVertexColor] sets a color per
-  /// point for gradients. The strip is a placeholder until the first
+  /// point for gradients. [cap] and [join] select rounded ends and
+  /// corners. The strip is a placeholder until the first
   /// [updateForCamera] call.
   factory PolylineGeometry(
     List<Vector3> points, {
     double width = 8.0,
     PolylineWidthMode widthMode = PolylineWidthMode.screenPixels,
+    PolylineCap cap = PolylineCap.butt,
+    PolylineJoin join = PolylineJoin.miter,
     List<double>? perVertexWidth,
     List<Vector4>? perVertexColor,
   }) {
@@ -63,33 +89,46 @@ class PolylineGeometry extends MeshGeometry {
             ? List<double>.of(perVertexWidth)
             : List<double>.filled(count, width);
 
+    // Cumulative arc length at each point, for the texture v coordinate.
+    final distances = List<double>.filled(count, 0.0);
+    for (var i = 1; i < count; i++) {
+      distances[i] = distances[i - 1] + copied[i].distanceTo(copied[i - 1]);
+    }
+    Vector4 colorOf(int i) => perVertexColor?[i] ?? Vector4(1.0, 1.0, 1.0, 1.0);
+
     // Texture coordinates and colors do not depend on the camera, so
     // they are set once here. The placeholder positions collapse the
     // strip onto the points until updateForCamera runs.
-    final texCoords = Float32List(count * 2 * 2);
-    final colors = Float32List(count * 2 * 4);
-    final placeholder = Float32List(count * 2 * 3);
-    final normals = Float32List(count * 2 * 3);
-    var distance = 0.0;
-    for (var i = 0; i < count; i++) {
-      if (i > 0) distance += copied[i].distanceTo(copied[i - 1]);
-      final color = perVertexColor?[i] ?? Vector4(1.0, 1.0, 1.0, 1.0);
-      for (var side = 0; side < 2; side++) {
-        final v = i * 2 + side;
-        placeholder[v * 3] = copied[i].x;
-        placeholder[v * 3 + 1] = copied[i].y;
-        placeholder[v * 3 + 2] = copied[i].z;
-        normals[v * 3 + 2] = 1.0;
-        texCoords[v * 2] = side.toDouble();
-        texCoords[v * 2 + 1] = distance;
-        colors[v * 4] = color.x;
-        colors[v * 4 + 1] = color.y;
-        colors[v * 4 + 2] = color.z;
-        colors[v * 4 + 3] = color.w;
-      }
+    final diskPoints = diskPointIndices(count, cap, join);
+    final stripVertexCount = count * 2;
+    final vertexCount =
+        stripVertexCount + diskPoints.length * (_diskSegments + 1);
+    final positions = Float32List(vertexCount * 3);
+    final normals = Float32List(vertexCount * 3);
+    final texCoords = Float32List(vertexCount * 2);
+    final colors = Float32List(vertexCount * 4);
+
+    void writeVertex(int v, Vector3 at, double u, double texV, Vector4 color) {
+      positions[v * 3] = at.x;
+      positions[v * 3 + 1] = at.y;
+      positions[v * 3 + 2] = at.z;
+      normals[v * 3 + 2] = 1.0;
+      texCoords[v * 2] = u;
+      texCoords[v * 2 + 1] = texV;
+      colors[v * 4] = color.x;
+      colors[v * 4 + 1] = color.y;
+      colors[v * 4 + 2] = color.z;
+      colors[v * 4 + 3] = color.w;
     }
 
     final indices = <int>[];
+
+    // The strip: two vertices per point.
+    for (var i = 0; i < count; i++) {
+      final color = colorOf(i);
+      writeVertex(i * 2, copied[i], 0.0, distances[i], color);
+      writeVertex(i * 2 + 1, copied[i], 1.0, distances[i], color);
+    }
     for (var i = 0; i < count - 1; i++) {
       final a = i * 2;
       indices
@@ -97,11 +136,27 @@ class PolylineGeometry extends MeshGeometry {
         ..addAll([a + 1, a + 2, a + 3]);
     }
 
+    // A triangle-fan disk for each round cap or join point.
+    for (var ord = 0; ord < diskPoints.length; ord++) {
+      final point = diskPoints[ord];
+      final base = stripVertexCount + ord * (_diskSegments + 1);
+      final color = colorOf(point);
+      for (var k = 0; k <= _diskSegments; k++) {
+        writeVertex(base + k, copied[point], 0.5, distances[point], color);
+      }
+      for (var k = 0; k < _diskSegments; k++) {
+        final next = (k + 1) % _diskSegments;
+        indices.addAll([base, base + 1 + next, base + 1 + k]);
+      }
+    }
+
     return PolylineGeometry._(
       copied,
       widths,
       widthMode,
-      positions: placeholder,
+      cap,
+      join,
+      positions: positions,
       normals: normals,
       texCoords: texCoords,
       colors: colors,
@@ -112,7 +167,9 @@ class PolylineGeometry extends MeshGeometry {
   PolylineGeometry._(
     this._points,
     this._widths,
-    this._widthMode, {
+    this._widthMode,
+    this._cap,
+    this._join, {
     required super.positions,
     required super.normals,
     required super.texCoords,
@@ -123,6 +180,8 @@ class PolylineGeometry extends MeshGeometry {
   final List<Vector3> _points;
   final List<double> _widths;
   final PolylineWidthMode _widthMode;
+  final PolylineCap _cap;
+  final PolylineJoin _join;
 
   /// Rebuilds the camera-facing strip for [camera] and [viewportSize].
   ///
@@ -132,6 +191,8 @@ class PolylineGeometry extends MeshGeometry {
       _points,
       widths: _widths,
       widthMode: _widthMode,
+      cap: _cap,
+      join: _join,
       viewProjection: camera.getViewTransform(viewportSize),
       cameraPosition: camera.position,
       viewportSize: viewportSize,
@@ -141,88 +202,126 @@ class PolylineGeometry extends MeshGeometry {
   }
 }
 
-/// Expands [points] into a camera-facing triangle-strip's vertex
-/// positions and normals.
+/// The polyline point indices that receive a round cap or join disk, in
+/// the order [expandPolyline] emits them: the two end points first,
+/// then the interior points.
+List<int> diskPointIndices(int count, PolylineCap cap, PolylineJoin join) {
+  final indices = <int>[];
+  if (cap == PolylineCap.round) {
+    indices
+      ..add(0)
+      ..add(count - 1);
+  }
+  if (join == PolylineJoin.round) {
+    for (var i = 1; i < count - 1; i++) {
+      indices.add(i);
+    }
+  }
+  return indices;
+}
+
+/// Expands [points] into a camera-facing triangle strip's vertex
+/// positions and normals, including round cap and join disks.
 ///
 /// Pure: it takes the view-projection matrix rather than touching the
-/// GPU, so it can be exercised without a render context. Returns two
-/// vertices per point (the strip edges), with normals facing the
-/// camera.
+/// GPU, so it can be exercised without a render context. The strip is
+/// two vertices per point; each round cap or join adds a disk of
+/// `1 + 16` vertices.
 ({Float32List positions, Float32List normals}) expandPolyline(
   List<Vector3> points, {
   required List<double> widths,
   required PolylineWidthMode widthMode,
+  required PolylineCap cap,
+  required PolylineJoin join,
   required Matrix4 viewProjection,
   required Vector3 cameraPosition,
   required ui.Size viewportSize,
 }) {
   final count = points.length;
-  final positions = Float32List(count * 2 * 3);
-  final normals = Float32List(count * 2 * 3);
   final tangents = _pointTangents(points);
+  final viewDirections = <Vector3>[
+    for (final p in points) _towardCamera(cameraPosition, p),
+  ];
+
+  // Strip edge vertices, computed per point.
+  final left = List<Vector3>.filled(count, Vector3.zero());
+  final right = List<Vector3>.filled(count, Vector3.zero());
 
   if (widthMode == PolylineWidthMode.worldUnits) {
     for (var i = 0; i < count; i++) {
-      final point = points[i];
-      final viewDirection = _towardCamera(cameraPosition, point);
-      var across = tangents[i].cross(viewDirection);
+      var across = tangents[i].cross(viewDirections[i]);
       if (across.length2 < 1e-12) across = _anyPerpendicular(tangents[i]);
       across = across.normalized() * (widths[i] / 2.0);
-      _writePair(
-        positions,
-        normals,
-        i,
-        point - across,
-        point + across,
-        viewDirection,
+      left[i] = points[i] - across;
+      right[i] = points[i] + across;
+    }
+  } else {
+    final inverse = Matrix4.inverted(viewProjection);
+    final clip = <Vector4>[
+      for (final p in points)
+        viewProjection.transformed(Vector4(p.x, p.y, p.z, 1.0)),
+    ];
+    final width = viewportSize.width;
+    final height = viewportSize.height;
+    for (var i = 0; i < count; i++) {
+      final here = clip[i];
+      final w = here.w.abs() < 1e-6 ? 1e-6 : here.w;
+      final previous = clip[i == 0 ? 0 : i - 1];
+      final next = clip[i == count - 1 ? count - 1 : i + 1];
+      // Screen-space direction between the neighbors.
+      var screenX = (_ndcX(next) - _ndcX(previous)) * width;
+      var screenY = -(_ndcY(next) - _ndcY(previous)) * height;
+      var length = math.sqrt(screenX * screenX + screenY * screenY);
+      if (length < 1e-9) {
+        screenX = 1.0;
+        screenY = 0.0;
+        length = 1.0;
+      }
+      screenX /= length;
+      screenY /= length;
+      // Perpendicular, offset by half the pixel width, expressed in NDC.
+      final half = widths[i] / 2.0;
+      final ndcOffsetX = -screenY * half * 2.0 / width;
+      final ndcOffsetY = -screenX * half * 2.0 / height;
+      left[i] = _unproject(
+        inverse,
+        here.x + ndcOffsetX * w,
+        here.y + ndcOffsetY * w,
+        here.z,
+        w,
+      );
+      right[i] = _unproject(
+        inverse,
+        here.x - ndcOffsetX * w,
+        here.y - ndcOffsetY * w,
+        here.z,
+        w,
       );
     }
-    return (positions: positions, normals: normals);
   }
 
-  final inverse = Matrix4.inverted(viewProjection);
-  final clip = <Vector4>[
-    for (final p in points)
-      viewProjection.transformed(Vector4(p.x, p.y, p.z, 1.0)),
-  ];
-  final width = viewportSize.width;
-  final height = viewportSize.height;
+  final diskPoints = diskPointIndices(count, cap, join);
+  final vertexCount = count * 2 + diskPoints.length * (_diskSegments + 1);
+  final positions = Float32List(vertexCount * 3);
+  final normals = Float32List(vertexCount * 3);
+
   for (var i = 0; i < count; i++) {
-    final here = clip[i];
-    final w = here.w.abs() < 1e-6 ? 1e-6 : here.w;
-    final previous = clip[i == 0 ? 0 : i - 1];
-    final next = clip[i == count - 1 ? count - 1 : i + 1];
-    // Screen-space direction between the neighbors.
-    var screenX = (_ndcX(next) - _ndcX(previous)) * width;
-    var screenY = -(_ndcY(next) - _ndcY(previous)) * height;
-    var length = math.sqrt(screenX * screenX + screenY * screenY);
-    if (length < 1e-9) {
-      screenX = 1.0;
-      screenY = 0.0;
-      length = 1.0;
-    }
-    screenX /= length;
-    screenY /= length;
-    // Perpendicular, offset by half the pixel width, expressed in NDC.
-    final half = widths[i] / 2.0;
-    final ndcOffsetX = -screenY * half * 2.0 / width;
-    final ndcOffsetY = -screenX * half * 2.0 / height;
-    final viewDirection = _towardCamera(cameraPosition, points[i]);
-    final left = _unproject(
-      inverse,
-      here.x + ndcOffsetX * w,
-      here.y + ndcOffsetY * w,
-      here.z,
-      w,
+    _writePair(positions, normals, i, left[i], right[i], viewDirections[i]);
+  }
+
+  var base = count * 2;
+  for (final point in diskPoints) {
+    // The strip half-width at the point, recovered from its two edges,
+    // works for both world and screen modes.
+    final radius = (left[point] - right[point]).length / 2.0;
+    base = _emitDisk(
+      positions,
+      normals,
+      base,
+      points[point],
+      viewDirections[point],
+      radius,
     );
-    final right = _unproject(
-      inverse,
-      here.x - ndcOffsetX * w,
-      here.y - ndcOffsetY * w,
-      here.z,
-      w,
-    );
-    _writePair(positions, normals, i, left, right, viewDirection);
   }
   return (positions: positions, normals: normals);
 }
@@ -245,6 +344,32 @@ List<Vector3> _pointTangents(List<Vector3> points) {
             : delta.normalized();
       }(),
   ];
+}
+
+// Emits a camera-facing disk: a center vertex and a ring, fanned into
+// triangles. The disk is nudged slightly toward the camera so it draws
+// over the strip rather than z-fighting with it.
+int _emitDisk(
+  Float32List positions,
+  Float32List normals,
+  int base,
+  Vector3 center,
+  Vector3 viewDirection,
+  double radius,
+) {
+  final faceCenter = center + viewDirection * (radius * 0.1);
+  final u = _anyPerpendicular(viewDirection);
+  final v = viewDirection.cross(u);
+  _writeVertex(positions, normals, base, faceCenter, viewDirection);
+  for (var k = 0; k < _diskSegments; k++) {
+    final angle = 2.0 * math.pi * k / _diskSegments;
+    final rim =
+        faceCenter +
+        u * (radius * math.cos(angle)) +
+        v * (radius * math.sin(angle));
+    _writeVertex(positions, normals, base + 1 + k, rim, viewDirection);
+  }
+  return base + 1 + _diskSegments;
 }
 
 double _ndcX(Vector4 clip) => clip.x / (clip.w.abs() < 1e-6 ? 1e-6 : clip.w);
@@ -270,6 +395,22 @@ Vector3 _anyPerpendicular(Vector3 direction) {
   return direction.cross(reference).normalized();
 }
 
+void _writeVertex(
+  Float32List positions,
+  Float32List normals,
+  int vertex,
+  Vector3 position,
+  Vector3 normal,
+) {
+  final base = vertex * 3;
+  positions[base] = position.x;
+  positions[base + 1] = position.y;
+  positions[base + 2] = position.z;
+  normals[base] = normal.x;
+  normals[base + 1] = normal.y;
+  normals[base + 2] = normal.z;
+}
+
 void _writePair(
   Float32List positions,
   Float32List normals,
@@ -278,16 +419,6 @@ void _writePair(
   Vector3 right,
   Vector3 normal,
 ) {
-  final base = point * 2 * 3;
-  positions[base] = left.x;
-  positions[base + 1] = left.y;
-  positions[base + 2] = left.z;
-  positions[base + 3] = right.x;
-  positions[base + 4] = right.y;
-  positions[base + 5] = right.z;
-  for (var v = 0; v < 6; v += 3) {
-    normals[base + v] = normal.x;
-    normals[base + v + 1] = normal.y;
-    normals[base + v + 2] = normal.z;
-  }
+  _writeVertex(positions, normals, point * 2, left, normal);
+  _writeVertex(positions, normals, point * 2 + 1, right, normal);
 }

--- a/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
@@ -28,6 +28,21 @@ enum PolylineCap {
   round,
 }
 
+/// A repeating dash-and-gap pattern for a [PolylineGeometry], measured
+/// in scene units along the line's arc length.
+class DashPattern {
+  /// Creates a dash pattern; both lengths must be positive.
+  const DashPattern({required this.dashLength, required this.gapLength})
+    : assert(dashLength > 0, 'dashLength must be positive'),
+      assert(gapLength > 0, 'gapLength must be positive');
+
+  /// The drawn length of each dash.
+  final double dashLength;
+
+  /// The undrawn length between dashes.
+  final double gapLength;
+}
+
 // Triangle-fan segments in a round cap disk.
 const int _diskSegments = 16;
 
@@ -41,50 +56,74 @@ const int _diskSegments = 16;
 /// The result is an ordinary triangle mesh: pair it with any material,
 /// and use [perVertexColor] for gradient or distance-fade effects.
 ///
-/// [PolylineCap.round] adds a camera-facing disk at each end point, and
-/// [drawStart]/[drawEnd] trim the line or animate it drawing on.
-/// Corners use an averaged direction, which stays smooth on a finely
-/// sampled curve but can pinch on a very sharp turn. Dashes, rounded
-/// corner joins, and a GPU vertex-shader expansion that avoids the
-/// per-frame rebuild are planned follow-ups; see
-/// `docs/dynamic_geometry.md`.
+/// [PolylineCap.round] adds a camera-facing disk at each end point,
+/// [drawStart]/[drawEnd] trim the line or animate it drawing on, and a
+/// [DashPattern] breaks it into dashes. Corners use an averaged
+/// direction, which stays smooth on a finely sampled curve but can
+/// pinch on a very sharp turn. Rounded corner joins and a GPU
+/// vertex-shader expansion that avoids the per-frame rebuild are
+/// planned follow-ups; see `docs/dynamic_geometry.md`.
 class PolylineGeometry extends MeshGeometry {
   /// Creates a polyline through [points] (at least two).
   ///
   /// [width] is measured per [widthMode]. [perVertexWidth] overrides it
   /// per point for tapering, and [perVertexColor] sets a color per
-  /// point for gradients. [cap] selects rounded or flat ends. The strip
-  /// is a placeholder until the first [updateForCamera] call.
+  /// point for gradients. [cap] selects rounded or flat ends, and
+  /// [dash] breaks the line into dashes. The strip is a placeholder
+  /// until the first [updateForCamera] call.
   factory PolylineGeometry(
     List<Vector3> points, {
     double width = 8.0,
     PolylineWidthMode widthMode = PolylineWidthMode.screenPixels,
     PolylineCap cap = PolylineCap.butt,
+    DashPattern? dash,
     List<double>? perVertexWidth,
     List<Vector4>? perVertexColor,
   }) {
     if (points.length < 2) {
       throw ArgumentError('A polyline needs at least two points');
     }
-    final copied = <Vector3>[for (final p in points) p.clone()];
-    final count = copied.length;
-    if (perVertexWidth != null && perVertexWidth.length != count) {
+    final inputCount = points.length;
+    if (perVertexWidth != null && perVertexWidth.length != inputCount) {
       throw ArgumentError('perVertexWidth must have one entry per point');
     }
-    if (perVertexColor != null && perVertexColor.length != count) {
+    if (perVertexColor != null && perVertexColor.length != inputCount) {
       throw ArgumentError('perVertexColor must have one entry per point');
     }
-    final widths =
+    var working = <Vector3>[for (final p in points) p.clone()];
+    var workingWidths =
         perVertexWidth != null
             ? List<double>.of(perVertexWidth)
-            : List<double>.filled(count, width);
+            : List<double>.filled(inputCount, width);
+    var workingColors = <Vector4>[
+      for (var i = 0; i < inputCount; i++)
+        perVertexColor?[i] ?? Vector4(1.0, 1.0, 1.0, 1.0),
+    ];
+
+    // Dashes resample the line into dash segments joined by zero-width
+    // gap points, so the gap regions draw nothing.
+    if (dash != null) {
+      final dashed = resampleDashed(
+        working,
+        workingWidths,
+        workingColors,
+        dash,
+      );
+      working = dashed.points;
+      workingWidths = dashed.widths;
+      workingColors = dashed.colors;
+    }
+
+    final copied = working;
+    final widths = workingWidths;
+    final count = copied.length;
 
     // Cumulative arc length at each point, for the texture v coordinate.
     final distances = List<double>.filled(count, 0.0);
     for (var i = 1; i < count; i++) {
       distances[i] = distances[i - 1] + copied[i].distanceTo(copied[i - 1]);
     }
-    Vector4 colorOf(int i) => perVertexColor?[i] ?? Vector4(1.0, 1.0, 1.0, 1.0);
+    Vector4 colorOf(int i) => workingColors[i];
 
     // Texture coordinates and colors do not depend on the camera, so
     // they are set once here. The placeholder positions collapse the
@@ -380,6 +419,81 @@ Vector3 _pointAtArc(List<Vector3> points, List<double> arc, double target) {
   final span = arc[hi] - arc[lo];
   final local = span > 1e-12 ? (clamped - arc[lo]) / span : 0.0;
   return points[lo] + (points[hi] - points[lo]) * local;
+}
+
+/// Resamples a polyline into dash segments per [dash].
+///
+/// Each dash starts and ends with a full-width point at the exact dash
+/// boundary; consecutive dashes are joined by zero-width gap points so
+/// the gap draws nothing. The overall line keeps its two end points, so
+/// round caps still apply to them.
+({List<Vector3> points, List<double> widths, List<Vector4> colors})
+resampleDashed(
+  List<Vector3> points,
+  List<double> widths,
+  List<Vector4> colors,
+  DashPattern dash,
+) {
+  final count = points.length;
+  final arc = List<double>.filled(count, 0.0);
+  for (var i = 1; i < count; i++) {
+    arc[i] = arc[i - 1] + points[i].distanceTo(points[i - 1]);
+  }
+  final total = arc[count - 1];
+  if (total <= 0.0) return (points: points, widths: widths, colors: colors);
+
+  // Position, width, and color at an arc-length distance.
+  (Vector3, double, Vector4) sampleAt(double distance) {
+    final target = distance < 0.0 ? 0.0 : (distance > total ? total : distance);
+    var hi = 1;
+    while (hi < count - 1 && arc[hi] < target) {
+      hi++;
+    }
+    final lo = hi - 1;
+    final span = arc[hi] - arc[lo];
+    final local = span > 1e-12 ? (target - arc[lo]) / span : 0.0;
+    return (
+      points[lo] + (points[hi] - points[lo]) * local,
+      widths[lo] + (widths[hi] - widths[lo]) * local,
+      colors[lo] + (colors[hi] - colors[lo]) * local,
+    );
+  }
+
+  final period = dash.dashLength + dash.gapLength;
+  final dashes = <(double, double)>[];
+  for (var k = 0; k * period < total; k++) {
+    final a = k * period;
+    dashes.add((a, math.min(a + dash.dashLength, total)));
+  }
+
+  final outPoints = <Vector3>[];
+  final outWidths = <double>[];
+  final outColors = <Vector4>[];
+  void emit(Vector3 p, double w, Vector4 c) {
+    outPoints.add(p);
+    outWidths.add(w);
+    outColors.add(c);
+  }
+
+  for (var k = 0; k < dashes.length; k++) {
+    final (a, b) = dashes[k];
+    final (startPos, startWidth, startColor) = sampleAt(a);
+    final (endPos, endWidth, endColor) = sampleAt(b);
+    // A zero-width gap connector before every dash but the first.
+    if (k > 0) emit(startPos, 0.0, startColor);
+    emit(startPos, startWidth, startColor);
+    for (var i = 0; i < count; i++) {
+      if (arc[i] > a && arc[i] < b) emit(points[i], widths[i], colors[i]);
+    }
+    emit(endPos, endWidth, endColor);
+    // A zero-width gap connector after every dash but the last.
+    if (k < dashes.length - 1) emit(endPos, 0.0, endColor);
+  }
+
+  if (outPoints.length < 2) {
+    return (points: points, widths: widths, colors: colors);
+  }
+  return (points: outPoints, widths: outWidths, colors: outColors);
 }
 
 List<Vector3> _pointTangents(List<Vector3> points) {

--- a/packages/flutter_scene/lib/src/geometry/primitives.dart
+++ b/packages/flutter_scene/lib/src/geometry/primitives.dart
@@ -186,10 +186,10 @@ PrimitiveArrays buildPlaneArrays({
       final v10 = v00 + 1;
       final v01 = v00 + columns;
       final v11 = v01 + 1;
-      // Wound counter-clockwise as seen from +Y.
+      // Wound so the lit surface faces +Y, toward a camera above.
       indices
-        ..addAll([v00, v01, v10])
-        ..addAll([v10, v01, v11]);
+        ..addAll([v00, v10, v01])
+        ..addAll([v10, v11, v01]);
     }
   }
 

--- a/packages/flutter_scene/lib/src/geometry/primitives.dart
+++ b/packages/flutter_scene/lib/src/geometry/primitives.dart
@@ -1,8 +1,22 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
+
+/// Vertex attribute arrays produced by a primitive generator.
+///
+/// A `null` attribute is left to [MeshGeometry.fromArrays] to default or
+/// generate. Used internally to build the procedural primitives below.
+typedef PrimitiveArrays =
+    ({
+      Float32List positions,
+      Float32List? normals,
+      Float32List? texCoords,
+      Float32List? colors,
+      List<int> indices,
+    });
 
 /// An axis-aligned box geometry spanning `-extents/2` to `+extents/2` on
 /// each axis.
@@ -11,99 +25,113 @@ import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
 /// distinct vertex color, which can be visualized with an unlit material.
 class CuboidGeometry extends MeshGeometry {
   /// Builds a cuboid sized to [extents].
-  CuboidGeometry(Vector3 extents)
-    : super.fromArrays(
-        positions: _positions(extents),
-        texCoords: _texCoords,
-        colors: _colors,
-        indices: _indices,
-      );
+  factory CuboidGeometry(Vector3 extents) =>
+      CuboidGeometry._(buildCuboidArrays(extents));
 
-  static Float32List _positions(Vector3 extents) {
-    final e = extents * 0.5;
-    return Float32List.fromList(<double>[
-      -e.x,
-      -e.y,
-      -e.z,
-      e.x,
-      -e.y,
-      -e.z,
-      e.x,
-      e.y,
-      -e.z,
-      -e.x,
-      e.y,
-      -e.z,
-      -e.x,
-      -e.y,
-      e.z,
-      e.x,
-      -e.y,
-      e.z,
-      e.x,
-      e.y,
-      e.z,
-      -e.x,
-      e.y,
-      e.z,
-    ]);
+  CuboidGeometry._(PrimitiveArrays arrays)
+    : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        colors: arrays.colors,
+        indices: arrays.indices,
+      );
+}
+
+/// A flat rectangular grid in the XZ plane, centered on the origin, with
+/// its surface facing `+Y`.
+///
+/// [width] spans X and [depth] spans Z. [segmentsX] and [segmentsZ] set
+/// the number of grid cells along each axis; subdividing is useful when
+/// the surface will be deformed or lit by per-vertex data.
+class PlaneGeometry extends MeshGeometry {
+  /// Builds a plane of the given size and subdivision.
+  factory PlaneGeometry({
+    double width = 1.0,
+    double depth = 1.0,
+    int segmentsX = 1,
+    int segmentsZ = 1,
+  }) {
+    return PlaneGeometry._(
+      buildPlaneArrays(
+        width: width,
+        depth: depth,
+        segmentsX: segmentsX,
+        segmentsZ: segmentsZ,
+      ),
+    );
   }
 
-  static final Float32List _texCoords = Float32List.fromList(<double>[
-    0,
-    0,
-    1,
-    0,
-    1,
-    1,
-    0,
-    1,
-    0,
-    0,
-    1,
-    0,
-    1,
-    1,
-    0,
-    1,
-  ]);
+  PlaneGeometry._(PrimitiveArrays arrays)
+    : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+      );
+}
 
-  static final Float32List _colors = Float32List.fromList(<double>[
-    1,
-    0,
-    0,
-    1,
-    0,
-    1,
-    0,
-    1,
-    0,
-    0,
-    1,
-    1,
-    0,
-    0,
-    0,
-    1,
-    0,
-    1,
-    1,
-    1,
-    1,
-    0,
-    1,
-    1,
-    1,
-    1,
-    0,
-    1,
-    1,
-    1,
-    1,
-    1,
-  ]);
+/// A UV sphere centered on the origin.
+///
+/// [segments] is the number of divisions around the equator and
+/// [rings] the number of divisions from pole to pole. Vertex normals
+/// point radially outward and texture coordinates wrap longitude in `u`
+/// and latitude in `v`.
+class SphereGeometry extends MeshGeometry {
+  /// Builds a sphere of the given [radius] and tessellation.
+  factory SphereGeometry({
+    double radius = 0.5,
+    int segments = 32,
+    int rings = 16,
+  }) {
+    return SphereGeometry._(
+      buildSphereArrays(radius: radius, segments: segments, rings: rings),
+    );
+  }
 
-  static const List<int> _indices = <int>[
+  SphereGeometry._(PrimitiveArrays arrays)
+    : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+      );
+}
+
+/// Generates the vertex arrays for a [CuboidGeometry] sized to [extents].
+PrimitiveArrays buildCuboidArrays(Vector3 extents) {
+  final e = extents * 0.5;
+  final positions = Float32List.fromList(<double>[
+    -e.x, -e.y, -e.z, //
+    e.x, -e.y, -e.z, //
+    e.x, e.y, -e.z, //
+    -e.x, e.y, -e.z, //
+    -e.x, -e.y, e.z, //
+    e.x, -e.y, e.z, //
+    e.x, e.y, e.z, //
+    -e.x, e.y, e.z, //
+  ]);
+  final texCoords = Float32List.fromList(<double>[
+    0, 0, //
+    1, 0, //
+    1, 1, //
+    0, 1, //
+    0, 0, //
+    1, 0, //
+    1, 1, //
+    0, 1, //
+  ]);
+  final colors = Float32List.fromList(<double>[
+    1, 0, 0, 1, //
+    0, 1, 0, 1, //
+    0, 0, 1, 1, //
+    0, 0, 0, 1, //
+    0, 1, 1, 1, //
+    1, 0, 1, 1, //
+    1, 1, 0, 1, //
+    1, 1, 1, 1, //
+  ]);
+  const indices = <int>[
     0, 1, 3, 3, 1, 2, //
     1, 5, 2, 2, 5, 6, //
     5, 4, 6, 6, 4, 7, //
@@ -111,4 +139,130 @@ class CuboidGeometry extends MeshGeometry {
     3, 2, 7, 7, 2, 6, //
     4, 5, 0, 0, 5, 1, //
   ];
+  return (
+    positions: positions,
+    normals: null,
+    texCoords: texCoords,
+    colors: colors,
+    indices: indices,
+  );
+}
+
+/// Generates the vertex arrays for a [PlaneGeometry].
+PrimitiveArrays buildPlaneArrays({
+  required double width,
+  required double depth,
+  required int segmentsX,
+  required int segmentsZ,
+}) {
+  if (segmentsX < 1 || segmentsZ < 1) {
+    throw ArgumentError('A plane needs at least one segment on each axis');
+  }
+  final columns = segmentsX + 1;
+  final rows = segmentsZ + 1;
+  final vertexCount = columns * rows;
+  final positions = Float32List(vertexCount * 3);
+  final normals = Float32List(vertexCount * 3);
+  final texCoords = Float32List(vertexCount * 2);
+
+  for (var r = 0; r < rows; r++) {
+    final z = -depth / 2 + depth * r / segmentsZ;
+    for (var c = 0; c < columns; c++) {
+      final x = -width / 2 + width * c / segmentsX;
+      final v = r * columns + c;
+      positions[v * 3] = x;
+      positions[v * 3 + 1] = 0.0;
+      positions[v * 3 + 2] = z;
+      normals[v * 3 + 1] = 1.0;
+      texCoords[v * 2] = c / segmentsX;
+      texCoords[v * 2 + 1] = r / segmentsZ;
+    }
+  }
+
+  final indices = <int>[];
+  for (var r = 0; r < segmentsZ; r++) {
+    for (var c = 0; c < segmentsX; c++) {
+      final v00 = r * columns + c;
+      final v10 = v00 + 1;
+      final v01 = v00 + columns;
+      final v11 = v01 + 1;
+      // Wound counter-clockwise as seen from +Y.
+      indices
+        ..addAll([v00, v01, v10])
+        ..addAll([v10, v01, v11]);
+    }
+  }
+
+  return (
+    positions: positions,
+    normals: normals,
+    texCoords: texCoords,
+    colors: null,
+    indices: indices,
+  );
+}
+
+/// Generates the vertex arrays for a [SphereGeometry].
+PrimitiveArrays buildSphereArrays({
+  required double radius,
+  required int segments,
+  required int rings,
+}) {
+  if (segments < 3) {
+    throw ArgumentError('A sphere needs at least three segments');
+  }
+  if (rings < 2) {
+    throw ArgumentError('A sphere needs at least two rings');
+  }
+  final columns = segments + 1;
+  final rowCount = rings + 1;
+  final vertexCount = columns * rowCount;
+  final positions = Float32List(vertexCount * 3);
+  final normals = Float32List(vertexCount * 3);
+  final texCoords = Float32List(vertexCount * 2);
+
+  for (var r = 0; r < rowCount; r++) {
+    final latitude = math.pi * r / rings;
+    final sinLat = math.sin(latitude);
+    final cosLat = math.cos(latitude);
+    for (var s = 0; s < columns; s++) {
+      final longitude = 2 * math.pi * s / segments;
+      final sinLon = math.sin(longitude);
+      final cosLon = math.cos(longitude);
+      final nx = sinLat * cosLon;
+      final ny = cosLat;
+      final nz = sinLat * sinLon;
+      final v = r * columns + s;
+      positions[v * 3] = radius * nx;
+      positions[v * 3 + 1] = radius * ny;
+      positions[v * 3 + 2] = radius * nz;
+      normals[v * 3] = nx;
+      normals[v * 3 + 1] = ny;
+      normals[v * 3 + 2] = nz;
+      texCoords[v * 2] = s / segments;
+      texCoords[v * 2 + 1] = r / rings;
+    }
+  }
+
+  final indices = <int>[];
+  for (var r = 0; r < rings; r++) {
+    for (var s = 0; s < segments; s++) {
+      final a = r * columns + s;
+      final b = a + 1;
+      final c = a + columns;
+      final d = c + 1;
+      // Wound counter-clockwise as seen from outside the sphere.
+      indices
+        ..addAll([a, c, b])
+        ..addAll([b, c, d]);
+    }
+  }
+
+  return (
+    positions: positions,
+    normals: normals,
+    texCoords: texCoords,
+    colors: null,
+    indices: indices,
+  );
 }

--- a/packages/flutter_scene/lib/src/geometry/primitives.dart
+++ b/packages/flutter_scene/lib/src/geometry/primitives.dart
@@ -1,0 +1,114 @@
+import 'dart:typed_data';
+
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
+
+/// An axis-aligned box geometry spanning `-extents/2` to `+extents/2` on
+/// each axis.
+///
+/// Useful as a quick placeholder or for debugging. Each corner carries a
+/// distinct vertex color, which can be visualized with an unlit material.
+class CuboidGeometry extends MeshGeometry {
+  /// Builds a cuboid sized to [extents].
+  CuboidGeometry(Vector3 extents)
+    : super.fromArrays(
+        positions: _positions(extents),
+        texCoords: _texCoords,
+        colors: _colors,
+        indices: _indices,
+      );
+
+  static Float32List _positions(Vector3 extents) {
+    final e = extents * 0.5;
+    return Float32List.fromList(<double>[
+      -e.x,
+      -e.y,
+      -e.z,
+      e.x,
+      -e.y,
+      -e.z,
+      e.x,
+      e.y,
+      -e.z,
+      -e.x,
+      e.y,
+      -e.z,
+      -e.x,
+      -e.y,
+      e.z,
+      e.x,
+      -e.y,
+      e.z,
+      e.x,
+      e.y,
+      e.z,
+      -e.x,
+      e.y,
+      e.z,
+    ]);
+  }
+
+  static final Float32List _texCoords = Float32List.fromList(<double>[
+    0,
+    0,
+    1,
+    0,
+    1,
+    1,
+    0,
+    1,
+    0,
+    0,
+    1,
+    0,
+    1,
+    1,
+    0,
+    1,
+  ]);
+
+  static final Float32List _colors = Float32List.fromList(<double>[
+    1,
+    0,
+    0,
+    1,
+    0,
+    1,
+    0,
+    1,
+    0,
+    0,
+    1,
+    1,
+    0,
+    0,
+    0,
+    1,
+    0,
+    1,
+    1,
+    1,
+    1,
+    0,
+    1,
+    1,
+    1,
+    1,
+    0,
+    1,
+    1,
+    1,
+    1,
+    1,
+  ]);
+
+  static const List<int> _indices = <int>[
+    0, 1, 3, 3, 1, 2, //
+    1, 5, 2, 2, 5, 6, //
+    5, 4, 6, 6, 4, 7, //
+    4, 0, 7, 7, 0, 3, //
+    3, 2, 7, 7, 2, 6, //
+    4, 5, 0, 0, 5, 1, //
+  ];
+}

--- a/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
@@ -1,0 +1,224 @@
+import 'dart:typed_data';
+
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
+import 'package:flutter_scene/src/scene_path.dart';
+
+/// Vertex attribute arrays produced by a swept-geometry generator.
+typedef SweptArrays =
+    ({
+      Float32List positions,
+      Float32List normals,
+      Float32List texCoords,
+      List<int> indices,
+    });
+
+/// How a [RibbonGeometry] orients its strip across the path.
+enum RibbonAlignment {
+  /// The strip stays horizontal, its width running perpendicular to the
+  /// path as seen from above. Suited to a route drawn on the ground.
+  ground,
+
+  /// The strip lies in the path's own frame and rolls with it.
+  path,
+}
+
+/// A flat strip of constant width swept along a [ScenePath].
+///
+/// Useful for a route ribbon or a painted lane marking. The result is an
+/// ordinary triangle mesh that works with any material; texture
+/// coordinates run `0..1` across the width and by arc-length distance
+/// along the path.
+class RibbonGeometry extends MeshGeometry {
+  /// Sweeps a ribbon of the given [width] along [path].
+  ///
+  /// [stations] is the number of cross-sections sampled along the path.
+  /// [up] is the reference up direction for [RibbonAlignment.ground]
+  /// (default `+Y`). Pass [GeometryStorage.updatable] to allow
+  /// [updatePath].
+  factory RibbonGeometry(
+    ScenePath path, {
+    double width = 1.0,
+    int stations = 64,
+    RibbonAlignment alignment = RibbonAlignment.ground,
+    Vector3? up,
+    GeometryStorage storage = GeometryStorage.fixed,
+  }) {
+    final resolvedUp = up ?? Vector3(0.0, 1.0, 0.0);
+    return RibbonGeometry._(
+      width,
+      stations,
+      alignment,
+      resolvedUp,
+      buildRibbonArrays(
+        path,
+        width: width,
+        stations: stations,
+        alignment: alignment,
+        up: resolvedUp,
+      ),
+      storage,
+    );
+  }
+
+  RibbonGeometry._(
+    this._width,
+    this._stations,
+    this._alignment,
+    this._up,
+    SweptArrays arrays,
+    GeometryStorage storage,
+  ) : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+        storage: storage,
+      );
+
+  final double _width;
+  final int _stations;
+  final RibbonAlignment _alignment;
+  final Vector3 _up;
+
+  /// Re-sweeps the ribbon along [path], reusing the GPU buffers.
+  ///
+  /// The width, station count, and alignment are unchanged, so the
+  /// topology is stable. Requires [GeometryStorage.updatable].
+  void updatePath(ScenePath path) {
+    final arrays = buildRibbonArrays(
+      path,
+      width: _width,
+      stations: _stations,
+      alignment: _alignment,
+      up: _up,
+    );
+    updatePositions(arrays.positions);
+    updateNormals(arrays.normals);
+    updateTexCoords(arrays.texCoords);
+  }
+}
+
+/// Generates the vertex arrays for a [RibbonGeometry].
+SweptArrays buildRibbonArrays(
+  ScenePath path, {
+  required double width,
+  required int stations,
+  required RibbonAlignment alignment,
+  required Vector3 up,
+}) {
+  if (stations < 2) {
+    throw ArgumentError.value(stations, 'stations', 'must be at least two');
+  }
+  final frames = evenlySpacedFrames(path, stations);
+  final length = path.length;
+  final half = width / 2.0;
+  final accumulator = MeshAccumulator();
+  final ringBases = <int>[];
+
+  for (var i = 0; i < stations; i++) {
+    final frame = frames[i];
+    final Vector3 across;
+    final Vector3 normal;
+    if (alignment == RibbonAlignment.ground) {
+      var sideways = up.cross(frame.tangent);
+      if (sideways.length2 < 1e-12) sideways = frame.binormal;
+      across = sideways.normalized();
+      normal = up.normalized();
+    } else {
+      across = frame.binormal;
+      normal = frame.normal;
+    }
+    final v = stations == 1 ? 0.0 : length * i / (stations - 1);
+    ringBases.add(accumulator.vertexCount);
+    accumulator.addVertex(frame.position - across * half, normal, 0.0, v);
+    accumulator.addVertex(frame.position + across * half, normal, 1.0, v);
+  }
+
+  stitchRings(accumulator, ringBases, 2);
+  return accumulator.toArrays();
+}
+
+/// Samples [stations] rotation-minimizing frames along [path], spaced by
+/// equal arc length.
+List<ScenePathFrame> evenlySpacedFrames(ScenePath path, int stations) {
+  final length = path.length;
+  return <ScenePathFrame>[
+    for (var i = 0; i < stations; i++)
+      path.frameAtDistance(stations == 1 ? 0.0 : length * i / (stations - 1)),
+  ];
+}
+
+/// Connects consecutive cross-section rings into a triangle strip.
+///
+/// Each ring has [ringSize] vertices; [ringBases] holds the index of the
+/// first vertex of each ring. Vertex `j` of one ring joins vertex `j` of
+/// the next, for `j` in `0..ringSize - 2`.
+void stitchRings(
+  MeshAccumulator accumulator,
+  List<int> ringBases,
+  int ringSize,
+) {
+  for (var s = 0; s < ringBases.length - 1; s++) {
+    final base = ringBases[s];
+    final nextBase = ringBases[s + 1];
+    for (var j = 0; j < ringSize - 1; j++) {
+      final a = base + j;
+      final b = base + j + 1;
+      final c = nextBase + j;
+      final d = nextBase + j + 1;
+      accumulator
+        ..addTriangle(a, c, b)
+        ..addTriangle(b, c, d);
+    }
+  }
+}
+
+/// A growable builder of interleaved-ready vertex attribute arrays.
+///
+/// Used by the swept-geometry generators to collect positions, normals,
+/// texture coordinates, and triangle indices before producing a
+/// [SweptArrays] record.
+class MeshAccumulator {
+  final List<double> _positions = [];
+  final List<double> _normals = [];
+  final List<double> _texCoords = [];
+  final List<int> _indices = [];
+
+  /// The number of vertices added so far.
+  int get vertexCount => _positions.length ~/ 3;
+
+  /// Appends a vertex and returns its index.
+  int addVertex(Vector3 position, Vector3 normal, double u, double v) {
+    final index = vertexCount;
+    _positions
+      ..add(position.x)
+      ..add(position.y)
+      ..add(position.z);
+    _normals
+      ..add(normal.x)
+      ..add(normal.y)
+      ..add(normal.z);
+    _texCoords
+      ..add(u)
+      ..add(v);
+    return index;
+  }
+
+  /// Appends a triangle referencing three vertex indices.
+  void addTriangle(int a, int b, int c) {
+    _indices
+      ..add(a)
+      ..add(b)
+      ..add(c);
+  }
+
+  /// Produces the finished attribute arrays.
+  SweptArrays toArrays() => (
+    positions: Float32List.fromList(_positions),
+    normals: Float32List.fromList(_normals),
+    texCoords: Float32List.fromList(_texCoords),
+    indices: _indices,
+  );
+}

--- a/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
@@ -421,3 +421,180 @@ void addFanCap(
     }
   }
 }
+
+/// An arbitrary closed 2D profile swept along a [ScenePath].
+///
+/// The profile is a closed polygon in the path's cross-section plane.
+/// Texture coordinates run `0..1` around the profile and by arc-length
+/// distance along the path. End caps assume a convex profile.
+class ExtrudeGeometry extends MeshGeometry {
+  /// Sweeps [profile] along [path].
+  ///
+  /// [profile] is a closed polygon of at least three points, in the
+  /// path's normal/binormal plane. [stations] is the number of
+  /// cross-sections along the path. With [caps] the two ends are
+  /// closed. Pass [GeometryStorage.updatable] to allow [updatePath].
+  factory ExtrudeGeometry(
+    ScenePath path, {
+    required List<Vector2> profile,
+    int stations = 64,
+    bool caps = true,
+    GeometryStorage storage = GeometryStorage.fixed,
+  }) {
+    final copied = <Vector2>[for (final p in profile) p.clone()];
+    return ExtrudeGeometry._(
+      copied,
+      stations,
+      caps,
+      buildExtrudeArrays(path, profile: copied, stations: stations, caps: caps),
+      storage,
+    );
+  }
+
+  ExtrudeGeometry._(
+    this._profile,
+    this._stations,
+    this._caps,
+    SweptArrays arrays,
+    GeometryStorage storage,
+  ) : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+        storage: storage,
+      );
+
+  final List<Vector2> _profile;
+  final int _stations;
+  final bool _caps;
+
+  /// Re-sweeps the profile along [path], reusing the GPU buffers.
+  ///
+  /// The profile, station count, and caps are unchanged, so the
+  /// topology is stable. Requires [GeometryStorage.updatable].
+  void updatePath(ScenePath path) {
+    final arrays = buildExtrudeArrays(
+      path,
+      profile: _profile,
+      stations: _stations,
+      caps: _caps,
+    );
+    updatePositions(arrays.positions);
+    updateNormals(arrays.normals);
+    updateTexCoords(arrays.texCoords);
+  }
+}
+
+/// Generates the vertex arrays for an [ExtrudeGeometry].
+SweptArrays buildExtrudeArrays(
+  ScenePath path, {
+  required List<Vector2> profile,
+  required int stations,
+  required bool caps,
+}) {
+  if (stations < 2) {
+    throw ArgumentError.value(stations, 'stations', 'must be at least two');
+  }
+  if (profile.length < 3) {
+    throw ArgumentError.value(
+      profile.length,
+      'profile',
+      'needs at least three points',
+    );
+  }
+  final frames = evenlySpacedFrames(path, stations);
+  final length = path.length;
+  final pointCount = profile.length;
+  final profileNormals = _profileNormals(profile);
+  final accumulator = MeshAccumulator();
+  final ringBases = <int>[];
+
+  for (var i = 0; i < stations; i++) {
+    final frame = frames[i];
+    final v = length * i / (stations - 1);
+    ringBases.add(accumulator.vertexCount);
+    // One extra vertex closes the loop so the texture seam is clean.
+    for (var k = 0; k <= pointCount; k++) {
+      final point = profile[k % pointCount];
+      final profileNormal = profileNormals[k % pointCount];
+      final position =
+          frame.position + frame.normal * point.x + frame.binormal * point.y;
+      final normal =
+          (frame.normal * profileNormal.x + frame.binormal * profileNormal.y)
+              .normalized();
+      accumulator.addVertex(position, normal, k / pointCount, v);
+    }
+  }
+
+  stitchRings(accumulator, ringBases, pointCount + 1);
+
+  if (caps) {
+    _addProfileCap(accumulator, frames.first, profile, atEnd: false);
+    _addProfileCap(accumulator, frames.last, profile, atEnd: true);
+  }
+  return accumulator.toArrays();
+}
+
+// Closes one end of an extrusion with a fan over the profile.
+void _addProfileCap(
+  MeshAccumulator accumulator,
+  ScenePathFrame frame,
+  List<Vector2> profile, {
+  required bool atEnd,
+}) {
+  var centerX = 0.0;
+  var centerY = 0.0;
+  for (final point in profile) {
+    centerX += point.x;
+    centerY += point.y;
+  }
+  centerX /= profile.length;
+  centerY /= profile.length;
+
+  Vector3 lift(double x, double y) =>
+      frame.position + frame.normal * x + frame.binormal * y;
+
+  addFanCap(
+    accumulator,
+    center: lift(centerX, centerY),
+    normal: atEnd ? frame.tangent : -frame.tangent,
+    ringPositions: <Vector3>[
+      for (final point in profile) lift(point.x, point.y),
+    ],
+    ringTexCoords: <Vector2>[
+      for (final point in profile) Vector2(point.x, point.y),
+    ],
+    centerTexCoord: Vector2(centerX, centerY),
+    reverseWinding: !atEnd,
+  );
+}
+
+// Per-vertex outward 2D normals for a closed profile. The polygon's
+// signed area picks the outward direction, so either winding works.
+List<Vector2> _profileNormals(List<Vector2> profile) {
+  final count = profile.length;
+  var doubledArea = 0.0;
+  for (var k = 0; k < count; k++) {
+    final a = profile[k];
+    final b = profile[(k + 1) % count];
+    doubledArea += a.x * b.y - b.x * a.y;
+  }
+  final sign = doubledArea >= 0.0 ? 1.0 : -1.0;
+
+  Vector2 edgeNormal(Vector2 edge) => Vector2(edge.y, -edge.x) * sign;
+
+  return <Vector2>[
+    for (var k = 0; k < count; k++)
+      () {
+        final previous = profile[(k - 1 + count) % count];
+        final current = profile[k];
+        final next = profile[(k + 1) % count];
+        var normal =
+            edgeNormal(current - previous) + edgeNormal(next - current);
+        if (normal.length2 < 1e-12) normal = edgeNormal(next - current);
+        if (normal.length2 < 1e-12) normal = Vector2(1.0, 0.0);
+        return normal.normalized();
+      }(),
+  ];
+}

--- a/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
@@ -123,7 +123,9 @@ SweptArrays buildRibbonArrays(
     final Vector3 across;
     final Vector3 normal;
     if (alignment == RibbonAlignment.ground) {
-      var sideways = up.cross(frame.tangent);
+      // tangent cross up (not up cross tangent) so the strip is wound
+      // with its lit surface facing up, like the path-aligned branch.
+      var sideways = frame.tangent.cross(up);
       if (sideways.length2 < 1e-12) sideways = frame.binormal;
       across = sideways.normalized();
       normal = up.normalized();

--- a/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:vector_math/vector_math.dart';
@@ -221,4 +222,202 @@ class MeshAccumulator {
     texCoords: Float32List.fromList(_texCoords),
     indices: _indices,
   );
+}
+
+/// A round cross-section of constant radius swept along a [ScenePath].
+///
+/// Useful for a 3D route tube or pipe. Texture coordinates run `0..1`
+/// around the circumference and by arc-length distance along the path.
+class TubeGeometry extends MeshGeometry {
+  /// Sweeps a tube of the given [radius] along [path].
+  ///
+  /// [radialSegments] sets how many faces wrap the circumference and
+  /// [stations] how many cross-sections run along the path. With [caps]
+  /// the two ends are closed by a disk. Pass [GeometryStorage.updatable]
+  /// to allow [updatePath].
+  factory TubeGeometry(
+    ScenePath path, {
+    double radius = 0.5,
+    int radialSegments = 12,
+    int stations = 64,
+    bool caps = true,
+    GeometryStorage storage = GeometryStorage.fixed,
+  }) {
+    return TubeGeometry._(
+      radius,
+      radialSegments,
+      stations,
+      caps,
+      buildTubeArrays(
+        path,
+        radius: radius,
+        radialSegments: radialSegments,
+        stations: stations,
+        caps: caps,
+      ),
+      storage,
+    );
+  }
+
+  TubeGeometry._(
+    this._radius,
+    this._radialSegments,
+    this._stations,
+    this._caps,
+    SweptArrays arrays,
+    GeometryStorage storage,
+  ) : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+        storage: storage,
+      );
+
+  final double _radius;
+  final int _radialSegments;
+  final int _stations;
+  final bool _caps;
+
+  /// Re-sweeps the tube along [path], reusing the GPU buffers.
+  ///
+  /// The radius, tessellation, and caps are unchanged, so the topology
+  /// is stable. Requires [GeometryStorage.updatable].
+  void updatePath(ScenePath path) {
+    final arrays = buildTubeArrays(
+      path,
+      radius: _radius,
+      radialSegments: _radialSegments,
+      stations: _stations,
+      caps: _caps,
+    );
+    updatePositions(arrays.positions);
+    updateNormals(arrays.normals);
+    updateTexCoords(arrays.texCoords);
+  }
+}
+
+/// Generates the vertex arrays for a [TubeGeometry].
+SweptArrays buildTubeArrays(
+  ScenePath path, {
+  required double radius,
+  required int radialSegments,
+  required int stations,
+  required bool caps,
+}) {
+  if (stations < 2) {
+    throw ArgumentError.value(stations, 'stations', 'must be at least two');
+  }
+  if (radialSegments < 3) {
+    throw ArgumentError.value(
+      radialSegments,
+      'radialSegments',
+      'must be at least three',
+    );
+  }
+  final frames = evenlySpacedFrames(path, stations);
+  final length = path.length;
+  final accumulator = MeshAccumulator();
+  final ringBases = <int>[];
+
+  for (var i = 0; i < stations; i++) {
+    final frame = frames[i];
+    final v = length * i / (stations - 1);
+    ringBases.add(accumulator.vertexCount);
+    // One extra vertex closes the loop so the texture seam is clean.
+    for (var k = 0; k <= radialSegments; k++) {
+      final theta = 2 * math.pi * k / radialSegments;
+      final radial =
+          frame.normal * math.cos(theta) + frame.binormal * math.sin(theta);
+      accumulator.addVertex(
+        frame.position + radial * radius,
+        radial,
+        k / radialSegments,
+        v,
+      );
+    }
+  }
+
+  stitchRings(accumulator, ringBases, radialSegments + 1);
+
+  if (caps) {
+    _addDiskCap(
+      accumulator,
+      frames.first,
+      radius,
+      radialSegments,
+      atEnd: false,
+    );
+    _addDiskCap(accumulator, frames.last, radius, radialSegments, atEnd: true);
+  }
+  return accumulator.toArrays();
+}
+
+// Closes one end of a tube with a fan of triangles.
+void _addDiskCap(
+  MeshAccumulator accumulator,
+  ScenePathFrame frame,
+  double radius,
+  int radialSegments, {
+  required bool atEnd,
+}) {
+  final ringPositions = <Vector3>[];
+  final ringTexCoords = <Vector2>[];
+  for (var k = 0; k < radialSegments; k++) {
+    final theta = 2 * math.pi * k / radialSegments;
+    final radial =
+        frame.normal * math.cos(theta) + frame.binormal * math.sin(theta);
+    ringPositions.add(frame.position + radial * radius);
+    ringTexCoords.add(
+      Vector2(0.5 + 0.5 * math.cos(theta), 0.5 + 0.5 * math.sin(theta)),
+    );
+  }
+  addFanCap(
+    accumulator,
+    center: frame.position,
+    normal: atEnd ? frame.tangent : -frame.tangent,
+    ringPositions: ringPositions,
+    ringTexCoords: ringTexCoords,
+    centerTexCoord: Vector2(0.5, 0.5),
+    reverseWinding: !atEnd,
+  );
+}
+
+/// Adds a triangle fan that closes a cross-section ring.
+///
+/// The fan runs from [center] to each vertex of [ringPositions], which
+/// must be ordered around the ring. Every vertex takes the cap [normal].
+void addFanCap(
+  MeshAccumulator accumulator, {
+  required Vector3 center,
+  required Vector3 normal,
+  required List<Vector3> ringPositions,
+  required List<Vector2> ringTexCoords,
+  required Vector2 centerTexCoord,
+  required bool reverseWinding,
+}) {
+  final count = ringPositions.length;
+  final centerIndex = accumulator.addVertex(
+    center,
+    normal,
+    centerTexCoord.x,
+    centerTexCoord.y,
+  );
+  final ringIndices = <int>[
+    for (var k = 0; k < count; k++)
+      accumulator.addVertex(
+        ringPositions[k],
+        normal,
+        ringTexCoords[k].x,
+        ringTexCoords[k].y,
+      ),
+  ];
+  for (var k = 0; k < count; k++) {
+    final next = (k + 1) % count;
+    if (reverseWinding) {
+      accumulator.addTriangle(centerIndex, ringIndices[next], ringIndices[k]);
+    } else {
+      accumulator.addTriangle(centerIndex, ringIndices[k], ringIndices[next]);
+    }
+  }
 }

--- a/packages/flutter_scene/lib/src/mesh.dart
+++ b/packages/flutter_scene/lib/src/mesh.dart
@@ -45,13 +45,20 @@ base class Mesh {
 
   vm.Aabb3? _localBoundsCache;
   bool _localBoundsCached = false;
+  List<int>? _cachedBoundsVersions;
 
   /// Local-space union of every primitive's [Geometry.localBounds], or
-  /// `null` when no primitive has computable bounds. Cached; call
-  /// [markLocalBoundsDirty] after replacing a primitive's geometry or
-  /// mutating geometry that participates in the union.
+  /// `null` when no primitive has computable bounds.
+  ///
+  /// Cached. The cache refreshes itself when a primitive's geometry
+  /// reports a new [Geometry.localBoundsVersion], so an updatable
+  /// geometry that is mutated in place stays correct without an explicit
+  /// invalidation. Call [markLocalBoundsDirty] after replacing a
+  /// primitive's geometry.
   vm.Aabb3? get localBounds {
-    if (_localBoundsCached) return _localBoundsCache;
+    if (_localBoundsCached && _boundsVersionsUnchanged()) {
+      return _localBoundsCache;
+    }
     vm.Aabb3? result;
     for (final p in primitives) {
       final b = p.geometry.localBounds;
@@ -64,14 +71,30 @@ base class Mesh {
     }
     _localBoundsCache = result;
     _localBoundsCached = true;
+    _cachedBoundsVersions = <int>[
+      for (final p in primitives) p.geometry.localBoundsVersion,
+    ];
     return result;
   }
 
+  bool _boundsVersionsUnchanged() {
+    final snapshot = _cachedBoundsVersions;
+    if (snapshot == null || snapshot.length != primitives.length) {
+      return false;
+    }
+    for (var i = 0; i < primitives.length; i++) {
+      if (snapshot[i] != primitives[i].geometry.localBoundsVersion) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /// Invalidate the cached [localBounds]. Call this after replacing a
-  /// primitive's geometry or mutating geometry that participates in the
-  /// union.
+  /// primitive's geometry.
   void markLocalBoundsDirty() {
     _localBoundsCache = null;
     _localBoundsCached = false;
+    _cachedBoundsVersions = null;
   }
 }

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -63,6 +63,7 @@ class ShadowEncoder {
       _depthShader,
     );
     _renderPass.bindPipeline(pipeline);
+    _renderPass.setPrimitiveType(item.geometry.primitiveType);
 
     final instances = item.instanceTransforms;
     if (instances != null) {

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -213,6 +213,7 @@ base class SceneEncoder {
       _camera.position,
     );
     material.bind(_renderPass, _transientsBuffer, _lighting);
+    _renderPass.setPrimitiveType(geometry.primitiveType);
     _renderPass.draw();
   }
 
@@ -229,6 +230,7 @@ base class SceneEncoder {
     _renderPass.clearBindings();
     _bindPipeline(pipeline);
     material.bind(_renderPass, _transientsBuffer, _lighting);
+    _renderPass.setPrimitiveType(geometry.primitiveType);
     for (final instanceTransform in instances) {
       geometry.bind(
         _renderPass,

--- a/packages/flutter_scene/lib/src/scene_path.dart
+++ b/packages/flutter_scene/lib/src/scene_path.dart
@@ -1,0 +1,274 @@
+import 'package:vector_math/vector_math.dart';
+
+/// An oriented coordinate frame at a point along a [ScenePath].
+///
+/// The three axes are unit length and mutually perpendicular: [tangent]
+/// runs along the path, and [normal] and [binormal] span the plane
+/// across it. Frames along a path are rotation-minimizing, so a profile
+/// swept through them does not twist.
+class ScenePathFrame {
+  /// Creates a frame from its position and axes.
+  const ScenePathFrame({
+    required this.position,
+    required this.tangent,
+    required this.normal,
+    required this.binormal,
+  });
+
+  /// The point on the path.
+  final Vector3 position;
+
+  /// Unit direction along the path.
+  final Vector3 tangent;
+
+  /// Unit direction across the path, perpendicular to [tangent].
+  final Vector3 normal;
+
+  /// Unit direction completing the frame: `tangent` cross `normal`.
+  final Vector3 binormal;
+}
+
+/// A curve through 3D space, independent of any geometry or rendering.
+///
+/// A `ScenePath` is an immutable value type. Subclasses ([PolylinePath],
+/// [CatmullRomPath], [BezierPath]) define the curve; this base class adds
+/// arc-length measurement and rotation-minimizing frames on top.
+///
+/// Two parameter spaces are available. The natural parameter `t` runs
+/// `0..1` and is spaced evenly per segment ([positionAt], [tangentAt],
+/// [frameAt]). Arc-length distance `d` runs `0..length` and is spaced
+/// evenly along the curve ([positionAtDistance], [frameAtDistance]); use
+/// it when spacing must stay uniform around bends, such as for dashes or
+/// a swept profile.
+abstract class ScenePath {
+  /// The point on the curve at natural parameter [t] (clamped to `0..1`).
+  Vector3 positionAt(double t);
+
+  /// The unit tangent at natural parameter [t] (clamped to `0..1`).
+  Vector3 tangentAt(double t);
+
+  /// The natural parameters at which the curve is sampled when baking
+  /// the arc-length and frame tables. Strictly increasing, starting at
+  /// `0` and ending at `1`.
+  List<double> sampleParameters();
+
+  _PathTable? _table;
+  _PathTable get _baked => _table ??= _bake();
+
+  /// The total arc length of the curve.
+  double get length => _baked.cumulativeLengths.last;
+
+  /// The point at arc-length distance [d] (clamped to `0..length`).
+  Vector3 positionAtDistance(double d) => positionAt(parameterAtDistance(d));
+
+  /// An oriented frame at natural parameter [t] (clamped to `0..1`).
+  ScenePathFrame frameAt(double t) {
+    final clamped = _clamp01(t);
+    final table = _baked;
+    final params = table.parameters;
+    var hi = 1;
+    while (hi < params.length - 1 && params[hi] < clamped) {
+      hi++;
+    }
+    final lo = hi - 1;
+    final span = params[hi] - params[lo];
+    final local = span > 1e-12 ? (clamped - params[lo]) / span : 0.0;
+
+    final position = positionAt(clamped);
+    var tangent = tangentAt(clamped);
+    if (tangent.length2 < 1e-12) {
+      tangent = table.tangents[hi].clone();
+    }
+    tangent = tangent.normalized();
+
+    var normal = table.normals[lo] * (1.0 - local) + table.normals[hi] * local;
+    normal = normal - tangent * normal.dot(tangent);
+    if (normal.length2 < 1e-12) {
+      normal = _perpendicularTo(tangent);
+    }
+    normal = normal.normalized();
+
+    return ScenePathFrame(
+      position: position,
+      tangent: tangent,
+      normal: normal,
+      binormal: tangent.cross(normal).normalized(),
+    );
+  }
+
+  /// An oriented frame at arc-length distance [d] (clamped to
+  /// `0..length`).
+  ScenePathFrame frameAtDistance(double d) => frameAt(parameterAtDistance(d));
+
+  /// The natural parameter at arc-length distance [d] (clamped to
+  /// `0..length`).
+  double parameterAtDistance(double d) {
+    final table = _baked;
+    final cumulative = table.cumulativeLengths;
+    final total = cumulative.last;
+    if (total <= 0.0) return 0.0;
+    final target = d < 0.0 ? 0.0 : (d > total ? total : d);
+    var lo = 0;
+    var hi = cumulative.length - 1;
+    while (lo + 1 < hi) {
+      final mid = (lo + hi) >> 1;
+      if (cumulative[mid] <= target) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+    final segment = cumulative[hi] - cumulative[lo];
+    final local = segment > 1e-12 ? (target - cumulative[lo]) / segment : 0.0;
+    return table.parameters[lo] +
+        (table.parameters[hi] - table.parameters[lo]) * local;
+  }
+
+  /// Returns [count] points along the curve.
+  ///
+  /// With [evenlySpaced] the points are spaced by equal arc length;
+  /// otherwise they are spaced by equal natural parameter. [count] must
+  /// be at least two.
+  List<Vector3> sample(int count, {bool evenlySpaced = false}) {
+    if (count < 2) {
+      throw ArgumentError.value(count, 'count', 'must be at least two');
+    }
+    final total = length;
+    return <Vector3>[
+      for (var i = 0; i < count; i++)
+        if (evenlySpaced)
+          positionAtDistance(i / (count - 1) * total)
+        else
+          positionAt(i / (count - 1)),
+    ];
+  }
+
+  _PathTable _bake() {
+    final params = sampleParameters();
+    final positions = <Vector3>[for (final t in params) positionAt(t)];
+    final tangents = <Vector3>[for (final t in params) tangentAt(t)];
+
+    final cumulative = List<double>.filled(params.length, 0.0);
+    for (var i = 1; i < params.length; i++) {
+      cumulative[i] =
+          cumulative[i - 1] + positions[i].distanceTo(positions[i - 1]);
+    }
+
+    return _PathTable(
+      parameters: params,
+      tangents: tangents,
+      normals: _rotationMinimizingNormals(positions, tangents),
+      cumulativeLengths: cumulative,
+    );
+  }
+
+  // Propagates a normal along the sampled curve with the double
+  // reflection method, which minimizes frame rotation between samples.
+  static List<Vector3> _rotationMinimizingNormals(
+    List<Vector3> positions,
+    List<Vector3> tangents,
+  ) {
+    final count = positions.length;
+    final normals = List<Vector3>.filled(count, Vector3.zero());
+    normals[0] = _perpendicularTo(tangents[0]);
+    for (var i = 0; i < count - 1; i++) {
+      var reference = normals[i];
+      final v1 = positions[i + 1] - positions[i];
+      final c1 = v1.dot(v1);
+      if (c1 > 1e-12) {
+        final reflectedRef = reference - v1 * (2.0 / c1 * v1.dot(reference));
+        final reflectedTan =
+            tangents[i] - v1 * (2.0 / c1 * v1.dot(tangents[i]));
+        final v2 = tangents[i + 1] - reflectedTan;
+        final c2 = v2.dot(v2);
+        reference =
+            c2 > 1e-12
+                ? reflectedRef - v2 * (2.0 / c2 * v2.dot(reflectedRef))
+                : reflectedRef;
+      }
+      // Re-orthonormalize against the next tangent.
+      reference = reference - tangents[i + 1] * reference.dot(tangents[i + 1]);
+      if (reference.length2 < 1e-12) {
+        reference = _perpendicularTo(tangents[i + 1]);
+      }
+      normals[i + 1] = reference.normalized();
+    }
+    return normals;
+  }
+
+  // An arbitrary unit vector perpendicular to [direction].
+  static Vector3 _perpendicularTo(Vector3 direction) {
+    final ax = direction.x.abs();
+    final ay = direction.y.abs();
+    final az = direction.z.abs();
+    final Vector3 axis;
+    if (ax <= ay && ax <= az) {
+      axis = Vector3(1.0, 0.0, 0.0);
+    } else if (ay <= az) {
+      axis = Vector3(0.0, 1.0, 0.0);
+    } else {
+      axis = Vector3(0.0, 0.0, 1.0);
+    }
+    final result = axis.cross(direction);
+    if (result.length2 < 1e-12) return Vector3(0.0, 1.0, 0.0);
+    return result.normalized();
+  }
+}
+
+double _clamp01(double v) => v < 0.0 ? 0.0 : (v > 1.0 ? 1.0 : v);
+
+class _PathTable {
+  _PathTable({
+    required this.parameters,
+    required this.tangents,
+    required this.normals,
+    required this.cumulativeLengths,
+  });
+
+  final List<double> parameters;
+  final List<Vector3> tangents;
+  final List<Vector3> normals;
+  final List<double> cumulativeLengths;
+}
+
+/// A path of straight segments connecting a list of points.
+class PolylinePath extends ScenePath {
+  /// Creates a polyline through [points], which is copied. At least two
+  /// points are required.
+  PolylinePath(List<Vector3> points)
+    : _points = <Vector3>[for (final p in points) p.clone()] {
+    if (_points.length < 2) {
+      throw ArgumentError('A path needs at least two points');
+    }
+  }
+
+  final List<Vector3> _points;
+
+  @override
+  Vector3 positionAt(double t) {
+    final (segment, local) = _segmentAt(t);
+    return _points[segment] * (1.0 - local) + _points[segment + 1] * local;
+  }
+
+  @override
+  Vector3 tangentAt(double t) {
+    final (segment, _) = _segmentAt(t);
+    final direction = _points[segment + 1] - _points[segment];
+    if (direction.length2 < 1e-12) return Vector3(1.0, 0.0, 0.0);
+    return direction.normalized();
+  }
+
+  @override
+  List<double> sampleParameters() {
+    final segments = _points.length - 1;
+    return <double>[for (var i = 0; i <= segments; i++) i / segments];
+  }
+
+  (int, double) _segmentAt(double t) {
+    final segments = _points.length - 1;
+    final scaled = _clamp01(t) * segments;
+    var segment = scaled.floor();
+    if (segment >= segments) segment = segments - 1;
+    return (segment, scaled - segment);
+  }
+}

--- a/packages/flutter_scene/lib/src/scene_path.dart
+++ b/packages/flutter_scene/lib/src/scene_path.dart
@@ -217,6 +217,15 @@ abstract class ScenePath {
 
 double _clamp01(double v) => v < 0.0 ? 0.0 : (v > 1.0 ? 1.0 : v);
 
+// Maps natural parameter [t] to a segment index and a local `0..1`
+// offset within it, given a curve of [segments] equal-parameter spans.
+(int, double) _segmentOf(double t, int segments) {
+  final scaled = _clamp01(t) * segments;
+  var segment = scaled.floor();
+  if (segment >= segments) segment = segments - 1;
+  return (segment, scaled - segment);
+}
+
 class _PathTable {
   _PathTable({
     required this.parameters,
@@ -246,13 +255,13 @@ class PolylinePath extends ScenePath {
 
   @override
   Vector3 positionAt(double t) {
-    final (segment, local) = _segmentAt(t);
+    final (segment, local) = _segmentOf(t, _points.length - 1);
     return _points[segment] * (1.0 - local) + _points[segment + 1] * local;
   }
 
   @override
   Vector3 tangentAt(double t) {
-    final (segment, _) = _segmentAt(t);
+    final (segment, _) = _segmentOf(t, _points.length - 1);
     final direction = _points[segment + 1] - _points[segment];
     if (direction.length2 < 1e-12) return Vector3(1.0, 0.0, 0.0);
     return direction.normalized();
@@ -263,12 +272,131 @@ class PolylinePath extends ScenePath {
     final segments = _points.length - 1;
     return <double>[for (var i = 0; i <= segments; i++) i / segments];
   }
+}
 
-  (int, double) _segmentAt(double t) {
-    final segments = _points.length - 1;
-    final scaled = _clamp01(t) * segments;
-    var segment = scaled.floor();
-    if (segment >= segments) segment = segments - 1;
-    return (segment, scaled - segment);
+// Natural-parameter samples per segment for the smooth curve types,
+// used to bake their arc-length and frame tables.
+const int _smoothCurveSamplesPerSegment = 24;
+
+List<double> _subdividedParameters(int segments) {
+  final params = <double>[];
+  for (var s = 0; s < segments; s++) {
+    for (var k = 0; k < _smoothCurveSamplesPerSegment; k++) {
+      params.add((s + k / _smoothCurveSamplesPerSegment) / segments);
+    }
   }
+  params.add(1.0);
+  return params;
+}
+
+/// A smooth curve passing through every one of a list of points.
+///
+/// The curve interpolates its control points with uniform Catmull-Rom
+/// segments, so `positionAt` returns a control point exactly at that
+/// point's natural parameter.
+class CatmullRomPath extends ScenePath {
+  /// Creates a Catmull-Rom curve through [points], which is copied. At
+  /// least two points are required.
+  CatmullRomPath(List<Vector3> points)
+    : _points = <Vector3>[for (final p in points) p.clone()] {
+    if (_points.length < 2) {
+      throw ArgumentError('A path needs at least two points');
+    }
+  }
+
+  final List<Vector3> _points;
+
+  @override
+  Vector3 positionAt(double t) {
+    final (segment, s) = _segmentOf(t, _points.length - 1);
+    final (p0, p1, p2, p3) = _controlPoints(segment);
+    final s2 = s * s;
+    final s3 = s2 * s;
+    return (p1 * 2.0 +
+            (p2 - p0) * s +
+            (p0 * 2.0 - p1 * 5.0 + p2 * 4.0 - p3) * s2 +
+            (p1 * 3.0 - p0 - p2 * 3.0 + p3) * s3) *
+        0.5;
+  }
+
+  @override
+  Vector3 tangentAt(double t) {
+    final (segment, s) = _segmentOf(t, _points.length - 1);
+    final (p0, p1, p2, p3) = _controlPoints(segment);
+    final derivative =
+        ((p2 - p0) +
+            (p0 * 2.0 - p1 * 5.0 + p2 * 4.0 - p3) * (2.0 * s) +
+            (p1 * 3.0 - p0 - p2 * 3.0 + p3) * (3.0 * s * s)) *
+        0.5;
+    if (derivative.length2 < 1e-12) return Vector3(1.0, 0.0, 0.0);
+    return derivative.normalized();
+  }
+
+  @override
+  List<double> sampleParameters() => _subdividedParameters(_points.length - 1);
+
+  // The four control points for [segment], with the endpoints repeated
+  // so the first and last segments still interpolate cleanly.
+  (Vector3, Vector3, Vector3, Vector3) _controlPoints(int segment) {
+    final last = _points.length - 1;
+    Vector3 at(int i) => _points[i < 0 ? 0 : (i > last ? last : i)];
+    return (at(segment - 1), at(segment), at(segment + 1), at(segment + 2));
+  }
+}
+
+/// A path of joined cubic Bezier segments.
+///
+/// Each segment is defined by four control points, and adjacent
+/// segments share an endpoint, so the control point count must be
+/// `3 * segments + 1`.
+class BezierPath extends ScenePath {
+  /// Creates a Bezier path from [controlPoints], which is copied. The
+  /// count must be `3 * segments + 1` for one or more segments.
+  BezierPath(List<Vector3> controlPoints)
+    : _points = <Vector3>[for (final p in controlPoints) p.clone()] {
+    if (_points.length < 4 || (_points.length - 1) % 3 != 0) {
+      throw ArgumentError(
+        'A Bezier path needs 3 * segments + 1 control points',
+      );
+    }
+  }
+
+  final List<Vector3> _points;
+
+  int get _segments => (_points.length - 1) ~/ 3;
+
+  @override
+  Vector3 positionAt(double t) {
+    final (segment, s) = _segmentOf(t, _segments);
+    final base = segment * 3;
+    final p0 = _points[base];
+    final p1 = _points[base + 1];
+    final p2 = _points[base + 2];
+    final p3 = _points[base + 3];
+    final u = 1.0 - s;
+    return p0 * (u * u * u) +
+        p1 * (3.0 * u * u * s) +
+        p2 * (3.0 * u * s * s) +
+        p3 * (s * s * s);
+  }
+
+  @override
+  Vector3 tangentAt(double t) {
+    final (segment, s) = _segmentOf(t, _segments);
+    final base = segment * 3;
+    final p0 = _points[base];
+    final p1 = _points[base + 1];
+    final p2 = _points[base + 2];
+    final p3 = _points[base + 3];
+    final u = 1.0 - s;
+    final derivative =
+        (p1 - p0) * (3.0 * u * u) +
+        (p2 - p1) * (6.0 * u * s) +
+        (p3 - p2) * (3.0 * s * s);
+    if (derivative.length2 < 1e-12) return Vector3(1.0, 0.0, 0.0);
+    return derivative.normalized();
+  }
+
+  @override
+  List<double> sampleParameters() => _subdividedParameters(_segments);
 }

--- a/packages/flutter_scene/test/bounds_test.dart
+++ b/packages/flutter_scene/test/bounds_test.dart
@@ -71,6 +71,15 @@ void main() {
       expect(g.localBounds, isNull);
       expect(g.localBoundingSphere, isNull);
     });
+
+    test('localBoundsVersion increments on each set', () {
+      final g = _StubGeometry();
+      expect(g.localBoundsVersion, 0);
+      g.setLocalBounds(_aabb(Vector3.zero(), Vector3.all(1)), null);
+      expect(g.localBoundsVersion, 1);
+      g.setLocalBounds(null, null);
+      expect(g.localBoundsVersion, 2);
+    });
   });
 
   group('Mesh.localBounds', () {
@@ -126,6 +135,24 @@ void main() {
       expect(m.localBounds!.max, Vector3(1, 1, 1), reason: 'cache hit');
       m.markLocalBoundsDirty();
       expect(m.localBounds!.max, Vector3(5, 5, 5), reason: 'after dirty');
+    });
+
+    test('refreshes when a geometry mutates its bounds in place', () {
+      final geometry = _StubGeometry(
+        aabb: _aabb(Vector3(0, 0, 0), Vector3(1, 1, 1)),
+      );
+      final m = Mesh.primitives(
+        primitives: [MeshPrimitive(geometry, _StubMaterial())],
+      );
+      // Prime the cache.
+      expect(m.localBounds!.max, Vector3(1, 1, 1));
+      // Mutate the same geometry object in place. The localBoundsVersion
+      // bump lets the cache notice without a markLocalBoundsDirty call.
+      geometry.setLocalBounds(
+        _aabb(Vector3(0, 0, 0), Vector3(7, 7, 7)),
+        Sphere.centerRadius(Vector3.zero(), 1),
+      );
+      expect(m.localBounds!.max, Vector3(7, 7, 7));
     });
   });
 

--- a/packages/flutter_scene/test/geometry_test.dart
+++ b/packages/flutter_scene/test/geometry_test.dart
@@ -1,0 +1,35 @@
+// Geometry.primitiveType: default and round-trip. The render-pass
+// wiring that consumes it (SceneEncoder, ShadowEncoder) draws to the
+// GPU and is exercised by the example app rather than here.
+
+import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// Geometry that skips shader-library and GPU access, so the base-class
+/// state can be exercised without a Flutter GPU context.
+class _StubGeometry extends Geometry {
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Matrix4 modelTransform,
+    Matrix4 cameraTransform,
+    Vector3 cameraPosition,
+  ) {
+    throw UnsupportedError('Stub geometry is not renderable');
+  }
+}
+
+void main() {
+  test('primitiveType defaults to a triangle list', () {
+    expect(_StubGeometry().primitiveType, gpu.PrimitiveType.triangle);
+  });
+
+  test('primitiveType is mutable', () {
+    final geometry =
+        _StubGeometry()..primitiveType = gpu.PrimitiveType.lineStrip;
+    expect(geometry.primitiveType, gpu.PrimitiveType.lineStrip);
+  });
+}

--- a/packages/flutter_scene/test/interleaved_layout_test.dart
+++ b/packages/flutter_scene/test/interleaved_layout_test.dart
@@ -1,0 +1,135 @@
+// Covers InterleavedLayoutAdapter: structure-of-arrays attributes packed
+// into the interleaved unskinned vertex layout, index-buffer width
+// selection, and area-weighted normal generation. Pure logic, so these
+// run without a Flutter GPU context.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('packUnskinned', () {
+    test('interleaves every supplied attribute', () {
+      // All values are exactly representable as 32-bit floats so the
+      // packed bytes can be compared without a tolerance.
+      final bytes = InterleavedLayoutAdapter.packUnskinned(
+        positions: Float32List.fromList([1, 2, 3, 4, 5, 6]),
+        vertexCount: 2,
+        normals: Float32List.fromList([0, 1, 0, 1, 0, 0]),
+        texCoords: Float32List.fromList([0.5, 0.25, 0.75, 0.125]),
+        colors: Float32List.fromList([1, 0, 0, 1, 0, 1, 0, 0.5]),
+      );
+      final floats = Float32List.sublistView(bytes);
+      expect(floats, hasLength(2 * InterleavedLayoutAdapter.floatsPerVertex));
+      // Vertex 0.
+      expect(floats.sublist(0, 12), [1, 2, 3, 0, 1, 0, 0.5, 0.25, 1, 0, 0, 1]);
+      // Vertex 1.
+      expect(floats.sublist(12, 24), [
+        4,
+        5,
+        6,
+        1,
+        0,
+        0,
+        0.75,
+        0.125,
+        0,
+        1,
+        0,
+        0.5,
+      ]);
+    });
+
+    test('fills defaults for absent attributes', () {
+      final bytes = InterleavedLayoutAdapter.packUnskinned(
+        positions: Float32List.fromList([1, 2, 3]),
+        vertexCount: 1,
+      );
+      final floats = Float32List.sublistView(bytes);
+      // Position, default normal (0,0,1), default uv (0,0), default
+      // color opaque white.
+      expect(floats, [1, 2, 3, 0, 0, 1, 0, 0, 1, 1, 1, 1]);
+    });
+
+    test('throws when an attribute length mismatches the vertex count', () {
+      expect(
+        () => InterleavedLayoutAdapter.packUnskinned(
+          positions: Float32List.fromList([1, 2, 3]),
+          vertexCount: 1,
+          normals: Float32List.fromList([0, 0, 1, 0, 0, 1]),
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('packIndices', () {
+    test('uses a 16-bit buffer when every index fits', () {
+      final packed = InterleavedLayoutAdapter.packIndices([0, 1, 2, 0xFFFF]);
+      expect(packed.is32Bit, isFalse);
+      expect(packed.bytes, hasLength(4 * 2));
+      expect(Uint16List.sublistView(packed.bytes), [0, 1, 2, 0xFFFF]);
+    });
+
+    test('uses a 32-bit buffer when an index exceeds 16 bits', () {
+      final packed = InterleavedLayoutAdapter.packIndices([0, 70000]);
+      expect(packed.is32Bit, isTrue);
+      expect(packed.bytes, hasLength(2 * 4));
+      expect(Uint32List.sublistView(packed.bytes), [0, 70000]);
+    });
+
+    test('throws on a negative index', () {
+      expect(
+        () => InterleavedLayoutAdapter.packIndices([0, -1, 2]),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('generateNormals', () {
+    test('generates +Z for a counter-clockwise triangle in the XY plane', () {
+      final normals = InterleavedLayoutAdapter.generateNormals(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        vertexCount: 3,
+        indices: [0, 1, 2],
+      );
+      for (var v = 0; v < 3; v++) {
+        expect(normals[v * 3 + 0], closeTo(0, 1e-6));
+        expect(normals[v * 3 + 1], closeTo(0, 1e-6));
+        expect(normals[v * 3 + 2], closeTo(1, 1e-6));
+      }
+    });
+
+    test('handles a non-indexed triangle list', () {
+      final normals = InterleavedLayoutAdapter.generateNormals(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        vertexCount: 3,
+      );
+      expect(normals[2], closeTo(1, 1e-6));
+    });
+
+    test('falls back to (0, 0, 1) for a vertex touched by no triangle', () {
+      // Four vertices, one triangle referencing only the first three.
+      final normals = InterleavedLayoutAdapter.generateNormals(
+        positions: Float32List.fromList([
+          0, 0, 0, 1, 0, 0, 0, 1, 0, 9, 9, 9, //
+        ]),
+        vertexCount: 4,
+        indices: [0, 1, 2],
+      );
+      expect(normals.sublist(9, 12), [0, 0, 1]);
+    });
+
+    test('throws when an indexed list is not a multiple of three', () {
+      expect(
+        () => InterleavedLayoutAdapter.generateNormals(
+          positions: Float32List.fromList([0, 0, 0, 1, 0, 0]),
+          vertexCount: 2,
+          indices: [0, 1],
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/packages/flutter_scene/test/mesh_geometry_test.dart
+++ b/packages/flutter_scene/test/mesh_geometry_test.dart
@@ -102,4 +102,23 @@ void main() {
       expect(floats.sublist(3, 6), [0, 1, 0]);
     });
   });
+
+  group('nextBufferCapacity', () {
+    test('returns the minimum when the need is small', () {
+      expect(nextBufferCapacity(0), 16);
+      expect(nextBufferCapacity(16), 16);
+    });
+
+    test('rounds up to the next power of two', () {
+      expect(nextBufferCapacity(17), 32);
+      expect(nextBufferCapacity(100), 128);
+      expect(nextBufferCapacity(128), 128);
+      expect(nextBufferCapacity(1000), 1024);
+    });
+
+    test('honors a custom minimum', () {
+      expect(nextBufferCapacity(3, minimum: 8), 8);
+      expect(nextBufferCapacity(9, minimum: 8), 16);
+    });
+  });
 }

--- a/packages/flutter_scene/test/mesh_geometry_test.dart
+++ b/packages/flutter_scene/test/mesh_geometry_test.dart
@@ -1,0 +1,105 @@
+// Covers GeometryBuilder accumulation: vertex indexing, deduplication,
+// triangle validation, sticky attributes, and interleaved packing.
+// GeometryBuilder.build() and MeshGeometry.fromArrays() upload to the
+// GPU and are exercised by the example app, not here.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  group('GeometryBuilder', () {
+    test('addVertex returns sequential indices', () {
+      final builder = GeometryBuilder(deduplicate: false);
+      expect(builder.addVertex(Vector3(0, 0, 0)), 0);
+      expect(builder.addVertex(Vector3(1, 0, 0)), 1);
+      expect(builder.addVertex(Vector3(2, 0, 0)), 2);
+      expect(builder.vertexCount, 3);
+    });
+
+    test('deduplicate merges a vertex equal to one already added', () {
+      final builder = GeometryBuilder();
+      final first = builder.addVertex(Vector3(1, 2, 3));
+      final second = builder.addVertex(Vector3(1, 2, 3));
+      expect(second, first);
+      expect(builder.vertexCount, 1);
+    });
+
+    test('deduplicate distinguishes vertices by sticky attributes', () {
+      final builder = GeometryBuilder();
+      builder.color(Vector4(1, 0, 0, 1));
+      builder.addVertex(Vector3(1, 2, 3));
+      builder.color(Vector4(0, 1, 0, 1));
+      builder.addVertex(Vector3(1, 2, 3));
+      // Same position, different color: not merged.
+      expect(builder.vertexCount, 2);
+    });
+
+    test('deduplicate: false keeps identical vertices', () {
+      final builder = GeometryBuilder(deduplicate: false);
+      builder.addVertex(Vector3(1, 2, 3));
+      builder.addVertex(Vector3(1, 2, 3));
+      expect(builder.vertexCount, 2);
+    });
+
+    test('addTriangle records indices and reports triangle count', () {
+      final builder =
+          GeometryBuilder(deduplicate: false)
+            ..addVertex(Vector3(0, 0, 0))
+            ..addVertex(Vector3(1, 0, 0))
+            ..addVertex(Vector3(0, 1, 0))
+            ..addTriangle(0, 1, 2);
+      expect(builder.triangleCount, 1);
+    });
+
+    test('addTriangle rejects an out-of-range vertex index', () {
+      final builder = GeometryBuilder()..addVertex(Vector3(0, 0, 0));
+      expect(() => builder.addTriangle(0, 1, 2), throwsRangeError);
+    });
+
+    test('sticky attributes apply to subsequently added vertices', () {
+      final builder =
+          GeometryBuilder(deduplicate: false)
+            ..color(Vector4(1, 0, 0, 1))
+            ..addVertex(Vector3(0, 0, 0))
+            ..color(Vector4(0, 1, 0, 1))
+            ..texCoord(Vector2(0.5, 0.5))
+            ..addVertex(Vector3(1, 0, 0));
+
+      final floats = Float32List.sublistView(builder.packVertices());
+      // Vertex 0 color (floats 8..11) is the first sticky color.
+      expect(floats.sublist(8, 12), [1, 0, 0, 1]);
+      // Vertex 1 color and texCoord (floats 6..7) are the later values.
+      expect(floats.sublist(12 + 6, 12 + 8), [0.5, 0.5]);
+      expect(floats.sublist(12 + 8, 12 + 12), [0, 1, 0, 1]);
+    });
+
+    test('packVertices generates normals for an authored triangle', () {
+      final builder =
+          GeometryBuilder(deduplicate: false)
+            ..addVertex(Vector3(0, 0, 0))
+            ..addVertex(Vector3(1, 0, 0))
+            ..addVertex(Vector3(0, 1, 0))
+            ..addTriangle(0, 1, 2);
+      final floats = Float32List.sublistView(builder.packVertices());
+      // Vertex 0 normal (floats 3..5) is the generated face normal +Z.
+      expect(floats[3], closeTo(0, 1e-6));
+      expect(floats[4], closeTo(0, 1e-6));
+      expect(floats[5], closeTo(1, 1e-6));
+    });
+
+    test('authored normals override generation', () {
+      final builder =
+          GeometryBuilder(deduplicate: false)
+            ..normal(Vector3(0, 1, 0))
+            ..addVertex(Vector3(0, 0, 0))
+            ..addVertex(Vector3(1, 0, 0))
+            ..addVertex(Vector3(0, 1, 0))
+            ..addTriangle(0, 1, 2);
+      final floats = Float32List.sublistView(builder.packVertices());
+      expect(floats.sublist(3, 6), [0, 1, 0]);
+    });
+  });
+}

--- a/packages/flutter_scene/test/polyline_geometry_test.dart
+++ b/packages/flutter_scene/test/polyline_geometry_test.dart
@@ -1,8 +1,8 @@
 // Covers PolylineGeometry: the camera-facing strip expansion math,
-// round cap and join disks, and the factory's argument checks. The
-// expansion is pure (it takes a view-projection matrix), so it runs
-// without a GPU context; the PolylineGeometry class itself uploads to
-// the GPU and is exercised by the example app.
+// round cap disks, and the factory's argument checks. The expansion is
+// pure (it takes a view-projection matrix), so it runs without a GPU
+// context; the PolylineGeometry class itself uploads to the GPU and is
+// exercised by the example app.
 
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -64,34 +64,11 @@ void main() {
 
   group('diskPointIndices', () {
     test('round caps add the two end points', () {
-      expect(diskPointIndices(5, PolylineCap.round, PolylineJoin.miter), [
-        0,
-        4,
-      ]);
+      expect(diskPointIndices(5, PolylineCap.round), [0, 4]);
     });
 
-    test('round joins add the interior points', () {
-      expect(diskPointIndices(5, PolylineCap.butt, PolylineJoin.round), [
-        1,
-        2,
-        3,
-      ]);
-    });
-
-    test('round caps and joins add both, end points first', () {
-      expect(diskPointIndices(4, PolylineCap.round, PolylineJoin.round), [
-        0,
-        3,
-        1,
-        2,
-      ]);
-    });
-
-    test('butt caps and miter joins add no disks', () {
-      expect(
-        diskPointIndices(5, PolylineCap.butt, PolylineJoin.miter),
-        isEmpty,
-      );
+    test('butt caps add no disks', () {
+      expect(diskPointIndices(5, PolylineCap.butt), isEmpty);
     });
   });
 
@@ -102,7 +79,6 @@ void main() {
       widths: [0.5, 0.5],
       widthMode: PolylineWidthMode.worldUnits,
       cap: PolylineCap.butt,
-      join: PolylineJoin.miter,
       viewProjection: viewProjection,
       cameraPosition: camera.position,
       viewportSize: size,
@@ -145,7 +121,6 @@ void main() {
         widths: [24.0, 24.0],
         widthMode: PolylineWidthMode.screenPixels,
         cap: PolylineCap.butt,
-        join: PolylineJoin.miter,
         viewProjection: viewProjection,
         cameraPosition: camera.position,
         viewportSize: size,
@@ -172,7 +147,6 @@ void main() {
             widths: [16.0, 16.0],
             widthMode: PolylineWidthMode.screenPixels,
             cap: PolylineCap.butt,
-            join: PolylineJoin.miter,
             viewProjection: viewProjection,
             cameraPosition: camera.position,
             viewportSize: size,
@@ -191,11 +165,10 @@ void main() {
     });
   });
 
-  group('round caps and joins', () {
+  group('round caps', () {
     ({Float32List positions, Float32List normals}) expand(
       List<Vector3> points, {
       required PolylineCap cap,
-      required PolylineJoin join,
       double width = 2.0,
     }) {
       return expandPolyline(
@@ -203,7 +176,6 @@ void main() {
         widths: List<double>.filled(points.length, width),
         widthMode: PolylineWidthMode.worldUnits,
         cap: cap,
-        join: join,
         viewProjection: viewProjection,
         cameraPosition: camera.position,
         viewportSize: size,
@@ -211,32 +183,27 @@ void main() {
     }
 
     test('round caps add a disk at each end', () {
-      final expanded = expand(
-        [Vector3(-1, 0, 0), Vector3(1, 0, 0)],
-        cap: PolylineCap.round,
-        join: PolylineJoin.miter,
-      );
+      final expanded = expand([
+        Vector3(-1, 0, 0),
+        Vector3(1, 0, 0),
+      ], cap: PolylineCap.round);
       // The strip (2 points) plus a 17-vertex disk at each end.
       expect(expanded.positions, hasLength((2 * 2 + 2 * 17) * 3));
     });
 
-    test('round joins add a disk at each interior point', () {
-      final expanded = expand(
-        [Vector3(-1, 0, 0), Vector3(0, 1, 0), Vector3(1, 0, 0)],
-        cap: PolylineCap.butt,
-        join: PolylineJoin.round,
-      );
-      // The strip (3 points) plus a 17-vertex disk at the one interior
-      // point.
-      expect(expanded.positions, hasLength((3 * 2 + 1 * 17) * 3));
+    test('butt caps add no disk vertices', () {
+      final expanded = expand([
+        Vector3(-1, 0, 0),
+        Vector3(1, 0, 0),
+      ], cap: PolylineCap.butt);
+      expect(expanded.positions, hasLength(2 * 2 * 3));
     });
 
     test('a cap disk rim sits at the line half-width', () {
-      final expanded = expand(
-        [Vector3(-1, 0, 0), Vector3(1, 0, 0)],
-        cap: PolylineCap.round,
-        join: PolylineJoin.miter,
-      );
+      final expanded = expand([
+        Vector3(-1, 0, 0),
+        Vector3(1, 0, 0),
+      ], cap: PolylineCap.round);
       // Strip is 4 vertices; the first disk's center is vertex 4 and
       // its rim is vertices 5..20.
       final center = _vertex(expanded.positions, 4);
@@ -248,11 +215,10 @@ void main() {
 
     test('a cap disk faces the camera', () {
       final start = Vector3(-1, 0, 0);
-      final expanded = expand(
-        [start, Vector3(1, 0, 0)],
-        cap: PolylineCap.round,
-        join: PolylineJoin.miter,
-      );
+      final expanded = expand([
+        start,
+        Vector3(1, 0, 0),
+      ], cap: PolylineCap.round);
       // The first disk triangle is (center, rim[1], rim[0]). The engine
       // front face is opposite the right-hand normal, so that normal
       // points away from the camera.

--- a/packages/flutter_scene/test/polyline_geometry_test.dart
+++ b/packages/flutter_scene/test/polyline_geometry_test.dart
@@ -1,8 +1,8 @@
-// Covers PolylineGeometry: the camera-facing strip expansion math and
-// the factory's argument checks. The expansion is pure (it takes a
-// view-projection matrix), so it runs without a GPU context; the
-// PolylineGeometry class itself uploads to the GPU and is exercised by
-// the example app.
+// Covers PolylineGeometry: the camera-facing strip expansion math,
+// round cap and join disks, and the factory's argument checks. The
+// expansion is pure (it takes a view-projection matrix), so it runs
+// without a GPU context; the PolylineGeometry class itself uploads to
+// the GPU and is exercised by the example app.
 
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -62,12 +62,47 @@ void main() {
     });
   });
 
+  group('diskPointIndices', () {
+    test('round caps add the two end points', () {
+      expect(diskPointIndices(5, PolylineCap.round, PolylineJoin.miter), [
+        0,
+        4,
+      ]);
+    });
+
+    test('round joins add the interior points', () {
+      expect(diskPointIndices(5, PolylineCap.butt, PolylineJoin.round), [
+        1,
+        2,
+        3,
+      ]);
+    });
+
+    test('round caps and joins add both, end points first', () {
+      expect(diskPointIndices(4, PolylineCap.round, PolylineJoin.round), [
+        0,
+        3,
+        1,
+        2,
+      ]);
+    });
+
+    test('butt caps and miter joins add no disks', () {
+      expect(
+        diskPointIndices(5, PolylineCap.butt, PolylineJoin.miter),
+        isEmpty,
+      );
+    });
+  });
+
   group('expandPolyline worldUnits', () {
     final points = [Vector3(-1, 0, 0), Vector3(1, 0, 0)];
     final expanded = expandPolyline(
       points,
       widths: [0.5, 0.5],
       widthMode: PolylineWidthMode.worldUnits,
+      cap: PolylineCap.butt,
+      join: PolylineJoin.miter,
       viewProjection: viewProjection,
       cameraPosition: camera.position,
       viewportSize: size,
@@ -97,8 +132,7 @@ void main() {
     test('normals are unit length', () {
       final count = expanded.normals.length ~/ 3;
       for (var v = 0; v < count; v++) {
-        final n = _vertex(expanded.normals, v);
-        expect(n.length, closeTo(1, 1e-5));
+        expect(_vertex(expanded.normals, v).length, closeTo(1, 1e-5));
       }
     });
   });
@@ -110,6 +144,8 @@ void main() {
         points,
         widths: [24.0, 24.0],
         widthMode: PolylineWidthMode.screenPixels,
+        cap: PolylineCap.butt,
+        join: PolylineJoin.miter,
         viewProjection: viewProjection,
         cameraPosition: camera.position,
         viewportSize: size,
@@ -135,6 +171,8 @@ void main() {
             [Vector3(-1, 0, z), Vector3(1, 0, z)],
             widths: [16.0, 16.0],
             widthMode: PolylineWidthMode.screenPixels,
+            cap: PolylineCap.butt,
+            join: PolylineJoin.miter,
             viewProjection: viewProjection,
             cameraPosition: camera.position,
             viewportSize: size,
@@ -150,6 +188,79 @@ void main() {
       expect(near, closeTo(16, 0.5));
       expect(far, closeTo(16, 0.5));
       expect((near - far).abs(), lessThan(0.5));
+    });
+  });
+
+  group('round caps and joins', () {
+    ({Float32List positions, Float32List normals}) expand(
+      List<Vector3> points, {
+      required PolylineCap cap,
+      required PolylineJoin join,
+      double width = 2.0,
+    }) {
+      return expandPolyline(
+        points,
+        widths: List<double>.filled(points.length, width),
+        widthMode: PolylineWidthMode.worldUnits,
+        cap: cap,
+        join: join,
+        viewProjection: viewProjection,
+        cameraPosition: camera.position,
+        viewportSize: size,
+      );
+    }
+
+    test('round caps add a disk at each end', () {
+      final expanded = expand(
+        [Vector3(-1, 0, 0), Vector3(1, 0, 0)],
+        cap: PolylineCap.round,
+        join: PolylineJoin.miter,
+      );
+      // The strip (2 points) plus a 17-vertex disk at each end.
+      expect(expanded.positions, hasLength((2 * 2 + 2 * 17) * 3));
+    });
+
+    test('round joins add a disk at each interior point', () {
+      final expanded = expand(
+        [Vector3(-1, 0, 0), Vector3(0, 1, 0), Vector3(1, 0, 0)],
+        cap: PolylineCap.butt,
+        join: PolylineJoin.round,
+      );
+      // The strip (3 points) plus a 17-vertex disk at the one interior
+      // point.
+      expect(expanded.positions, hasLength((3 * 2 + 1 * 17) * 3));
+    });
+
+    test('a cap disk rim sits at the line half-width', () {
+      final expanded = expand(
+        [Vector3(-1, 0, 0), Vector3(1, 0, 0)],
+        cap: PolylineCap.round,
+        join: PolylineJoin.miter,
+      );
+      // Strip is 4 vertices; the first disk's center is vertex 4 and
+      // its rim is vertices 5..20.
+      final center = _vertex(expanded.positions, 4);
+      for (var k = 0; k < 16; k++) {
+        final rim = _vertex(expanded.positions, 5 + k);
+        expect(center.distanceTo(rim), closeTo(1.0, 1e-4));
+      }
+    });
+
+    test('a cap disk faces the camera', () {
+      final start = Vector3(-1, 0, 0);
+      final expanded = expand(
+        [start, Vector3(1, 0, 0)],
+        cap: PolylineCap.round,
+        join: PolylineJoin.miter,
+      );
+      // The first disk triangle is (center, rim[1], rim[0]). The engine
+      // front face is opposite the right-hand normal, so that normal
+      // points away from the camera.
+      final center = _vertex(expanded.positions, 4);
+      final rim0 = _vertex(expanded.positions, 5);
+      final rim1 = _vertex(expanded.positions, 6);
+      final geometricNormal = (rim1 - center).cross(rim0 - center);
+      expect(geometricNormal.dot(camera.position - start), lessThan(0));
     });
   });
 }

--- a/packages/flutter_scene/test/polyline_geometry_test.dart
+++ b/packages/flutter_scene/test/polyline_geometry_test.dart
@@ -287,4 +287,45 @@ void main() {
       expect(geometricNormal.dot(camera.position - start), lessThan(0));
     });
   });
+
+  group('resampleDashed', () {
+    final white = Vector4(1, 1, 1, 1);
+
+    test('splits a line into dashes joined by zero-width gaps', () {
+      final result = resampleDashed(
+        [Vector3(0, 0, 0), Vector3(10, 0, 0)],
+        List<double>.filled(2, 1.0),
+        [white, white],
+        const DashPattern(dashLength: 3, gapLength: 1),
+      );
+      // Dashes (0,3), (4,7), (8,10): 3 + 4 + 3 points.
+      expect(result.points, hasLength(10));
+      // One zero-width gap connector on each side of each interior gap.
+      expect(result.widths.where((w) => w == 0.0), hasLength(4));
+    });
+
+    test('the line keeps full-width end points for the caps', () {
+      final result = resampleDashed(
+        [Vector3(0, 0, 0), Vector3(10, 0, 0)],
+        List<double>.filled(2, 2.0),
+        [white, white],
+        const DashPattern(dashLength: 3, gapLength: 1),
+      );
+      expect(result.widths.first, 2.0);
+      expect(result.widths.last, 2.0);
+      _expectVector(result.points.first, Vector3(0, 0, 0));
+      _expectVector(result.points.last, Vector3(10, 0, 0));
+    });
+
+    test('a zero-length line is returned unchanged', () {
+      final points = [Vector3(0, 0, 0), Vector3(0, 0, 0)];
+      final result = resampleDashed(
+        points,
+        [1.0, 1.0],
+        [white, white],
+        const DashPattern(dashLength: 1, gapLength: 1),
+      );
+      expect(result.points, same(points));
+    });
+  });
 }

--- a/packages/flutter_scene/test/polyline_geometry_test.dart
+++ b/packages/flutter_scene/test/polyline_geometry_test.dart
@@ -1,8 +1,8 @@
 // Covers PolylineGeometry: the camera-facing strip expansion math,
-// round cap disks, and the factory's argument checks. The expansion is
-// pure (it takes a view-projection matrix), so it runs without a GPU
-// context; the PolylineGeometry class itself uploads to the GPU and is
-// exercised by the example app.
+// round cap disks, the draw-on range, and the factory's argument
+// checks. The expansion is pure (it takes a view-projection matrix),
+// so it runs without a GPU context; the PolylineGeometry class itself
+// uploads to the GPU and is exercised by the example app.
 
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -27,6 +27,12 @@ Vector3 _vertex(Float32List positions, int index) => Vector3(
   positions[index * 3 + 1],
   positions[index * 3 + 2],
 );
+
+void _expectVector(Vector3 actual, Vector3 expected, {double tol = 1e-5}) {
+  expect(actual.x, closeTo(expected.x, tol));
+  expect(actual.y, closeTo(expected.y, tol));
+  expect(actual.z, closeTo(expected.z, tol));
+}
 
 void main() {
   const size = ui.Size(800, 600);
@@ -79,6 +85,8 @@ void main() {
       widths: [0.5, 0.5],
       widthMode: PolylineWidthMode.worldUnits,
       cap: PolylineCap.butt,
+      drawStart: 0.0,
+      drawEnd: 1.0,
       viewProjection: viewProjection,
       cameraPosition: camera.position,
       viewportSize: size,
@@ -121,6 +129,8 @@ void main() {
         widths: [24.0, 24.0],
         widthMode: PolylineWidthMode.screenPixels,
         cap: PolylineCap.butt,
+        drawStart: 0.0,
+        drawEnd: 1.0,
         viewProjection: viewProjection,
         cameraPosition: camera.position,
         viewportSize: size,
@@ -147,6 +157,8 @@ void main() {
             widths: [16.0, 16.0],
             widthMode: PolylineWidthMode.screenPixels,
             cap: PolylineCap.butt,
+            drawStart: 0.0,
+            drawEnd: 1.0,
             viewProjection: viewProjection,
             cameraPosition: camera.position,
             viewportSize: size,
@@ -165,6 +177,50 @@ void main() {
     });
   });
 
+  group('expandPolyline draw range', () {
+    ({Float32List positions, Float32List normals}) expand(
+      double drawStart,
+      double drawEnd,
+    ) => expandPolyline(
+      [Vector3(0, 0, 0), Vector3(1, 0, 0), Vector3(2, 0, 0), Vector3(3, 0, 0)],
+      widths: List<double>.filled(4, 1.0),
+      widthMode: PolylineWidthMode.worldUnits,
+      cap: PolylineCap.butt,
+      drawStart: drawStart,
+      drawEnd: drawEnd,
+      viewProjection: viewProjection,
+      cameraPosition: camera.position,
+      viewportSize: size,
+    );
+
+    double pairWidth(Float32List positions, int point) => _vertex(
+      positions,
+      point * 2,
+    ).distanceTo(_vertex(positions, point * 2 + 1));
+
+    test('the full range leaves every point at width', () {
+      final expanded = expand(0.0, 1.0);
+      for (var i = 0; i < 4; i++) {
+        expect(pairWidth(expanded.positions, i), closeTo(1.0, 1e-5));
+      }
+    });
+
+    test('a point past drawEnd collapses onto the end boundary', () {
+      // Length 3; drawEnd 0.5 means the visible range ends at arc 1.5.
+      final expanded = expand(0.0, 0.5);
+      // Point 2 (arc 2) is past the range.
+      expect(pairWidth(expanded.positions, 2), closeTo(0, 1e-5));
+      _expectVector(_vertex(expanded.positions, 4), Vector3(1.5, 0, 0));
+    });
+
+    test('a point before drawStart collapses onto the start boundary', () {
+      final expanded = expand(0.5, 1.0);
+      // Point 0 (arc 0) is before the range.
+      expect(pairWidth(expanded.positions, 0), closeTo(0, 1e-5));
+      _expectVector(_vertex(expanded.positions, 0), Vector3(1.5, 0, 0));
+    });
+  });
+
   group('round caps', () {
     ({Float32List positions, Float32List normals}) expand(
       List<Vector3> points, {
@@ -176,6 +232,8 @@ void main() {
         widths: List<double>.filled(points.length, width),
         widthMode: PolylineWidthMode.worldUnits,
         cap: cap,
+        drawStart: 0.0,
+        drawEnd: 1.0,
         viewProjection: viewProjection,
         cameraPosition: camera.position,
         viewportSize: size,

--- a/packages/flutter_scene/test/polyline_geometry_test.dart
+++ b/packages/flutter_scene/test/polyline_geometry_test.dart
@@ -84,7 +84,7 @@ void main() {
       points,
       widths: [0.5, 0.5],
       widthMode: PolylineWidthMode.worldUnits,
-      cap: PolylineCap.butt,
+      diskPoints: const <int>[],
       drawStart: 0.0,
       drawEnd: 1.0,
       viewProjection: viewProjection,
@@ -128,7 +128,7 @@ void main() {
         points,
         widths: [24.0, 24.0],
         widthMode: PolylineWidthMode.screenPixels,
-        cap: PolylineCap.butt,
+        diskPoints: const <int>[],
         drawStart: 0.0,
         drawEnd: 1.0,
         viewProjection: viewProjection,
@@ -156,7 +156,7 @@ void main() {
             [Vector3(-1, 0, z), Vector3(1, 0, z)],
             widths: [16.0, 16.0],
             widthMode: PolylineWidthMode.screenPixels,
-            cap: PolylineCap.butt,
+            diskPoints: const <int>[],
             drawStart: 0.0,
             drawEnd: 1.0,
             viewProjection: viewProjection,
@@ -185,7 +185,7 @@ void main() {
       [Vector3(0, 0, 0), Vector3(1, 0, 0), Vector3(2, 0, 0), Vector3(3, 0, 0)],
       widths: List<double>.filled(4, 1.0),
       widthMode: PolylineWidthMode.worldUnits,
-      cap: PolylineCap.butt,
+      diskPoints: const <int>[],
       drawStart: drawStart,
       drawEnd: drawEnd,
       viewProjection: viewProjection,
@@ -231,7 +231,7 @@ void main() {
         points,
         widths: List<double>.filled(points.length, width),
         widthMode: PolylineWidthMode.worldUnits,
-        cap: cap,
+        diskPoints: diskPointIndices(points.length, cap),
         drawStart: 0.0,
         drawEnd: 1.0,
         viewProjection: viewProjection,
@@ -286,6 +286,22 @@ void main() {
       final geometricNormal = (rim1 - center).cross(rim0 - center);
       expect(geometricNormal.dot(camera.position - start), lessThan(0));
     });
+
+    test('a disk is emitted for every requested disk point', () {
+      final expanded = expandPolyline(
+        [Vector3(0, 0, 0), Vector3(1, 0, 0), Vector3(2, 0, 0)],
+        widths: List<double>.filled(3, 2.0),
+        widthMode: PolylineWidthMode.worldUnits,
+        diskPoints: const <int>[0, 1, 2],
+        drawStart: 0.0,
+        drawEnd: 1.0,
+        viewProjection: viewProjection,
+        cameraPosition: camera.position,
+        viewportSize: size,
+      );
+      // The strip is 3 points (6 vertices) plus a 17-vertex disk each.
+      expect(expanded.positions, hasLength((3 * 2 + 3 * 17) * 3));
+    });
   });
 
   group('resampleDashed', () {
@@ -326,6 +342,21 @@ void main() {
         const DashPattern(dashLength: 1, gapLength: 1),
       );
       expect(result.points, same(points));
+    });
+
+    test('dash cap indices mark both ends of every dash', () {
+      final result = resampleDashed(
+        [Vector3(0, 0, 0), Vector3(10, 0, 0)],
+        List<double>.filled(2, 2.0),
+        [white, white],
+        const DashPattern(dashLength: 3, gapLength: 1, cap: PolylineCap.round),
+      );
+      // Dashes (0,3), (4,7), (8,10): two boundary points each.
+      expect(result.dashCapIndices, hasLength(6));
+      // Every marked index is a full-width dash boundary, never a gap.
+      for (final index in result.dashCapIndices) {
+        expect(result.widths[index], 2.0);
+      }
     });
   });
 }

--- a/packages/flutter_scene/test/polyline_geometry_test.dart
+++ b/packages/flutter_scene/test/polyline_geometry_test.dart
@@ -1,0 +1,155 @@
+// Covers PolylineGeometry: the camera-facing strip expansion math and
+// the factory's argument checks. The expansion is pure (it takes a
+// view-projection matrix), so it runs without a GPU context; the
+// PolylineGeometry class itself uploads to the GPU and is exercised by
+// the example app.
+
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/geometry/polyline_geometry.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+ui.Offset _toScreen(Matrix4 viewProjection, Vector3 world, ui.Size size) {
+  final clip = viewProjection.transformed(
+    Vector4(world.x, world.y, world.z, 1.0),
+  );
+  return ui.Offset(
+    (clip.x / clip.w * 0.5 + 0.5) * size.width,
+    (clip.y / clip.w * 0.5 + 0.5) * size.height,
+  );
+}
+
+Vector3 _vertex(Float32List positions, int index) => Vector3(
+  positions[index * 3],
+  positions[index * 3 + 1],
+  positions[index * 3 + 2],
+);
+
+void main() {
+  const size = ui.Size(800, 600);
+  final camera = PerspectiveCamera(
+    position: Vector3(0, 0, 5),
+    target: Vector3(0, 0, 0),
+  );
+  final viewProjection = camera.getViewTransform(size);
+
+  group('PolylineGeometry construction', () {
+    test('rejects fewer than two points', () {
+      expect(() => PolylineGeometry([Vector3(0, 0, 0)]), throwsArgumentError);
+    });
+
+    test('rejects a mismatched perVertexWidth length', () {
+      expect(
+        () => PolylineGeometry(
+          [Vector3(-1, 0, 0), Vector3(1, 0, 0)],
+          perVertexWidth: [1.0],
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects a mismatched perVertexColor length', () {
+      expect(
+        () => PolylineGeometry(
+          [Vector3(-1, 0, 0), Vector3(1, 0, 0)],
+          perVertexColor: [Vector4(1, 1, 1, 1)],
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('expandPolyline worldUnits', () {
+    final points = [Vector3(-1, 0, 0), Vector3(1, 0, 0)];
+    final expanded = expandPolyline(
+      points,
+      widths: [0.5, 0.5],
+      widthMode: PolylineWidthMode.worldUnits,
+      viewProjection: viewProjection,
+      cameraPosition: camera.position,
+      viewportSize: size,
+    );
+
+    test('emits two vertices per point', () {
+      expect(expanded.positions, hasLength(points.length * 2 * 3));
+    });
+
+    test('the strip edges are one width apart', () {
+      for (var i = 0; i < points.length; i++) {
+        final left = _vertex(expanded.positions, i * 2);
+        final right = _vertex(expanded.positions, i * 2 + 1);
+        expect(left.distanceTo(right), closeTo(0.5, 1e-5));
+      }
+    });
+
+    test('the offset is perpendicular to the view direction', () {
+      for (var i = 0; i < points.length; i++) {
+        final left = _vertex(expanded.positions, i * 2);
+        final right = _vertex(expanded.positions, i * 2 + 1);
+        final viewDirection = camera.position - points[i];
+        expect((left - right).dot(viewDirection), closeTo(0, 1e-5));
+      }
+    });
+
+    test('normals are unit length', () {
+      final count = expanded.normals.length ~/ 3;
+      for (var v = 0; v < count; v++) {
+        final n = _vertex(expanded.normals, v);
+        expect(n.length, closeTo(1, 1e-5));
+      }
+    });
+  });
+
+  group('expandPolyline screenPixels', () {
+    test('the strip is the requested pixel width on screen', () {
+      final points = [Vector3(-1, 0, 0), Vector3(1, 0, 0)];
+      final expanded = expandPolyline(
+        points,
+        widths: [24.0, 24.0],
+        widthMode: PolylineWidthMode.screenPixels,
+        viewProjection: viewProjection,
+        cameraPosition: camera.position,
+        viewportSize: size,
+      );
+      for (var i = 0; i < points.length; i++) {
+        final left = _toScreen(
+          viewProjection,
+          _vertex(expanded.positions, i * 2),
+          size,
+        );
+        final right = _toScreen(
+          viewProjection,
+          _vertex(expanded.positions, i * 2 + 1),
+          size,
+        );
+        expect((left - right).distance, closeTo(24, 0.5));
+      }
+    });
+
+    test('a closer line and a farther line keep the same pixel width', () {
+      ({Float32List positions, Float32List normals}) atDepth(double z) =>
+          expandPolyline(
+            [Vector3(-1, 0, z), Vector3(1, 0, z)],
+            widths: [16.0, 16.0],
+            widthMode: PolylineWidthMode.screenPixels,
+            viewProjection: viewProjection,
+            cameraPosition: camera.position,
+            viewportSize: size,
+          );
+      double pixelWidth(Float32List positions) {
+        final left = _toScreen(viewProjection, _vertex(positions, 0), size);
+        final right = _toScreen(viewProjection, _vertex(positions, 1), size);
+        return (left - right).distance;
+      }
+
+      final near = pixelWidth(atDepth(2).positions);
+      final far = pixelWidth(atDepth(-3).positions);
+      expect(near, closeTo(16, 0.5));
+      expect(far, closeTo(16, 0.5));
+      expect((near - far).abs(), lessThan(0.5));
+    });
+  });
+}

--- a/packages/flutter_scene/test/primitives_test.dart
+++ b/packages/flutter_scene/test/primitives_test.dart
@@ -4,10 +4,22 @@
 // uploads to the GPU and is exercised by the example app.
 
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:flutter_scene/src/geometry/primitives.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart';
+
+// Right-hand-rule normal of a triangle. The engine treats the side
+// opposite this normal as the front face.
+Vector3 triangleNormal(Float32List positions, List<int> indices, int triangle) {
+  Vector3 at(int v) =>
+      Vector3(positions[v * 3], positions[v * 3 + 1], positions[v * 3 + 2]);
+  final a = at(indices[triangle * 3]);
+  final b = at(indices[triangle * 3 + 1]);
+  final c = at(indices[triangle * 3 + 2]);
+  return (b - a).cross(c - a);
+}
 
 void main() {
   group('buildCuboidArrays', () {
@@ -53,6 +65,20 @@ void main() {
       expect(
         () => buildPlaneArrays(width: 1, depth: 1, segmentsX: 0, segmentsZ: 1),
         throwsArgumentError,
+      );
+    });
+
+    test('triangles are wound so the surface faces +Y', () {
+      final arrays = buildPlaneArrays(
+        width: 2,
+        depth: 2,
+        segmentsX: 1,
+        segmentsZ: 1,
+      );
+      // A +Y-facing surface has a -Y geometric normal.
+      expect(
+        triangleNormal(arrays.positions, arrays.indices, 0).y,
+        lessThan(0),
       );
     });
   });

--- a/packages/flutter_scene/test/primitives_test.dart
+++ b/packages/flutter_scene/test/primitives_test.dart
@@ -1,0 +1,93 @@
+// Covers the procedural primitive generators: cuboid, plane, and
+// sphere vertex/index arrays. Pure logic, so these run without a
+// Flutter GPU context; constructing the geometry classes themselves
+// uploads to the GPU and is exercised by the example app.
+
+import 'dart:math' as math;
+
+import 'package:flutter_scene/src/geometry/primitives.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  group('buildCuboidArrays', () {
+    test('produces eight colored corners and twelve triangles', () {
+      final arrays = buildCuboidArrays(Vector3(2, 2, 2));
+      expect(arrays.positions, hasLength(8 * 3));
+      expect(arrays.colors, hasLength(8 * 4));
+      expect(arrays.indices, hasLength(12 * 3));
+      // The first corner sits at -extents/2 on each axis.
+      expect(arrays.positions.sublist(0, 3), [-1, -1, -1]);
+    });
+  });
+
+  group('buildPlaneArrays', () {
+    test('a single-segment plane is one quad facing +Y', () {
+      final arrays = buildPlaneArrays(
+        width: 2,
+        depth: 4,
+        segmentsX: 1,
+        segmentsZ: 1,
+      );
+      expect(arrays.positions, hasLength(4 * 3));
+      expect(arrays.indices, hasLength(6));
+      for (var v = 0; v < 4; v++) {
+        expect(arrays.normals!.sublist(v * 3, v * 3 + 3), [0, 1, 0]);
+        // The surface lies in the y == 0 plane.
+        expect(arrays.positions[v * 3 + 1], 0);
+      }
+    });
+
+    test('subdivision sets the vertex and index counts', () {
+      final arrays = buildPlaneArrays(
+        width: 1,
+        depth: 1,
+        segmentsX: 3,
+        segmentsZ: 2,
+      );
+      expect(arrays.positions, hasLength((3 + 1) * (2 + 1) * 3));
+      expect(arrays.indices, hasLength(3 * 2 * 6));
+    });
+
+    test('rejects a plane with no segments', () {
+      expect(
+        () => buildPlaneArrays(width: 1, depth: 1, segmentsX: 0, segmentsZ: 1),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('buildSphereArrays', () {
+    test('vertex and index counts follow the tessellation', () {
+      final arrays = buildSphereArrays(radius: 1, segments: 8, rings: 4);
+      expect(arrays.positions, hasLength((8 + 1) * (4 + 1) * 3));
+      expect(arrays.indices, hasLength(8 * 4 * 6));
+    });
+
+    test('normals are unit length and positions lie on the radius', () {
+      final arrays = buildSphereArrays(radius: 2, segments: 12, rings: 6);
+      final count = arrays.positions.length ~/ 3;
+      for (var v = 0; v < count; v++) {
+        final nx = arrays.normals![v * 3];
+        final ny = arrays.normals![v * 3 + 1];
+        final nz = arrays.normals![v * 3 + 2];
+        expect(math.sqrt(nx * nx + ny * ny + nz * nz), closeTo(1, 1e-5));
+        final px = arrays.positions[v * 3];
+        final py = arrays.positions[v * 3 + 1];
+        final pz = arrays.positions[v * 3 + 2];
+        expect(math.sqrt(px * px + py * py + pz * pz), closeTo(2, 1e-4));
+      }
+    });
+
+    test('rejects a degenerate tessellation', () {
+      expect(
+        () => buildSphereArrays(radius: 1, segments: 2, rings: 4),
+        throwsArgumentError,
+      );
+      expect(
+        () => buildSphereArrays(radius: 1, segments: 8, rings: 1),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/packages/flutter_scene/test/scene_path_test.dart
+++ b/packages/flutter_scene/test/scene_path_test.dart
@@ -1,0 +1,110 @@
+// Covers ScenePath: PolylinePath evaluation, arc-length measurement,
+// and rotation-minimizing frames. Pure logic, no GPU context needed.
+
+import 'package:flutter_scene/src/scene_path.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void _expectVector(Vector3 actual, Vector3 expected, {double tol = 1e-6}) {
+  expect(actual.x, closeTo(expected.x, tol));
+  expect(actual.y, closeTo(expected.y, tol));
+  expect(actual.z, closeTo(expected.z, tol));
+}
+
+void main() {
+  group('PolylinePath', () {
+    test('rejects fewer than two points', () {
+      expect(() => PolylinePath([Vector3(0, 0, 0)]), throwsArgumentError);
+    });
+
+    test('positionAt spans the endpoints', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(4, 0, 0)]);
+      _expectVector(path.positionAt(0), Vector3(0, 0, 0));
+      _expectVector(path.positionAt(1), Vector3(4, 0, 0));
+      _expectVector(path.positionAt(0.5), Vector3(2, 0, 0));
+    });
+
+    test('tangentAt is the unit segment direction', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(0, 3, 0)]);
+      _expectVector(path.tangentAt(0.5), Vector3(0, 1, 0));
+    });
+
+    test('length sums the segments', () {
+      final path = PolylinePath([
+        Vector3(0, 0, 0),
+        Vector3(1, 0, 0),
+        Vector3(1, 4, 0),
+      ]);
+      expect(path.length, closeTo(5, 1e-6));
+    });
+
+    test('natural and arc-length parameters differ on uneven segments', () {
+      // Segment lengths 1 and 4; the natural midpoint sits at the
+      // corner, the arc-length midpoint sits partway along segment two.
+      final path = PolylinePath([
+        Vector3(0, 0, 0),
+        Vector3(1, 0, 0),
+        Vector3(1, 4, 0),
+      ]);
+      _expectVector(path.positionAt(0.5), Vector3(1, 0, 0));
+      _expectVector(path.positionAtDistance(2.5), Vector3(1, 1.5, 0));
+    });
+
+    test('parameterAtDistance maps the endpoints and a knot', () {
+      final path = PolylinePath([
+        Vector3(0, 0, 0),
+        Vector3(1, 0, 0),
+        Vector3(1, 4, 0),
+      ]);
+      expect(path.parameterAtDistance(0), closeTo(0, 1e-6));
+      expect(path.parameterAtDistance(5), closeTo(1, 1e-6));
+      expect(path.parameterAtDistance(1), closeTo(0.5, 1e-6));
+    });
+
+    test('sample evenly spaced yields equal arc-length steps', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(4, 0, 0)]);
+      final points = path.sample(5, evenlySpaced: true);
+      expect(points, hasLength(5));
+      for (var i = 0; i < points.length; i++) {
+        _expectVector(points[i], Vector3(i.toDouble(), 0, 0));
+      }
+    });
+
+    test('sample requires at least two points', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(1, 0, 0)]);
+      expect(() => path.sample(1), throwsArgumentError);
+    });
+  });
+
+  group('ScenePath frames', () {
+    test('frameAt is orthonormal', () {
+      final path = PolylinePath([
+        Vector3(0, 0, 0),
+        Vector3(2, 1, 0),
+        Vector3(4, 0, 3),
+      ]);
+      for (final t in [0.0, 0.25, 0.5, 0.75, 1.0]) {
+        final frame = path.frameAt(t);
+        expect(frame.tangent.length, closeTo(1, 1e-5));
+        expect(frame.normal.length, closeTo(1, 1e-5));
+        expect(frame.binormal.length, closeTo(1, 1e-5));
+        expect(frame.tangent.dot(frame.normal), closeTo(0, 1e-5));
+        expect(frame.tangent.dot(frame.binormal), closeTo(0, 1e-5));
+        expect(frame.normal.dot(frame.binormal), closeTo(0, 1e-5));
+      }
+    });
+
+    test('a straight path keeps a constant frame', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(10, 0, 0)]);
+      final start = path.frameAt(0);
+      final end = path.frameAt(1);
+      _expectVector(start.normal, end.normal, tol: 1e-5);
+      _expectVector(start.binormal, end.binormal, tol: 1e-5);
+    });
+
+    test('frameAtDistance tracks the arc-length position', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(8, 0, 0)]);
+      _expectVector(path.frameAtDistance(2).position, Vector3(2, 0, 0));
+    });
+  });
+}

--- a/packages/flutter_scene/test/scene_path_test.dart
+++ b/packages/flutter_scene/test/scene_path_test.dart
@@ -107,4 +107,98 @@ void main() {
       _expectVector(path.frameAtDistance(2).position, Vector3(2, 0, 0));
     });
   });
+
+  group('CatmullRomPath', () {
+    test('rejects fewer than two points', () {
+      expect(() => CatmullRomPath([Vector3(0, 0, 0)]), throwsArgumentError);
+    });
+
+    test('passes through every control point', () {
+      final points = [
+        Vector3(0, 0, 0),
+        Vector3(1, 2, 0),
+        Vector3(3, 1, 1),
+        Vector3(4, 0, 0),
+      ];
+      final path = CatmullRomPath(points);
+      for (var i = 0; i < points.length; i++) {
+        _expectVector(path.positionAt(i / (points.length - 1)), points[i]);
+      }
+    });
+
+    test('an interior segment of collinear points stays straight', () {
+      final path = CatmullRomPath([
+        Vector3(0, 0, 0),
+        Vector3(1, 0, 0),
+        Vector3(2, 0, 0),
+        Vector3(3, 0, 0),
+      ]);
+      // Midpoint of the segment between points 1 and 2.
+      _expectVector(path.positionAt(0.5), Vector3(1.5, 0, 0));
+    });
+
+    test('length is at least the endpoint chord', () {
+      final path = CatmullRomPath([
+        Vector3(0, 0, 0),
+        Vector3(2, 3, 0),
+        Vector3(6, 0, 0),
+      ]);
+      expect(path.length, greaterThanOrEqualTo(6 - 1e-6));
+    });
+  });
+
+  group('BezierPath', () {
+    test('rejects a control point count that is not 3n + 1', () {
+      expect(
+        () => BezierPath([Vector3(0, 0, 0), Vector3(1, 0, 0)]),
+        throwsArgumentError,
+      );
+      expect(
+        () => BezierPath([
+          Vector3(0, 0, 0),
+          Vector3(1, 0, 0),
+          Vector3(2, 0, 0),
+          Vector3(3, 0, 0),
+          Vector3(4, 0, 0),
+        ]),
+        throwsArgumentError,
+      );
+    });
+
+    test('spans the first and last control points', () {
+      final path = BezierPath([
+        Vector3(0, 0, 0),
+        Vector3(1, 2, 0),
+        Vector3(3, 2, 0),
+        Vector3(4, 0, 0),
+      ]);
+      _expectVector(path.positionAt(0), Vector3(0, 0, 0));
+      _expectVector(path.positionAt(1), Vector3(4, 0, 0));
+    });
+
+    test('evenly spaced collinear controls trace the straight line', () {
+      final path = BezierPath([
+        Vector3(0, 0, 0),
+        Vector3(1, 0, 0),
+        Vector3(2, 0, 0),
+        Vector3(3, 0, 0),
+      ]);
+      _expectVector(path.positionAt(0.5), Vector3(1.5, 0, 0));
+      _expectVector(path.tangentAt(0.5), Vector3(1, 0, 0));
+    });
+
+    test('joins two segments through the shared control point', () {
+      final path = BezierPath([
+        Vector3(0, 0, 0),
+        Vector3(1, 1, 0),
+        Vector3(2, 1, 0),
+        Vector3(3, 0, 0),
+        Vector3(4, -1, 0),
+        Vector3(5, -1, 0),
+        Vector3(6, 0, 0),
+      ]);
+      _expectVector(path.positionAt(0.5), Vector3(3, 0, 0));
+      _expectVector(path.positionAt(1), Vector3(6, 0, 0));
+    });
+  });
 }

--- a/packages/flutter_scene/test/swept_geometry_test.dart
+++ b/packages/flutter_scene/test/swept_geometry_test.dart
@@ -17,6 +17,21 @@ double _distance(Float32List positions, int a, int b) {
   return math.sqrt(dx * dx + dy * dy + dz * dz);
 }
 
+// Right-hand-rule normal of a triangle. The engine treats the side
+// opposite this normal as the front face.
+Vector3 _triangleNormal(
+  Float32List positions,
+  List<int> indices,
+  int triangle,
+) {
+  Vector3 at(int v) =>
+      Vector3(positions[v * 3], positions[v * 3 + 1], positions[v * 3 + 2]);
+  final a = at(indices[triangle * 3]);
+  final b = at(indices[triangle * 3 + 1]);
+  final c = at(indices[triangle * 3 + 2]);
+  return (b - a).cross(c - a);
+}
+
 void main() {
   group('evenlySpacedFrames', () {
     test('returns the requested count spaced by arc length', () {
@@ -101,6 +116,21 @@ void main() {
         up: Vector3(0, 1, 0),
       );
       expect(_distance(arrays.positions, 0, 1), closeTo(3, 1e-5));
+    });
+
+    test('a ground ribbon is wound so the surface faces +Y', () {
+      final arrays = buildRibbonArrays(
+        PolylinePath([Vector3(0, 0, 0), Vector3(10, 0, 0)]),
+        width: 2,
+        stations: 2,
+        alignment: RibbonAlignment.ground,
+        up: Vector3(0, 1, 0),
+      );
+      // A +Y-facing surface has a -Y geometric normal.
+      expect(
+        _triangleNormal(arrays.positions, arrays.indices, 0).y,
+        lessThan(0),
+      );
     });
   });
 

--- a/packages/flutter_scene/test/swept_geometry_test.dart
+++ b/packages/flutter_scene/test/swept_geometry_test.dart
@@ -103,4 +103,74 @@ void main() {
       expect(_distance(arrays.positions, 0, 1), closeTo(3, 1e-5));
     });
   });
+
+  group('buildTubeArrays', () {
+    SweptArrays tube({required bool caps}) => buildTubeArrays(
+      PolylinePath([Vector3(0, 0, 0), Vector3(10, 0, 0)]),
+      radius: 2,
+      radialSegments: 8,
+      stations: 3,
+      caps: caps,
+    );
+
+    test('rejects a degenerate tessellation', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(1, 0, 0)]);
+      expect(
+        () => buildTubeArrays(
+          path,
+          radius: 1,
+          radialSegments: 2,
+          stations: 3,
+          caps: false,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => buildTubeArrays(
+          path,
+          radius: 1,
+          radialSegments: 8,
+          stations: 1,
+          caps: false,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('side surface vertex and index counts follow the tessellation', () {
+      final arrays = tube(caps: false);
+      // stations * (radialSegments + 1) vertices.
+      expect(arrays.positions, hasLength(3 * 9 * 3));
+      // (stations - 1) * radialSegments quads.
+      expect(arrays.indices, hasLength(2 * 8 * 6));
+    });
+
+    test('caps add a fan at each end', () {
+      final withCaps = tube(caps: true);
+      // Side surface plus a center and ring per cap.
+      expect(withCaps.positions, hasLength((3 * 9 + 2 * 9) * 3));
+      expect(withCaps.indices, hasLength(2 * 8 * 6 + 2 * 8 * 3));
+    });
+
+    test('side vertices sit at the radius from the centerline', () {
+      final arrays = tube(caps: false);
+      final count = arrays.positions.length ~/ 3;
+      for (var v = 0; v < count; v++) {
+        final y = arrays.positions[v * 3 + 1];
+        final z = arrays.positions[v * 3 + 2];
+        expect(math.sqrt(y * y + z * z), closeTo(2, 1e-5));
+      }
+    });
+
+    test('every normal is unit length', () {
+      final arrays = tube(caps: true);
+      final count = arrays.normals.length ~/ 3;
+      for (var v = 0; v < count; v++) {
+        final nx = arrays.normals[v * 3];
+        final ny = arrays.normals[v * 3 + 1];
+        final nz = arrays.normals[v * 3 + 2];
+        expect(math.sqrt(nx * nx + ny * ny + nz * nz), closeTo(1, 1e-5));
+      }
+    });
+  });
 }

--- a/packages/flutter_scene/test/swept_geometry_test.dart
+++ b/packages/flutter_scene/test/swept_geometry_test.dart
@@ -173,4 +173,67 @@ void main() {
       }
     });
   });
+
+  group('buildExtrudeArrays', () {
+    final square = [
+      Vector2(-1, -1),
+      Vector2(1, -1),
+      Vector2(1, 1),
+      Vector2(-1, 1),
+    ];
+
+    SweptArrays extrude({required bool caps}) => buildExtrudeArrays(
+      PolylinePath([Vector3(0, 0, 0), Vector3(10, 0, 0)]),
+      profile: square,
+      stations: 3,
+      caps: caps,
+    );
+
+    test('rejects a profile with fewer than three points', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(1, 0, 0)]);
+      expect(
+        () => buildExtrudeArrays(
+          path,
+          profile: [Vector2(0, 0), Vector2(1, 0)],
+          stations: 2,
+          caps: false,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects fewer than two stations', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(1, 0, 0)]);
+      expect(
+        () =>
+            buildExtrudeArrays(path, profile: square, stations: 1, caps: false),
+        throwsArgumentError,
+      );
+    });
+
+    test('side surface vertex and index counts follow the profile', () {
+      final arrays = extrude(caps: false);
+      // stations * (profilePoints + 1) vertices.
+      expect(arrays.positions, hasLength(3 * 5 * 3));
+      // (stations - 1) * profilePoints quads.
+      expect(arrays.indices, hasLength(2 * 4 * 6));
+    });
+
+    test('caps add a fan at each end', () {
+      final arrays = extrude(caps: true);
+      expect(arrays.positions, hasLength((3 * 5 + 2 * 5) * 3));
+      expect(arrays.indices, hasLength(2 * 4 * 6 + 2 * 4 * 3));
+    });
+
+    test('every normal is unit length', () {
+      final arrays = extrude(caps: true);
+      final count = arrays.normals.length ~/ 3;
+      for (var v = 0; v < count; v++) {
+        final nx = arrays.normals[v * 3];
+        final ny = arrays.normals[v * 3 + 1];
+        final nz = arrays.normals[v * 3 + 2];
+        expect(math.sqrt(nx * nx + ny * ny + nz * nz), closeTo(1, 1e-5));
+      }
+    });
+  });
 }

--- a/packages/flutter_scene/test/swept_geometry_test.dart
+++ b/packages/flutter_scene/test/swept_geometry_test.dart
@@ -1,0 +1,106 @@
+// Covers the swept-geometry generators. Pure logic, no GPU context;
+// the RibbonGeometry class itself uploads to the GPU and is exercised
+// by the example app.
+
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/geometry/swept_geometry.dart';
+import 'package:flutter_scene/src/scene_path.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+double _distance(Float32List positions, int a, int b) {
+  final dx = positions[a * 3] - positions[b * 3];
+  final dy = positions[a * 3 + 1] - positions[b * 3 + 1];
+  final dz = positions[a * 3 + 2] - positions[b * 3 + 2];
+  return math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+void main() {
+  group('evenlySpacedFrames', () {
+    test('returns the requested count spaced by arc length', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(10, 0, 0)]);
+      final frames = evenlySpacedFrames(path, 5);
+      expect(frames, hasLength(5));
+      for (var i = 0; i < 5; i++) {
+        expect(frames[i].position.x, closeTo(i * 2.5, 1e-5));
+      }
+    });
+  });
+
+  group('stitchRings', () {
+    test('connects two rings into a quad', () {
+      final accumulator =
+          MeshAccumulator()
+            ..addVertex(Vector3(0, 0, 0), Vector3(0, 1, 0), 0, 0)
+            ..addVertex(Vector3(1, 0, 0), Vector3(0, 1, 0), 1, 0)
+            ..addVertex(Vector3(0, 0, 1), Vector3(0, 1, 0), 0, 1)
+            ..addVertex(Vector3(1, 0, 1), Vector3(0, 1, 0), 1, 1);
+      stitchRings(accumulator, [0, 2], 2);
+      // One quad is two triangles.
+      expect(accumulator.toArrays().indices, hasLength(6));
+    });
+  });
+
+  group('buildRibbonArrays', () {
+    test('rejects fewer than two stations', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(1, 0, 0)]);
+      expect(
+        () => buildRibbonArrays(
+          path,
+          width: 1,
+          stations: 1,
+          alignment: RibbonAlignment.ground,
+          up: Vector3(0, 1, 0),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('emits two vertices per station and a quad per gap', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(10, 0, 0)]);
+      final arrays = buildRibbonArrays(
+        path,
+        width: 2,
+        stations: 4,
+        alignment: RibbonAlignment.ground,
+        up: Vector3(0, 1, 0),
+      );
+      expect(arrays.positions, hasLength(4 * 2 * 3));
+      expect(arrays.indices, hasLength(3 * 6));
+    });
+
+    test('ground alignment makes every normal point up', () {
+      final path = PolylinePath([
+        Vector3(0, 0, 0),
+        Vector3(4, 0, 0),
+        Vector3(8, 0, 4),
+      ]);
+      final arrays = buildRibbonArrays(
+        path,
+        width: 1,
+        stations: 6,
+        alignment: RibbonAlignment.ground,
+        up: Vector3(0, 1, 0),
+      );
+      for (var v = 0; v < arrays.positions.length ~/ 3; v++) {
+        expect(arrays.normals[v * 3], closeTo(0, 1e-6));
+        expect(arrays.normals[v * 3 + 1], closeTo(1, 1e-6));
+        expect(arrays.normals[v * 3 + 2], closeTo(0, 1e-6));
+      }
+    });
+
+    test('the two edge vertices of a station are width apart', () {
+      final path = PolylinePath([Vector3(0, 0, 0), Vector3(10, 0, 0)]);
+      final arrays = buildRibbonArrays(
+        path,
+        width: 3,
+        stations: 2,
+        alignment: RibbonAlignment.ground,
+        up: Vector3(0, 1, 0),
+      );
+      expect(_distance(arrays.positions, 0, 1), closeTo(3, 1e-5));
+    });
+  });
+}


### PR DESCRIPTION
This branch adds a dynamic geometry system to flutter_scene for building and updating mesh geometry at runtime, along with a new example that exercises it.

https://github.com/user-attachments/assets/d1d3b0ae-98a4-488f-8c10-38f98df4db08

https://github.com/user-attachments/assets/9553a9b0-d036-45ab-a5f1-46b2f6314832


**Dynamic geometry**

- Runtime mesh construction: build meshes from attribute arrays, or incrementally with `GeometryBuilder`.
- New primitive geometries (plane, sphere, cuboid) and line and point primitive types.
- Updatable mesh storage, so a mesh's vertex data can be mutated in place without rebuilding, backed by a self-refreshing bounds cache.
- Scene paths: polyline, Catmull-Rom, and Bezier curves with arc-length measurement and rotation-minimizing frames.
- Swept geometry builders that sweep a profile along a path: ribbon, tube, and extrude.
- `PolylineGeometry`, a thick camera-facing line with screen-pixel or world-unit width, round caps, dashes (optionally round-capped per dash), a draw-on range, and per-vertex color and width.

**Navigation Route example**

A new example that puts the system to work. The example car drives a long looping road track built from a Catmull-Rom path, with a ribbon road surface, painted edge and center lane lines, a smooth chase camera, a collapsible car controls submenu, scene shadows, and a pulsing route line drawn on the road ahead of the car.

**Also**

- Fixes back-face winding on the plane and ground ribbon.
