### PR TITLE
Improved HDR image-based-lighting environments

### DIFF
--- a/examples/flutter_app/lib/example_stress_tests.dart
+++ b/examples/flutter_app/lib/example_stress_tests.dart
@@ -6,13 +6,17 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show compute;
 import 'package:flutter/material.dart' hide Animation;
 import 'package:flutter/services.dart';
 import 'package:flutter_scene/scene.dart' hide Material;
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:vector_math/vector_math.dart' as vm;
+
+import 'hdr_image.dart';
 
 // Toggle these on to inspect scenes as they load. Both are off by
 // default; flip them locally when debugging a renderer regression in
@@ -65,6 +69,18 @@ const _catalog = <_StressTest>[
         'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/'
         'main/Models/AntiqueCamera/glTF-Binary/AntiqueCamera.glb',
     sizeBytes: 17540348,
+  ),
+  _StressTest(
+    id: 'DamagedHelmet',
+    title: 'Damaged Helmet',
+    description:
+        'The canonical glTF PBR test asset: one mesh with base color, '
+        'normal, metallic-roughness, emissive, and occlusion maps. A quick '
+        'all-in-one PBR fidelity check.',
+    url:
+        'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/'
+        'main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb',
+    sizeBytes: 3773916,
   ),
   _StressTest(
     id: 'SciFiHelmet',
@@ -203,6 +219,124 @@ const _catalog = <_StressTest>[
   ),
 ];
 
