### PR TITLE
Honor glTF material.doubleSided (runtime importer)

### DIFF
--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -159,6 +159,13 @@ abstract class Material {
     }
   }
 
+  /// Whether to render both faces of triangles drawn with this material
+  /// (glTF's `material.doubleSided`). When true, [bind] disables back-face
+  /// culling so the geometry is visible from both sides; otherwise back faces
+  /// are culled. Defaults to false. The runtime importer sets it from the glTF
+  /// material.
+  bool doubleSided = false;
+
   gpu.Shader? _fragmentShader;
 
   /// The fragment shader used when rendering geometry with this material.
@@ -191,7 +198,7 @@ abstract class Material {
     gpu.HostBuffer transientsBuffer,
     Lighting lighting,
   ) {
-    pass.setCullMode(gpu.CullMode.backFace);
+    pass.setCullMode(doubleSided ? gpu.CullMode.none : gpu.CullMode.backFace);
     pass.setWindingOrder(gpu.WindingOrder.counterClockwise);
   }
 

--- a/packages/flutter_scene/lib/src/runtime_importer/material_builder.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/material_builder.dart
@@ -21,6 +21,7 @@ Material buildMaterial(GltfMaterial? gm, List<gpu.Texture> textures) {
       final t = _resolveTexture(pbr.baseColorTexture, textures);
       if (t != null) m.baseColorTexture = t;
     }
+    m.doubleSided = gm.doubleSided;
     return m;
   }
   final m = PhysicallyBasedMaterial();
@@ -52,6 +53,7 @@ Material buildMaterial(GltfMaterial? gm, List<gpu.Texture> textures) {
   );
   m.alphaMode = _alphaMode(gm.alphaMode);
   m.alphaCutoff = gm.alphaCutoff;
+  m.doubleSided = gm.doubleSided;
   return m;
 }
 

--- a/packages/flutter_scene/test/material_double_sided_test.dart
+++ b/packages/flutter_scene/test/material_double_sided_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/importer/gltf.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Coverage for the runtime doubleSided wiring (PR #139): glTF
+// material.doubleSided is parsed, and Material carries a doubleSided knob.
+//
+// The middle of the chain (buildMaterial setting it on a real
+// PhysicallyBasedMaterial / UnlitMaterial, and Material.bind disabling
+// back-face culling) constructs engine materials, which load the shader
+// bundle and need a Flutter GPU context the headless test harness doesn't
+// provide. That part is exercised by the example app, the same boundary noted
+// in shader_material_test.dart.
+
+void main() {
+  group('Material.doubleSided field', () {
+    test('defaults to false', () {
+      expect(ShaderMaterial().doubleSided, isFalse);
+    });
+
+    test('is settable', () {
+      expect((ShaderMaterial()..doubleSided = true).doubleSided, isTrue);
+    });
+  });
+
+  group('glTF parser reads material.doubleSided', () {
+    test('true when present', () {
+      final doc = parseGltfJson(<String, Object?>{
+        'materials': [
+          <String, Object?>{'doubleSided': true},
+        ],
+      });
+      expect(doc.materials.single.doubleSided, isTrue);
+    });
+
+    test('false when omitted (glTF default)', () {
+      final doc = parseGltfJson(<String, Object?>{
+        'materials': [<String, Object?>{}],
+      });
+      expect(doc.materials.single.doubleSided, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Found while fixing #134.

`doubleSided` was parsed from glTF but never used, so double-sided materials were always back-face culled and their far faces went missing. `Material` now carries a `doubleSided` flag and `bind` disables culling when it's set. The runtime importer (`Node.fromGlbBytes` / `fromGltfBytes`) sets it from the glTF material, for both unlit and physically based materials.

The offline `.model` path still needs a `double_sided` field in `scene.fbs` (plus the emitter and the `.model` to `Material` loader) to carry it through ahead-of-time imports. That schema change is left for a separate PR.