### PR TITLE
Fix image-based lighting on the OpenGL ES backend

### DIFF
--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -3,6 +3,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/render/y_flip.dart';
 import 'package:flutter_scene/src/shaders.dart';
 
 import 'package:flutter_scene/src/importer/flatbuffer.dart' as fb;
@@ -248,9 +249,11 @@ class PhysicallyBasedMaterial extends Material {
     //   [135]     float shadow_fade (world-space far-edge fade width)
     //   [136]     float shadow_softness (world-space penumbra radius)
     //   [137]     float shadow_cascade_count
-    //   [138..139] padding to a 16-byte boundary
-    //   [140..150] mat3  environment_transform (3 vec3 columns, w padding)
-    final fragInfo = Float32List(152);
+    //   [138]     float prefilter_flip_y (OpenGL ES atlas latitude flip)
+    //   [139]     padding to a 16-byte boundary
+    //   [140..155] mat4  environment_transform (3x3 rotation, last col/row
+    //              identity; mat4 not mat3 to dodge a GLES std140-mat3 bug)
+    final fragInfo = Float32List(156);
     fragInfo[0] = baseColorFactor.r;
     fragInfo[1] = baseColorFactor.g;
     fragInfo[2] = baseColorFactor.b;
@@ -304,15 +307,24 @@ class PhysicallyBasedMaterial extends Material {
     fragInfo[135] = light?.shadowFadeRange ?? 0.0;
     fragInfo[136] = light?.shadowSoftness ?? 0.0;
     fragInfo[137] = cascades.length.toDouble();
-    // mat3 environment_transform: std140 stores each column as a vec3
-    // padded to 16 bytes, so the three columns land at [140], [144],
-    // [148]. Matrix3.storage is column-major (3 floats per column).
+    // prefilter_flip_y: invert the atlas latitude when sampling on backends
+    // that store render-to-texture bottom-up (OpenGL ES). See y_flip.dart and
+    // SamplePrefilteredRadiance. Temporary, part of the Y-flip workaround.
+    fragInfo[138] = backendFlipsRenderTargetY ? 1.0 : 0.0;
+    // mat4 environment_transform: the 3x3 rotation in the upper-left, last
+    // row/column identity. A mat4 (not mat3) because Impeller's OpenGL ES
+    // backend mis-reads a std140 mat3 uniform (its padded vec3 columns),
+    // which collapsed the IBL lookup directions to a constant on GLES; a
+    // mat4's columns are tightly-packed vec4s, identical across backends.
+    // std140 mat4 columns are 16 bytes each, landing at [140], [144], [148],
+    // [152]. Matrix3.storage is column-major (3 floats per column).
     final envTransform = lighting.environmentTransform.storage;
     for (var col = 0; col < 3; col++) {
       fragInfo[140 + col * 4] = envTransform[col * 3];
       fragInfo[141 + col * 4] = envTransform[col * 3 + 1];
       fragInfo[142 + col * 4] = envTransform[col * 3 + 2];
     }
+    fragInfo[155] = 1.0; // mat4 column 3 = (0, 0, 0, 1)
     pass.bindUniform(
       fragmentShader.getUniformSlot("FragInfo"),
       transientsBuffer.emplace(ByteData.sublistView(fragInfo)),

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -55,10 +55,17 @@ uniform FragInfo {
   float shadow_softness;
   // Number of valid cascades in light_space_matrix (1 to 4).
   float shadow_cascade_count;
+  // 1 to invert the prefiltered-radiance atlas latitude when sampling, 0
+  // otherwise. Set on backends that store render-to-texture bottom-up (OpenGL
+  // ES); see SamplePrefilteredRadiance and y_flip.dart. Temporary workaround.
+  float prefilter_flip_y;
   // Rotates the image-based-lighting environment: the diffuse-SH and
   // prefiltered-radiance lookup directions are transformed by this before
-  // sampling. Identity leaves the environment unrotated.
-  mat3 environment_transform;
+  // sampling. Identity leaves the environment unrotated. A mat4 (not mat3)
+  // so the std140 columns are tightly packed vec4s: Impeller's OpenGL ES
+  // backend mis-reads a std140 mat3 uniform (padded vec3 columns), which
+  // collapsed env_normal/env_reflection to a constant on GLES.
+  mat4 environment_transform;
 }
 frag_info;
 
@@ -292,13 +299,14 @@ void main() {
   vec3 k_S = FresnelSchlickRoughness(n_dot_v, reflectance, roughness);
 
   // The IBL environment can be rotated; transform the lookup directions.
-  vec3 env_normal = frag_info.environment_transform * normal;
-  vec3 env_reflection = frag_info.environment_transform * reflection_normal;
+  mat3 environment_transform = mat3(frag_info.environment_transform);
+  vec3 env_normal = environment_transform * normal;
+  vec3 env_reflection = environment_transform * reflection_normal;
   vec3 irradiance = max(EvaluateDiffuseSH(env_normal), vec3(0.0)) *
                     frag_info.environment_intensity;
   vec3 prefiltered_color =
-      SamplePrefilteredRadiance(prefiltered_radiance, env_reflection,
-                                roughness) *
+      SamplePrefilteredRadiance(prefiltered_radiance, env_reflection, roughness,
+                                frag_info.prefilter_flip_y) *
       frag_info.environment_intensity;
 
   // Split-sum DFG terms (Karis '13). The LUT is sampled slightly inside

--- a/packages/flutter_scene/shaders/texture.glsl
+++ b/packages/flutter_scene/shaders/texture.glsl
@@ -53,13 +53,20 @@ const float kPrefilterBandEdgeClamp = 1.0 / kPrefilterBandHeight;
 
 // Samples the prefiltered radiance atlas for reflection `direction` at the
 // given perceptual `roughness`, interpolating between the two nearest
-// bands. The atlas samples in the same V orientation it was rendered (the
-// prefilter's full-screen pass already accounts for the render-to-texture
-// orientation), so no flip is applied here. Sample the atlas with a
-// horizontal-repeat / vertical-clamp sampler.
-vec3 SamplePrefilteredRadiance(sampler2D atlas, vec3 direction,
-                               float roughness) {
+// bands. Sample the atlas with a horizontal-repeat / vertical-clamp sampler.
+//
+// `flip_v` (0 or 1) inverts the sampled latitude within each band. The atlas
+// is a render-to-texture target; on backends that store render-to-texture
+// bottom-up (OpenGL ES, see y_flip.dart), the prefilter's vertex-stage flip
+// leaves each band's latitude inverted relative to the lookup, so the caller
+// passes 1 there to compensate. 0 on Metal/Vulkan/web (stored top-down).
+// Temporary, alongside the rest of the OpenGL ES Y-flip workaround.
+vec3 SamplePrefilteredRadiance(sampler2D atlas, vec3 direction, float roughness,
+                               float flip_v) {
   vec2 eq = SphericalToEquirectangular(direction);
+  if (flip_v > 0.5) {
+    eq.y = 1.0 - eq.y;
+  }
   eq.y = clamp(eq.y, kPrefilterBandEdgeClamp, 1.0 - kPrefilterBandEdgeClamp);
   float band = clamp(roughness, 0.0, 1.0) * (kPrefilterBands - 1.0);
   float b0 = floor(band);


### PR DESCRIPTION
Fixes two bugs that broke image-based lighting on the OpenGL ES backend. They surfaced in the Linux smoke-render goldens: the IBL specular reflection was flat (and, once that was fixed, vertically flipped), while macOS, Vulkan, and web were correct.

**1. `environment_transform` collapsed the whole environment to a constant.**
It was a std140 `mat3` uniform. GLSL ES 1.00 has no uniform buffer objects, so `FragInfo` compiles as a uniform struct and the OpenGL ES backend mis-reads the `mat3` (its `vec3` columns are padded to 16 bytes in std140 but read tightly packed), so it arrived near zero. That collapsed both the diffuse-SH and prefiltered-radiance lookup directions to a constant, so the environment read as one flat color on GLES. Passing it as a `mat4` (tightly-packed `vec4` columns) reads identically on every backend.

**2. The prefiltered-radiance atlas was sampled with inverted latitude on GLES.**
The atlas is a render-to-texture target. On backends that store render-to-texture bottom-up, the prefilter pass leaves each band's sampled latitude inverted, so specular reflections came out vertically flipped once bug 1 was fixed. `FragInfo.prefilter_flip_y` (gated on `backendFlipsRenderTargetY`) inverts the atlas latitude when sampling there.

Bug 1 is an OpenGL ES backend issue, filed upstream: https://github.com/flutter/flutter/issues/187083. Bug 2 is part of the temporary OpenGL ES Y-flip workaround and is removable alongside it (#145).

**Verification.** macOS and web goldens are byte-identical before and after (both changes are no-ops there). On Linux, `pbr_cuboid` now matches macOS to three decimals and `pbr_metallic` is correctly oriented (the small remaining specular softness is genuine llvmpipe precision). `flutter analyze` is clean.
