### PR TITLE
Cascaded shadow maps for directional lights

### DIFF
--- a/examples/flutter_app/lib/example_logo.dart
+++ b/examples/flutter_app/lib/example_logo.dart
@@ -24,7 +24,6 @@ class ExampleLogoState extends State<ExampleLogo> {
       color: vm.Vector3(1.0, 0.97, 0.9),
       intensity: 3.0,
       castsShadow: true,
-      shadowFrustumSize: 8.0,
     );
 
     // A simple ground plane to catch the logo's shadow.

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
@@ -85,6 +86,12 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
   // frame by the painter; the node and material persist.
   final Node _navNode = Node();
   final UnlitMaterial _navMaterial = UnlitMaterial();
+
+  // The free "inspection" camera, and whether it is active. While
+  // inactive it is kept synced to the chase camera (by the painter), so
+  // toggling it on does not jump the view.
+  bool _freeCamera = false;
+  final _FreeCamState _freeCam = _FreeCamState();
 
   @override
   void initState() {
@@ -240,41 +247,124 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
     }
   }
 
+  // Toggles the free inspection camera. Returning to the chase camera
+  // snaps it back onto the car.
+  void _toggleFreeCamera() {
+    setState(() {
+      _freeCamera = !_freeCamera;
+      _freeCam.heldKeys.clear();
+      _freeCam.lastElapsed = widget.elapsedSeconds;
+      if (!_freeCamera) {
+        _followCam.anchorPosition = null;
+        _followCam.anchorDirection = null;
+      }
+    });
+  }
+
+  // Tracks held keys for the free camera. Movement keys are consumed
+  // while it is active so the platform does not beep at them.
+  KeyEventResult _onFreeCameraKey(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent) {
+      _freeCam.heldKeys.add(event.logicalKey);
+    } else if (event is KeyUpEvent) {
+      _freeCam.heldKeys.remove(event.logicalKey);
+    }
+    return _freeCamera && _freeCamMoveKeys.contains(event.logicalKey)
+        ? KeyEventResult.handled
+        : KeyEventResult.ignored;
+  }
+
+  // Rotates the free camera by a drag.
+  void _onFreeCameraLook(DragUpdateDetails details) {
+    setState(() {
+      _freeCam.yaw += details.delta.dx * 0.005;
+      _freeCam.pitch = (_freeCam.pitch - details.delta.dy * 0.005).clamp(
+        -1.5,
+        1.5,
+      );
+    });
+  }
+
+  // Advances the free camera by the held movement keys, once per frame.
+  void _moveFreeCamera() {
+    final dt = (widget.elapsedSeconds - _freeCam.lastElapsed).clamp(0.0, 0.1);
+    _freeCam.lastElapsed = widget.elapsedSeconds;
+    const speed = 20.0;
+    final keys = _freeCam.heldKeys;
+    final forward = _freeCam.forward;
+    final right = vm.Vector3(0, 1, 0).cross(forward)..normalize();
+    final move = vm.Vector3.zero();
+    if (keys.contains(LogicalKeyboardKey.keyW)) move.add(forward);
+    if (keys.contains(LogicalKeyboardKey.keyS)) move.sub(forward);
+    if (keys.contains(LogicalKeyboardKey.keyD)) move.add(right);
+    if (keys.contains(LogicalKeyboardKey.keyA)) move.sub(right);
+    if (keys.contains(LogicalKeyboardKey.space)) {
+      move.add(vm.Vector3(0, 1, 0));
+    }
+    if (keys.contains(LogicalKeyboardKey.shiftLeft) ||
+        keys.contains(LogicalKeyboardKey.shiftRight)) {
+      move.sub(vm.Vector3(0, 1, 0));
+    }
+    if (move.length2 > 1e-6) {
+      move.normalize();
+      _freeCam.position += move * (speed * dt);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     _applyCarParts();
-    return Stack(
-      children: [
-        SizedBox.expand(
-          child: CustomPaint(
-            painter: _NavRoutePainter(
-              scene: scene,
-              road: mainRoad,
-              markings: markings,
-              carNode: carNode,
-              carScale: carScale,
-              carLift: carLift,
-              followCam: _followCam,
-              navNode: _navNode,
-              navMaterial: _navMaterial,
-              elapsedSeconds: widget.elapsedSeconds,
+    if (_freeCamera) _moveFreeCamera();
+    return Focus(
+      autofocus: true,
+      onKeyEvent: _onFreeCameraKey,
+      child: Stack(
+        children: [
+          // The 3D scene. In free-camera mode a drag rotates the view.
+          Positioned.fill(
+            child: GestureDetector(
+              onPanUpdate: _freeCamera ? _onFreeCameraLook : null,
+              child: CustomPaint(
+                painter: _NavRoutePainter(
+                  scene: scene,
+                  road: mainRoad,
+                  markings: markings,
+                  carNode: carNode,
+                  carScale: carScale,
+                  carLift: carLift,
+                  followCam: _followCam,
+                  freeCamera: _freeCamera,
+                  freeCam: _freeCam,
+                  navNode: _navNode,
+                  navMaterial: _navMaterial,
+                  elapsedSeconds: widget.elapsedSeconds,
+                ),
+              ),
             ),
           ),
-        ),
-        if (_carPartsReady)
+          if (_carPartsReady)
+            Positioned(
+              top: 8,
+              right: 8,
+              child: _CarControlsMenu(
+                open: _controlsOpen,
+                onToggle: () => setState(() => _controlsOpen = !_controlsOpen),
+                parts: _carParts,
+                onControl:
+                    (key, value) =>
+                        setState(() => _carParts[key]!.amount = value),
+              ),
+            ),
           Positioned(
-            top: 8,
-            right: 8,
-            child: _CarControlsMenu(
-              open: _controlsOpen,
-              onToggle: () => setState(() => _controlsOpen = !_controlsOpen),
-              parts: _carParts,
-              onControl:
-                  (key, value) =>
-                      setState(() => _carParts[key]!.amount = value),
+            left: 8,
+            bottom: 8,
+            child: _CameraToggle(
+              freeCamera: _freeCamera,
+              onToggle: _toggleFreeCamera,
             ),
           ),
-      ],
+        ],
+      ),
     );
   }
 }
@@ -323,8 +413,8 @@ MeshGeometry _buildNavLine(
   const samples = 88;
   const startOffset = 1.6; // begins just past the car's front
   const aheadLength = 84.0; // how far ahead the route reaches
-  const lift = 0.58; // floats just above the road
-  const halfWidth = 0.55; // a ~1.1 unit wide ribbon
+  const lift = 0.18; // floats just above the road
+  const halfWidth = 0.35; // a ~1.1 unit wide ribbon
   final up = vm.Vector3(0, 1, 0);
   final deep = vm.Vector3(0.05, 0.18, 0.55);
   final bright = vm.Vector3(0.45, 0.85, 1.5);
@@ -376,6 +466,31 @@ class _FollowCamState {
   double lastElapsed = 0.0;
 }
 
+// The keys the free camera consumes for movement.
+final Set<LogicalKeyboardKey> _freeCamMoveKeys = {
+  LogicalKeyboardKey.keyW,
+  LogicalKeyboardKey.keyA,
+  LogicalKeyboardKey.keyS,
+  LogicalKeyboardKey.keyD,
+  LogicalKeyboardKey.space,
+  LogicalKeyboardKey.shiftLeft,
+  LogicalKeyboardKey.shiftRight,
+};
+
+// Mutable state for the free "inspection" camera: a fly camera driven
+// by held keys and drag-to-look.
+class _FreeCamState {
+  vm.Vector3 position = vm.Vector3(0, 12, 30);
+  double yaw = 0.0;
+  double pitch = 0.0;
+  final Set<LogicalKeyboardKey> heldKeys = {};
+  double lastElapsed = 0.0;
+
+  // The unit look direction from [yaw] (around Y) and [pitch].
+  vm.Vector3 get forward =>
+      vm.Vector3(sin(yaw) * cos(pitch), sin(pitch), cos(yaw) * cos(pitch));
+}
+
 class _NavRoutePainter extends CustomPainter {
   _NavRoutePainter({
     required this.scene,
@@ -385,6 +500,8 @@ class _NavRoutePainter extends CustomPainter {
     required this.carScale,
     required this.carLift,
     required this.followCam,
+    required this.freeCamera,
+    required this.freeCam,
     required this.navNode,
     required this.navMaterial,
     required this.elapsedSeconds,
@@ -397,6 +514,8 @@ class _NavRoutePainter extends CustomPainter {
   final double carScale;
   final double carLift;
   final _FollowCamState followCam;
+  final bool freeCamera;
+  final _FreeCamState freeCam;
   final Node navNode;
   final UnlitMaterial navMaterial;
   final double elapsedSeconds;
@@ -414,7 +533,22 @@ class _NavRoutePainter extends CustomPainter {
     // The car travels against the path tangent.
     final travelDirection = -frame.tangent;
 
-    final camera = _followCamera(carPosition, travelDirection);
+    // The free inspection camera replaces the chase camera when active.
+    // While the chase camera is in use the free camera is kept synced
+    // to it, so toggling the free camera on does not jump the view.
+    final PerspectiveCamera camera;
+    if (freeCamera) {
+      camera = PerspectiveCamera(
+        position: freeCam.position.clone(),
+        target: freeCam.position + freeCam.forward,
+      );
+    } else {
+      camera = _followCamera(carPosition, travelDirection);
+      freeCam.position = camera.position.clone();
+      final look = (camera.target - camera.position)..normalize();
+      freeCam.yaw = atan2(look.x, look.z);
+      freeCam.pitch = asin(look.y.clamp(-1.0, 1.0));
+    }
 
     // The camera-facing marking lines are rebuilt for the current view.
     for (final marking in markings) {
@@ -644,6 +778,63 @@ class _SliderRow extends StatelessWidget {
         ),
         Expanded(
           child: Slider(value: value, min: min, max: max, onChanged: onChanged),
+        ),
+      ],
+    );
+  }
+}
+
+// A toggle for the free "inspection" camera, with a usage hint shown
+// while it is active. Styled to match the Car Controls card.
+class _CameraToggle extends StatelessWidget {
+  const _CameraToggle({required this.freeCamera, required this.onToggle});
+
+  final bool freeCamera;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (freeCamera)
+          Card(
+            color: Colors.black54,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              child: Text(
+                'WASD to move, Space and Shift for up and down, drag to look',
+                style: TextStyle(color: Colors.white.withValues(alpha: 0.85)),
+              ),
+            ),
+          ),
+        Card(
+          color: Colors.black54,
+          child: InkWell(
+            onTap: onToggle,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    freeCamera ? Icons.videocam : Icons.videocam_outlined,
+                    color: Colors.white,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    freeCamera ? 'Free camera' : 'Chase camera',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
         ),
       ],
     );

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -88,12 +88,13 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
 
   @override
   void initState() {
-    // A directional "sun" that lights the scene and casts shadows. Its
-    // shadow frustum is small; the painter recenters it on the car each
-    // frame so the car's shadow on the road stays crisp.
+    // A directional "sun" that lights the scene and casts cascaded
+    // shadows. The shadow distance is kept tight to this scene so the
+    // near cascade stays high-resolution under the car.
     scene.directionalLight = DirectionalLight(
       direction: vm.Vector3(-0.45, -1.0, -0.35),
       castsShadow: true,
+      shadowMaxDistance: 60.0,
     );
 
     // The ground. A lit material, so it receives the car's shadow.
@@ -304,8 +305,8 @@ List<vm.Vector3> _offsetPath(
 
 // Arc length between bright bands in the route line, and how fast (in
 // pattern cycles per second) the bands flow forward along it.
-const double _navWavelength = 7.0;
-const double _navPulseSpeed = 0.8;
+const double _navWavelength = 20.0;
+const double _navPulseSpeed = 0.4;
 
 // Builds the route line: a thick blue ribbon lying flat just above the
 // car's lane, starting just ahead of the car and reaching forward along
@@ -319,10 +320,10 @@ MeshGeometry _buildNavLine(
   double carDistance,
   double elapsedSeconds,
 ) {
-  const samples = 44;
+  const samples = 88;
   const startOffset = 1.6; // begins just past the car's front
-  const aheadLength = 32.0; // how far ahead the route reaches
-  const lift = 0.08; // floats just above the road
+  const aheadLength = 84.0; // how far ahead the route reaches
+  const lift = 0.58; // floats just above the road
   const halfWidth = 0.55; // a ~1.1 unit wide ribbon
   final up = vm.Vector3(0, 1, 0);
   final deep = vm.Vector3(0.05, 0.18, 0.55);
@@ -412,10 +413,6 @@ class _NavRoutePainter extends CustomPainter {
         frame.position + _lateral(frame.tangent) * (_roadWidth / 4);
     // The car travels against the path tangent.
     final travelDirection = -frame.tangent;
-
-    // Keep the shadow frustum centered on the car so its shadow on the
-    // road stays inside the (small, crisp) shadow map.
-    scene.directionalLight?.shadowFocusPoint = carPosition;
 
     final camera = _followCamera(carPosition, travelDirection);
 

--- a/examples/flutter_app/lib/example_stress_tests.dart
+++ b/examples/flutter_app/lib/example_stress_tests.dart
@@ -329,7 +329,6 @@ class _StressSceneState extends State<_StressScene> {
       color: vm.Vector3(1.0, 0.97, 0.9),
       intensity: 2.5,
       castsShadow: true,
-      shadowFrustumSize: 8.0,
     );
     unawaited(_load());
   }

--- a/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
+++ b/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
@@ -10,7 +10,6 @@ import 'package:flutter_scene_importer/constants.dart';
 /// 12 floats (48 bytes) per vertex, ordered position (3), normal (3),
 /// texture coordinates (2), color (4).
 ///
-/// This is the translation layer described in `docs/dynamic_geometry.md`.
 /// The geometry construction API accepts attributes as independent typed
 /// arrays; this adapter packs them into the single interleaved buffer the
 /// built-in pipelines consume. It is intentionally the one place that

--- a/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
@@ -70,7 +70,7 @@ const int _diskSegments = 16;
 /// direction, which stays smooth on a finely sampled curve but can
 /// pinch on a very sharp turn. Rounded corner joins and a GPU
 /// vertex-shader expansion that avoids the per-frame rebuild are
-/// planned follow-ups; see `docs/dynamic_geometry.md`.
+/// planned follow-ups.
 class PolylineGeometry extends MeshGeometry {
   /// Creates a polyline through [points] (at least two).
   ///

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -16,7 +16,9 @@ import 'package:flutter_scene/src/material/environment.dart';
 /// fixed orthographic frustum: a [shadowFrustumSize] × [shadowFrustumSize]
 /// square, [shadowFrustumDepth] deep, centered on [shadowFocusPoint].
 /// Geometry outside that box is unshadowed, so size the box (and move the
-/// focus point) to cover the part of the scene you care about.
+/// focus point) to cover the part of the scene you care about. Shadowing
+/// fades back to lit over the box's outer [shadowFadeRange] world units,
+/// so its edge is soft rather than a hard cutoff.
 class DirectionalLight {
   /// Creates a [DirectionalLight].
   ///
@@ -31,6 +33,8 @@ class DirectionalLight {
     Vector3? shadowFocusPoint,
     this.shadowFrustumSize = 12.0,
     this.shadowFrustumDepth = 50.0,
+    this.shadowFadeRange = 2.0,
+    this.shadowSoftness = 0.3,
     this.shadowMapResolution = 1024,
     this.shadowDepthBias = 0.0015,
     this.shadowNormalBias = 0.02,
@@ -61,6 +65,17 @@ class DirectionalLight {
   /// Depth (near-to-far extent) of the orthographic shadow frustum, in
   /// world units, centered on [shadowFocusPoint] along the light axis.
   double shadowFrustumDepth;
+
+  /// World-space width of the band at the shadow frustum's edge over
+  /// which shadowing fades back to lit, softening the otherwise hard
+  /// box edge. Clamped to half [shadowFrustumSize]; `0` disables the
+  /// fade.
+  double shadowFadeRange;
+
+  /// World-space radius of the shadow penumbra. Larger values give a
+  /// softer shadow edge; `0` gives a hard edge. Sampled by a rotated
+  /// Poisson-disk PCF kernel.
+  double shadowSoftness;
 
   /// Pixel resolution of the (square) shadow map.
   int shadowMapResolution;
@@ -112,7 +127,19 @@ class DirectionalLight {
       -near / (far - near),
       1.0, //
     );
-    return ortho * view;
+    final matrix = ortho * view;
+
+    // Texel snapping: shift the projection by a sub-texel amount so a
+    // fixed world reference (the origin) always lands on a texel center.
+    // Without this the shadow map's texel grid slides under the scene as
+    // the focus point moves, and shadow edges shimmer.
+    final reference = matrix.transformed(Vector4(0.0, 0.0, 0.0, 1.0));
+    final resolution = shadowMapResolution.toDouble();
+    final texelX = (reference.x * 0.5 + 0.5) * resolution;
+    final texelY = (reference.y * 0.5 + 0.5) * resolution;
+    final offsetX = (texelX.roundToDouble() - texelX) / resolution * 2.0;
+    final offsetY = (texelY.roundToDouble() - texelY) / resolution * 2.0;
+    return Matrix4.translation(Vector3(offsetX, offsetY, 0.0)) * matrix;
   }
 
   static Matrix4 _lookAt(Vector3 position, Vector3 target, Vector3 up) {

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -1,6 +1,9 @@
+import 'dart:math' as math;
+
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 
+import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 
 /// An infinitely-distant light source (e.g. the sun) that illuminates
@@ -35,6 +38,9 @@ class DirectionalLight {
     this.shadowFrustumDepth = 50.0,
     this.shadowFadeRange = 2.0,
     this.shadowSoftness = 0.3,
+    this.shadowCascadeCount = 4,
+    this.shadowMaxDistance = 150.0,
+    this.shadowCascadeSplitLambda = 0.6,
     this.shadowMapResolution = 1024,
     this.shadowDepthBias = 0.0015,
     this.shadowNormalBias = 0.02,
@@ -77,7 +83,22 @@ class DirectionalLight {
   /// Poisson-disk PCF kernel.
   double shadowSoftness;
 
-  /// Pixel resolution of the (square) shadow map.
+  /// Number of shadow cascades, clamped to 1 through 4. More cascades
+  /// keep shadows crisp over a longer view distance, each at the cost
+  /// of one more depth pass. Used by [computeCascades].
+  int shadowCascadeCount;
+
+  /// View distance, in world units, out to which [computeCascades]
+  /// spreads the shadow cascades. Beyond it surfaces are unshadowed.
+  double shadowMaxDistance;
+
+  /// Blends the cascade split spacing between logarithmic (`1.0`) and
+  /// uniform (`0.0`). Higher values give the near cascades
+  /// proportionally more resolution. Used by [computeCascades].
+  double shadowCascadeSplitLambda;
+
+  /// Pixel resolution of the (square) shadow map. With cascades this is
+  /// the resolution of each cascade's tile.
   int shadowMapResolution;
 
   /// Constant depth bias subtracted from the receiver's light-space depth
@@ -142,6 +163,137 @@ class DirectionalLight {
     return Matrix4.translation(Vector3(offsetX, offsetY, 0.0)) * matrix;
   }
 
+  /// Builds the [shadowCascadeCount] shadow cascades that cover
+  /// [camera]'s view out to [shadowMaxDistance], for a render target of
+  /// the given [aspectRatio]. Returned near-to-far.
+  ///
+  /// Each cascade fits a bounding sphere to its slice of the camera
+  /// frustum, so the cascade's projection size stays constant as the
+  /// camera rotates; the projection is then texel-snapped so shadow
+  /// edges do not shimmer.
+  List<ShadowCascade> computeCascades(
+    PerspectiveCamera camera,
+    double aspectRatio,
+  ) {
+    final count = shadowCascadeCount.clamp(1, 4);
+    final near = camera.fovNear;
+    final far = shadowMaxDistance;
+
+    // Practical split scheme: a blend of logarithmic and uniform
+    // spacing, so the near cascades get proportionally more resolution.
+    final splits = <double>[near];
+    for (var i = 1; i <= count; i++) {
+      final ratio = i / count;
+      final logSplit = near * math.pow(far / near, ratio);
+      final uniformSplit = near + (far - near) * ratio;
+      splits.add(
+        shadowCascadeSplitLambda * logSplit +
+            (1.0 - shadowCascadeSplitLambda) * uniformSplit,
+      );
+    }
+
+    // Camera basis and field-of-view tangents.
+    final forward = (camera.target - camera.position).normalized();
+    final right = camera.up.cross(forward).normalized();
+    final up = forward.cross(right).normalized();
+    final tanV = math.tan(camera.fovRadiansY * 0.5);
+    final tanH = tanV * aspectRatio;
+
+    final lightLength = direction.length;
+    final lightDir =
+        lightLength == 0.0
+            ? Vector3(0.0, -1.0, 0.0)
+            : direction * (1.0 / lightLength);
+
+    final cascades = <ShadowCascade>[];
+    for (var c = 0; c < count; c++) {
+      // The eight world-space corners of this cascade's frustum slice.
+      final corners = <Vector3>[];
+      final center = Vector3.zero();
+      for (final depth in [splits[c], splits[c + 1]]) {
+        final planeCenter = camera.position + forward * depth;
+        for (final sx in const [-1.0, 1.0]) {
+          for (final sy in const [-1.0, 1.0]) {
+            final corner =
+                planeCenter +
+                right * (sx * depth * tanH) +
+                up * (sy * depth * tanV);
+            corners.add(corner);
+            center.add(corner);
+          }
+        }
+      }
+      // The slice is symmetric about the view axis, so the corner
+      // average is the center of their bounding sphere.
+      center.scale(1.0 / 8.0);
+      var radius = 0.0;
+      for (final corner in corners) {
+        radius = math.max(radius, (corner - center).length);
+      }
+
+      cascades.add(
+        ShadowCascade(
+          lightSpaceMatrix: _cascadeLightSpaceMatrix(lightDir, center, radius),
+          splitDistance: splits[c + 1],
+        ),
+      );
+    }
+    return cascades;
+  }
+
+  // The world -> light-clip matrix for a cascade whose frustum slice is
+  // bounded by a sphere ([sphereCenter], [sphereRadius]). The
+  // orthographic box is the sphere's bounding square, extended along
+  // the light axis so casters behind the slice still reach it, and
+  // texel-snapped against the world origin.
+  Matrix4 _cascadeLightSpaceMatrix(
+    Vector3 lightDir,
+    Vector3 sphereCenter,
+    double sphereRadius,
+  ) {
+    final up =
+        lightDir.y.abs() > 0.99
+            ? Vector3(0.0, 0.0, 1.0)
+            : Vector3(0.0, 1.0, 0.0);
+    // The eye sits well behind the sphere so casters between it and the
+    // slice are captured.
+    final eye = sphereCenter - lightDir * (sphereRadius * 3.0);
+    final view = _lookAt(eye, sphereCenter, up);
+
+    const near = 0.0;
+    final far = sphereRadius * 6.0;
+    final s = sphereRadius * 2.0;
+    final ortho = Matrix4(
+      2.0 / s,
+      0.0,
+      0.0,
+      0.0, //
+      0.0,
+      2.0 / s,
+      0.0,
+      0.0, //
+      0.0,
+      0.0,
+      1.0 / (far - near),
+      0.0, //
+      0.0,
+      0.0,
+      -near / (far - near),
+      1.0, //
+    );
+    final matrix = ortho * view;
+
+    // Texel-snap against the world origin so the cascade's texel grid
+    // is stable as the camera (and so the cascade) moves.
+    final reference = matrix.transformed(Vector4(0.0, 0.0, 0.0, 1.0));
+    final resolution = shadowMapResolution.toDouble();
+    final texelX = (reference.x * 0.5 + 0.5) * resolution;
+    final texelY = (reference.y * 0.5 + 0.5) * resolution;
+    final offsetX = (texelX.roundToDouble() - texelX) / resolution * 2.0;
+    final offsetY = (texelY.roundToDouble() - texelY) / resolution * 2.0;
+    return Matrix4.translation(Vector3(offsetX, offsetY, 0.0)) * matrix;
+  }
+
   static Matrix4 _lookAt(Vector3 position, Vector3 target, Vector3 up) {
     final forward = (target - position).normalized();
     final right = up.cross(forward).normalized();
@@ -165,6 +317,26 @@ class DirectionalLight {
       1.0, //
     );
   }
+}
+
+/// One cascade of a cascaded shadow map, produced by
+/// [DirectionalLight.computeCascades].
+///
+/// A cascade owns the world -> light-clip-space matrix that renders and
+/// samples its shadow map tile, plus the camera view distance at which
+/// its coverage ends.
+class ShadowCascade {
+  /// Creates a cascade from its [lightSpaceMatrix] and [splitDistance].
+  ShadowCascade({required this.lightSpaceMatrix, required this.splitDistance});
+
+  /// World -> light-clip-space matrix that renders and samples this
+  /// cascade's shadow map tile.
+  final Matrix4 lightSpaceMatrix;
+
+  /// Camera view-space distance, in world units, at which this
+  /// cascade's coverage ends. A fragment uses the first cascade whose
+  /// [splitDistance] exceeds its view depth.
+  final double splitDistance;
 }
 
 /// The lighting state handed to a [Material] when it binds for a draw.

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -14,14 +14,14 @@ import 'package:flutter_scene/src/material/environment.dart';
 /// analytic contribution is layered on top of the IBL ambient term. The
 /// shader normalizes [direction], so it need not be unit length.
 ///
-/// When [castsShadow] is true the renderer adds a depth-only shadow pass
-/// from the light's point of view, sampled with PCF. The shadow uses a
-/// fixed orthographic frustum: a [shadowFrustumSize] × [shadowFrustumSize]
-/// square, [shadowFrustumDepth] deep, centered on [shadowFocusPoint].
-/// Geometry outside that box is unshadowed, so size the box (and move the
-/// focus point) to cover the part of the scene you care about. Shadowing
-/// fades back to lit over the box's outer [shadowFadeRange] world units,
-/// so its edge is soft rather than a hard cutoff.
+/// When [castsShadow] is true the renderer adds a depth-only shadow
+/// pass. Shadows are cascaded: the camera view is split into
+/// [shadowCascadeCount] depth ranges out to [shadowMaxDistance], each
+/// fit with its own shadow map so near geometry stays crisp over a long
+/// view distance. The penumbra is a soft Poisson-disk PCF kernel of
+/// radius [shadowSoftness], and shadowing fades back to lit at the far
+/// edge over [shadowFadeRange]. Cascaded shadows require the scene to
+/// render with a [PerspectiveCamera].
 class DirectionalLight {
   /// Creates a [DirectionalLight].
   ///
@@ -33,20 +33,16 @@ class DirectionalLight {
     Vector3? color,
     this.intensity = 3.0,
     this.castsShadow = false,
-    Vector3? shadowFocusPoint,
-    this.shadowFrustumSize = 12.0,
-    this.shadowFrustumDepth = 50.0,
     this.shadowFadeRange = 2.0,
-    this.shadowSoftness = 0.3,
+    this.shadowSoftness = 0.08,
     this.shadowCascadeCount = 4,
     this.shadowMaxDistance = 150.0,
     this.shadowCascadeSplitLambda = 0.6,
     this.shadowMapResolution = 1024,
-    this.shadowDepthBias = 0.0015,
+    this.shadowDepthBias = 0.02,
     this.shadowNormalBias = 0.02,
   }) : direction = direction ?? Vector3(-0.3, -1.0, -0.2),
-       color = color ?? Vector3(1.0, 1.0, 1.0),
-       shadowFocusPoint = shadowFocusPoint ?? Vector3.zero();
+       color = color ?? Vector3(1.0, 1.0, 1.0);
 
   /// The direction the light travels, in world space (from the light
   /// toward the scene). Need not be unit length.
@@ -61,21 +57,9 @@ class DirectionalLight {
   /// Whether this light casts shadows (adds a shadow-map pass).
   bool castsShadow;
 
-  /// World-space point the orthographic shadow frustum is centered on.
-  Vector3 shadowFocusPoint;
-
-  /// Side length of the (square) orthographic shadow frustum, in world
-  /// units. Larger covers more scene at lower effective resolution.
-  double shadowFrustumSize;
-
-  /// Depth (near-to-far extent) of the orthographic shadow frustum, in
-  /// world units, centered on [shadowFocusPoint] along the light axis.
-  double shadowFrustumDepth;
-
-  /// World-space width of the band at the shadow frustum's edge over
-  /// which shadowing fades back to lit, softening the otherwise hard
-  /// box edge. Clamped to half [shadowFrustumSize]; `0` disables the
-  /// fade.
+  /// World-space width of the band at the far shadow cascade's edge
+  /// over which shadowing fades back to lit, so the shadow distance
+  /// limit is soft rather than a hard cutoff. `0` disables the fade.
   double shadowFadeRange;
 
   /// World-space radius of the shadow penumbra. Larger values give a
@@ -101,8 +85,10 @@ class DirectionalLight {
   /// the resolution of each cascade's tile.
   int shadowMapResolution;
 
-  /// Constant depth bias subtracted from the receiver's light-space depth
-  /// before the shadow test, to combat self-shadow acne.
+  /// World-space depth bias subtracted from the receiver before the
+  /// shadow test. Converted into each cascade's clip-space depth range,
+  /// so a caster's shadow appears at the same world-height threshold in
+  /// every cascade rather than fading out in the coarser far ones.
   double shadowDepthBias;
 
   /// World-space offset along the surface normal applied to the receiver
@@ -110,58 +96,6 @@ class DirectionalLight {
   /// no slope-scaled depth-bias rasterizer state, so this carries the
   /// load of acne removal on grazing surfaces.
   double shadowNormalBias;
-
-  /// Builds the world → light-clip-space matrix used to render and sample
-  /// the shadow map. Uses the same column-vector / `[0, 1]` depth
-  /// conventions as [PerspectiveCamera.getViewTransform].
-  Matrix4 computeLightSpaceMatrix() {
-    final length = direction.length;
-    final dir =
-        length == 0.0 ? Vector3(0.0, -1.0, 0.0) : Vector3.copy(direction)
-          ..scale(1.0 / length);
-    final up =
-        dir.y.abs() > 0.99 ? Vector3(0.0, 0.0, 1.0) : Vector3(0.0, 1.0, 0.0);
-
-    const near = 0.01;
-    final far = shadowFrustumDepth;
-    final eye = shadowFocusPoint - dir * (far * 0.5);
-    final view = _lookAt(eye, shadowFocusPoint, up);
-
-    final s = shadowFrustumSize;
-    // Symmetric orthographic projection, column-major, mapping z in
-    // [near, far] to [0, 1] (matching the perspective projection).
-    final ortho = Matrix4(
-      2.0 / s,
-      0.0,
-      0.0,
-      0.0, //
-      0.0,
-      2.0 / s,
-      0.0,
-      0.0, //
-      0.0,
-      0.0,
-      1.0 / (far - near),
-      0.0, //
-      0.0,
-      0.0,
-      -near / (far - near),
-      1.0, //
-    );
-    final matrix = ortho * view;
-
-    // Texel snapping: shift the projection by a sub-texel amount so a
-    // fixed world reference (the origin) always lands on a texel center.
-    // Without this the shadow map's texel grid slides under the scene as
-    // the focus point moves, and shadow edges shimmer.
-    final reference = matrix.transformed(Vector4(0.0, 0.0, 0.0, 1.0));
-    final resolution = shadowMapResolution.toDouble();
-    final texelX = (reference.x * 0.5 + 0.5) * resolution;
-    final texelY = (reference.y * 0.5 + 0.5) * resolution;
-    final offsetX = (texelX.roundToDouble() - texelX) / resolution * 2.0;
-    final offsetY = (texelY.roundToDouble() - texelY) / resolution * 2.0;
-    return Matrix4.translation(Vector3(offsetX, offsetY, 0.0)) * matrix;
-  }
 
   /// Builds the [shadowCascadeCount] shadow cascades that cover
   /// [camera]'s view out to [shadowMaxDistance], for a render target of
@@ -235,6 +169,7 @@ class DirectionalLight {
         ShadowCascade(
           lightSpaceMatrix: _cascadeLightSpaceMatrix(lightDir, center, radius),
           splitDistance: splits[c + 1],
+          boxSize: radius * 2.0,
         ),
       );
     }
@@ -326,17 +261,26 @@ class DirectionalLight {
 /// samples its shadow map tile, plus the camera view distance at which
 /// its coverage ends.
 class ShadowCascade {
-  /// Creates a cascade from its [lightSpaceMatrix] and [splitDistance].
-  ShadowCascade({required this.lightSpaceMatrix, required this.splitDistance});
+  /// Creates a cascade from its [lightSpaceMatrix], [splitDistance], and
+  /// [boxSize].
+  ShadowCascade({
+    required this.lightSpaceMatrix,
+    required this.splitDistance,
+    required this.boxSize,
+  });
 
   /// World -> light-clip-space matrix that renders and samples this
   /// cascade's shadow map tile.
   final Matrix4 lightSpaceMatrix;
 
   /// Camera view-space distance, in world units, at which this
-  /// cascade's coverage ends. A fragment uses the first cascade whose
-  /// [splitDistance] exceeds its view depth.
+  /// cascade's coverage ends.
   final double splitDistance;
+
+  /// World-space side length of this cascade's orthographic box, used
+  /// to convert world-space softness and fade widths into the
+  /// cascade's UV space.
+  final double boxSize;
 }
 
 /// The lighting state handed to a [Material] when it binds for a draw.
@@ -350,7 +294,7 @@ class Lighting {
     this.environmentIntensity = 1.0,
     this.directionalLight,
     this.shadowMap,
-    this.lightSpaceMatrix,
+    this.cascades = const [],
   });
 
   /// The image-based-lighting environment in effect for this draw.
@@ -363,12 +307,12 @@ class Lighting {
   /// The scene's directional light, or null when there isn't one.
   final DirectionalLight? directionalLight;
 
-  /// The shadow map (a depth-in-`.r` texture) for [directionalLight], or
-  /// null when shadows are off for this frame. Sampled with
-  /// [lightSpaceMatrix].
+  /// The cascaded shadow map atlas (a depth-in-`.r` texture holding the
+  /// cascade tiles as a horizontal strip) for [directionalLight], or
+  /// null when shadows are off for this frame. Sampled with [cascades].
   final gpu.Texture? shadowMap;
 
-  /// World → light-clip-space matrix matching [shadowMap], or null when
-  /// there is no shadow map this frame.
-  final Matrix4? lightSpaceMatrix;
+  /// The shadow cascades matching [shadowMap], near-to-far, or empty
+  /// when there is no shadow map this frame.
+  final List<ShadowCascade> cascades;
 }

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -220,7 +220,7 @@ class PhysicallyBasedMaterial extends Material {
     final shadowMatrix =
         lighting.shadowMap == null ? null : lighting.lightSpaceMatrix;
 
-    // FragInfo std140 layout (336 bytes / 84 floats; the trailing run of
+    // FragInfo std140 layout (352 bytes / 88 floats; the trailing run of
     // scalars pads the block up to a 16-byte multiple):
     //   [0..3]   vec4  color
     //   [4..7]   vec4  emissive_factor
@@ -243,8 +243,10 @@ class PhysicallyBasedMaterial extends Material {
     //   [80]     float render_target_flip_y
     //   [81]     float alpha_mode (0 opaque, 1 mask, 2 blend)
     //   [82]     float alpha_cutoff
-    //   [83]     padding to a 16-byte multiple
-    final fragInfo = Float32List(84);
+    //   [83]     float shadow_fade (UV-space border fade half-width)
+    //   [84]     float shadow_softness (UV-space penumbra radius)
+    //   [85..87] padding to a 16-byte multiple
+    final fragInfo = Float32List(88);
     fragInfo[0] = baseColorFactor.r;
     fragInfo[1] = baseColorFactor.g;
     fragInfo[2] = baseColorFactor.b;
@@ -289,6 +291,18 @@ class PhysicallyBasedMaterial extends Material {
     fragInfo[80] = gpu.gpuContext.doesSupportOffscreenMSAA ? 1.0 : 0.0;
     fragInfo[81] = alphaMode.index.toDouble();
     fragInfo[82] = alphaCutoff;
+    // UV-space half-width of the shadow map's soft border, from the
+    // light's world-space fade range. Zero when there is no shadow.
+    fragInfo[83] =
+        light == null || shadowMatrix == null
+            ? 0.0
+            : (light.shadowFadeRange / light.shadowFrustumSize).clamp(0.0, 0.5);
+    // UV-space radius of the soft-shadow (PCF) kernel, from the light's
+    // world-space penumbra radius.
+    fragInfo[84] =
+        light == null || shadowMatrix == null
+            ? 0.0
+            : (light.shadowSoftness / light.shadowFrustumSize).clamp(0.0, 0.04);
     pass.bindUniform(
       fragmentShader.getUniformSlot("FragInfo"),
       transientsBuffer.emplace(ByteData.sublistView(fragInfo)),

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -370,15 +370,20 @@ class PhysicallyBasedMaterial extends Material {
         heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
       ),
     );
-    // Nearest + clamp (the SamplerOptions defaults): the shader does a
-    // manual PCF comparison, so we don't want linear-filtered depths, and
-    // out-of-bounds PCF taps should clamp rather than wrap. When there's
-    // no shadow this frame, the white placeholder reads as depth 1.0
-    // (always lit) and casts_shadow is 0 anyway.
+    // Bilinear + clamp. Linear filtering interpolates the stored depth
+    // between texels, so a flat receiver compares against the smooth
+    // surface rather than a coarse cascade's blocky per-texel depth,
+    // which removes the patchy self-shadow on distant ground. Clamp (not
+    // wrap) keeps out-of-bounds PCF taps from reading another cascade's
+    // tile. When there's no shadow this frame the white placeholder
+    // reads as depth 1.0 (always lit) and casts_shadow is 0 anyway.
     pass.bindTexture(
       fragmentShader.getUniformSlot('shadow_map'),
       Material.whitePlaceholder(lighting.shadowMap),
-      sampler: gpu.SamplerOptions(),
+      sampler: gpu.SamplerOptions(
+        minFilter: gpu.MinMagFilter.linear,
+        magFilter: gpu.MinMagFilter.linear,
+      ),
     );
   }
 

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -217,36 +217,39 @@ class PhysicallyBasedMaterial extends Material {
 
     final EnvironmentMap env = environment ?? lighting.environmentMap;
     final DirectionalLight? light = lighting.directionalLight;
-    final shadowMatrix =
-        lighting.shadowMap == null ? null : lighting.lightSpaceMatrix;
+    final cascades =
+        lighting.shadowMap == null
+            ? const <ShadowCascade>[]
+            : lighting.cascades;
 
-    // FragInfo std140 layout (352 bytes / 88 floats; the trailing run of
-    // scalars pads the block up to a 16-byte multiple):
-    //   [0..3]   vec4  color
-    //   [4..7]   vec4  emissive_factor
-    //   [8..43]  vec4  diffuse_sh0..8 (xyz used, w padding)
-    //   [44..47] vec4  directional_light_direction (xyz used)
-    //   [48..51] vec4  directional_light_color (rgb = color * intensity)
-    //   [52..67] mat4  light_space_matrix (column-major)
-    //   [68]     float vertex_color_weight
-    //   [69]     float metallic_factor
-    //   [70]     float roughness_factor
-    //   [71]     float has_normal_map
-    //   [72]     float normal_scale
-    //   [73]     float occlusion_strength
-    //   [74]     float environment_intensity
-    //   [75]     float has_directional_light
-    //   [76]     float casts_shadow
-    //   [77]     float shadow_bias
-    //   [78]     float shadow_normal_bias
-    //   [79]     float shadow_texel_size
-    //   [80]     float render_target_flip_y
-    //   [81]     float alpha_mode (0 opaque, 1 mask, 2 blend)
-    //   [82]     float alpha_cutoff
-    //   [83]     float shadow_fade (UV-space border fade half-width)
-    //   [84]     float shadow_softness (UV-space penumbra radius)
-    //   [85..87] padding to a 16-byte multiple
-    final fragInfo = Float32List(88);
+    // FragInfo std140 layout (560 bytes / 140 floats):
+    //   [0..3]    vec4  color
+    //   [4..7]    vec4  emissive_factor
+    //   [8..43]   vec4  diffuse_sh0..8 (xyz used, w padding)
+    //   [44..47]  vec4  directional_light_direction (xyz used)
+    //   [48..51]  vec4  directional_light_color (rgb = color * intensity)
+    //   [52..115] mat4  light_space_matrix[4] (shadow cascades)
+    //   [116..119] vec4 cascade_box_sizes (world-space box size each)
+    //   [120]     float vertex_color_weight
+    //   [121]     float metallic_factor
+    //   [122]     float roughness_factor
+    //   [123]     float has_normal_map
+    //   [124]     float normal_scale
+    //   [125]     float occlusion_strength
+    //   [126]     float environment_intensity
+    //   [127]     float has_directional_light
+    //   [128]     float casts_shadow
+    //   [129]     float shadow_bias
+    //   [130]     float shadow_normal_bias
+    //   [131]     float shadow_texel_size (1 / cascade tile resolution)
+    //   [132]     float render_target_flip_y
+    //   [133]     float alpha_mode (0 opaque, 1 mask, 2 blend)
+    //   [134]     float alpha_cutoff
+    //   [135]     float shadow_fade (world-space far-edge fade width)
+    //   [136]     float shadow_softness (world-space penumbra radius)
+    //   [137]     float shadow_cascade_count
+    //   [138..139] padding to a 16-byte multiple
+    final fragInfo = Float32List(140);
     fragInfo[0] = baseColorFactor.r;
     fragInfo[1] = baseColorFactor.g;
     fragInfo[2] = baseColorFactor.b;
@@ -269,40 +272,36 @@ class PhysicallyBasedMaterial extends Material {
       fragInfo[49] = light.color.y * light.intensity;
       fragInfo[50] = light.color.z * light.intensity;
     }
-    if (shadowMatrix != null) {
-      fragInfo.setRange(52, 68, shadowMatrix.storage);
+    for (var i = 0; i < cascades.length; i++) {
+      fragInfo.setRange(
+        52 + i * 16,
+        68 + i * 16,
+        cascades[i].lightSpaceMatrix.storage,
+      );
+      fragInfo[116 + i] = cascades[i].boxSize;
     }
-    fragInfo[68] = vertexColorWeight;
-    fragInfo[69] = metallicFactor;
-    fragInfo[70] = roughnessFactor;
-    fragInfo[71] = normalTexture != null ? 1.0 : 0.0;
-    fragInfo[72] = normalScale;
-    fragInfo[73] = occlusionStrength;
-    fragInfo[74] = lighting.environmentIntensity;
-    fragInfo[75] = light != null ? 1.0 : 0.0;
-    fragInfo[76] = shadowMatrix != null ? 1.0 : 0.0;
-    fragInfo[77] = light?.shadowDepthBias ?? 0.0;
-    fragInfo[78] = light?.shadowNormalBias ?? 0.0;
-    fragInfo[79] = light == null ? 0.0 : 1.0 / light.shadowMapResolution;
+    fragInfo[120] = vertexColorWeight;
+    fragInfo[121] = metallicFactor;
+    fragInfo[122] = roughnessFactor;
+    fragInfo[123] = normalTexture != null ? 1.0 : 0.0;
+    fragInfo[124] = normalScale;
+    fragInfo[125] = occlusionStrength;
+    fragInfo[126] = lighting.environmentIntensity;
+    fragInfo[127] = light != null ? 1.0 : 0.0;
+    fragInfo[128] = cascades.isEmpty ? 0.0 : 1.0;
+    fragInfo[129] = light?.shadowDepthBias ?? 0.0;
+    fragInfo[130] = light?.shadowNormalBias ?? 0.0;
+    fragInfo[131] = light == null ? 0.0 : 1.0 / light.shadowMapResolution;
     // Render-to-texture targets (the shadow map, the prefiltered-radiance
     // atlas) sample top-down on Metal/Vulkan and bottom-up on OpenGL ES.
     // Flutter GPU has no backend query; offscreen-MSAA support is a proxy
     // (true on Metal/Vulkan, false on OpenGL ES).
-    fragInfo[80] = gpu.gpuContext.doesSupportOffscreenMSAA ? 1.0 : 0.0;
-    fragInfo[81] = alphaMode.index.toDouble();
-    fragInfo[82] = alphaCutoff;
-    // UV-space half-width of the shadow map's soft border, from the
-    // light's world-space fade range. Zero when there is no shadow.
-    fragInfo[83] =
-        light == null || shadowMatrix == null
-            ? 0.0
-            : (light.shadowFadeRange / light.shadowFrustumSize).clamp(0.0, 0.5);
-    // UV-space radius of the soft-shadow (PCF) kernel, from the light's
-    // world-space penumbra radius.
-    fragInfo[84] =
-        light == null || shadowMatrix == null
-            ? 0.0
-            : (light.shadowSoftness / light.shadowFrustumSize).clamp(0.0, 0.04);
+    fragInfo[132] = gpu.gpuContext.doesSupportOffscreenMSAA ? 1.0 : 0.0;
+    fragInfo[133] = alphaMode.index.toDouble();
+    fragInfo[134] = alphaCutoff;
+    fragInfo[135] = light?.shadowFadeRange ?? 0.0;
+    fragInfo[136] = light?.shadowSoftness ?? 0.0;
+    fragInfo[137] = cascades.length.toDouble();
     pass.bindUniform(
       fragmentShader.getUniformSlot("FragInfo"),
       transientsBuffer.emplace(ByteData.sublistView(fragInfo)),

--- a/packages/flutter_scene/lib/src/render/render_graph.dart
+++ b/packages/flutter_scene/lib/src/render/render_graph.dart
@@ -226,7 +226,7 @@ abstract class RenderGraphPass {
 /// [TransientTexturePool], and passes communicate through a per-frame
 /// [Blackboard]. It does not insert GPU barriers (Flutter GPU handles
 /// synchronization internally), alias transient memory, or cull unused
-/// passes. See `docs/renderer-roadmap.md`.
+/// passes.
 class RenderGraph {
   final List<RenderGraphPass> _passes = [];
   final Blackboard _blackboard = Blackboard();

--- a/packages/flutter_scene/lib/src/render/scene_pass.dart
+++ b/packages/flutter_scene/lib/src/render/scene_pass.dart
@@ -1,7 +1,6 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter_gpu/gpu.dart' as gpu;
-import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/light.dart';
@@ -29,7 +28,7 @@ class ScenePass extends RenderGraphPass {
     required double environmentIntensity,
     required bool enableMsaa,
     DirectionalLight? directionalLight,
-    Matrix4? lightSpaceMatrix,
+    List<ShadowCascade> cascades = const [],
   }) : _camera = camera,
        _renderScene = renderScene,
        _dimensions = dimensions,
@@ -37,7 +36,7 @@ class ScenePass extends RenderGraphPass {
        _environmentIntensity = environmentIntensity,
        _enableMsaa = enableMsaa,
        _directionalLight = directionalLight,
-       _lightSpaceMatrix = lightSpaceMatrix;
+       _cascades = cascades;
 
   final Camera _camera;
   final RenderScene _renderScene;
@@ -46,7 +45,7 @@ class ScenePass extends RenderGraphPass {
   final double _environmentIntensity;
   final bool _enableMsaa;
   final DirectionalLight? _directionalLight;
-  final Matrix4? _lightSpaceMatrix;
+  final List<ShadowCascade> _cascades;
 
   static const gpu.PixelFormat _hdrFormat = gpu.PixelFormat.r16g16b16a16Float;
 
@@ -108,7 +107,7 @@ class ScenePass extends RenderGraphPass {
       environmentIntensity: _environmentIntensity,
       directionalLight: _directionalLight,
       shadowMap: shadowMap,
-      lightSpaceMatrix: shadowMap == null ? null : _lightSpaceMatrix,
+      cascades: shadowMap == null ? const [] : _cascades,
     );
 
     final commandBuffer = gpu.gpuContext.createCommandBuffer();

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -4,6 +4,14 @@ import 'package:vector_math/vector_math.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/shaders.dart';
 
+/// Process-lifetime cache of depth-pass render pipelines, keyed by vertex
+/// shader. The depth fragment shader is constant, so only the (skinned /
+/// unskinned) vertex shader varies; the engine loads each shader once, so
+/// the depth pass only ever needs two pipelines. Caching them keeps the
+/// shadow pass from rebuilding a pipeline for every caster, every cascade,
+/// every frame.
+final Map<gpu.Shader, gpu.RenderPipeline> _depthPipelineCache = {};
+
 /// Records each opaque shadow caster's depth into a shadow-map render
 /// pass, from a directional light's point of view.
 ///
@@ -43,6 +51,11 @@ class ShadowEncoder {
   /// Reusable AABB for the per-item cull check.
   final Aabb3 cullScratchAabb = Aabb3();
 
+  /// The pipeline currently bound on the render pass, or null before the
+  /// first draw. `clearBindings` leaves the pipeline in place, so
+  /// consecutive casters that share one only bind it once.
+  gpu.RenderPipeline? _boundPipeline;
+
   /// Records [item]'s depth, unless it is hidden, translucent (no shadow),
   /// or culled by the light frustum.
   void submit(RenderItem item) {
@@ -58,11 +71,13 @@ class ShadowEncoder {
       }
     }
     _renderPass.clearBindings();
-    final pipeline = gpu.gpuContext.createRenderPipeline(
-      item.geometry.vertexShader,
-      _depthShader,
-    );
-    _renderPass.bindPipeline(pipeline);
+    final pipeline =
+        _depthPipelineCache[item.geometry.vertexShader] ??= gpu.gpuContext
+            .createRenderPipeline(item.geometry.vertexShader, _depthShader);
+    if (!identical(_boundPipeline, pipeline)) {
+      _renderPass.bindPipeline(pipeline);
+      _boundPipeline = pipeline;
+    }
     _renderPass.setPrimitiveType(item.geometry.primitiveType);
 
     final instances = item.instanceTransforms;

--- a/packages/flutter_scene/lib/src/render/shadow_pass.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_pass.dart
@@ -1,51 +1,55 @@
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 
+import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/render/shadow_encoder.dart';
 
 /// Render-graph blackboard key under which [ShadowPass] publishes the
-/// directional shadow map (a depth-in-`.r` fp16 texture). The downstream
-/// scene pass reads it from here.
+/// directional shadow map atlas (a depth-in-`.r` fp16 texture). The
+/// downstream scene pass reads it from here.
 const String kShadowMapBlackboardKey = 'directional_shadow_map';
 
-/// Renders the scene's depth from a directional light into an offscreen
-/// shadow map and publishes it on the render-graph blackboard.
+/// Renders the scene's depth from a directional light into a cascaded
+/// shadow map atlas and publishes it on the render-graph blackboard.
 ///
-/// The shadow map is an fp16 color attachment with the window-space depth
-/// in its red channel (a transient depth attachment backs the depth
-/// test). Cleared to 1.0 so texels no caster covers read as "lit".
+/// The atlas is one fp16 color texture holding the cascade tiles as a
+/// horizontal strip, each [tileResolution] square; window-space depth
+/// goes in the red channel (a transient depth attachment backs the
+/// depth test). It is cleared to 1.0 so texels no caster covers read as
+/// "lit". Each cascade renders into its own tile through a viewport.
 class ShadowPass extends RenderGraphPass {
   ShadowPass({
     required RenderScene renderScene,
-    required Matrix4 lightSpaceMatrix,
-    required int resolution,
+    required List<ShadowCascade> cascades,
+    required int tileResolution,
   }) : _renderScene = renderScene,
-       _lightSpaceMatrix = lightSpaceMatrix,
-       _resolution = resolution;
+       _cascades = cascades,
+       _tileResolution = tileResolution;
 
   final RenderScene _renderScene;
-  final Matrix4 _lightSpaceMatrix;
-  final int _resolution;
+  final List<ShadowCascade> _cascades;
+  final int _tileResolution;
 
   @override
   String get name => 'ShadowPass';
 
   @override
   void execute(RenderGraphContext context) {
+    final atlasWidth = _tileResolution * _cascades.length;
     final color = context.texturePool.acquire(
       TransientTextureDescriptor.color(
-        width: _resolution,
-        height: _resolution,
+        width: atlasWidth,
+        height: _tileResolution,
         format: gpu.PixelFormat.r16g16b16a16Float,
         debugName: 'directional_shadow_map',
       ),
     );
     final depth = context.texturePool.acquire(
       TransientTextureDescriptor.depth(
-        width: _resolution,
-        height: _resolution,
+        width: atlasWidth,
+        height: _tileResolution,
         format: gpu.gpuContext.defaultDepthStencilFormat,
         debugName: 'directional_shadow_map_depth',
       ),
@@ -63,12 +67,27 @@ class ShadowPass extends RenderGraphPass {
     );
     final commandBuffer = gpu.gpuContext.createCommandBuffer();
     final renderPass = commandBuffer.createRenderPass(target);
-    final encoder = ShadowEncoder(
-      renderPass,
-      context.transientsBuffer,
-      _lightSpaceMatrix,
-    );
-    _renderScene.cull(encoder.frustum, encoder.submit);
+
+    // Each cascade renders into its own tile of the strip. The viewport
+    // restricts rasterization to the tile; the shared depth attachment
+    // is cleared once for the whole atlas.
+    for (var c = 0; c < _cascades.length; c++) {
+      renderPass.setViewport(
+        gpu.Viewport(
+          x: c * _tileResolution,
+          y: 0,
+          width: _tileResolution,
+          height: _tileResolution,
+        ),
+      );
+      final encoder = ShadowEncoder(
+        renderPass,
+        context.transientsBuffer,
+        _cascades[c].lightSpaceMatrix,
+      );
+      _renderScene.cull(encoder.frustum, encoder.submit);
+    }
+
     commandBuffer.submit();
     context.blackboard.set(kShadowMapBlackboardKey, color);
   }

--- a/packages/flutter_scene/lib/src/render/shadow_pass.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_pass.dart
@@ -7,14 +7,14 @@ import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/render/shadow_encoder.dart';
 
 /// Render-graph blackboard key under which [ShadowPass] publishes the
-/// directional shadow map atlas (a depth-in-`.r` fp16 texture). The
+/// directional shadow map atlas (a depth-in-`.r` fp32 texture). The
 /// downstream scene pass reads it from here.
 const String kShadowMapBlackboardKey = 'directional_shadow_map';
 
 /// Renders the scene's depth from a directional light into a cascaded
 /// shadow map atlas and publishes it on the render-graph blackboard.
 ///
-/// The atlas is one fp16 color texture holding the cascade tiles as a
+/// The atlas is one fp32 color texture holding the cascade tiles as a
 /// horizontal strip, each [tileResolution] square; window-space depth
 /// goes in the red channel (a transient depth attachment backs the
 /// depth test). It is cleared to 1.0 so texels no caster covers read as
@@ -38,11 +38,15 @@ class ShadowPass extends RenderGraphPass {
   @override
   void execute(RenderGraphContext context) {
     final atlasWidth = _tileResolution * _cascades.length;
+    // fp32 (not fp16): the far cascade's orthographic depth range spans
+    // hundreds of world units, and fp16's ~11-bit mantissa quantizes
+    // window-space depth into steps coarser than the shadow depth bias.
+    // That made the flat distant ground self-shadow in moire bands.
     final color = context.texturePool.acquire(
       TransientTextureDescriptor.color(
         width: atlasWidth,
         height: _tileResolution,
-        format: gpu.PixelFormat.r16g16b16a16Float,
+        format: gpu.PixelFormat.r32g32b32a32Float,
         debugName: 'directional_shadow_map',
       ),
     );

--- a/packages/flutter_scene/lib/src/render/shadow_pass.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_pass.dart
@@ -42,6 +42,9 @@ class ShadowPass extends RenderGraphPass {
     // hundreds of world units, and fp16's ~11-bit mantissa quantizes
     // window-space depth into steps coarser than the shadow depth bias.
     // That made the flat distant ground self-shadow in moire bands.
+    //
+    // TODO(bdero): Only the red channel is used. Add r32Float to Flutter
+    // GPU and use it here instead.
     final color = context.texturePool.acquire(
       TransientTextureDescriptor.color(
         width: atlasWidth,

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -312,9 +312,12 @@ base class Scene implements SceneGraph {
     transientsBuffer.reset();
 
     final light = directionalLight;
-    final castsShadow = light != null && light.castsShadow;
-    final lightSpaceMatrix =
-        castsShadow ? light.computeLightSpaceMatrix() : null;
+    // Cascaded shadows fit the camera frustum, so they require a
+    // perspective camera; other camera types render without shadows.
+    final cascades =
+        light != null && light.castsShadow && camera is PerspectiveCamera
+            ? light.computeCascades(camera, pixelSize.width / pixelSize.height)
+            : const <ShadowCascade>[];
 
     // Walk the graph once to tick components and animations and refresh
     // the flat render list before the passes iterate it. Skipped when
@@ -331,12 +334,12 @@ base class Scene implements SceneGraph {
     renderScene.rebuildIfDirty();
 
     final graph = RenderGraph();
-    if (castsShadow) {
+    if (cascades.isNotEmpty) {
       graph.addPass(
         ShadowPass(
           renderScene: renderScene,
-          lightSpaceMatrix: lightSpaceMatrix!,
-          resolution: light.shadowMapResolution,
+          cascades: cascades,
+          tileResolution: light!.shadowMapResolution,
         ),
       );
     }
@@ -349,7 +352,7 @@ base class Scene implements SceneGraph {
         environmentIntensity: environmentIntensity,
         enableMsaa: enableMsaa,
         directionalLight: light,
-        lightSpaceMatrix: lightSpaceMatrix,
+        cascades: cascades,
       ),
     );
     graph.addPass(

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -19,9 +19,13 @@ uniform FragInfo {
   // Active only when has_directional_light > 0.5.
   vec4 directional_light_direction;
   vec4 directional_light_color;
-  // World -> light-clip-space matrix for sampling shadow_map. Used only
-  // when casts_shadow > 0.5.
-  mat4 light_space_matrix;
+  // World -> light-clip-space matrix per shadow cascade; the first
+  // shadow_cascade_count entries are valid. Used when casts_shadow > 0.5.
+  mat4 light_space_matrix[4];
+  // World-space orthographic box size of each cascade (x..w map to
+  // cascade 0..3), used to scale world-space softness and fade widths
+  // into a cascade's UV space.
+  vec4 cascade_box_sizes;
   float vertex_color_weight;
   float metallic_factor;
   float roughness_factor;
@@ -44,12 +48,13 @@ uniform FragInfo {
   // forced fully opaque.
   float alpha_mode;
   float alpha_cutoff;
-  // UV-space half-width over which shadowing fades back to lit at the
-  // shadow map border, softening the box edge. 0 disables the fade.
+  // World-space width over which shadowing fades back to lit at the far
+  // cascade's edge, softening the shadow distance limit. 0 disables it.
   float shadow_fade;
-  // UV-space radius of the soft-shadow (PCF) sampling disk; the shadow
-  // penumbra width.
+  // World-space radius of the soft-shadow (PCF) penumbra.
   float shadow_softness;
+  // Number of valid cascades in light_space_matrix (1 to 4).
+  float shadow_cascade_count;
 }
 frag_info;
 
@@ -102,31 +107,42 @@ const vec2 kPoissonDisk[16] = vec2[](
     vec2(-0.24188840, 0.99706507), vec2(-0.81409955, 0.91437590),
     vec2(0.19984126, 0.78641367), vec2(0.14383161, -0.14100790));
 
-// Soft PCF shadow lookup. Returns 1.0 (lit) .. 0.0 (fully shadowed).
-// `world_pos` and `n` are world-space; `n` is the (perturbed) shading
-// normal, used for normal-offset bias to fight grazing-angle acne.
-float SampleShadow(vec3 world_pos, vec3 n) {
-  vec3 biased_pos = world_pos + n * frag_info.shadow_normal_bias;
-  vec4 light_clip = frag_info.light_space_matrix * vec4(biased_pos, 1.0);
+// Samples one cascade's tile of the shadow atlas strip with a rotated
+// 16-tap Poisson-disk PCF. `world_pos` and `n` are world-space.
+float SampleCascade(int cascade, vec3 world_pos, vec3 n, int count) {
+  float box = frag_info.cascade_box_sizes[cascade];
+
+  // Normal-offset bias. A soft PCF kernel on a surface tilted relative
+  // to the light straddles a depth gradient and would self-shadow, so
+  // lift the receiver along its normal far enough that the whole kernel
+  // clears the surface. The offset scales with the kernel's world
+  // radius (shadow_softness) and the surface's slope to the light. It
+  // depends only on geometry, not the cascade, so all cascades agree
+  // and there is no banding at their seams.
+  vec3 light_toward = -normalize(frag_info.directional_light_direction.xyz);
+  float ndotl = max(dot(n, light_toward), 0.15);
+  float slope = min(sqrt(max(1.0 - ndotl * ndotl, 0.0)) / (ndotl * ndotl),
+                    8.0);
+  float normal_offset =
+      frag_info.shadow_normal_bias + frag_info.shadow_softness * slope;
+  vec3 biased = world_pos + n * normal_offset;
+
+  vec4 light_clip =
+      frag_info.light_space_matrix[cascade] * vec4(biased, 1.0);
   vec3 proj = light_clip.xyz / light_clip.w;
   vec2 uv = proj.xy * 0.5 + 0.5;
-  // The shadow map is a render-to-texture target; flip V to match its
-  // sampled Y orientation (top-down on Metal/Vulkan, bottom-up on OpenGL
-  // ES -- see render_target_flip_y).
-  if (frag_info.render_target_flip_y > 0.5) {
-    uv.y = 1.0 - uv.y;
-  }
-  // Outside the orthographic shadow frustum: treat as lit.
-  if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0 || proj.z < 0.0 ||
-      proj.z > 1.0) {
-    return 1.0;
-  }
-  float receiver_depth = proj.z - frag_info.shadow_bias;
+  // The depth bias is world-space; convert it to this cascade's clip-z
+  // (its orthographic depth range is 3 * box) so a caster crosses the
+  // shadow threshold at the same world height in every cascade, with
+  // no discontinuity where cascades meet.
+  float receiver_depth = proj.z - frag_info.shadow_bias / (3.0 * box);
 
-  // Poisson-disk PCF. The disk radius is the penumbra width; a
-  // per-fragment rotation hides the sample pattern so 16 taps read as
-  // a smooth soft edge instead of banding.
-  float radius = max(frag_info.shadow_softness, frag_info.shadow_texel_size);
+  // World-space penumbra -> this cascade's UV space, floored at a texel.
+  float radius =
+      max(frag_info.shadow_softness / box, frag_info.shadow_texel_size);
+  float inv_count = 1.0 / float(count);
+
+  // A per-fragment rotation hides the 16-tap pattern as a smooth edge.
   float noise = fract(
       52.9829189 *
       fract(dot(gl_FragCoord.xy, vec2(0.06711056, 0.00583715))));
@@ -137,20 +153,53 @@ float SampleShadow(vec3 world_pos, vec3 n) {
   for (int i = 0; i < 16; i++) {
     vec2 p = kPoissonDisk[i];
     vec2 offset = vec2(p.x * ca - p.y * sa, p.x * sa + p.y * ca) * radius;
-    float caster_depth = texture(shadow_map, uv + offset).r;
+    // Keep samples in this cascade's tile, then place into the strip.
+    vec2 cuv = clamp(uv + offset, vec2(0.0), vec2(1.0));
+    vec2 atlas_uv = vec2((float(cascade) + cuv.x) * inv_count, cuv.y);
+    // The atlas is a render-to-texture target; flip V to match its
+    // sampled Y orientation (see render_target_flip_y).
+    if (frag_info.render_target_flip_y > 0.5) {
+      atlas_uv.y = 1.0 - atlas_uv.y;
+    }
+    float caster_depth = texture(shadow_map, atlas_uv).r;
     lit += receiver_depth <= caster_depth ? 1.0 : 0.0;
   }
   float shadow = lit / 16.0;
 
-  // Fade shadowing back to lit over the outer `shadow_fade` of UV space
-  // so the shadow map's box edge is soft rather than a hard cutoff.
-  float fade = frag_info.shadow_fade;
-  if (fade > 0.0) {
+  // Only the last cascade has a real outer edge (inner cascades hand
+  // off to the next), so fade just it back to lit at the boundary.
+  if (cascade == count - 1 && frag_info.shadow_fade > 0.0) {
+    float fade = frag_info.shadow_fade / box;
     vec2 edge = smoothstep(vec2(0.0), vec2(fade), uv) *
                 smoothstep(vec2(0.0), vec2(fade), vec2(1.0) - uv);
     shadow = mix(1.0, shadow, edge.x * edge.y);
   }
   return shadow;
+}
+
+// Soft cascaded-shadow lookup. Returns 1.0 (lit) .. 0.0 (fully
+// shadowed). `world_pos` and `n` are world-space; `n` is the
+// (perturbed) shading normal. Picks the first (highest-resolution)
+// cascade whose box contains the fragment.
+float SampleShadow(vec3 world_pos, vec3 n) {
+  int count = int(frag_info.shadow_cascade_count);
+  for (int c = 0; c < 4; c++) {
+    if (c >= count) {
+      break;
+    }
+    // Containment test with the unbiased position.
+    vec4 light_clip =
+        frag_info.light_space_matrix[c] * vec4(world_pos, 1.0);
+    vec3 proj = light_clip.xyz / light_clip.w;
+    vec2 uv = proj.xy * 0.5 + 0.5;
+    // Skip cascades whose box does not contain the fragment.
+    if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0 ||
+        proj.z < 0.0 || proj.z > 1.0) {
+      continue;
+    }
+    return SampleCascade(c, world_pos, n, count);
+  }
+  return 1.0;
 }
 
 void main() {

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -44,6 +44,12 @@ uniform FragInfo {
   // forced fully opaque.
   float alpha_mode;
   float alpha_cutoff;
+  // UV-space half-width over which shadowing fades back to lit at the
+  // shadow map border, softening the box edge. 0 disables the fade.
+  float shadow_fade;
+  // UV-space radius of the soft-shadow (PCF) sampling disk; the shadow
+  // penumbra width.
+  float shadow_softness;
 }
 frag_info;
 
@@ -85,7 +91,18 @@ vec3 EvaluateDiffuseSH(vec3 n) {
          frag_info.diffuse_sh8.xyz * (0.546274 * (n.x * n.x - n.y * n.y));
 }
 
-// 3x3 PCF shadow lookup. Returns 1.0 (lit) .. 0.0 (fully shadowed).
+// A 16-tap Poisson disk, sampled by the soft-shadow PCF kernel.
+const vec2 kPoissonDisk[16] = vec2[](
+    vec2(-0.94201624, -0.39906216), vec2(0.94558609, -0.76890725),
+    vec2(-0.09418410, -0.92938870), vec2(0.34495938, 0.29387760),
+    vec2(-0.91588581, 0.45771432), vec2(-0.81544232, -0.87912464),
+    vec2(-0.38277543, 0.27676845), vec2(0.97484398, 0.75648379),
+    vec2(0.44323325, -0.97511554), vec2(0.53742981, -0.47373420),
+    vec2(-0.26496911, -0.41893023), vec2(0.79197514, 0.19090188),
+    vec2(-0.24188840, 0.99706507), vec2(-0.81409955, 0.91437590),
+    vec2(0.19984126, 0.78641367), vec2(0.14383161, -0.14100790));
+
+// Soft PCF shadow lookup. Returns 1.0 (lit) .. 0.0 (fully shadowed).
 // `world_pos` and `n` are world-space; `n` is the (perturbed) shading
 // normal, used for normal-offset bias to fight grazing-angle acne.
 float SampleShadow(vec3 world_pos, vec3 n) {
@@ -105,16 +122,35 @@ float SampleShadow(vec3 world_pos, vec3 n) {
     return 1.0;
   }
   float receiver_depth = proj.z - frag_info.shadow_bias;
-  float texel = frag_info.shadow_texel_size;
+
+  // Poisson-disk PCF. The disk radius is the penumbra width; a
+  // per-fragment rotation hides the sample pattern so 16 taps read as
+  // a smooth soft edge instead of banding.
+  float radius = max(frag_info.shadow_softness, frag_info.shadow_texel_size);
+  float noise = fract(
+      52.9829189 *
+      fract(dot(gl_FragCoord.xy, vec2(0.06711056, 0.00583715))));
+  float angle = noise * 6.28318530718;
+  float ca = cos(angle);
+  float sa = sin(angle);
   float lit = 0.0;
-  for (int dx = -1; dx <= 1; dx++) {
-    for (int dy = -1; dy <= 1; dy++) {
-      vec2 sample_uv = uv + vec2(float(dx), float(dy)) * texel;
-      float caster_depth = texture(shadow_map, sample_uv).r;
-      lit += receiver_depth <= caster_depth ? 1.0 : 0.0;
-    }
+  for (int i = 0; i < 16; i++) {
+    vec2 p = kPoissonDisk[i];
+    vec2 offset = vec2(p.x * ca - p.y * sa, p.x * sa + p.y * ca) * radius;
+    float caster_depth = texture(shadow_map, uv + offset).r;
+    lit += receiver_depth <= caster_depth ? 1.0 : 0.0;
   }
-  return lit / 9.0;
+  float shadow = lit / 16.0;
+
+  // Fade shadowing back to lit over the outer `shadow_fade` of UV space
+  // so the shadow map's box edge is soft rather than a hard cutoff.
+  float fade = frag_info.shadow_fade;
+  if (fade > 0.0) {
+    vec2 edge = smoothstep(vec2(0.0), vec2(fade), uv) *
+                smoothstep(vec2(0.0), vec2(fade), vec2(1.0) - uv);
+    shadow = mix(1.0, shadow, edge.x * edge.y);
+  }
+  return shadow;
 }
 
 void main() {

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -192,9 +192,15 @@ float SampleShadow(vec3 world_pos, vec3 n) {
         frag_info.light_space_matrix[c] * vec4(world_pos, 1.0);
     vec3 proj = light_clip.xyz / light_clip.w;
     vec2 uv = proj.xy * 0.5 + 0.5;
-    // Skip cascades whose box does not contain the fragment.
-    if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0 ||
-        proj.z < 0.0 || proj.z > 1.0) {
+    // Require room for the PCF kernel inside the cascade's tile, so its
+    // samples never clamp against the tile edge (which would smear the
+    // edge texel into a thin seam). A fragment closer to the edge than
+    // the kernel radius falls through to the next, larger cascade.
+    float margin =
+        max(frag_info.shadow_softness / frag_info.cascade_box_sizes[c],
+            frag_info.shadow_texel_size);
+    if (uv.x < margin || uv.x > 1.0 - margin || uv.y < margin ||
+        uv.y > 1.0 - margin || proj.z < 0.0 || proj.z > 1.0) {
       continue;
     }
     return SampleCascade(c, world_pos, n, count);

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -153,8 +153,11 @@ float SampleCascade(int cascade, vec3 world_pos, vec3 n, int count) {
   for (int i = 0; i < 16; i++) {
     vec2 p = kPoissonDisk[i];
     vec2 offset = vec2(p.x * ca - p.y * sa, p.x * sa + p.y * ca) * radius;
-    // Keep samples in this cascade's tile, then place into the strip.
-    vec2 cuv = clamp(uv + offset, vec2(0.0), vec2(1.0));
+    // Keep samples a texel inside this cascade's tile, so bilinear
+    // filtering of the atlas never reaches across the tile boundary
+    // into a neighbouring cascade's depths.
+    vec2 cuv = clamp(uv + offset, vec2(frag_info.shadow_texel_size),
+                     vec2(1.0 - frag_info.shadow_texel_size));
     vec2 atlas_uv = vec2((float(cascade) + cuv.x) * inv_count, cuv.y);
     // The atlas is a render-to-texture target; flip V to match its
     // sampled Y orientation (see render_target_flip_y).

--- a/packages/flutter_scene/test/light_test.dart
+++ b/packages/flutter_scene/test/light_test.dart
@@ -1,7 +1,10 @@
-// Covers DirectionalLight.computeLightSpaceMatrix, in particular the
-// texel snapping that pins the shadow map's texel grid to the world so
-// shadow edges do not shimmer as the focus point moves.
+// Covers DirectionalLight's shadow matrix math: the texel snapping that
+// keeps the shadow map's grid pinned to the world, and the cascaded
+// shadow map split scheme and per-cascade fitting.
 
+import 'dart:math';
+
+import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart';
@@ -31,6 +34,68 @@ void main() {
         final texelY = (clip.y * 0.5 + 0.5) * resolution;
         expect(texelX - texelX.roundToDouble(), closeTo(0.0, 1e-3));
         expect(texelY - texelY.roundToDouble(), closeTo(0.0, 1e-3));
+      }
+    });
+  });
+
+  group('DirectionalLight.computeCascades', () {
+    final camera = PerspectiveCamera(
+      position: Vector3(0, 8, -20),
+      target: Vector3(0, 0, 0),
+    );
+    const aspectRatio = 16.0 / 9.0;
+
+    test('returns the requested cascades ordered near to far', () {
+      final light = DirectionalLight(castsShadow: true, shadowCascadeCount: 4);
+      final cascades = light.computeCascades(camera, aspectRatio);
+      expect(cascades, hasLength(4));
+      for (var i = 1; i < cascades.length; i++) {
+        expect(
+          cascades[i].splitDistance,
+          greaterThan(cascades[i - 1].splitDistance),
+        );
+      }
+      expect(
+        cascades.last.splitDistance,
+        closeTo(light.shadowMaxDistance, 1e-6),
+      );
+    });
+
+    // Every corner of a cascade's slice of the camera frustum must
+    // project inside that cascade's shadow box, or geometry in view
+    // would fall outside the shadow map.
+    test('each frustum slice fits inside its cascade box', () {
+      final light = DirectionalLight(castsShadow: true, shadowCascadeCount: 3);
+      final cascades = light.computeCascades(camera, aspectRatio);
+
+      final forward = (camera.target - camera.position).normalized();
+      final right = camera.up.cross(forward).normalized();
+      final up = forward.cross(right).normalized();
+      final tanV = tan(camera.fovRadiansY * 0.5);
+      final tanH = tanV * aspectRatio;
+
+      var sliceNear = camera.fovNear;
+      for (final cascade in cascades) {
+        final sliceFar = cascade.splitDistance;
+        for (final depth in [sliceNear, sliceFar]) {
+          final planeCenter = camera.position + forward * depth;
+          for (final sx in [-1.0, 1.0]) {
+            for (final sy in [-1.0, 1.0]) {
+              final corner =
+                  planeCenter +
+                  right * (sx * depth * tanH) +
+                  up * (sy * depth * tanV);
+              final clip = cascade.lightSpaceMatrix.transformed(
+                Vector4(corner.x, corner.y, corner.z, 1),
+              );
+              // Allow a texel of slack for the snapping shift.
+              expect(clip.x, inInclusiveRange(-1.02, 1.02));
+              expect(clip.y, inInclusiveRange(-1.02, 1.02));
+              expect(clip.z, inInclusiveRange(0.0, 1.0));
+            }
+          }
+        }
+        sliceNear = sliceFar;
       }
     });
   });

--- a/packages/flutter_scene/test/light_test.dart
+++ b/packages/flutter_scene/test/light_test.dart
@@ -1,6 +1,5 @@
-// Covers DirectionalLight's shadow matrix math: the texel snapping that
-// keeps the shadow map's grid pinned to the world, and the cascaded
-// shadow map split scheme and per-cascade fitting.
+// Covers DirectionalLight.computeCascades: the cascaded shadow map
+// split scheme and per-cascade frustum fitting.
 
 import 'dart:math';
 
@@ -10,34 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart';
 
 void main() {
-  group('DirectionalLight.computeLightSpaceMatrix', () {
-    // Snapping shifts the projection so a fixed world reference lands on
-    // a texel center. The world origin should therefore project to an
-    // integer texel for any focus point; that is what keeps the texel
-    // grid pinned to the world.
-    test('texel snapping pins the world origin to a texel center', () {
-      for (final focus in [
-        Vector3(0.3, 0.0, 0.0),
-        Vector3(5.123, 0.0, -2.7),
-        Vector3(-11.9, 0.4, 8.05),
-      ]) {
-        final light = DirectionalLight(
-          direction: Vector3(-0.3, -1.0, -0.2),
-          castsShadow: true,
-          shadowFocusPoint: focus,
-        );
-        final clip = light.computeLightSpaceMatrix().transformed(
-          Vector4(0, 0, 0, 1),
-        );
-        final resolution = light.shadowMapResolution.toDouble();
-        final texelX = (clip.x * 0.5 + 0.5) * resolution;
-        final texelY = (clip.y * 0.5 + 0.5) * resolution;
-        expect(texelX - texelX.roundToDouble(), closeTo(0.0, 1e-3));
-        expect(texelY - texelY.roundToDouble(), closeTo(0.0, 1e-3));
-      }
-    });
-  });
-
   group('DirectionalLight.computeCascades', () {
     final camera = PerspectiveCamera(
       position: Vector3(0, 8, -20),
@@ -96,6 +67,16 @@ void main() {
           }
         }
         sliceNear = sliceFar;
+      }
+    });
+
+    // Each cascade reports the world-space size of its orthographic
+    // box, used to scale world-space softness and fade into UV space.
+    test('reports a positive box size for every cascade', () {
+      final light = DirectionalLight(castsShadow: true);
+      final cascades = light.computeCascades(camera, aspectRatio);
+      for (final cascade in cascades) {
+        expect(cascade.boxSize, greaterThan(0.0));
       }
     });
   });

--- a/packages/flutter_scene/test/light_test.dart
+++ b/packages/flutter_scene/test/light_test.dart
@@ -1,0 +1,37 @@
+// Covers DirectionalLight.computeLightSpaceMatrix, in particular the
+// texel snapping that pins the shadow map's texel grid to the world so
+// shadow edges do not shimmer as the focus point moves.
+
+import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  group('DirectionalLight.computeLightSpaceMatrix', () {
+    // Snapping shifts the projection so a fixed world reference lands on
+    // a texel center. The world origin should therefore project to an
+    // integer texel for any focus point; that is what keeps the texel
+    // grid pinned to the world.
+    test('texel snapping pins the world origin to a texel center', () {
+      for (final focus in [
+        Vector3(0.3, 0.0, 0.0),
+        Vector3(5.123, 0.0, -2.7),
+        Vector3(-11.9, 0.4, 8.05),
+      ]) {
+        final light = DirectionalLight(
+          direction: Vector3(-0.3, -1.0, -0.2),
+          castsShadow: true,
+          shadowFocusPoint: focus,
+        );
+        final clip = light.computeLightSpaceMatrix().transformed(
+          Vector4(0, 0, 0, 1),
+        );
+        final resolution = light.shadowMapResolution.toDouble();
+        final texelX = (clip.x * 0.5 + 0.5) * resolution;
+        final texelY = (clip.y * 0.5 + 0.5) * resolution;
+        expect(texelX - texelX.roundToDouble(), closeTo(0.0, 1e-3));
+        expect(texelY - texelY.roundToDouble(), closeTo(0.0, 1e-3));
+      }
+    });
+  });
+}


### PR DESCRIPTION
Replaces the single fixed-frustum directional shadow map with cascaded shadow maps, so shadows stay crisp near the camera while covering a long view distance.

https://github.com/user-attachments/assets/35a06f68-2be1-4abd-9d28-c3033f78a47e

What this does:

- Splits the camera view into depth slices, each with its own shadow map fit to that slice, packed into one atlas texture.
- Fits each cascade with a bounding sphere and snaps it to the texel grid, so shadows stay stable and do not shimmer as the camera moves.
- Samples shadows with a 16-tap rotated Poisson-disk PCF kernel for a soft edge, and fades shadowing back to lit at the far cascade edge instead of a hard cutoff.
- Stores the shadow atlas at fp32 to remove depth-precision banding on distant ground.
- Caches the shadow pass pipelines instead of rebuilding them per draw.
- Adds a free-fly inspection camera to the navigation route example (WASD to move, Space and Shift for up and down, drag to look).

The old single-frustum DirectionalLight knobs (shadowFocusPoint, shadowFrustumSize, shadowFrustumDepth) are removed in favor of camera-derived cascades. This is a breaking change.