+// An image-based-lighting environment selectable from the scene's
+// environment menu.
+class _Environment {
+  const _Environment({required this.id, required this.title, this.url});
+
+  final String id;
+  final String title;
+
+  /// Radiance `.hdr` URL, or null for the renderer's built-in procedural
+  /// studio environment.
+  final String? url;
+}
+
+// Khronos sample-environment HDRs, downloaded at runtime. They are Git LFS
+// blobs, so they are fetched through media.githubusercontent.com (the
+// raw.githubusercontent.com path serves only the LFS pointer).
+const _kEnvironmentBaseUrl =
+    'https://media.githubusercontent.com/media/KhronosGroup/'
+    'glTF-Sample-Environments/main';
+
+const _environments = <_Environment>[
+  _Environment(id: 'studio', title: 'Studio (built-in)'),
+  _Environment(id: 'axis_test', title: 'Axis Test (solid colors)'),
+  _Environment(
+    id: 'neutral',
+    title: 'Studio Neutral',
+    url: '$_kEnvironmentBaseUrl/neutral.hdr',
+  ),
+  _Environment(
+    id: 'footprint_court',
+    title: 'Footprint Court',
+    url: '$_kEnvironmentBaseUrl/footprint_court.hdr',
+  ),
+  _Environment(
+    id: 'pisa',
+    title: 'Pisa',
+    url: '$_kEnvironmentBaseUrl/pisa.hdr',
+  ),
+  _Environment(
+    id: 'doge2',
+    title: "Doge's Palace",
+    url: '$_kEnvironmentBaseUrl/doge2.hdr',
+  ),
+  _Environment(
+    id: 'ennis',
+    title: 'Ennis House',
+    url: '$_kEnvironmentBaseUrl/ennis.hdr',
+  ),
+  _Environment(
+    id: 'field',
+    title: 'Field',
+    url: '$_kEnvironmentBaseUrl/field.hdr',
+  ),
+  _Environment(
+    id: 'helipad',
+    title: 'Helipad',
+    url: '$_kEnvironmentBaseUrl/helipad.hdr',
+  ),
+  _Environment(
+    id: 'papermill',
+    title: 'Papermill Ruins',
+    url: '$_kEnvironmentBaseUrl/papermill.hdr',
+  ),
+  _Environment(
+    id: 'directional',
+    title: 'Directional (test)',
+    url: '$_kEnvironmentBaseUrl/directional.hdr',
+  ),
+  _Environment(
+    id: 'chromatic',
+    title: 'Chromatic (test)',
+    url: '$_kEnvironmentBaseUrl/chromatic.hdr',
+  ),
+];
+
+// Generates a procedural test environment: a low-resolution equirect
+// colored by the dominant world axis of each direction (+X red, -X cyan,
+// +Y green, -Y magenta, +Z blue, -Z yellow). Solid colors make the
+// environment's orientation unambiguous in reflections and ambient light.
+({Float32List pixels, int width, int height}) _buildAxisTestEquirect() {
+  const width = 256;
+  const height = 128;
+  final pixels = Float32List(width * height * 4);
+  for (var py = 0; py < height; py++) {
+    // Row 0 is the down pole, matching EnvironmentMap.studio's convention.
+    final v = (py + 0.5) / height;
+    final latitude = (v - 0.5) * pi;
+    final cosLat = cos(latitude);
+    final dirY = sin(latitude);
+    for (var px = 0; px < width; px++) {
+      final u = (px + 0.5) / width;
+      final longitude = (u - 0.5) * 2.0 * pi;
+      final dirX = cosLat * cos(longitude);
+      final dirZ = cosLat * sin(longitude);
+      double r, g, b;
+      if (dirX.abs() >= dirY.abs() && dirX.abs() >= dirZ.abs()) {
+        r = dirX >= 0 ? 1.0 : 0.0; // +X red, -X cyan
+        g = dirX >= 0 ? 0.0 : 1.0;
+        b = dirX >= 0 ? 0.0 : 1.0;
+      } else if (dirY.abs() >= dirZ.abs()) {
+        r = dirY >= 0 ? 0.0 : 1.0; // +Y green, -Y magenta
+        g = dirY >= 0 ? 1.0 : 0.0;
+        b = dirY >= 0 ? 0.0 : 1.0;
+      } else {
+        r = dirZ >= 0 ? 0.0 : 1.0; // +Z blue, -Z yellow
+        g = dirZ >= 0 ? 0.0 : 1.0;
+        b = dirZ >= 0 ? 1.0 : 0.0;
+      }
+      final o = (py * width + px) * 4;
+      pixels[o] = r;
+      pixels[o + 1] = g;
+      pixels[o + 2] = b;
+      pixels[o + 3] = 1.0;
+    }
+  }
+  return (pixels: pixels, width: width, height: height);
+}
+
 class ExampleStressTests extends StatefulWidget {
   const ExampleStressTests({super.key, this.elapsedSeconds = 0});
   final double elapsedSeconds;
@@ -321,15 +455,28 @@ class _StressSceneState extends State<_StressScene> {
   int? _total;
   Object? _error;
 
+  // Image-based-lighting environment. `_activeEnvironment` tracks the menu
+  // choice; the renderer's built-in studio environment is the default.
+  // Loaded HDR environments are cached so re-selecting one is instant.
+  _Environment _activeEnvironment = _environments.first;
+  bool _environmentLoading = false;
+  final Map<String, EnvironmentMap> _environmentCache = {};
+
+  // Tone-mapping exposure and image-based-lighting intensity, tunable
+  // from the lighting panel. Both default to the renderer's neutral 1.0.
+  double _exposure = 1.0;
+  double _environmentIntensity = 1.0;
+
+  // Environment rotation in degrees about each world axis.
+  double _envRotationX = 0.0;
+  double _envRotationY = 0.0;
+  double _envRotationZ = 0.0;
+
   @override
   void initState() {
     super.initState();
-    _scene.directionalLight = DirectionalLight(
-      direction: vm.Vector3(0.4, -1.0, 0.3),
-      color: vm.Vector3(1.0, 0.97, 0.9),
-      intensity: 2.5,
-      castsShadow: true,
-    );
+    // No analytic light: these scenes are lit purely by the image-based
+    // environment, so the environment menu is what's being evaluated.
     unawaited(_load());
   }
 
@@ -403,6 +550,82 @@ class _StressSceneState extends State<_StressScene> {
       if (!mounted) return;
       setState(() => _error = e);
     }
+  }
+
+  // Switches the scene's image-based-lighting environment. Downloads and
+  // decodes the HDR on first use (cached afterward); the built-in studio
+  // environment needs no download.
+  Future<void> _selectEnvironment(_Environment environment) async {
+    if (environment.id == _activeEnvironment.id && !_environmentLoading) {
+      return;
+    }
+    setState(() {
+      _activeEnvironment = environment;
+      _environmentLoading = true;
+    });
+    try {
+      final map = await _resolveEnvironment(environment);
+      if (!mounted) return;
+      setState(() {
+        _scene.environment = map;
+        _environmentLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _environmentLoading = false);
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(content: Text('Failed to load ${environment.title}: $e')),
+      );
+    }
+  }
+
+  // Returns the [EnvironmentMap] for [environment], or null for the
+  // renderer's built-in studio default. HDR environments are downloaded,
+  // decoded off the UI isolate, prefiltered, and cached; the axis-test
+  // environment is generated procedurally.
+  Future<EnvironmentMap?> _resolveEnvironment(_Environment environment) async {
+    if (environment.id == 'studio') return null; // renderer's built-in
+
+    final cached = _environmentCache[environment.id];
+    if (cached != null) return cached;
+
+    final EnvironmentMap map;
+    if (environment.id == 'axis_test') {
+      final test = _buildAxisTestEquirect();
+      map = await EnvironmentMap.fromEquirectHdr(
+        linearPixels: test.pixels,
+        width: test.width,
+        height: test.height,
+      );
+    } else {
+      final supportDir = await getApplicationSupportDirectory();
+      final dir = Directory('${supportDir.path}/stress_tests/environments');
+      if (!await dir.exists()) {
+        await dir.create(recursive: true);
+      }
+      final bytes = await _fetchCached(
+        environment.url!,
+        File('${dir.path}/${environment.id}.hdr'),
+        onChunk: (_) {},
+      );
+      final hdr = await compute(loadHdrEnvironment, bytes);
+      map = await EnvironmentMap.fromEquirectHdr(
+        linearPixels: hdr.pixels,
+        width: hdr.width,
+        height: hdr.height,
+      );
+    }
+    _environmentCache[environment.id] = map;
+    return map;
+  }
+
+  // Rebuilds the scene's environment rotation from the three Euler angles.
+  void _applyEnvironmentRotation() {
+    const degToRad = pi / 180.0;
+    _scene.environmentTransform =
+        vm.Matrix3.rotationY(_envRotationY * degToRad) *
+        vm.Matrix3.rotationX(_envRotationX * degToRad) *
+        vm.Matrix3.rotationZ(_envRotationZ * degToRad);
   }
 
   Animation? _findAnimation(Node root, String name) {
@@ -654,6 +877,51 @@ class _StressSceneState extends State<_StressScene> {
         ),
         if (_ready)
           Positioned(
+            left: 8,
+            bottom: 8,
+            child: _LightingPanel(
+              activeEnvironment: _activeEnvironment,
+              environmentLoading: _environmentLoading,
+              onEnvironmentSelected: _selectEnvironment,
+              exposure: _exposure,
+              environmentIntensity: _environmentIntensity,
+              envRotationX: _envRotationX,
+              envRotationY: _envRotationY,
+              envRotationZ: _envRotationZ,
+              onExposureChanged: (value) {
+                setState(() {
+                  _exposure = value;
+                  _scene.exposure = value;
+                });
+              },
+              onEnvironmentIntensityChanged: (value) {
+                setState(() {
+                  _environmentIntensity = value;
+                  _scene.environmentIntensity = value;
+                });
+              },
+              onEnvRotationXChanged: (value) {
+                setState(() {
+                  _envRotationX = value;
+                  _applyEnvironmentRotation();
+                });
+              },
+              onEnvRotationYChanged: (value) {
+                setState(() {
+                  _envRotationY = value;
+                  _applyEnvironmentRotation();
+                });
+              },
+              onEnvRotationZChanged: (value) {
+                setState(() {
+                  _envRotationZ = value;
+                  _applyEnvironmentRotation();
+                });
+              },
+            ),
+          ),
+        if (_ready)
+          Positioned(
             right: 8,
             bottom: 8,
             child: IgnorePointer(
@@ -712,6 +980,223 @@ class _LoadingOverlay extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+// The "Active Environment" menu: a compact dark pill that opens the list
+// of selectable image-based-lighting environments. Shows a spinner while
+// the chosen environment downloads and prefilters.
+class _EnvironmentMenu extends StatelessWidget {
+  const _EnvironmentMenu({
+    required this.active,
+    required this.loading,
+    required this.onSelected,
+  });
+
+  final _Environment active;
+  final bool loading;
+  final ValueChanged<_Environment> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white12,
+      borderRadius: BorderRadius.circular(4),
+      child: PopupMenuButton<_Environment>(
+        tooltip: 'Select environment',
+        position: PopupMenuPosition.over,
+        onSelected: onSelected,
+        itemBuilder:
+            (context) => [
+              for (final environment in _environments)
+                PopupMenuItem<_Environment>(
+                  value: environment,
+                  child: Text(environment.title),
+                ),
+            ],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.light_mode, color: Colors.white, size: 16),
+              const SizedBox(width: 6),
+              Text(
+                active.title,
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+              ),
+              const SizedBox(width: 6),
+              loading
+                  ? const SizedBox(
+                    width: 12,
+                    height: 12,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.white,
+                    ),
+                  )
+                  : const Icon(
+                    Icons.arrow_drop_down,
+                    color: Colors.white,
+                    size: 18,
+                  ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// Bottom-left lighting panel: the environment menu plus exposure and
+// image-based-lighting intensity sliders.
+class _LightingPanel extends StatelessWidget {
+  const _LightingPanel({
+    required this.activeEnvironment,
+    required this.environmentLoading,
+    required this.onEnvironmentSelected,
+    required this.exposure,
+    required this.environmentIntensity,
+    required this.envRotationX,
+    required this.envRotationY,
+    required this.envRotationZ,
+    required this.onExposureChanged,
+    required this.onEnvironmentIntensityChanged,
+    required this.onEnvRotationXChanged,
+    required this.onEnvRotationYChanged,
+    required this.onEnvRotationZChanged,
+  });
+
+  final _Environment activeEnvironment;
+  final bool environmentLoading;
+  final ValueChanged<_Environment> onEnvironmentSelected;
+  final double exposure;
+  final double environmentIntensity;
+  final double envRotationX;
+  final double envRotationY;
+  final double envRotationZ;
+  final ValueChanged<double> onExposureChanged;
+  final ValueChanged<double> onEnvironmentIntensityChanged;
+  final ValueChanged<double> onEnvRotationXChanged;
+  final ValueChanged<double> onEnvRotationYChanged;
+  final ValueChanged<double> onEnvRotationZChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 248,
+      constraints: const BoxConstraints(maxHeight: 440),
+      padding: const EdgeInsets.fromLTRB(10, 8, 10, 8),
+      decoration: BoxDecoration(
+        color: Colors.black54,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _EnvironmentMenu(
+              active: activeEnvironment,
+              loading: environmentLoading,
+              onSelected: onEnvironmentSelected,
+            ),
+            const SizedBox(height: 4),
+            _LabeledSlider(
+              label: 'Exposure',
+              value: exposure,
+              min: 0.1,
+              max: 8.0,
+              onChanged: onExposureChanged,
+            ),
+            _LabeledSlider(
+              label: 'IBL intensity',
+              value: environmentIntensity,
+              min: 0.0,
+              max: 4.0,
+              onChanged: onEnvironmentIntensityChanged,
+            ),
+            _LabeledSlider(
+              label: 'Env rotation X',
+              value: envRotationX,
+              min: -180.0,
+              max: 180.0,
+              onChanged: onEnvRotationXChanged,
+            ),
+            _LabeledSlider(
+              label: 'Env rotation Y',
+              value: envRotationY,
+              min: -180.0,
+              max: 180.0,
+              onChanged: onEnvRotationYChanged,
+            ),
+            _LabeledSlider(
+              label: 'Env rotation Z',
+              value: envRotationZ,
+              min: -180.0,
+              max: 180.0,
+              onChanged: onEnvRotationZChanged,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// A compact labeled slider for the lighting panel: label and current
+// value on one row, the slider below.
+class _LabeledSlider extends StatelessWidget {
+  const _LabeledSlider({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                label,
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+              ),
+              Text(
+                value.toStringAsFixed(2),
+                style: const TextStyle(color: Colors.white70, fontSize: 12),
+              ),
+            ],
+          ),
+        ),
+        SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            trackHeight: 2,
+            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
+            overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
+          ),
+          child: Slider(
+            value: value.clamp(min, max),
+            min: min,
+            max: max,
+            onChanged: onChanged,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/examples/flutter_app/lib/hdr_image.dart
+++ b/examples/flutter_app/lib/hdr_image.dart
@@ -1,0 +1,212 @@
+// A decoder for Radiance HDR (`.hdr`, RGBE) equirectangular images.
+//
+// flutter_scene's EnvironmentMap.fromEquirectHdr wants linear-radiance
+// RGBA float pixels; Flutter's built-in image codecs do not handle the
+// Radiance format, so this fills the gap. Decodes the new-style adaptive
+// RLE scanlines (and a flat / old-RLE fallback), converts RGBE mantissas
+// to linear float radiance, and box-downsamples to a manageable size.
+
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+/// A decoded equirectangular HDR image: linear-radiance RGBA float pixels,
+/// row-major, [width] by [height] (row 0 at the top).
+class HdrImage {
+  HdrImage(this.width, this.height, this.pixels)
+    : assert(pixels.length == width * height * 4);
+
+  final int width;
+  final int height;
+
+  /// Linear radiance, four floats per pixel (alpha is always 1.0).
+  final Float32List pixels;
+}
+
+/// Decodes a Radiance HDR file and box-downsamples it so its width is at
+/// most [maxWidth]. Suitable to run in an isolate via `compute`.
+HdrImage loadHdrEnvironment(Uint8List bytes) {
+  return _downsample(decodeRadianceHdr(bytes), 1024);
+}
+
+/// 2^(e - 136) for every possible RGBE exponent byte, the per-pixel scale
+/// that turns an RGBE mantissa into linear radiance.
+final Float64List _exponentScale = Float64List.fromList(
+  List<double>.generate(256, (e) => math.pow(2.0, e - 136).toDouble()),
+);
+
+/// Decodes a Radiance HDR (`.hdr`) file to linear-radiance float pixels.
+///
+/// Supports the standard `32-bit_rle_rgbe` format in the common `-Y +X`
+/// orientation, with new-style adaptive RLE scanlines plus a flat /
+/// old-RLE fallback.
+HdrImage decodeRadianceHdr(Uint8List bytes) {
+  var pos = 0;
+
+  String readLine() {
+    final sb = StringBuffer();
+    while (pos < bytes.length) {
+      final c = bytes[pos++];
+      if (c == 0x0a) break; // newline
+      sb.writeCharCode(c);
+    }
+    return sb.toString();
+  }
+
+  final magic = readLine();
+  if (!magic.startsWith('#?')) {
+    throw const FormatException('Not a Radiance HDR file');
+  }
+  var format = '';
+  while (true) {
+    final line = readLine();
+    if (line.isEmpty) break; // a blank line ends the header
+    if (line.startsWith('FORMAT=')) format = line.substring(7).trim();
+  }
+  if (format.isNotEmpty && format != '32-bit_rle_rgbe') {
+    throw FormatException('Unsupported HDR format: $format');
+  }
+
+  final resolution = readLine().trim().split(RegExp(r'\s+'));
+  if (resolution.length != 4 ||
+      resolution[0] != '-Y' ||
+      resolution[2] != '+X') {
+    throw FormatException(
+      'Unsupported HDR orientation: ${resolution.join(' ')}',
+    );
+  }
+  final height = int.parse(resolution[1]);
+  final width = int.parse(resolution[3]);
+
+  final pixels = Float32List(width * height * 4);
+  final scanline = Uint8List(width * 4); // one row of raw RGBE
+
+  for (var y = 0; y < height; y++) {
+    pos = _readScanline(bytes, pos, scanline, width);
+    // Radiance `-Y` files store rows top-down (row 0 = up pole), but
+    // flutter_scene's equirect convention is row 0 = down pole (what
+    // EnvironmentMap.studio emits and the SH projection expects), so
+    // write each scanline into the vertically-mirrored destination row.
+    final rowBase = (height - 1 - y) * width * 4;
+    for (var x = 0; x < width; x++) {
+      final si = x * 4;
+      final exponent = scanline[si + 3];
+      final di = rowBase + si;
+      if (exponent != 0) {
+        final scale = _exponentScale[exponent];
+        pixels[di] = scanline[si] * scale;
+        pixels[di + 1] = scanline[si + 1] * scale;
+        pixels[di + 2] = scanline[si + 2] * scale;
+      }
+      pixels[di + 3] = 1.0;
+    }
+  }
+  return HdrImage(width, height, pixels);
+}
+
+// Decodes one scanline of [width] RGBE pixels into [out], returning the
+// new read position. Picks new-style adaptive RLE when the scanline
+// header marks it, otherwise falls back to flat / old-RLE pixels.
+int _readScanline(Uint8List bytes, int pos, Uint8List out, int width) {
+  if (width >= 8 && width <= 0x7fff) {
+    final r = bytes[pos];
+    final g = bytes[pos + 1];
+    final b = bytes[pos + 2];
+    final e = bytes[pos + 3];
+    if (r == 2 && g == 2 && (b & 0x80) == 0) {
+      if (((b << 8) | e) != width) {
+        throw const FormatException('HDR scanline width mismatch');
+      }
+      pos += 4;
+      // Each of the four channels is RLE-encoded across the whole
+      // scanline: a count above 128 is a run of (count - 128) copies of
+      // the next byte, otherwise it is that many literal bytes.
+      for (var c = 0; c < 4; c++) {
+        var x = 0;
+        while (x < width) {
+          var count = bytes[pos++];
+          if (count > 128) {
+            count -= 128;
+            final value = bytes[pos++];
+            for (var k = 0; k < count; k++) {
+              out[(x++) * 4 + c] = value;
+            }
+          } else {
+            for (var k = 0; k < count; k++) {
+              out[(x++) * 4 + c] = bytes[pos++];
+            }
+          }
+        }
+      }
+      return pos;
+    }
+  }
+  return _readFlatScanline(bytes, pos, out, width);
+}
+
+// Reads a scanline stored as flat RGBE quads, honoring old-style RLE
+// where a (1, 1, 1, n) quad repeats the previous pixel.
+int _readFlatScanline(Uint8List bytes, int pos, Uint8List out, int width) {
+  var x = 0;
+  var runShift = 0;
+  while (x < width) {
+    final r = bytes[pos];
+    final g = bytes[pos + 1];
+    final b = bytes[pos + 2];
+    final e = bytes[pos + 3];
+    pos += 4;
+    if (r == 1 && g == 1 && b == 1 && x > 0) {
+      final count = e << (runShift * 8);
+      final prev = (x - 1) * 4;
+      for (var k = 0; k < count && x < width; k++) {
+        final o = x * 4;
+        out[o] = out[prev];
+        out[o + 1] = out[prev + 1];
+        out[o + 2] = out[prev + 2];
+        out[o + 3] = out[prev + 3];
+        x++;
+      }
+      runShift++;
+    } else {
+      final o = x * 4;
+      out[o] = r;
+      out[o + 1] = g;
+      out[o + 2] = b;
+      out[o + 3] = e;
+      x++;
+      runShift = 0;
+    }
+  }
+  return pos;
+}
+
+// Box-downsamples [src] by an integer factor so its width does not exceed
+// [maxWidth]. Averaging is done in linear radiance, which is correct for
+// HDR data. Returns [src] unchanged when it is already small enough.
+HdrImage _downsample(HdrImage src, int maxWidth) {
+  if (src.width <= maxWidth) return src;
+  final factor = (src.width / maxWidth).ceil();
+  final dw = src.width ~/ factor;
+  final dh = src.height ~/ factor;
+  final out = Float32List(dw * dh * 4);
+  final inverseArea = 1.0 / (factor * factor);
+  for (var y = 0; y < dh; y++) {
+    for (var x = 0; x < dw; x++) {
+      var r = 0.0, g = 0.0, b = 0.0;
+      for (var sy = 0; sy < factor; sy++) {
+        var si = ((y * factor + sy) * src.width + x * factor) * 4;
+        for (var sx = 0; sx < factor; sx++) {
+          r += src.pixels[si];
+          g += src.pixels[si + 1];
+          b += src.pixels[si + 2];
+          si += 4;
+        }
+      }
+      final di = (y * dw + x) * 4;
+      out[di] = r * inverseArea;
+      out[di + 1] = g * inverseArea;
+      out[di + 2] = b * inverseArea;
+      out[di + 3] = 1.0;
+    }
+  }
+  return HdrImage(dw, dh, out);
+}

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -292,10 +292,11 @@ class Lighting {
   Lighting({
     required this.environmentMap,
     this.environmentIntensity = 1.0,
+    Matrix3? environmentTransform,
     this.directionalLight,
     this.shadowMap,
     this.cascades = const [],
-  });
+  }) : environmentTransform = environmentTransform ?? Matrix3.identity();
 
   /// The image-based-lighting environment in effect for this draw.
   final EnvironmentMap environmentMap;
@@ -303,6 +304,10 @@ class Lighting {
   /// Scalar multiplier applied to [environmentMap]'s contribution
   /// (the scene's `environmentIntensity`).
   final double environmentIntensity;
+
+  /// Rotation applied to the image-based-lighting environment (the
+  /// scene's `environmentTransform`). Identity leaves it unrotated.
+  final Matrix3 environmentTransform;
 
   /// The scene's directional light, or null when there isn't one.
   final DirectionalLight? directionalLight;

--- a/packages/flutter_scene/lib/src/material/environment.dart
+++ b/packages/flutter_scene/lib/src/material/environment.dart
@@ -95,6 +95,74 @@ base class EnvironmentMap {
     );
   }
 
+  /// Builds an [EnvironmentMap] from a high-dynamic-range equirectangular
+  /// radiance map: linear (not sRGB) RGBA float pixels, row-major,
+  /// [width] by [height].
+  ///
+  /// Unlike [fromUIImages], the input is linear HDR, so radiance above 1.0
+  /// (bright skies, the sun) is preserved through the prefilter and lights
+  /// the scene at its true intensity. Pass [diffuseSphericalHarmonics] to
+  /// supply your own diffuse term instead of projecting it.
+  static Future<EnvironmentMap> fromEquirectHdr({
+    required Float32List linearPixels,
+    required int width,
+    required int height,
+    List<Vector3>? diffuseSphericalHarmonics,
+  }) async {
+    assert(linearPixels.length == width * height * 4);
+    // The radiance texture is fp16, not fp32: the prefilter samples it
+    // with a linear sampler, and 32-bit-float textures are not filterable
+    // on several GPU backends (notably Apple Silicon), which would make
+    // the prefiltered atlas read back as black. fp16 is universally
+    // filterable and carries ample range for radiance.
+    final radianceTexture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      width,
+      height,
+      format: gpu.PixelFormat.r16g16b16a16Float,
+    )..overwrite(ByteData.sublistView(_floatPixelsToHalf(linearPixels)));
+    final prefilteredRadiance = prefilterEquirectRadiance(
+      radianceTexture,
+      sourceIsLinear: true,
+    );
+    final sh =
+        diffuseSphericalHarmonics ??
+        _projectLinearEquirectToSphericalHarmonics(linearPixels, width, height);
+    return EnvironmentMap._(prefilteredRadiance, sh);
+  }
+
+  // Scratch storage for reinterpreting a 32-bit float as its raw bits.
+  static final Float32List _floatBits = Float32List(1);
+  static final Uint32List _floatBitsView = Uint32List.view(_floatBits.buffer);
+
+  /// Converts linear RGBA float [pixels] to half-float (fp16) bit patterns
+  /// for upload to an `r16g16b16a16Float` texture.
+  static Uint16List _floatPixelsToHalf(Float32List pixels) {
+    final half = Uint16List(pixels.length);
+    for (var i = 0; i < pixels.length; i++) {
+      half[i] = _floatToHalfBits(pixels[i]);
+    }
+    return half;
+  }
+
+  /// Converts one 32-bit float to a 16-bit half-float bit pattern.
+  /// Subnormals flush to zero; values past the half range clamp to the
+  /// largest finite half.
+  static int _floatToHalfBits(double value) {
+    _floatBits[0] = value;
+    final bits = _floatBitsView[0];
+    final sign = (bits >>> 16) & 0x8000;
+    final exponent = ((bits >>> 23) & 0xff) - 112; // rebias 127 -> 15
+    final mantissa = bits & 0x7fffff;
+    if (exponent >= 0x1f) {
+      return sign | 0x7bff; // overflow / inf / nan -> largest finite half
+    }
+    if (exponent <= 0) {
+      return sign; // underflow -> signed zero
+    }
+    return sign | (exponent << 10) | (mantissa >>> 13);
+  }
+
   /// Builds the package's built-in procedural "studio" environment.
   ///
   /// A neutral image-based-lighting setup generated on the fly (no bundled
@@ -241,12 +309,42 @@ base class EnvironmentMap {
     );
   }
 
-  /// Core SH-9 projection over RGBA8 equirectangular [bytes] of the given
-  /// dimensions. Shared by [computeDiffuseSphericalHarmonics] and [studio].
+  /// SH-9 projection over RGBA8 sRGB equirectangular [bytes].
   static List<Vector3> _projectEquirectToSphericalHarmonics(
     Uint8List bytes,
     int width,
     int height,
+  ) {
+    return _projectEquirect(width, height, (px, py) {
+      final o = (py * width + px) * 4;
+      // Linearize sRGB the same way the shader's SRGBToLinear does.
+      return (
+        _srgbToLinear(bytes[o] / 255.0),
+        _srgbToLinear(bytes[o + 1] / 255.0),
+        _srgbToLinear(bytes[o + 2] / 255.0),
+      );
+    });
+  }
+
+  /// SH-9 projection over linear-radiance RGBA float equirect [pixels].
+  static List<Vector3> _projectLinearEquirectToSphericalHarmonics(
+    Float32List pixels,
+    int width,
+    int height,
+  ) {
+    return _projectEquirect(width, height, (px, py) {
+      final o = (py * width + px) * 4;
+      return (pixels[o], pixels[o + 1], pixels[o + 2]);
+    });
+  }
+
+  /// Core SH-9 projection over an equirectangular image of the given
+  /// dimensions. [sampleLinearRgb] returns the linear RGB radiance at a
+  /// pixel; callers adapt their own storage (sRGB bytes, HDR floats).
+  static List<Vector3> _projectEquirect(
+    int width,
+    int height,
+    (double, double, double) Function(int px, int py) sampleLinearRgb,
   ) {
     // Quadrature over a regular grid in equirectangular UV space. The grid
     // resolution is independent of the source image; sampling 192x96 cells
@@ -274,12 +372,7 @@ base class EnvironmentMap {
         final dirZ = cosLat * math.sin(longitude);
         final px = (u * width).floor().clamp(0, width - 1);
 
-        final o = (py * width + px) * 4;
-        // Linearize sRGB the same way the shader's SRGBToLinear does.
-        final r = _srgbToLinear(bytes[o] / 255.0);
-        final g = _srgbToLinear(bytes[o + 1] / 255.0);
-        final b = _srgbToLinear(bytes[o + 2] / 255.0);
-
+        final (r, g, b) = sampleLinearRgb(px, py);
         _accumulateSh(coefficients, dirX, dirY, dirZ, r, g, b, weightRow);
       }
     }

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -222,7 +222,7 @@ class PhysicallyBasedMaterial extends Material {
             ? const <ShadowCascade>[]
             : lighting.cascades;
 
-    // FragInfo std140 layout (560 bytes / 140 floats):
+    // FragInfo std140 layout (608 bytes / 152 floats):
     //   [0..3]    vec4  color
     //   [4..7]    vec4  emissive_factor
     //   [8..43]   vec4  diffuse_sh0..8 (xyz used, w padding)
@@ -248,8 +248,9 @@ class PhysicallyBasedMaterial extends Material {
     //   [135]     float shadow_fade (world-space far-edge fade width)
     //   [136]     float shadow_softness (world-space penumbra radius)
     //   [137]     float shadow_cascade_count
-    //   [138..139] padding to a 16-byte multiple
-    final fragInfo = Float32List(140);
+    //   [138..139] padding to a 16-byte boundary
+    //   [140..150] mat3  environment_transform (3 vec3 columns, w padding)
+    final fragInfo = Float32List(152);
     fragInfo[0] = baseColorFactor.r;
     fragInfo[1] = baseColorFactor.g;
     fragInfo[2] = baseColorFactor.b;
@@ -302,6 +303,15 @@ class PhysicallyBasedMaterial extends Material {
     fragInfo[135] = light?.shadowFadeRange ?? 0.0;
     fragInfo[136] = light?.shadowSoftness ?? 0.0;
     fragInfo[137] = cascades.length.toDouble();
+    // mat3 environment_transform: std140 stores each column as a vec3
+    // padded to 16 bytes, so the three columns land at [140], [144],
+    // [148]. Matrix3.storage is column-major (3 floats per column).
+    final envTransform = lighting.environmentTransform.storage;
+    for (var col = 0; col < 3; col++) {
+      fragInfo[140 + col * 4] = envTransform[col * 3];
+      fragInfo[141 + col * 4] = envTransform[col * 3 + 1];
+      fragInfo[142 + col * 4] = envTransform[col * 3 + 2];
+    }
     pass.bindUniform(
       fragmentShader.getUniformSlot("FragInfo"),
       transientsBuffer.emplace(ByteData.sublistView(fragInfo)),

--- a/packages/flutter_scene/lib/src/render/env_prefilter.dart
+++ b/packages/flutter_scene/lib/src/render/env_prefilter.dart
@@ -36,6 +36,22 @@ final gpu.BufferView _fullscreenQuadView = gpu.BufferView(
   lengthInBytes: 6 * 2 * 4,
 );
 
+// TODO(bdero): Prefilter-quality follow-ups, roughly in priority order:
+//  - Filtered importance sampling: sample a mip chain of the source
+//    equirect (mapping each GGX sample's cone solid angle to a mip LOD)
+//    so a sample integrates an area instead of a point. That removes the
+//    residual sampling noise and lets kPrefilterSamples drop back to
+//    ~32. Blocked on two Flutter GPU gaps worth upstreaming: `textureLod`
+//    is unavailable in the shader dialect (see `SampleEnvironmentTextureLod`
+//    in texture.glsl), and there is no API to generate or upload texture
+//    mip levels.
+//  - A prefiltered cubemap instead of this equirectangular atlas: removes
+//    the pole distortion (smearing on near-vertical reflections) and the
+//    resolution ceiling. Needs mipmapped cubemap texture support in
+//    Flutter GPU (https://github.com/flutter/flutter/issues/145027).
+//  - A mip-style atlas: one large sharp band plus progressively smaller
+//    rough bands, rather than equal-size bands, so mirror reflections get
+//    real resolution without bloating the rough bands.
 /// Prefilters an equirectangular radiance texture into a vertical
 /// roughness-band atlas for image-based specular lighting.
 ///
@@ -46,9 +62,14 @@ final gpu.BufferView _fullscreenQuadView = gpu.BufferView(
 /// on the environment and sampled at draw time by the standard shader's
 /// `SamplePrefilteredRadiance`.
 ///
-/// [sourceEquirect] is treated as an sRGB-encoded equirectangular radiance
-/// map; the atlas stores linear radiance.
-gpu.Texture prefilterEquirectRadiance(gpu.Texture sourceEquirect) {
+/// [sourceEquirect] is an equirectangular radiance map. By default it is
+/// treated as sRGB-encoded; pass [sourceIsLinear] when it already holds
+/// linear radiance (an HDR environment), so it is not linearized twice.
+/// The atlas always stores linear radiance.
+gpu.Texture prefilterEquirectRadiance(
+  gpu.Texture sourceEquirect, {
+  bool sourceIsLinear = false,
+}) {
   final atlas = gpu.gpuContext.createTexture(
     gpu.StorageMode.devicePrivate,
     kPrefilterBandWidth,
@@ -82,6 +103,12 @@ gpu.Texture prefilterEquirectRadiance(gpu.Texture sourceEquirect) {
       widthAddressMode: gpu.SamplerAddressMode.repeat,
       heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
     ),
+  );
+  // A single float (std140-padded to 16 bytes): the sRGB-vs-linear flag.
+  final info = Float32List(4)..[0] = sourceIsLinear ? 1.0 : 0.0;
+  renderPass.bindUniform(
+    fragmentShader.getUniformSlot('PrefilterInfo'),
+    gpu.gpuContext.createHostBuffer().emplace(ByteData.sublistView(info)),
   );
   renderPass.draw();
   commandBuffer.submit();

--- a/packages/flutter_scene/lib/src/render/scene_pass.dart
+++ b/packages/flutter_scene/lib/src/render/scene_pass.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/light.dart';
@@ -26,6 +27,7 @@ class ScenePass extends RenderGraphPass {
     required ui.Size dimensions,
     required EnvironmentMap environmentMap,
     required double environmentIntensity,
+    Matrix3? environmentTransform,
     required bool enableMsaa,
     DirectionalLight? directionalLight,
     List<ShadowCascade> cascades = const [],
@@ -34,6 +36,7 @@ class ScenePass extends RenderGraphPass {
        _dimensions = dimensions,
        _environmentMap = environmentMap,
        _environmentIntensity = environmentIntensity,
+       _environmentTransform = environmentTransform,
        _enableMsaa = enableMsaa,
        _directionalLight = directionalLight,
        _cascades = cascades;
@@ -43,6 +46,7 @@ class ScenePass extends RenderGraphPass {
   final ui.Size _dimensions;
   final EnvironmentMap _environmentMap;
   final double _environmentIntensity;
+  final Matrix3? _environmentTransform;
   final bool _enableMsaa;
   final DirectionalLight? _directionalLight;
   final List<ShadowCascade> _cascades;
@@ -105,6 +109,7 @@ class ScenePass extends RenderGraphPass {
     final lighting = Lighting(
       environmentMap: _environmentMap,
       environmentIntensity: _environmentIntensity,
+      environmentTransform: _environmentTransform,
       directionalLight: _directionalLight,
       shadowMap: shadowMap,
       cascades: shadowMap == null ? const [] : _cascades,

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -4,6 +4,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:vector_math/vector_math.dart' show Matrix3;
 import 'camera.dart';
 import 'light.dart';
 import 'material/environment.dart';
@@ -179,6 +180,10 @@ base class Scene implements SceneGraph {
   /// (the default) is neutral.
   double environmentIntensity = 1.0;
 
+  /// Rotation applied to the image-based-lighting [environment] when it is
+  /// sampled. Identity (the default) leaves the environment unrotated.
+  Matrix3 environmentTransform = Matrix3.identity();
+
   /// Optional analytic directional light (e.g. a sun) layered on top of
   /// the image-based lighting. Null (the default) means IBL only.
   DirectionalLight? directionalLight;
@@ -350,6 +355,7 @@ base class Scene implements SceneGraph {
         dimensions: pixelSize,
         environmentMap: environmentMap,
         environmentIntensity: environmentIntensity,
+        environmentTransform: environmentTransform,
         enableMsaa: enableMsaa,
         directionalLight: light,
         cascades: cascades,

--- a/packages/flutter_scene/shaders/flutter_scene_prefilter_env.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_prefilter_env.frag
@@ -6,6 +6,13 @@
 
 uniform sampler2D source_equirect;
 
+uniform PrefilterInfo {
+  // 1.0 when source_equirect already holds linear radiance (an HDR
+  // environment); 0.0 when it is sRGB-encoded and must be linearized.
+  float source_is_linear;
+}
+prefilter_info;
+
 in vec2 v_uv;  // [0, 1]^2 over the whole atlas; v_uv.y = 0 at the top.
 
 out vec4 frag_color;
@@ -13,9 +20,17 @@ out vec4 frag_color;
 #include <pbr.glsl>      // kPi, SRGBToLinear
 #include <texture.glsl>  // kPrefilterBands, Spherical<->Equirectangular
 
+// Samples the source environment as linear radiance. An sRGB source is
+// linearized; an HDR source (source_is_linear) already is linear.
+vec3 SampleSourceRadiance(vec3 direction) {
+  vec3 c = SampleEnvironmentTexture(source_equirect, direction);
+  return prefilter_info.source_is_linear > 0.5 ? c : SRGBToLinear(c);
+}
+
 // GGX importance samples accumulated per output texel. Fixed (compile-time)
-// so the loop bound is constant.
-const int kPrefilterSamples = 64;
+// so the loop bound is constant. High enough that the per-texel-rotated
+// sample set (see main) reads as fine noise rather than visible swirls.
+const int kPrefilterSamples = 256;
 
 // Van der Corput radical inverse in base 2, computed with float ops only
 // (no integer bit operations, which aren't reliably available in the GLSL
@@ -59,20 +74,29 @@ void main() {
   vec3 v = n;
   float roughness = band_index / max(kPrefilterBands - 1.0, 1.0);
 
+  // Per-texel azimuthal rotation of the importance-sample set. The GGX
+  // samples live in a tangent frame that rotates with n, so a fixed
+  // sample set leaves a spatially-coherent under-sampling bias that shows
+  // up as concentric swirls in the rougher bands. Rotating the set by a
+  // per-texel pseudo-random angle decorrelates that bias into fine noise,
+  // which the prefilter average then smooths away.
+  float jitter = fract(
+      52.9829189 *
+      fract(dot(gl_FragCoord.xy, vec2(0.06711056, 0.00583715))));
+
   vec3 color = vec3(0.0);
   float total_weight = 0.0;
   for (int i = 0; i < kPrefilterSamples; i++) {
-    vec3 h = ImportanceSampleGGX(Hammersley(i, kPrefilterSamples), n, roughness);
+    vec2 xi = Hammersley(i, kPrefilterSamples);
+    xi.x = fract(xi.x + jitter);
+    vec3 h = ImportanceSampleGGX(xi, n, roughness);
     vec3 l = normalize(2.0 * dot(v, h) * h - v);
     float n_dot_l = dot(n, l);
     if (n_dot_l > 0.0) {
-      color +=
-          SRGBToLinear(SampleEnvironmentTexture(source_equirect, l)) * n_dot_l;
+      color += SampleSourceRadiance(l) * n_dot_l;
       total_weight += n_dot_l;
     }
   }
-  color = total_weight > 0.0
-              ? color / total_weight
-              : SRGBToLinear(SampleEnvironmentTexture(source_equirect, n));
+  color = total_weight > 0.0 ? color / total_weight : SampleSourceRadiance(n);
   frag_color = vec4(color, 1.0);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -55,6 +55,10 @@ uniform FragInfo {
   float shadow_softness;
   // Number of valid cascades in light_space_matrix (1 to 4).
   float shadow_cascade_count;
+  // Rotates the image-based-lighting environment: the diffuse-SH and
+  // prefiltered-radiance lookup directions are transformed by this before
+  // sampling. Identity leaves the environment unrotated.
+  mat3 environment_transform;
 }
 frag_info;
 
@@ -252,16 +256,22 @@ void main() {
   // camera.
   float n_dot_v = max(dot(normal, camera_normal), 0.0);
 
-  vec3 reflection_normal = reflect(camera_normal, normal);
+  // reflect() needs the incident ray (camera -> surface); camera_normal
+  // points surface -> camera, so negate it. Sampling the environment with
+  // the un-negated vector would mirror reflections to the opposite side.
+  vec3 reflection_normal = reflect(-camera_normal, normal);
 
   // Roughness-dependent Fresnel reflectance for the indirect specular lobe.
   vec3 k_S = FresnelSchlickRoughness(n_dot_v, reflectance, roughness);
 
-  vec3 irradiance = max(EvaluateDiffuseSH(normal), vec3(0.0)) *
+  // The IBL environment can be rotated; transform the lookup directions.
+  vec3 env_normal = frag_info.environment_transform * normal;
+  vec3 env_reflection = frag_info.environment_transform * reflection_normal;
+  vec3 irradiance = max(EvaluateDiffuseSH(env_normal), vec3(0.0)) *
                     frag_info.environment_intensity;
   vec3 prefiltered_color =
-      SamplePrefilteredRadiance(prefiltered_radiance, reflection_normal,
-                                roughness, frag_info.render_target_flip_y) *
+      SamplePrefilteredRadiance(prefiltered_radiance, env_reflection,
+                                roughness) *
       frag_info.environment_intensity;
 
   // Split-sum DFG terms (Karis '13). The LUT is sampled slightly inside

--- a/packages/flutter_scene/shaders/texture.glsl
+++ b/packages/flutter_scene/shaders/texture.glsl
@@ -52,13 +52,13 @@ const float kPrefilterBandHeight = 256.0;
 const float kPrefilterBandEdgeClamp = 1.0 / kPrefilterBandHeight;
 
 // Samples the prefiltered radiance atlas for reflection `direction` at the
-// given perceptual `roughness`, interpolating between the two nearest bands.
-// `flip_y` is 1.0 on backends whose render-to-texture targets sample
-// top-down (Metal/Vulkan) and 0.0 where they sample bottom-up (OpenGL ES);
-// Flutter GPU exposes no backend macro, so the caller passes it. Sample the
-// atlas with a horizontal-repeat / vertical-clamp sampler.
+// given perceptual `roughness`, interpolating between the two nearest
+// bands. The atlas samples in the same V orientation it was rendered (the
+// prefilter's full-screen pass already accounts for the render-to-texture
+// orientation), so no flip is applied here. Sample the atlas with a
+// horizontal-repeat / vertical-clamp sampler.
 vec3 SamplePrefilteredRadiance(sampler2D atlas, vec3 direction,
-                               float roughness, float flip_y) {
+                               float roughness) {
   vec2 eq = SphericalToEquirectangular(direction);
   eq.y = clamp(eq.y, kPrefilterBandEdgeClamp, 1.0 - kPrefilterBandEdgeClamp);
   float band = clamp(roughness, 0.0, 1.0) * (kPrefilterBands - 1.0);
@@ -67,10 +67,6 @@ vec3 SamplePrefilteredRadiance(sampler2D atlas, vec3 direction,
   float t = band - b0;
   float v0 = (b0 + eq.y) / kPrefilterBands;
   float v1 = (b1 + eq.y) / kPrefilterBands;
-  if (flip_y > 0.5) {
-    v0 = 1.0 - v0;
-    v1 = 1.0 - v1;
-  }
   return mix(texture(atlas, vec2(eq.x, v0)).rgb,
              texture(atlas, vec2(eq.x, v1)).rgb, t);
 }


### PR DESCRIPTION
Adds high-dynamic-range image-based-lighting environments and fixes three image-based specular bugs found along the way.


https://github.com/user-attachments/assets/216aea80-7903-4609-bfb7-feb430dc2ef0



Engine:

- EnvironmentMap.fromEquirectHdr builds an environment from linear HDR equirectangular radiance: it uploads an fp16 radiance texture, prefilters it through a linear-input path, and projects the diffuse spherical harmonics from the float pixels. The prefilter shader gains a source_is_linear flag so an HDR source is not sRGB-linearized twice.
- Scene.environmentTransform, a Matrix3 that rotates the image-based-lighting environment, threaded through Lighting and ScenePass into the standard shader as a mat3.

IBL specular fixes (all masked while the engine only used soft, near-symmetric environments):

- The reflection lookup used reflect(camera_normal, normal), but reflect needs the incident ray, so the negated camera_normal.
- The prefilter importance-sampled with a fixed 64-sample set in a tangent frame that rotates with the normal, leaving a coherent under-sampling bias visible as concentric swirls in the rougher bands. It now uses 256 samples with a per-texel rotation.
- SamplePrefilteredRadiance mirrored the whole atlas V to compensate the render-to-texture orientation, which reordered the roughness-band stack so glossy surfaces sampled the blurriest band.

Example:

- A Radiance HDR (.hdr / RGBE) decoder and an "Active Environment" menu in the stress tests, with a catalog of Khronos sample environments downloaded at runtime plus a procedural axis-test environment for checking orientation.
- Exposure, IBL-intensity, and environment X/Y/Z rotation sliders. The analytic directional light is dropped so these scenes are lit purely by the environment.

The environment's default orientation still needs work; rotation sliders are a workaround in the meantime.