### PR TITLE
Fix inside-out rendering of mirrored (negative-scale) nodes

### DIFF
--- a/packages/flutter_scene/lib/src/components/instanced_mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/instanced_mesh_component.dart
@@ -51,6 +51,7 @@ class InstancedMeshComponent extends Component {
     final frustumCulledChanged = item.frustumCulled != frustumCulled;
     item.frustumCulled = frustumCulled;
     item.worldTransform.setFrom(node.globalTransform);
+    item.windingFlipped = node.windingFlipped;
     item.instanceTransforms = instancedMesh.instances;
     item.instanceBounds = instancedMesh.aggregateBounds;
 

--- a/packages/flutter_scene/lib/src/components/mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/mesh_component.dart
@@ -74,6 +74,7 @@ class MeshComponent extends Component {
   void refreshRenderItems() {
     if (_renderItems.isEmpty) return;
     final worldTransform = node.globalTransform;
+    final windingFlipped = node.windingFlipped;
 
     // A skinned node uploads its joint matrices once per frame; both
     // render passes then sample the same joints texture.
@@ -93,6 +94,7 @@ class MeshComponent extends Component {
       final frustumCulledChanged = item.frustumCulled != frustumCulled;
       item.frustumCulled = frustumCulled;
       item.worldTransform.setFrom(worldTransform);
+      item.windingFlipped = windingFlipped;
 
       final wasBounded = item.worldBounds != null;
       final boundsChanged = item.refreshWorldBounds();

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -77,6 +77,18 @@ base class Node implements SceneGraph {
   final Matrix4 _worldTransform = Matrix4.identity();
   bool _worldTransformDirty = true;
 
+  // Whether this node's accumulated transform reverses triangle winding (an
+  // odd number of negative-determinant transforms up the chain). Cached
+  // alongside _worldTransform and invalidated by the same dirty flag.
+  bool _windingFlipped = false;
+
+  /// When true, this node's own transform is treated as a coordinate-system
+  /// convention rather than a geometry mirror, and excluded from
+  /// [windingFlipped]. The importers set this on the synthesized scene root
+  /// that flips glTF's handedness (`scale(1, 1, -1)`), so that flip does not
+  /// reverse cull winding the way a real mirror node should.
+  bool excludeFromWindingParity = false;
+
   /// The skin attached to this node, used for skeletal animation. Set by
   /// importers (both the offline .model path and the runtime glTF/GLB loader).
   Skin? skin;
@@ -109,15 +121,30 @@ base class Node implements SceneGraph {
   Matrix4 get globalTransform {
     if (!_worldTransformDirty) return _worldTransform;
     final parent = _parent;
+    final selfFlip =
+        !excludeFromWindingParity && _localTransform.determinant() < 0;
     if (parent == null) {
       _worldTransform.setFrom(_localTransform);
+      _windingFlipped = selfFlip;
     } else {
       _worldTransform
         ..setFrom(parent.globalTransform)
         ..multiply(_localTransform);
+      // parent.globalTransform above refreshed the parent's cache, so
+      // parent._windingFlipped is current.
+      _windingFlipped = selfFlip != parent._windingFlipped;
     }
     _worldTransformDirty = false;
     return _worldTransform;
+  }
+
+  /// Whether this node's accumulated transform reverses triangle winding (a
+  /// mirror / negative scale somewhere up the chain). The renderer flips cull
+  /// winding for such nodes so their front faces are not culled.
+  bool get windingFlipped {
+    // Touch globalTransform to refresh the cache (which sets _windingFlipped).
+    globalTransform;
+    return _windingFlipped;
   }
 
   Node? _parent;
@@ -541,7 +568,7 @@ base class Node implements SceneGraph {
     Node result = Node(
       name: 'root',
       localTransform: fbScene.transform?.toMatrix4() ?? Matrix4.identity(),
-    );
+    )..excludeFromWindingParity = true;
 
     if (fbScene.nodes == null || fbScene.children == null) {
       return result; // The scene is empty. ¯\_(ツ)_/¯

--- a/packages/flutter_scene/lib/src/render/render_scene.dart
+++ b/packages/flutter_scene/lib/src/render/render_scene.dart
@@ -27,6 +27,11 @@ class RenderItem {
   /// Mirrors the owning node's frustum-cull opt-in, refreshed each frame.
   bool frustumCulled = true;
 
+  /// Whether the owning node's transform reverses triangle winding (a mirror
+  /// up the chain). Refreshed each frame; the encoder flips cull winding when
+  /// set so mirrored nodes don't render inside-out.
+  bool windingFlipped = false;
+
   /// World-space transform, refreshed each frame from the owning node.
   final Matrix4 worldTransform = Matrix4.identity();
 

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -90,6 +90,11 @@ class ShadowEncoder {
           _lightSpaceMatrix,
           _cameraPositionPlaceholder,
         );
+        final flip =
+            item.windingFlipped != (instanceTransform.determinant() < 0);
+        _renderPass.setWindingOrder(
+          flip ? gpu.WindingOrder.clockwise : gpu.WindingOrder.counterClockwise,
+        );
         _renderPass.draw();
       }
       return;
@@ -101,6 +106,13 @@ class ShadowEncoder {
       item.worldTransform,
       _lightSpaceMatrix,
       _cameraPositionPlaceholder,
+    );
+    // Mirrored casters reverse winding; flip the cull order so the same faces
+    // that are visible also cast shadows.
+    _renderPass.setWindingOrder(
+      item.windingFlipped
+          ? gpu.WindingOrder.clockwise
+          : gpu.WindingOrder.counterClockwise,
     );
     _renderPass.draw();
   }

--- a/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
@@ -113,7 +113,7 @@ Future<Node> _buildScene(
   final root = Node(
     name: 'root',
     localTransform: Matrix4.identity()..setEntry(2, 2, -1.0),
-  );
+  )..excludeFromWindingParity = true;
   if (sceneIndex != null && sceneIndex < doc.scenes.length) {
     for (final rootNodeIdx in doc.scenes[sceneIndex].nodes) {
       if (rootNodeIdx >= 0 && rootNodeIdx < engineNodes.length) {

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -29,12 +29,14 @@ base class _TranslucentRecord {
     this.material,
     this.pipeline,
     this.depth,
+    this.windingFlipped,
   );
   final Matrix4 worldTransform;
   final Geometry geometry;
   final Material material;
   final gpu.RenderPipeline pipeline;
   final double depth;
+  final bool windingFlipped;
 }
 
 /// Render pipelines keyed by their (vertex, fragment) shader pair.
@@ -169,6 +171,7 @@ base class SceneEncoder {
             item.material,
             pipeline,
             _depthOf(worldTransform),
+            item.windingFlipped != (instanceTransform.determinant() < 0),
           ),
         );
       }
@@ -180,6 +183,7 @@ base class SceneEncoder {
           item.material,
           pipeline,
           _depthOf(item.worldTransform),
+          item.windingFlipped,
         ),
       );
     }
@@ -202,6 +206,7 @@ base class SceneEncoder {
     Matrix4 worldTransform,
     Geometry geometry,
     Material material,
+    bool windingFlipped,
   ) {
     _renderPass.clearBindings();
     _bindPipeline(pipeline);
@@ -213,6 +218,12 @@ base class SceneEncoder {
       _camera.position,
     );
     material.bind(_renderPass, _transientsBuffer, _lighting);
+    if (windingFlipped) {
+      // A mirrored (negative-determinant) transform reverses triangle
+      // winding; flip the cull order so front faces aren't culled. Material
+      // .bind set the default counter-clockwise winding.
+      _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
+    }
     _renderPass.setPrimitiveType(geometry.primitiveType);
     _renderPass.draw();
   }
@@ -226,6 +237,7 @@ base class SceneEncoder {
     Geometry geometry,
     Material material,
     List<Matrix4> instances,
+    bool windingFlipped,
   ) {
     _renderPass.clearBindings();
     _bindPipeline(pipeline);
@@ -238,6 +250,11 @@ base class SceneEncoder {
         nodeTransform * instanceTransform,
         _cameraTransform,
         _camera.position,
+      );
+      // Each instance can itself mirror; combine with the node's parity.
+      final flip = windingFlipped != (instanceTransform.determinant() < 0);
+      _renderPass.setWindingOrder(
+        flip ? gpu.WindingOrder.clockwise : gpu.WindingOrder.counterClockwise,
       );
       _renderPass.draw();
     }
@@ -267,6 +284,7 @@ base class SceneEncoder {
           item.geometry,
           item.material,
           instances,
+          item.windingFlipped,
         );
       } else {
         _encode(
@@ -274,6 +292,7 @@ base class SceneEncoder {
           item.worldTransform,
           item.geometry,
           item.material,
+          item.windingFlipped,
         );
       }
     }
@@ -300,6 +319,7 @@ base class SceneEncoder {
         record.worldTransform,
         record.geometry,
         record.material,
+        record.windingFlipped,
       );
     }
     _translucentRecords.clear();

--- a/packages/flutter_scene/test/node_winding_test.dart
+++ b/packages/flutter_scene/test/node_winding_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
+import 'package:test/test.dart';
+
+// Regression coverage for issue #134: a node whose accumulated transform has
+// negative determinant (a mirror / negative scale) reverses triangle winding,
+// and the renderer must flip cull winding for it (Node.windingFlipped).
+
+Node _node(Matrix4 transform) => Node(localTransform: transform);
+
+// `Matrix4.diagonal3Values(x, y, z)` is a pure scale (determinant x*y*z).
+Matrix4 _scale(double x, double y, double z) =>
+    Matrix4.diagonal3Values(x, y, z);
+
+void main() {
+  test('identity transform does not flip winding', () {
+    expect(_node(Matrix4.identity()).windingFlipped, isFalse);
+  });
+
+  test('a single negative-axis scale flips winding (any axis)', () {
+    expect(_node(_scale(-1, 1, 1)).windingFlipped, isTrue); // X
+    expect(_node(_scale(1, -1, 1)).windingFlipped, isTrue); // Y
+    expect(_node(_scale(1, 1, -1)).windingFlipped, isTrue); // Z
+  });
+
+  test('two negative scales cancel', () {
+    expect(_node(_scale(-1, -1, 1)).windingFlipped, isFalse);
+  });
+
+  test('parity accumulates down the hierarchy', () {
+    final parent = _node(_scale(-1, 1, 1));
+    final normalChild = _node(Matrix4.identity());
+    final mirroredChild = _node(_scale(-1, 1, 1));
+    parent.add(normalChild);
+    parent.add(mirroredChild);
+
+    expect(parent.windingFlipped, isTrue);
+    expect(normalChild.windingFlipped, isTrue); // inherits parent's flip
+    expect(mirroredChild.windingFlipped, isFalse); // own flip cancels parent's
+  });
+
+  test('a node excluded from winding parity does not contribute its flip', () {
+    // Mirrors the importers' coordinate-convention root (the glTF -> scene
+    // Z flip): determinant -1, but it must not reverse winding.
+    final root = _node(_scale(1, 1, -1))..excludeFromWindingParity = true;
+    expect(root.windingFlipped, isFalse);
+
+    // A normal node under the excluded root renders with normal winding.
+    final child = _node(Matrix4.identity());
+    root.add(child);
+    expect(child.windingFlipped, isFalse);
+
+    // A genuinely mirrored node under it is still flipped.
+    final mirrored = _node(_scale(-1, 1, 1));
+    root.add(mirrored);
+    expect(mirrored.windingFlipped, isTrue);
+  });
+
+  test('winding parity updates when a transform changes', () {
+    final node = _node(Matrix4.identity());
+    expect(node.windingFlipped, isFalse);
+    node.localTransform = _scale(-1, 1, 1);
+    expect(node.windingFlipped, isTrue);
+  });
+}


### PR DESCRIPTION
Resolves #134.

A node whose accumulated transform has negative determinant (a mirror or negative scale, common in models with mirrored parts) reverses triangle winding, so with the fixed counter-clockwise + back-face cull its front faces were culled and it rendered inside-out.

`Node` now tracks `windingFlipped`: the parity of negative-determinant local transforms up the parent chain, cached alongside `globalTransform`. The scene and shadow encoders flip the cull winding per draw when it's set, so mirrored geometry renders (and casts shadows) right side out. The importers' coordinate-conversion root (the glTF `scale(1, 1, -1)` Z flip, also determinant -1) is excluded from that parity, so the intentional handedness conversion is not treated as a mirror; that is why normal imported models were unaffected while a genuinely mirrored node was not. Instanced draws combine the node parity with each instance transform's determinant. Covered by `node_winding_test.dart`.