### PR TITLE
Release 0.14.2

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.14.2
+
+Rendering fixes.
+
+* Fixed mirrored geometry rendering inside-out. A node with a
+  negative-determinant transform (a mirror or negative scale) reverses
+  triangle winding, so its front faces were being culled. Cull winding now
+  follows the sign of the node's world-transform determinant, matching the
+  glTF 2.0 spec (section 3.7.4 Instantiation). Applies to the scene pass,
+  the shadow pass, and instanced draws.
+* Fixed `material.doubleSided` being ignored by the runtime glTF importer.
+  Double-sided materials are no longer back-face culled.
+
 ## 0.14.1
 
 Quality and packaging pass to a full pub.dev score.

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_scene
 description: A general-purpose realtime 3D rendering library for Flutter.
-version: 0.14.1
+version: 0.14.2
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
 platforms:


### PR DESCRIPTION
Release prep for 0.14.2. Two rendering fixes since 0.14.1:

- Mirrored geometry (negative-determinant node transforms) no longer renders inside-out; cull winding follows the node's world-transform determinant per glTF 2.0 section 3.7.4 (#137).
- `material.doubleSided` is now honored by the runtime importer, so double-sided materials are not back-face culled (#139).

Version bump and CHANGELOG only. `flutter pub publish --dry-run` passes (clean apart from the expected uncommitted-files warning before this commit).