### PR TITLE
[WIP] Custom material shaders (.fmat): preprocessor, build hook, runtime

### DIFF
--- a/MATERIALS.md
+++ b/MATERIALS.md
@@ -1,38 +1,220 @@
 # Custom materials in flutter_scene
 
-This doc walks through writing a custom material for flutter_scene by
-authoring a fragment shader. The current surface is `ShaderMaterial`;
-a more ergonomic declarative material format is planned and tracked
-in [issue #22][issue22].
+flutter_scene gives you two ways to write a custom material:
 
-If you've worked with Three.js's `ShaderMaterial`, Bevy's `Material`
-trait, or Filament's `.mat` files, the underlying mental model will
-be familiar. flutter_scene's surface is the most permissive of the
-three: you write a complete GLSL fragment shader, declare the uniform
-blocks and samplers you want, and bind them by name from Dart.
+1. **The `.fmat` declarative format (recommended).** You declare your
+   parameters once and fill in a small `Surface()` function in GLSL. A build
+   hook compiles it, and `PreprocessedMaterial` wires it up at runtime: typed,
+   name-addressed parameters with no std140 packing by hand, and the engine's
+   physically based lighting for free if you want it. This is the path most
+   materials should use.
+2. **`ShaderMaterial` (the low-level escape hatch).** You write a complete raw
+   GLSL fragment shader, declare your own uniform blocks and samplers, and bind
+   them by name from Dart, packing std140 yourself. Use this when you need full
+   control or a shader shape the `.fmat` format doesn't cover yet.
 
-## Authoring workflow at a glance
+Both paths share the same engine contract (the vertex outputs your shader
+receives and the color it must output), documented below. If you've used
+Filament's `.mat` files or Godot's shaders, the `.fmat` model will feel
+familiar; if you've used Three.js's `ShaderMaterial`, that's `ShaderMaterial`
+here.
 
-1. Add `flutter_gpu_shaders` to your app and create a shader bundle
-   manifest plus a `hook/build.dart` that compiles it.
-2. Write a fragment shader. Consume the standard vertex outputs the
-   engine provides; declare your own uniform blocks and textures.
-3. Load the compiled bundle at runtime with
-   `gpu.ShaderLibrary.fromAsset(...)` and pull out your fragment
-   shader entry by name.
-4. Construct a `ShaderMaterial` wrapping the shader; set its uniform
-   blocks and textures by name; attach it to the `MeshPrimitive`s
-   that should use it.
+The roadmap for this surface is tracked in [issue #22][issue22].
 
-The toon example under `examples/flutter_app/` is a complete worked
-case. Read along with this doc.
+---
 
-## The engine contract
+# The `.fmat` format
 
-flutter_scene's engine vertex shaders (`UnskinnedVertex` and
-`SkinnedVertex`, both in the bundle exposed as
-`baseShaderLibrary`) emit the same five outputs in both layouts.
-Your fragment shader receives them as `in` declarations:
+## Quick start
+
+Author a material. A `.fmat` file has two blocks: a `material { }` metadata
+block and a `fragment { }` GLSL block.
+
+```
+// materials/toon.fmat
+material {
+  name: "Toon",
+  shading_model: unlit,
+  blending: opaque,
+  culling: back,
+
+  parameters: [
+    { type: vec4,      name: base_color, hint: source_color, default: [1, 1, 1, 1] },
+    { type: vec3,      name: light_direction, default: [0.4, 0.7, 0.5] },
+    { type: int,       name: band_count, hint: range(1, 8, 1), default: 3 },
+    { type: sampler2d, name: base_color_texture, hint: default_white },
+  ],
+}
+
+fragment {
+  void Surface(inout MaterialInputs material) {
+    vec3 n = GetWorldNormal();
+    float n_dot_l = max(dot(n, normalize(material_params.light_direction)), 0.0);
+    float bands = max(float(material_params.band_count), 1.0);
+    float banded = floor(n_dot_l * bands) / bands;
+
+    vec4 tex = texture(base_color_texture, GetUV0());
+    material.base_color = vec4(
+        material_params.base_color.rgb * tex.rgb * banded,
+        material_params.base_color.a * tex.a);
+    PrepareMaterial(material);
+  }
+}
+```
+
+Compile it from your app's `hook/build.dart`:
+
+```dart
+import 'package:flutter_scene/build_hooks.dart';
+import 'package:hooks/hooks.dart';
+
+void main(List<String> args) {
+  build(args, (config, output) async {
+    await buildMaterials(
+      buildInput: config,
+      buildOutput: output,
+      materials: ['materials/toon.fmat'],
+    );
+  });
+}
+```
+
+Declare the outputs as assets in `pubspec.yaml` (a `.shaderbundle` plus a
+`.fmat.json` parameter sidecar):
+
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_scene: ^0.14.0
+  hooks: ^1.0.0
+
+flutter:
+  assets:
+    - build/shaderbundles/materials.shaderbundle
+    - build/shaderbundles/materials.fmat.json
+```
+
+Then construct and use it at runtime:
+
+```dart
+import 'dart:convert';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_scene/gpu.dart' as gpu;
+import 'package:flutter_scene/scene.dart';
+
+final library = gpu.ShaderLibrary.fromAsset(
+  'build/shaderbundles/materials.shaderbundle',
+)!;
+final sidecar = (jsonDecode(
+  await rootBundle.loadString('build/shaderbundles/materials.fmat.json'),
+) as Map).cast<String, Object?>();
+
+final toon = PreprocessedMaterial(
+  fragmentShader: library['Toon']!,
+  metadata: (sidecar['Toon'] as Map).cast<String, Object?>(),
+);
+toon.parameters
+  ..setColor('base_color', const Color(0xFFE0A030))
+  ..setInt('band_count', 4)
+  ..setTexture('base_color_texture', myTexture);
+
+node.mesh!.primitives[0].material = toon;
+```
+
+The bundle entry name and the sidecar key are the material's `name`
+(`"Toon"` above). One `buildMaterials` call can compile several `.fmat` files
+into one bundle; each becomes an entry keyed by its `name`.
+
+## The `material` block
+
+| Key | Values | Default | Meaning |
+| --- | --- | --- | --- |
+| `name` | string (required) | | The bundle entry name and sidecar key. |
+| `shading_model` | `lit`, `unlit` | `lit` | `lit` runs the engine's PBR lighting; `unlit` outputs your color directly. |
+| `blending` | `opaque`, `alpha` | `opaque` | `alpha` routes the material through the depth-sorted translucent pass. |
+| `culling` | `back`, `front`, `none` | `back` | Which faces are culled; `none` is double-sided. |
+| `parameters` | list of objects | `[]` | The material's parameters (see below). |
+
+## Parameters
+
+Each parameter is `{ type, name, hint?, default? }`.
+
+**Types.** Scalar and vector types (`float`, `int`, `vec2`, `vec3`, `vec4`,
+`mat4`) are packed into a uniform block named `MaterialParams`; you read them in
+the shader as `material_params.<name>`. Sampler types (`sampler2d`,
+`samplerCube`) are top-level uniforms; you read them by their bare name. `mat3`
+is intentionally unsupported because of a std140 layout bug on the GLES backend;
+use `mat4`.
+
+**Hints** add editor and runtime semantics:
+
+| Hint | Valid on | Effect |
+| --- | --- | --- |
+| `source_color` | `vec3`, `vec4` | The value is an sRGB-authored color; `setColor` decodes it to linear. |
+| `range(min, max, step)` | `float`, `int` | A bounded numeric range (recorded for tooling). |
+| `default_white` / `default_black` / `default_normal` / `default_transparent` | samplers | The placeholder texture used until you set one. |
+
+**Defaults** are a number for scalars, or a list for vectors and matrices
+(`default: [1, 1, 1, 1]` for a `vec4`). Samplers take a placeholder via their
+hint, not a `default`. Defaults are applied when the material is constructed, so
+an unset parameter still renders sensibly.
+
+## The `fragment` block
+
+The `fragment` block holds GLSL. A `lit` material must define
+`void Surface(inout MaterialInputs material)`; you fill the surface description
+and the engine runs the lighting. An `unlit` material's `Surface()` writes the
+final color into `material.base_color`.
+
+`MaterialInputs` is:
+
+```glsl
+struct MaterialInputs {
+  vec4 base_color;   // linear rgb, straight (non-premultiplied) alpha
+  vec3 normal;       // world-space shading normal
+  vec3 emissive;     // linear emissive radiance (lit only)
+  float metallic;    // 0 dielectric .. 1 conductor (lit only)
+  float roughness;   // perceptual roughness, 0..1 (lit only)
+  float occlusion;   // ambient occlusion, 1 = unoccluded (lit only)
+};
+```
+
+Call `PrepareMaterial(material)` before returning from `Surface()` (a Filament
+convention; it is reserved for derived-value setup).
+
+**Engine inputs are read through accessors** rather than the raw varyings:
+
+```glsl
+vec3 GetWorldPosition();   // world-space fragment position
+vec3 GetWorldNormal();     // normalized world-space geometric normal
+vec3 GetViewDirection();   // normalized direction toward the camera
+vec2 GetUV0();             // primary texture coordinates
+vec4 GetVertexColor();     // interpolated per-vertex color (white if none)
+```
+
+The standard GLSL helpers from the engine's shader library are `#include`d for
+you and available in `Surface()`: `SRGBToLinear`, the Cook-Torrance BRDF pieces
+(`FresnelSchlick`, `DistributionGGX`, ...), `PerturbNormal` (normal-map
+perturbation), and `SamplePrefilteredRadiance`.
+
+For a `lit` material, fill `base_color` / `metallic` / `roughness` / `normal` /
+`occlusion` / `emissive` and the engine produces the lit color (image-based
+lighting plus the scene's directional light, with shadows). For an `unlit`
+material, compute whatever you want and write it into `base_color`; the engine
+outputs it premultiplied.
+
+> The per-light `light()` hook (a custom BRDF inside the engine light loop) is
+> not implemented yet; today, `lit` uses the engine BRDF and `unlit` gives you
+> full control. See [issue #22][issue22].
+
+---
+
+# The engine contract (both paths)
+
+flutter_scene's engine vertex shaders (`UnskinnedVertex` and `SkinnedVertex`)
+emit the same five world-space outputs. The `.fmat` accessors wrap these; a raw
+`ShaderMaterial` declares them directly:
 
 ```glsl
 in vec3 v_position;        // world space
@@ -42,60 +224,90 @@ in vec2 v_texture_coords;
 in vec4 v_color;           // per-vertex color, white when the model has none
 ```
 
-You must write to `out vec4 frag_color;` (the location-0 fragment
-output is fixed by the engine). Everything else is up to you.
+The fragment output is `out vec4 frag_color;` at location 0.
 
-**Write linear color premultiplied by alpha.** flutter_scene renders
-into a floating-point HDR scene-color target and then runs a single
-full-screen resolve pass that applies exposure (`Scene.exposure`), the
-tone-mapping operator (`Scene.toneMapping` — Khronos PBR Neutral by
-default), and the display EOTF. So your fragment shader should output
-*linear* radiance — do **not** tone-map or gamma-encode in your shader
-— and should premultiply RGB by alpha (e.g.
-`frag_color = vec4(linear_rgb, 1.0) * alpha;`). Values above 1.0 are
-fine and desirable; they're what the tone curve rolls off. If you
-sample an sRGB-encoded texture (like a base-color map), linearize it
-first (`pow(c, vec3(2.2))`).
+**Output linear color premultiplied by alpha.** flutter_scene renders into a
+floating-point HDR scene-color target and then runs one full-screen resolve pass
+that applies exposure (`Scene.exposure`), the tone-mapping operator
+(`Scene.toneMapping`, Khronos PBR Neutral by default), and the display EOTF. So
+your shader outputs *linear* radiance (do not tone-map or gamma-encode), and
+premultiplies rgb by alpha. Values above 1.0 are fine — the tone curve rolls
+them off. When you sample an sRGB texture, linearize it first (`SRGBToLinear`,
+or `pow(c, vec3(2.2))`). A `.fmat` material gets the premultiplied output for
+free; `EvaluateLighting` (lit) and the unlit path both handle it.
 
-The engine binds a vertex uniform block named `FrameInfo` containing
-the model, camera, and camera-position matrices. You do not see this
-in your fragment shader directly; the vertex outputs above are
-already in world space.
+The vertex `FrameInfo` block (model / camera matrices) is engine-bound and not
+visible in the fragment stage; the world-space outputs already encode it.
 
-When you set `ShaderMaterial.useEnvironment = true`, the engine also
-binds the active `Scene`'s image-based-lighting textures to these
-standard sampler names if your fragment shader declares them:
+---
 
-```glsl
-uniform sampler2D prefiltered_radiance; // PMREM-style roughness-band atlas
-uniform sampler2D brdf_lut;             // split-sum DFG lookup
+# Building: the `buildMaterials` hook
+
+`buildMaterials` (from `package:flutter_scene/build_hooks.dart`) preprocesses
+each `.fmat`, emits GLSL, compiles it through `impellerc`, and writes two outputs
+under `build/shaderbundles/`:
+
+- `<bundleName>.shaderbundle` — the compiled Flutter GPU shader bundle.
+- `<bundleName>.fmat.json` — the parameter sidecar the runtime needs.
+
+`bundleName` defaults to `materials`. List both as assets (see the quick start).
+The generated shaders `#include` flutter_scene's framework GLSL; the hook puts
+that directory on `impellerc`'s include path for you, so nothing is copied into
+your project.
+
+You can call `buildMaterials` alongside `buildModels` and
+`buildShaderBundleJson` in the same hook.
+
+---
+
+# Runtime: `PreprocessedMaterial` and `MaterialParameters`
+
+Load the bundle (`gpu.ShaderLibrary.fromAsset`, or `loadShaderLibraryAsync` on
+web) and the sidecar (`rootBundle.loadString` + `jsonDecode`), then construct a
+`PreprocessedMaterial` per material entry (see the quick start). Set its
+parameters through `material.parameters`, a `MaterialParameters`.
+
+`MaterialParameters` is type-checked and name-addressed. You never compute std140
+offsets: parameter types come from the sidecar, byte offsets come from the
+compiled shader's reflection, and a wrong-typed value throws instead of silently
+corrupting the uniform block. Three tiers share one backing buffer:
+
+```dart
+// Typed setters (the safe default):
+params.setFloat('rim_width', 0.2);
+params.setVec4('tint', Vector4(0.5, 0.3, 1.0, 1.0));
+params.setColor('base_color', const Color(0xFF8844FF)); // sRGB-decoded if source_color
+params.setTexture('base_color_texture', myTexture);
+
+// Dynamic, dispatches on the declared type and throws on a mismatch:
+params['rim_width'] = 0.2;        // ok
+params['rim_width'] = Vector4.zero(); // throws: rim_width is float
+
+// Raw escape hatch for hot loops (you own correctness here):
+params.rawBlock.setFloat32(params.offsetOf('rim_width'), 0.2, Endian.host);
 ```
 
-`prefiltered_radiance` is a vertical atlas of equirectangular
-roughness bands (band `i` = perceptual roughness `i/(N-1)`, mirror at
-the top); sample it the way `flutter_scene_standard.frag`'s
-`SamplePrefilteredRadiance` does (interpolate between the two nearest
-bands, and flip V because it's a render-to-texture target). The diffuse
-irradiance spherical-harmonic coefficients are *not* bound generically
-— for the full PBR ambient term, declare your own uniform block for
-them or extend `PhysicallyBasedMaterial`. Leave these samplers
-undeclared if you don't want image-based lighting.
+A `source_color` parameter is sRGB-decoded to linear on `setColor` (matching the
+shader's `SRGBToLinear`), so authored colors look right. Setting an unknown name
+or a wrong type throws an `ArgumentError` with a message naming the parameter and
+its declared type.
 
-## Writing the fragment shader
+For a `lit` material, set `PreprocessedMaterial.environment` to override the
+scene-wide image-based-lighting environment for that material.
 
-Here's the smallest possible useful shader, which renders the
-per-vertex color modulated by a single uniform tint:
+---
+
+# `ShaderMaterial`: the low-level escape hatch
+
+When you need a shader shape the `.fmat` format doesn't cover, write a complete
+raw fragment shader and drive it with `ShaderMaterial`. You declare your own
+uniform blocks and samplers and bind them by name, packing std140 yourself.
 
 ```glsl
 // shaders/vertex_color.frag
-uniform FragInfo {
-  vec4 tint;
-}
-frag_info;
+uniform FragInfo { vec4 tint; } frag_info;
 
-in vec2 v_texture_coords;
 in vec4 v_color;
-
 out vec4 frag_color;
 
 void main() {
@@ -103,249 +315,120 @@ void main() {
 }
 ```
 
-Save the file under your app's shader directory, then add a manifest
-entry alongside the engine's built-in shaders:
-
-```json
-{
-  "VertexColorFragment": {
-    "type": "fragment",
-    "file": "shaders/vertex_color.frag"
-  }
-}
-```
-
-`flutter_gpu_shaders` compiles each entry through `impellerc` into a
-single `.shaderbundle` packaged with your app.
-
-## Building the shader bundle
-
-In your `hook/build.dart`:
+Add it to a `flutter_gpu_shaders` manifest, compile it with
+`buildShaderBundleJson` (add a `flutter_gpu_shaders: ^0.4.4` dependency), then:
 
 ```dart
-import 'package:hooks/hooks.dart';
-import 'package:flutter_gpu_shaders/build.dart';
-
-void main(List<String> args) {
-  build(args, (config, output) async {
-    await buildShaderBundleJson(
-      buildInput: config,
-      buildOutput: output,
-      manifestFileName: 'shaders/my_bundle.shaderbundle.json',
-    );
-  });
-}
-```
-
-In your `pubspec.yaml`:
-
-```yaml
-dependencies:
-  flutter:
-    sdk: flutter
-  flutter_gpu:
-    sdk: flutter
-  flutter_gpu_shaders: ^0.4.0
-  flutter_scene: ^0.14.0
-
-flutter:
-  assets:
-    - build/shaderbundles/my_bundle.shaderbundle
-```
-
-The bundle is written to `build/shaderbundles/<name>.shaderbundle`,
-relative to your package root. It's the same workflow flutter_scene
-uses for its own shaders.
-
-## Wiring it up in Dart
-
-```dart
-import 'package:flutter_gpu/gpu.dart' as gpu;
-import 'package:flutter_scene/scene.dart';
-
-// If you also `import 'package:flutter/material.dart'`, hide its
-// `Material` widget to avoid a clash with flutter_scene's:
-//
-//   import 'package:flutter/material.dart' hide Material;
-//
-// (flutter_scene's Material is the rendering material; Flutter
-// Material is the design system widget.)
-
-// 1. Load the bundle and pull out the fragment shader.
-final library = gpu.ShaderLibrary.fromAsset(
-  'build/shaderbundles/my_bundle.shaderbundle',
-)!;
-final fragmentShader = library['VertexColorFragment']!;
-
-// 2. Build a ShaderMaterial.
-final material = ShaderMaterial(fragmentShader: fragmentShader);
-
-// 3. Set parameters by name.
-material.setUniformBlockFromFloats('FragInfo', [
-  1.0, 0.8, 0.4, 1.0, // tint
-]);
-
-// 4. Attach to a mesh primitive.
+final library = gpu.ShaderLibrary.fromAsset('build/shaderbundles/my_bundle.shaderbundle')!;
+final material = ShaderMaterial(fragmentShader: library['VertexColorFragment']!);
+material.setUniformBlockFromFloats('FragInfo', [1.0, 0.8, 0.4, 1.0]); // tint
 node.mesh!.primitives[0].material = material;
 ```
 
-The runtime resolves uniform-block and sampler names against the
-shader's reflection metadata. If you misspell a name, Flutter GPU
-throws at draw time with a clear message naming the slot that
-couldn't be found.
+A uniform block is bound by its **type** name (`FragInfo`), not its instance
+name (`frag_info`). Set `ShaderMaterial.useEnvironment = true` to have the engine
+bind `prefiltered_radiance` and `brdf_lut` if your shader declares them (the
+diffuse-irradiance SH coefficients are not bound generically).
 
-## Uniform block packing
+## std140 packing (raw `ShaderMaterial` only)
 
-This is the largest footgun today. Flutter GPU resolves a uniform
-*block* by name and gives you a single byte buffer to fill. The
-contents of that buffer follow the GLSL std140 layout rules, which
-your packing code on the Dart side has to match exactly. The most
-common rules:
+With `ShaderMaterial` you fill a single byte buffer per uniform block, and its
+layout must match GLSL std140 exactly. (`.fmat` materials avoid this entirely —
+the runtime packs from reflection.)
 
-| Type            | Size  | Alignment | Notes |
-| --------------- | ----- | --------- | ----- |
-| `bool`, `int`, `float` | 4 | 4 | |
-| `vec2`          | 8     | 8         | |
-| `vec3`          | 12    | **16**    | Pads up to 16 bytes |
-| `vec4`          | 16    | 16        | |
-| `mat3`          | 48    | 16        | Three `vec4` columns, 4 bytes padding each |
-| `mat4`          | 64    | 16        | |
-| Array element   | varies | **16**   | Every array element strides to the next 16-byte boundary |
-| Struct          | varies | 16       | Same alignment as `vec4` |
+| Type | Size | Alignment | Notes |
+| --- | --- | --- | --- |
+| `bool` / `int` / `float` | 4 | 4 | |
+| `vec2` | 8 | 8 | |
+| `vec3` | 12 | **16** | pads to 16 |
+| `vec4` | 16 | 16 | |
+| `mat4` | 64 | 16 | four `vec4` columns |
+| array element | varies | **16** | each element strides to a 16-byte boundary |
 
-The two cases that bite most often: declare a `vec3` followed by a
-`float` and the float occupies the 4 bytes of trailing pad on the
-`vec3`, not a fresh 16-byte slot. Declare a `float` followed by a
-`vec3` and the `vec3` jumps to the next 16-byte boundary, leaving 12
-bytes of padding before it. **When in doubt, declare your block with
-`vec4`s and `float`s rounded up to multiples of four, and you'll be
-right.**
+The footguns are mixing `vec3` and `float`: a `float` after a `vec3` fills the
+`vec3`'s trailing pad, while a `vec3` after a `float` jumps to the next 16-byte
+boundary. **When in doubt, declare blocks with `vec4`s and group trailing scalars
+into `vec4`-aligned rows of four**, and the layout is unambiguous.
 
-A worked example: this GLSL block
+---
 
-```glsl
-uniform ToonInfo {
-  vec4 base_color;
-  vec4 rim_color;
-  vec4 light_direction;
-  float band_count;
-  float rim_strength;
-  float rim_width;
-  float ambient;
-}
-toon;
-```
+# Render state
 
-packs as 16 floats (64 bytes total), one `vec4` per row, with the
-four trailing scalars filling the final row. Construct it in Dart
-as:
+A `.fmat` material declares render state in its `material` block: `culling`
+(`back` / `front` / `none`) and `blending` (`opaque` / `alpha`). A
+`ShaderMaterial` exposes `cullingMode`, `windingOrder`, and `isOpaqueOverride`
+constructor fields.
 
-```dart
-material.setUniformBlock(
-  'ToonInfo',
-  ByteData.sublistView(
-    Float32List.fromList([
-      // base_color
-      1, 1, 1, 1,
-      // rim_color
-      0.6, 0.8, 1.0, 1.0,
-      // light_direction (vec4 with w=0)
-      0.4, 0.8, -0.5, 0,
-      // band_count, rim_strength, rim_width, ambient
-      3, 1.0, 0.6, 0.3,
-    ]),
-  ),
-);
-```
+Today `blending` is `opaque` (depth-write on, drawn in order) or `alpha`
+(depth-write off, depth-sorted, premultiplied source-over). Additive/multiply
+blend modes and per-material depth state are not configurable yet; they are
+encoder-controlled. See [issue #22][issue22].
 
-TODO ([#22][issue22]): the planned preprocessor will generate this
-packing code from a declarative material source so you never write
-it by hand. Until then, follow the std140 rules and document your
-block layouts in a comment near the GLSL declaration.
+---
 
-## Render-state knobs
+# Current state and what's next
 
-`ShaderMaterial` exposes a small set of render-state fields you can
-configure in the constructor or mutate later:
+The `.fmat` format, its preprocessor, the `buildMaterials` hook, and
+`PreprocessedMaterial` are implemented. Remaining and in-flight work, tracked in
+[issue #22][issue22]:
 
-- `cullingMode` (default `gpu.CullMode.backFace`): which faces to
-  cull before rasterization.
-- `windingOrder` (default `gpu.WindingOrder.counterClockwise`):
-  triangle winding convention. Match this to your model's
-  authoring; glTF uses counter-clockwise.
-- `isOpaqueOverride` (default `true`): whether the encoder treats
-  this material as opaque (depth-write enabled, drawn in submission
-  order) or translucent (deferred to a back-to-front pass with
-  alpha blending).
+- **Hot reload.** Today you restart to pick up a shader edit (the build hook
+  reruns on a restart when an input changes). The Flutter GPU shader hot-reload
+  chain is landing upstream (flutter/flutter#186346); once it rolls into the
+  Flutter SDK, editing a `.fmat` will hot reload in place with no app changes.
+- **The `light()` hook** for a custom per-light BRDF (toon banding inside the
+  engine light loop) is not implemented; use `unlit` for fully custom shading
+  for now.
+- **Typed codegen.** A future step will generate a typed Dart class per `.fmat`
+  (compile-time-checked setters); today you use the name-based
+  `MaterialParameters` API.
+- **Additive/multiply blending and per-material depth state** are not yet
+  configurable.
+- **Vertex-shader customization** is not exposed; materials use the engine's
+  standard vertex shaders.
+- **An inspector** that surfaces the parameter hints as UI does not exist (the
+  metadata is emitted for future tooling).
 
-Set `cullingMode: gpu.CullMode.none` to render double-sided. Set
-`isOpaqueOverride: false` to render translucent materials with
-alpha blending. There are no other render-state knobs today.
+---
 
-TODO ([#22][issue22]): expose the full pipeline-state surface
-declaratively (blend modes, depth modes, polygon mode) once the
-preprocessor lands.
+# Troubleshooting
 
-## Known limitations
+**`gpu.ShaderLibrary.fromAsset` returns null.** The bundle is not in your app's
+assets. Check that `build/shaderbundles/<name>.shaderbundle` (and, for `.fmat`,
+the `.fmat.json` sidecar) are under `flutter.assets`, and that your
+`hook/build.dart` ran. If a shader edit doesn't take effect, the build hook's
+input-hash cache may be stale; follow CLAUDE.md Trap #3's reset recipe.
 
-Each of these is tracked in [issue #22][issue22], which has the full
-design discussion for where the custom-materials surface is going.
+**A `MaterialParameters` setter throws.** You used an unknown parameter name or a
+type that doesn't match the declared type. The message names the parameter and
+its type. Check the `.fmat` `parameters` list.
 
-- **No shader hot reload.** Editing a `.frag` requires a full
-  restart; hot reload doesn't touch the `flutter_gpu_shaders` build
-  hook. This is the single largest authoring-friction gap today.
-- **No engine PBR helpers exposed to your shaders.** If you want
-  PBR-style shading with image-based lighting, you have to either
-  inline the math in your fragment shader or extend
-  `PhysicallyBasedMaterial`. The internal GLSL chunks
-  (`pbr.glsl`, `normals.glsl`, etc.) are not packaged for external
-  `#include` consumption yet.
-- **No declarative material format.** You write GLSL plus call
-  into `ShaderMaterial` from Dart. A planned `.mat`-style format
-  will drive both shader source and Dart bindings from one file.
-- **No inspector / hint annotations.** A planned preprocessor pass
-  will parse Godot-style uniform hints (`hint_range`,
-  `source_color`) and surface them for tooling.
-- **No vertex-shader customization.** Use `UnskinnedVertex` or
-  `SkinnedVertex` from `baseShaderLibrary` (or whichever the
-  geometry was built with).
+**"Failed to find uniform slot X" (raw `ShaderMaterial`).** Flutter GPU couldn't
+resolve a block or sampler name. A block is bound by its type name, not its
+instance name. Note that an instance name must fold (case- and
+underscore-insensitively) to the block name on the GLES backend
+(flutter/flutter#186394); the `.fmat` emitter handles this for you.
 
-## Troubleshooting
+**Wrong colors / black geometry (raw `ShaderMaterial`).** Almost always a std140
+packing mismatch; declare blocks without `vec3` members to rule it out. With a
+`.fmat` material this class of bug is gone (the runtime packs from reflection).
 
-**"`gpu.ShaderLibrary.fromAsset` returns null."** The bundle wasn't
-built into your app's asset directory. Check that
-`build/shaderbundles/<name>.shaderbundle` is listed under
-`flutter.assets` in your `pubspec.yaml`, and that your `hook/build.dart`
-ran (`flutter run` should rerun the hook on each build; if it doesn't,
-follow CLAUDE.md Trap #3's reset recipe).
+**Black or unlit model.** For a `lit` material, confirm the scene has an
+environment and/or a directional light. For raw `ShaderMaterial`, check
+`useEnvironment` and that all declared samplers are bound (unbound samplers read
+garbage on some backends).
 
-**"Failed to find uniform slot X."** Flutter GPU couldn't find a
-uniform block or sampler with the name you passed to `setUniformBlock`
-or `setTexture`. Most common cause: the shader declares it under a
-different name (the variable name, not the type name). For
-`uniform FragInfo { ... } frag_info;` the block is bound by the
-type name `FragInfo`, not the variable name `frag_info`.
+---
 
-**Wrong colors / black geometry.** Almost always a std140 packing
-mismatch. Add a `vec3` test to your block to verify the layout: if
-you read back something other than what you wrote, you have a
-padding bug. The simplest defense is to declare uniform blocks with
-no `vec3` members, just `vec4` and `float`/`vec2`/`vec4` aligned to
-4-float boundaries.
+# See also
 
-**Black model.** Check `useEnvironment` and your sampler bindings.
-Unbound samplers can read garbage on some backends.
-
-## See also
-
-- [Issue #22][issue22]: the declarative material format and
-  preprocessor design discussion.
-- `examples/flutter_app/lib/example_toon.dart`: the worked toon
-  shader that ships with the example app.
-- `packages/flutter_scene/shaders/flutter_scene_standard.frag`: the
-  engine's PBR fragment shader, useful as a reference for what a
-  full custom material can do.
-- `flutter_gpu_shaders` on pub.dev: the build-hook helper that
-  drives `impellerc`.
+- `examples/smoke_render/materials/toon.fmat` and the `fmat_toon` scene in
+  `examples/smoke_render/lib/smoke_scenes.dart`: a worked `.fmat` material
+  rendered through `PreprocessedMaterial`.
+- `examples/flutter_app/lib/example_toon.dart`: the raw-`ShaderMaterial` toon.
+- `packages/flutter_scene/shaders/flutter_scene_standard.frag` and
+  `material_lighting.glsl`: the engine's PBR shader and the lighting framework a
+  `lit` material composes against.
+- [Issue #22][issue22]: the custom-materials roadmap.
 
 [issue22]: https://github.com/bdero/flutter_scene/issues/22

--- a/examples/flutter_app/hook/build.dart
+++ b/examples/flutter_app/hook/build.dart
@@ -18,5 +18,14 @@ void main(List<String> args) {
       buildOutput: output,
       manifestFileName: 'shaders/example.shaderbundle.json',
     );
+    // Compile the .fmat custom material into its own bundle plus a parameter
+    // sidecar, consumed by the "Toon (.fmat)" example through
+    // PreprocessedMaterial. Produces build/shaderbundles/materials.shaderbundle
+    // and materials.fmat.json (both listed as assets in pubspec.yaml).
+    await buildMaterials(
+      buildInput: config,
+      buildOutput: output,
+      materials: ['materials/toon.fmat'],
+    );
   });
 }

--- a/examples/flutter_app/lib/example_toon_fmat.dart
+++ b/examples/flutter_app/lib/example_toon_fmat.dart
@@ -1,0 +1,292 @@
+// Toon example, authored with the `.fmat` custom-material format. This is the
+// `.fmat` counterpart to example_toon.dart (which hand-binds a raw
+// ShaderMaterial); rendering the same Dash model with the same controls makes
+// the two a before/after comparison of the two material workflows.
+//
+// Demonstrates the `.fmat` workflow end-to-end:
+//   1. Declare typed parameters and a small `Surface()` function in
+//      materials/toon.fmat (no hand-packed std140 uniform block).
+//   2. Compile it offline with the `buildMaterials` build hook into
+//      `build/shaderbundles/materials.shaderbundle` plus a parameter sidecar
+//      `materials.fmat.json`.
+//   3. Load the bundle + sidecar at runtime and build a PreprocessedMaterial.
+//   4. Set parameters by name through `material.parameters`; the setters are
+//      type-checked and the std140 offsets come from shader reflection, so
+//      there is no manual packing and a wrong-typed value throws.
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart' hide Material;
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_scene/gpu.dart' as gpu;
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+
+class ExampleToonFmat extends StatefulWidget {
+  const ExampleToonFmat({super.key, this.elapsedSeconds = 0});
+  final double elapsedSeconds;
+
+  @override
+  State<ExampleToonFmat> createState() => _ExampleToonFmatState();
+}
+
+class _ExampleToonFmatState extends State<ExampleToonFmat> {
+  Scene scene = Scene();
+  bool loaded = false;
+
+  // Wrapper around the loaded Dash node. Spinning this instead of the
+  // camera keeps the world-space light direction (which we use for
+  // shading) stable relative to the viewer.
+  final Node _dashGroup = Node();
+
+  // Material parameters surfaced as UI sliders below. The base color is
+  // a saturated cool blue with a brighter sky-blue rim, so the toon
+  // bands read clearly as a cohesive blue palette. Matches example_toon.dart
+  // so the two examples are directly comparable.
+  double bandCount = 3;
+  double rimStrength = 0.9;
+  double rimWidth = 0.55;
+  double ambient = 0.25;
+  vm.Vector4 baseColor = vm.Vector4(0.32, 0.55, 0.95, 1.0);
+  vm.Vector4 rimColor = vm.Vector4(0.55, 0.85, 1.0, 1.0);
+
+  PreprocessedMaterial? _toonMaterial;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    // Load the .fmat bundle and its parameter sidecar that buildMaterials
+    // produces. Use the async loader: shader bundles can't be read
+    // synchronously on web (gpu.ShaderLibrary.fromAsset throws there).
+    final shaderLibrary = await gpu.loadShaderLibraryAsync(
+      'build/shaderbundles/materials.shaderbundle',
+    );
+    final toonShader = shaderLibrary?['FmatToon'];
+    if (toonShader == null) {
+      throw StateError(
+        'FmatToon shader missing from materials.shaderbundle. The build hook '
+        'should have produced it; rerun `flutter run` with a clean build.',
+      );
+    }
+    final sidecar = await rootBundle.loadString(
+      'build/shaderbundles/materials.fmat.json',
+    );
+    final metadata = (jsonDecode(sidecar) as Map).cast<String, Object?>();
+    final toonMetadata = (metadata['FmatToon'] as Map).cast<String, Object?>();
+
+    final dash = await Node.fromAsset('build/models/dash.model');
+    dash.name = 'Dash';
+
+    // Build one PreprocessedMaterial; every skinned primitive on the model
+    // shares it so parameter tweaks are reflected everywhere. The
+    // base_color_texture sampler is declared with a `default_white` hint, so
+    // it falls back to a white placeholder when unset (no manual bind needed).
+    final material = PreprocessedMaterial(
+      fragmentShader: toonShader,
+      metadata: toonMetadata,
+    );
+    _refreshParameters(material);
+    _toonMaterial = material;
+
+    _applyMaterialToAllPrimitives(dash, material);
+
+    // Start the Walk animation looping. Dash walks in place, so the
+    // root transform doesn't drift; we drive the visible rotation
+    // via `_dashGroup.localTransform` in build() instead.
+    dash.createAnimationClip(dash.findAnimationByName('Walk')!)
+      ..loop = true
+      ..play();
+
+    _dashGroup.add(dash);
+    scene.add(_dashGroup);
+    scene.exposure = 1.5;
+    if (!mounted) return;
+    setState(() {
+      loaded = true;
+    });
+  }
+
+  @override
+  void dispose() {
+    scene.removeAll();
+    super.dispose();
+  }
+
+  void _applyMaterialToAllPrimitives(Node node, Material material) {
+    final mesh = node.mesh;
+    if (mesh != null) {
+      for (final p in mesh.primitives) {
+        p.material = material;
+      }
+    }
+    for (final child in node.children) {
+      _applyMaterialToAllPrimitives(child, material);
+    }
+  }
+
+  void _refreshParameters(PreprocessedMaterial material) {
+    final light = vm.Vector3(0.4, 0.8, -0.5).normalized();
+    // Set each parameter by its declared name. No std140 offsets, no padding:
+    // the runtime resolves offsets from shader reflection and the setters
+    // throw on a type mismatch. base_color/rim_color are written with setVec4
+    // (not setColor) so these linear values match example_toon.dart's
+    // hand-packed block byte-for-byte rather than being sRGB-decoded.
+    material.parameters
+      ..setVec4('base_color', baseColor)
+      ..setVec4('rim_color', rimColor)
+      ..setVec3('light_direction', light)
+      ..setFloat('band_count', bandCount)
+      ..setFloat('rim_strength', rimStrength)
+      ..setFloat('rim_width', rimWidth)
+      ..setFloat('ambient', ambient);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!loaded) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    // Rotate Dash in place. Keeping the camera fixed and the world-
+    // space light direction constant means the toon bands stay
+    // anchored to the viewer's perspective: the bright side of Dash
+    // sweeps around her body as she turns, the way a real character
+    // under a stable spotlight would look.
+    _dashGroup.localTransform = vm.Matrix4.rotationY(
+      widget.elapsedSeconds * 0.6,
+    );
+    _dashGroup.markBoundsDirty();
+
+    return Stack(
+      children: [
+        SizedBox.expand(
+          child: CustomPaint(
+            painter: _ScenePainter(scene, widget.elapsedSeconds),
+          ),
+        ),
+        Positioned(
+          left: 16,
+          right: 16,
+          bottom: 16,
+          child: Card(
+            color: Colors.black54,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _SliderRow(
+                    label: 'Band count',
+                    value: bandCount,
+                    min: 1,
+                    max: 8,
+                    onChanged:
+                        (v) => setState(() {
+                          bandCount = v.roundToDouble();
+                          _refreshParameters(_toonMaterial!);
+                        }),
+                  ),
+                  _SliderRow(
+                    label: 'Rim strength',
+                    value: rimStrength,
+                    min: 0,
+                    max: 2,
+                    onChanged:
+                        (v) => setState(() {
+                          rimStrength = v;
+                          _refreshParameters(_toonMaterial!);
+                        }),
+                  ),
+                  _SliderRow(
+                    label: 'Rim width',
+                    value: rimWidth,
+                    min: 0,
+                    max: 1,
+                    onChanged:
+                        (v) => setState(() {
+                          rimWidth = v;
+                          _refreshParameters(_toonMaterial!);
+                        }),
+                  ),
+                  _SliderRow(
+                    label: 'Ambient',
+                    value: ambient,
+                    min: 0,
+                    max: 1,
+                    onChanged:
+                        (v) => setState(() {
+                          ambient = v;
+                          _refreshParameters(_toonMaterial!);
+                        }),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SliderRow extends StatelessWidget {
+  const _SliderRow({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 110,
+          child: Text(
+            '$label: ${value.toStringAsFixed(2)}',
+            style: const TextStyle(color: Colors.white),
+          ),
+        ),
+        Expanded(
+          child: Slider(value: value, min: min, max: max, onChanged: onChanged),
+        ),
+      ],
+    );
+  }
+}
+
+class _ScenePainter extends CustomPainter {
+  _ScenePainter(this.scene, this.elapsedTime);
+  Scene scene;
+  double elapsedTime;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Camera is fixed so the toon material's world-space light stays
+    // stable from the viewer's perspective. Dash spins in place
+    // instead (see `_ExampleToonFmatState.build`). Distance matches the
+    // animation example.
+    final camera = PerspectiveCamera(
+      position: vm.Vector3(0, 2, -6),
+      target: vm.Vector3(0, 1.5, 0),
+    );
+    exampleSettings.applyTo(scene);
+    scene.render(camera, canvas, viewport: Offset.zero & size);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -11,6 +11,7 @@ import 'example_nav_route.dart';
 import 'example_settings.dart';
 import 'example_stress_tests.dart';
 import 'example_toon.dart';
+import 'example_toon_fmat.dart';
 
 void main() {
   runApp(const MyApp());
@@ -50,6 +51,8 @@ class _MyAppState extends State<MyApp> {
       'Navigation Route':
           (context) => ExampleNavRoute(elapsedSeconds: elapsedSeconds),
       'Toon': (context) => ExampleToon(elapsedSeconds: elapsedSeconds),
+      'Toon (.fmat)':
+          (context) => ExampleToonFmat(elapsedSeconds: elapsedSeconds),
       'Stress Tests':
           (context) => ExampleStressTests(elapsedSeconds: elapsedSeconds),
     };

--- a/examples/flutter_app/materials/toon.fmat
+++ b/examples/flutter_app/materials/toon.fmat
@@ -1,0 +1,52 @@
+// Toon custom material, authored in the .fmat format. Unlit: Surface() computes
+// the final banded-diffuse-plus-rim color directly. A port of the raw
+// example_toon.frag, but with declared, type-checked parameters and no
+// hand-packed uniform block.
+
+material {
+  name: "FmatToon",
+  shading_model: unlit,
+  blending: opaque,
+  culling: back,
+
+  parameters: [
+    { type: vec4, name: base_color, hint: source_color, default: [1.0, 1.0, 1.0, 1.0] },
+    { type: vec4, name: rim_color, hint: source_color, default: [1.0, 1.0, 1.0, 1.0] },
+    { type: vec3, name: light_direction, default: [0.4, 0.7, 0.5] },
+    { type: float, name: band_count, hint: range(1, 8, 1), default: 3.0 },
+    { type: float, name: rim_strength, hint: range(0, 2, 0.01), default: 0.6 },
+    { type: float, name: rim_width, hint: range(0, 1, 0.01), default: 0.3 },
+    { type: float, name: ambient, hint: range(0, 1, 0.01), default: 0.2 },
+    { type: sampler2d, name: base_color_texture, hint: default_white },
+  ],
+}
+
+fragment {
+  void Surface(inout MaterialInputs material) {
+    vec3 normal = GetWorldNormal();
+    vec3 light_dir = normalize(material_params.light_direction);
+    vec3 view_dir = GetViewDirection();
+
+    // Banded N.L diffuse: floor() quantizes the term into bands.
+    float n_dot_l = max(dot(normal, light_dir), 0.0);
+    float bands = max(material_params.band_count, 1.0);
+    float banded = floor(n_dot_l * bands + 0.001) / bands;
+
+    // Rim term: bright at grazing angles.
+    float n_dot_v = max(dot(normal, view_dir), 0.0);
+    float rim = 1.0 - n_dot_v;
+    rim = smoothstep(1.0 - material_params.rim_width, 1.0, rim) *
+          material_params.rim_strength;
+
+    vec4 albedo_sample = texture(base_color_texture, GetUV0());
+    vec3 albedo = material_params.base_color.rgb * albedo_sample.rgb;
+
+    vec3 lit = albedo *
+        (material_params.ambient + banded * (1.0 - material_params.ambient));
+    vec3 final_color = lit + material_params.rim_color.rgb * rim;
+
+    float alpha = material_params.base_color.a * albedo_sample.a;
+    material.base_color = vec4(final_color, alpha);
+    PrepareMaterial(material);
+  }
+}

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gpu_shaders: ^0.4.0
+  flutter_gpu_shaders: ^0.4.4
   flutter_scene: ^0.14.0
   hooks: ^1.0.0
   http: ^1.2.0
@@ -31,5 +31,9 @@ flutter:
     - build/models/
     # Source .glb files for the runtime importer demo.
     - assets_src/
-    # Custom shader bundle for the toon example.
+    # Custom shader bundle for the raw-ShaderMaterial toon example.
     - build/shaderbundles/example.shaderbundle
+    # .fmat custom-material bundle and its parameter sidecar, for the
+    # "Toon (.fmat)" example (built by buildMaterials in hook/build.dart).
+    - build/shaderbundles/materials.shaderbundle
+    - build/shaderbundles/materials.fmat.json

--- a/examples/smoke_render/analysis_options.yaml
+++ b/examples/smoke_render/analysis_options.yaml
@@ -9,6 +9,15 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  errors:
+    # The shader bundle and its sidecar are build-hook outputs (produced by
+    # buildMaterials in hook/build.dart) and are absent on a clean checkout,
+    # such as in CI before the build runs. Don't fail analysis on their being
+    # missing; `dart analyze` otherwise reports them as warnings and exits 2.
+    asset_does_not_exist: ignore
+    asset_directory_does_not_exist: ignore
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/examples/smoke_render/hook/build.dart
+++ b/examples/smoke_render/hook/build.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_scene/build_hooks.dart';
+import 'package:hooks/hooks.dart';
+
+void main(List<String> args) {
+  build(args, (config, output) async {
+    await buildMaterials(
+      buildInput: config,
+      buildOutput: output,
+      materials: ['materials/toon.fmat'],
+    );
+  });
+}

--- a/examples/smoke_render/integration_test/smoke_test.dart
+++ b/examples/smoke_render/integration_test/smoke_test.dart
@@ -20,6 +20,7 @@ void main() {
       // pumpWidget) touches baseShaderLibrary, which throws on web if touched
       // before initialization completes.
       await Scene.initializeStaticResources();
+      await loadSmokeMaterials();
 
       await tester.pumpWidget(
         MaterialApp(

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -1,4 +1,8 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_scene/gpu.dart' as gpu;
 import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
@@ -47,8 +51,26 @@ Node _cuboid(vm.Vector4 baseColor, double metallic, double roughness) {
     ..localTransform = vm.Matrix4.rotationY(0.6) * vm.Matrix4.rotationX(0.3);
 }
 
-/// The smoke scene set. Kept small and procedural (no asset/model build hook)
-/// so the captures are deterministic.
+/// Custom-material assets pre-loaded by [loadSmokeMaterials], so the
+/// synchronous [SmokeScene] setup closures can build a [PreprocessedMaterial].
+gpu.ShaderLibrary? _materialsLibrary;
+Map<String, Object?>? _materialsMetadata;
+
+/// Loads the `buildMaterials` output (bundle plus parameter sidecar) once. Call
+/// before pumping a scene that uses a custom material.
+Future<void> loadSmokeMaterials() async {
+  if (_materialsLibrary != null) return;
+  _materialsLibrary = await gpu.loadShaderLibraryAsync(
+    'build/shaderbundles/materials.shaderbundle',
+  );
+  final sidecar = await rootBundle.loadString(
+    'build/shaderbundles/materials.fmat.json',
+  );
+  _materialsMetadata = (jsonDecode(sidecar) as Map).cast<String, Object?>();
+}
+
+/// The smoke scene set. Mostly procedural for determinism; the final scene
+/// exercises a custom `.fmat` material compiled by the build hook.
 final List<SmokeScene> kSmokeScenes = <SmokeScene>[
   // Diffuse-ish PBR under the default studio IBL.
   SmokeScene('pbr_cuboid', () {
@@ -106,6 +128,36 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
           vm.Matrix4.rotationY(0.6);
     scene.add(caster);
     return (scene: scene, camera: _shadowCamera());
+  }),
+  // A custom .fmat material (the unlit toon) compiled by buildMaterials and
+  // driven through PreprocessedMaterial. Exercises the whole custom-material
+  // path end to end: the build hook, the generated shader, the sidecar, and
+  // the type-checked runtime parameters.
+  SmokeScene('fmat_toon', () {
+    final shader = _materialsLibrary!['FmatToon']!;
+    final metadata =
+        (_materialsMetadata!['FmatToon'] as Map).cast<String, Object?>();
+    final material = PreprocessedMaterial(
+      fragmentShader: shader,
+      metadata: metadata,
+    );
+    material.parameters
+      ..setColor('base_color', const Color(0xFFE0A030))
+      ..setColor('rim_color', const Color(0xFF40C0FF))
+      // Light toward the camera so the banded diffuse reads on the visible
+      // faces.
+      ..setVec3('light_direction', vm.Vector3(3.0, 2.0, 4.0))
+      ..setFloat('band_count', 4.0)
+      ..setFloat('ambient', 0.3)
+      ..setFloat('rim_strength', 0.4)
+      ..setFloat('rim_width', 0.35);
+    final scene = Scene();
+    scene.add(
+      Node(
+        mesh: Mesh(CuboidGeometry(vm.Vector3(1, 1, 1)), material),
+      )..localTransform = vm.Matrix4.rotationY(0.6) * vm.Matrix4.rotationX(0.3),
+    );
+    return (scene: scene, camera: _camera());
   }),
 ];
 

--- a/examples/smoke_render/materials/toon.fmat
+++ b/examples/smoke_render/materials/toon.fmat
@@ -1,0 +1,48 @@
+// Toon custom material (unlit) for the smoke-render harness. Surface() computes
+// banded N.L diffuse plus a rim term and writes the final color directly.
+
+material {
+  name: "FmatToon",
+  shading_model: unlit,
+  blending: opaque,
+  culling: back,
+
+  parameters: [
+    { type: vec4, name: base_color, hint: source_color, default: [1.0, 1.0, 1.0, 1.0] },
+    { type: vec4, name: rim_color, hint: source_color, default: [1.0, 1.0, 1.0, 1.0] },
+    { type: vec3, name: light_direction, default: [0.4, 0.7, 0.5] },
+    { type: float, name: band_count, hint: range(1, 8, 1), default: 3.0 },
+    { type: float, name: rim_strength, hint: range(0, 2, 0.01), default: 0.6 },
+    { type: float, name: rim_width, hint: range(0, 1, 0.01), default: 0.3 },
+    { type: float, name: ambient, hint: range(0, 1, 0.01), default: 0.2 },
+    { type: sampler2d, name: base_color_texture, hint: default_white },
+  ],
+}
+
+fragment {
+  void Surface(inout MaterialInputs material) {
+    vec3 normal = GetWorldNormal();
+    vec3 light_dir = normalize(material_params.light_direction);
+    vec3 view_dir = GetViewDirection();
+
+    float n_dot_l = max(dot(normal, light_dir), 0.0);
+    float bands = max(material_params.band_count, 1.0);
+    float banded = floor(n_dot_l * bands + 0.001) / bands;
+
+    float n_dot_v = max(dot(normal, view_dir), 0.0);
+    float rim = 1.0 - n_dot_v;
+    rim = smoothstep(1.0 - material_params.rim_width, 1.0, rim) *
+          material_params.rim_strength;
+
+    vec4 albedo_sample = texture(base_color_texture, GetUV0());
+    vec3 albedo = material_params.base_color.rgb * albedo_sample.rgb;
+
+    vec3 lit = albedo *
+        (material_params.ambient + banded * (1.0 - material_params.ambient));
+    vec3 final_color = lit + material_params.rim_color.rgb * rim;
+
+    float alpha = material_params.base_color.a * albedo_sample.a;
+    material.base_color = vec4(final_color, alpha);
+    PrepareMaterial(material);
+  }
+}

--- a/examples/smoke_render/pubspec.yaml
+++ b/examples/smoke_render/pubspec.yaml
@@ -12,7 +12,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_gpu_shaders: ^0.4.4
   flutter_scene: ^0.14.0
+  hooks: ^1.0.0
   vector_math: ^2.1.4
 
 dev_dependencies:
@@ -24,3 +26,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    # Custom material bundle + parameter sidecar, produced by buildMaterials in
+    # hook/build.dart.
+    - build/shaderbundles/materials.shaderbundle
+    - build/shaderbundles/materials.fmat.json

--- a/packages/flutter_scene/lib/build_hooks.dart
+++ b/packages/flutter_scene/lib/build_hooks.dart
@@ -1,7 +1,9 @@
 /// Build-hook helpers for flutter_scene.
 ///
-/// Call [buildModels] from your app's `hook/build.dart` to convert glTF
-/// (`.glb`) source assets into flutter_scene's `.model` format at build time:
+/// Call these from your app's `hook/build.dart` at build time: [buildModels]
+/// converts glTF (`.glb`) source assets into flutter_scene's `.model` format,
+/// and [buildMaterials] compiles `.fmat` custom-material files into a Flutter
+/// GPU shader bundle plus a parameter sidecar.
 ///
 /// ```dart
 /// import 'package:hooks/hooks.dart';
@@ -10,14 +12,22 @@
 /// void main(List<String> args) {
 ///   build(args, (config, output) async {
 ///     buildModels(buildInput: config, inputFilePaths: ['assets/dash.glb']);
+///     await buildMaterials(
+///       buildInput: config,
+///       buildOutput: output,
+///       materials: ['materials/toon.fmat'],
+///     );
 ///   });
 /// }
 /// ```
 library;
 
-// Native uses the real dart:io implementation; web/wasm resolves to a stub so
+// Native uses the real dart:io implementations; web/wasm resolves to stubs so
 // dart:io (and package:hooks) stay off the wasm dependency graph, keeping the
 // package WASM-compatible. Build hooks only ever run on the native host.
 export 'src/importer/build_hooks.dart'
     if (dart.library.js_interop) 'src/importer/build_hooks_unsupported.dart'
     show buildModels;
+export 'src/fmat/build_materials.dart'
+    if (dart.library.js_interop) 'src/fmat/build_materials_unsupported.dart'
+    show buildMaterials;

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -34,7 +34,9 @@ export 'src/geometry/swept_geometry.dart'
 
 export 'src/material/environment.dart';
 export 'src/material/material.dart';
+export 'src/material/material_parameters.dart';
 export 'src/material/physically_based_material.dart';
+export 'src/material/preprocessed_material.dart';
 export 'src/material/shader_material.dart';
 export 'src/material/unlit_material.dart';
 

--- a/packages/flutter_scene/lib/src/fmat/build_materials.dart
+++ b/packages/flutter_scene/lib/src/fmat/build_materials.dart
@@ -104,8 +104,9 @@ Future<void> buildMaterials({
     }
 
     final fragFileName = '$entryName.frag';
-    File(generatedDir.uri.resolve(fragFileName).toFilePath())
-        .writeAsStringSync(compiled.glsl);
+    File(
+      generatedDir.uri.resolve(fragFileName).toFilePath(),
+    ).writeAsStringSync(compiled.glsl);
 
     manifest[entryName] = <String, Object?>{
       'type': 'fragment',
@@ -122,8 +123,9 @@ Future<void> buildMaterials({
   // so its `file` entries resolve relative to it.
   final manifestRelativePath =
       'build/fmat/$bundleName/$bundleName.shaderbundle.json';
-  File(packageRoot.resolve(manifestRelativePath).toFilePath())
-      .writeAsStringSync(const JsonEncoder.withIndent('  ').convert(manifest));
+  File(
+    packageRoot.resolve(manifestRelativePath).toFilePath(),
+  ).writeAsStringSync(const JsonEncoder.withIndent('  ').convert(manifest));
 
   // Compile, with flutter_scene's shaders/ on the include path so the generated
   // shaders' framework `#include`s resolve directly (no copies).
@@ -135,10 +137,11 @@ Future<void> buildMaterials({
   );
 
   // Write the combined parameter sidecar next to the produced bundle.
-  File(packageRoot
-          .resolve('build/shaderbundles/$bundleName.fmat.json')
-          .toFilePath())
-      .writeAsStringSync(const JsonEncoder.withIndent('  ').convert(sidecars));
+  File(
+    packageRoot
+        .resolve('build/shaderbundles/$bundleName.fmat.json')
+        .toFilePath(),
+  ).writeAsStringSync(const JsonEncoder.withIndent('  ').convert(sidecars));
 
   // Declare the real inputs as dependencies. buildShaderBundleJson declares the
   // (generated) .frag files; the sources that actually drive a rebuild are the

--- a/packages/flutter_scene/lib/src/fmat/build_materials.dart
+++ b/packages/flutter_scene/lib/src/fmat/build_materials.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:flutter_gpu_shaders/build.dart';
+import 'package:hooks/hooks.dart';
+
+import 'fmat.dart';
+
+/// The framework GLSL files (in flutter_scene's `shaders/` directory) that a
+/// generated material shader can `#include`. Declared as build dependencies so
+/// editing one retriggers a consumer's material build. Transitive `#include`s
+/// inside these are not tracked until `impellerc --depfile` is consumed in
+/// `--shader-bundle` mode (bdero/flutter_gpu_shaders#15).
+const _frameworkShaderFiles = <String>[
+  'material_varyings.glsl',
+  'pbr.glsl',
+  'texture.glsl',
+  'normals.glsl',
+  'material_inputs.glsl',
+  'material_engine_lighting.glsl',
+  'material_lighting.glsl',
+];
+
+/// Compiles `.fmat` custom-material files into a Flutter GPU shader bundle plus
+/// a parameter-metadata sidecar, for use with `ShaderMaterial` /
+/// `PreprocessedMaterial` at runtime.
+///
+/// Call this from a consuming app's `hook/build.dart`, alongside
+/// [buildModels] and `buildShaderBundleJson`:
+///
+/// ```dart
+/// import 'package:hooks/hooks.dart';
+/// import 'package:flutter_scene/build_hooks.dart';
+///
+/// void main(List<String> args) {
+///   build(args, (config, output) async {
+///     await buildMaterials(
+///       buildInput: config,
+///       buildOutput: output,
+///       materials: ['materials/toon.fmat'],
+///     );
+///   });
+/// }
+/// ```
+///
+/// Each path in [materials] is resolved relative to the package root. The
+/// produced bundle is written to `build/shaderbundles/[bundleName].shaderbundle`
+/// (one fragment entry per material, named by the material's `name`), and the
+/// combined parameter sidecar to
+/// `build/shaderbundles/[bundleName].fmat.json`. List both as assets in the
+/// app's pubspec.
+///
+/// The generated shaders `#include` flutter_scene's framework GLSL; this hook
+/// puts flutter_scene's `shaders/` directory on `impellerc`'s include path (via
+/// `buildShaderBundleJson`'s `includeDirectories`), so no framework files are
+/// copied into the consumer's project.
+Future<void> buildMaterials({
+  required BuildInput buildInput,
+  required BuildOutputBuilder buildOutput,
+  required List<String> materials,
+  String bundleName = 'materials',
+}) async {
+  final packageRoot = buildInput.packageRoot;
+
+  // Locate flutter_scene's framework shader directory. flutter_scene has no
+  // top-level `flutter_scene.dart` library, so resolve through this package's
+  // `build_hooks.dart` (which always exists) and hop to the sibling `shaders/`.
+  final frameworkLib = await Isolate.resolvePackageUri(
+    Uri.parse('package:flutter_scene/build_hooks.dart'),
+  );
+  if (frameworkLib == null) {
+    throw Exception(
+      'buildMaterials could not resolve the flutter_scene package location.',
+    );
+  }
+  final frameworkShaders = frameworkLib.resolve('../shaders/');
+
+  // Generated GLSL and the synthesized manifest live under the package's build
+  // directory; they are regenerated each run.
+  final generatedDir = Directory.fromUri(
+    packageRoot.resolve('build/fmat/$bundleName/'),
+  );
+  generatedDir.createSync(recursive: true);
+
+  final manifest = <String, Object?>{};
+  final sidecars = <String, Object?>{};
+  final sourceDependencies = <Uri>[];
+
+  for (final materialPath in materials) {
+    if (!materialPath.endsWith('.fmat')) {
+      throw Exception('Material files must end with ".fmat": $materialPath');
+    }
+    final materialUri = packageRoot.resolve(materialPath);
+    final source = File(materialUri.toFilePath()).readAsStringSync();
+    final compiled = compileFmat(source, fileName: materialPath);
+    final entryName = compiled.material.name;
+
+    if (manifest.containsKey(entryName)) {
+      throw Exception(
+        'Two materials in bundle "$bundleName" share the name "$entryName"; '
+        'material names must be unique within a bundle.',
+      );
+    }
+
+    final fragFileName = '$entryName.frag';
+    File(generatedDir.uri.resolve(fragFileName).toFilePath())
+        .writeAsStringSync(compiled.glsl);
+
+    manifest[entryName] = <String, Object?>{
+      'type': 'fragment',
+      // impellerc resolves a bundle entry's `file` relative to the package
+      // root (its working directory), so reference the generated shader from
+      // there, not relative to the manifest.
+      'file': 'build/fmat/$bundleName/$fragFileName',
+    };
+    sidecars[entryName] = compiled.sidecar;
+    sourceDependencies.add(materialUri);
+  }
+
+  // Write the synthesized shader-bundle manifest next to the generated shaders,
+  // so its `file` entries resolve relative to it.
+  final manifestRelativePath =
+      'build/fmat/$bundleName/$bundleName.shaderbundle.json';
+  File(packageRoot.resolve(manifestRelativePath).toFilePath())
+      .writeAsStringSync(const JsonEncoder.withIndent('  ').convert(manifest));
+
+  // Compile, with flutter_scene's shaders/ on the include path so the generated
+  // shaders' framework `#include`s resolve directly (no copies).
+  await buildShaderBundleJson(
+    buildInput: buildInput,
+    buildOutput: buildOutput,
+    manifestFileName: manifestRelativePath,
+    includeDirectories: [frameworkShaders],
+  );
+
+  // Write the combined parameter sidecar next to the produced bundle.
+  File(packageRoot
+          .resolve('build/shaderbundles/$bundleName.fmat.json')
+          .toFilePath())
+      .writeAsStringSync(const JsonEncoder.withIndent('  ').convert(sidecars));
+
+  // Declare the real inputs as dependencies. buildShaderBundleJson declares the
+  // (generated) .frag files; the sources that actually drive a rebuild are the
+  // .fmat files and the framework GLSL they include.
+  buildOutput.dependencies.addAll(sourceDependencies);
+  buildOutput.dependencies.addAll(
+    _frameworkShaderFiles.map(frameworkShaders.resolve),
+  );
+}

--- a/packages/flutter_scene/lib/src/fmat/build_materials_unsupported.dart
+++ b/packages/flutter_scene/lib/src/fmat/build_materials_unsupported.dart
@@ -1,0 +1,20 @@
+/// Web/wasm stub for [buildMaterials]. The real implementation uses `dart:io`
+/// and `package:flutter_gpu_shaders` to compile `.fmat` materials, and only
+/// runs on the native build host (from a consumer's `hook/build.dart`).
+/// Routing the web/wasm import here keeps `dart:io` and `package:hooks` off the
+/// wasm dependency graph, so the package stays WASM-compatible. Calling it on
+/// web/wasm is never expected.
+library;
+
+/// Throws on web/wasm; see the library doc above. The native signature takes
+/// `BuildInput` / `BuildOutputBuilder` from `package:hooks`; this stub uses
+/// `Object` instead so it pulls in no `dart:io`.
+Never buildMaterials({
+  required Object buildInput,
+  required Object buildOutput,
+  required List<String> materials,
+  String bundleName = 'materials',
+}) =>
+    throw UnsupportedError(
+      'buildMaterials runs at build time on native platforms only.',
+    );

--- a/packages/flutter_scene/lib/src/fmat/fmat.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat.dart
@@ -10,7 +10,10 @@ import 'package:flutter_scene/src/fmat/fmat_parser.dart';
 
 export 'package:flutter_scene/src/fmat/fmat_ast.dart';
 export 'package:flutter_scene/src/fmat/fmat_emitter.dart'
-    show emitFragmentGlsl, buildSidecar, kMaterialParamsBlock,
+    show
+        emitFragmentGlsl,
+        buildSidecar,
+        kMaterialParamsBlock,
         kMaterialParamsInstance;
 export 'package:flutter_scene/src/fmat/fmat_parser.dart' show parseFmat;
 

--- a/packages/flutter_scene/lib/src/fmat/fmat.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat.dart
@@ -1,0 +1,39 @@
+// The `.fmat` custom-material preprocessor: parse a declarative material into
+// an AST, then emit standard GLSL plus a metadata sidecar for `impellerc` and
+// the runtime. This is pure Dart with no GPU dependency; the build hook
+// (package:flutter_scene/build.dart) drives it, and the runtime consumes the
+// sidecar.
+
+import 'package:flutter_scene/src/fmat/fmat_ast.dart';
+import 'package:flutter_scene/src/fmat/fmat_emitter.dart';
+import 'package:flutter_scene/src/fmat/fmat_parser.dart';
+
+export 'package:flutter_scene/src/fmat/fmat_ast.dart';
+export 'package:flutter_scene/src/fmat/fmat_emitter.dart'
+    show emitFragmentGlsl, buildSidecar, kMaterialParamsBlock,
+        kMaterialParamsInstance;
+export 'package:flutter_scene/src/fmat/fmat_parser.dart' show parseFmat;
+
+/// The result of preprocessing a `.fmat` source: the parsed material, the
+/// emitted GLSL fragment shader, and the metadata sidecar.
+class FmatCompilation {
+  FmatCompilation({
+    required this.material,
+    required this.glsl,
+    required this.sidecar,
+  });
+
+  final FmatMaterial material;
+  final String glsl;
+  final Map<String, Object?> sidecar;
+}
+
+/// Parses, validates, and emits [source]. Throws [FmatException] on error.
+FmatCompilation compileFmat(String source, {String? fileName}) {
+  final material = parseFmat(source, fileName: fileName);
+  return FmatCompilation(
+    material: material,
+    glsl: emitFragmentGlsl(material),
+    sidecar: buildSidecar(material),
+  );
+}

--- a/packages/flutter_scene/lib/src/fmat/fmat_ast.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_ast.dart
@@ -1,0 +1,183 @@
+// Abstract syntax tree for the `.fmat` custom-material format and the error
+// type the parser, validator, and emitter throw.
+
+/// The lighting contract a material opts into.
+enum FmatShadingModel {
+  /// The engine runs its physically based lighting (image-based lighting plus
+  /// the analytic directional light). The material's `Surface()` fills the
+  /// surface description; the framework produces the lit color.
+  lit,
+
+  /// No lighting. The material's `Surface()` writes the final color into
+  /// `base_color`; the framework outputs it premultiplied. Use for stylized
+  /// or self-lit effects (matches Godot's `unshaded`).
+  unlit,
+}
+
+/// How the material's alpha is composited.
+enum FmatBlending {
+  /// Drawn in the opaque pass with no blending.
+  opaque,
+
+  /// Drawn in the depth-sorted translucent pass with premultiplied
+  /// source-over blending.
+  alpha,
+}
+
+/// Which triangle faces are culled.
+enum FmatCulling { back, front, none }
+
+/// The type of a material parameter. Scalar and vector types are packed into
+/// the generated `MaterialParams` uniform block; sampler types are declared as
+/// top-level uniforms.
+enum FmatType {
+  float_('float', 4),
+  int_('int', 4),
+  vec2('vec2', 8),
+  vec3('vec3', 12),
+  vec4('vec4', 16),
+  mat4('mat4', 64),
+  sampler2d('sampler2D', 0),
+  samplerCube('samplerCube', 0);
+
+  const FmatType(this.glslType, this.componentBytes);
+
+  /// The GLSL type name emitted for this parameter.
+  final String glslType;
+
+  /// The tightly packed (non-std140) size in bytes, or 0 for samplers. The
+  /// runtime resolves real std140 offsets from shader reflection, so this is
+  /// informational only.
+  final int componentBytes;
+
+  bool get isSampler => this == sampler2d || this == samplerCube;
+
+  /// The number of scalar components, or 0 for samplers (mat4 counts as 16).
+  int get componentCount => switch (this) {
+    float_ || int_ => 1,
+    vec2 => 2,
+    vec3 => 3,
+    vec4 => 4,
+    mat4 => 16,
+    sampler2d || samplerCube => 0,
+  };
+
+  static FmatType? fromToken(String token) {
+    for (final t in FmatType.values) {
+      // Accept the GLSL spelling (vec4, sampler2D) and a lowercase alias
+      // (sampler2d) for the author's convenience.
+      if (token == t.glslType || token == t.glslType.toLowerCase()) {
+        return t;
+      }
+    }
+    if (token == 'int') return FmatType.int_;
+    if (token == 'float') return FmatType.float_;
+    return null;
+  }
+}
+
+/// What kind of authoring hint annotates a parameter. Hints carry editor and
+/// runtime semantics (sRGB decode, value ranges, sampler placeholders).
+enum FmatHintKind {
+  /// An sRGB-authored color: decoded to linear when set. Valid on vec3/vec4.
+  sourceColor,
+
+  /// A bounded numeric range with a step. Valid on float/int.
+  range,
+
+  /// Sampler placeholder defaults, used when the texture is unset.
+  defaultWhite,
+  defaultBlack,
+  defaultNormal,
+  defaultTransparent,
+}
+
+/// An authoring hint on a parameter.
+class FmatHint {
+  const FmatHint(this.kind, {this.rangeMin, this.rangeMax, this.rangeStep});
+
+  final FmatHintKind kind;
+
+  /// Set only when [kind] is [FmatHintKind.range].
+  final double? rangeMin;
+  final double? rangeMax;
+  final double? rangeStep;
+}
+
+/// A single declared material parameter.
+class FmatParameter {
+  FmatParameter({
+    required this.type,
+    required this.name,
+    this.hint,
+    this.defaultValue,
+  });
+
+  final FmatType type;
+  final String name;
+  final FmatHint? hint;
+
+  /// The default value: a `num` for scalars, a `List<num>` for vectors and
+  /// matrices, or `null`. Samplers carry their default via [hint].
+  final Object? defaultValue;
+
+  bool get isSampler => type.isSampler;
+}
+
+/// A fully parsed and validated `.fmat` material.
+class FmatMaterial {
+  FmatMaterial({
+    required this.name,
+    required this.shadingModel,
+    required this.blending,
+    required this.culling,
+    required this.parameters,
+    required this.fragmentSource,
+    required this.fragmentSourceLine,
+  });
+
+  final String name;
+  final FmatShadingModel shadingModel;
+  final FmatBlending blending;
+  final FmatCulling culling;
+  final List<FmatParameter> parameters;
+
+  /// The verbatim contents of the `fragment { }` block.
+  final String fragmentSource;
+
+  /// The 1-based line in the source where [fragmentSource] begins, used to
+  /// emit a `#line` directive so compiler errors map back to the `.fmat`.
+  final int fragmentSourceLine;
+
+  /// Parameters packed into the `MaterialParams` uniform block, in declared
+  /// order.
+  Iterable<FmatParameter> get uniformParameters =>
+      parameters.where((p) => !p.isSampler);
+
+  /// Parameters declared as top-level sampler uniforms.
+  Iterable<FmatParameter> get samplerParameters =>
+      parameters.where((p) => p.isSampler);
+}
+
+/// Thrown when a `.fmat` source is malformed or fails validation. Carries a
+/// 1-based source location when one is known.
+class FmatException implements Exception {
+  FmatException(this.message, {this.fileName, this.line, this.column});
+
+  final String message;
+  final String? fileName;
+  final int? line;
+  final int? column;
+
+  @override
+  String toString() {
+    final location = StringBuffer();
+    if (fileName != null) location.write(fileName);
+    if (line != null) {
+      location.write('${fileName != null ? ':' : ''}$line');
+      if (column != null) location.write(':$column');
+    }
+    final prefix = location.isEmpty ? '' : '$location: ';
+    return 'FmatException: $prefix$message';
+  }
+}

--- a/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
@@ -1,0 +1,117 @@
+// Emits standard GLSL and a metadata sidecar from a parsed [FmatMaterial].
+//
+// The emitted fragment shader composes the engine framework includes, a
+// generated `MaterialParams` uniform block plus sampler declarations, the
+// author's verbatim `Surface()` body, and a generated `main()`. The sidecar
+// records each parameter's type, default, and hint so the runtime can offer
+// type-checked, name-based parameter setting (offsets come from shader
+// reflection at load time; the sidecar supplies the types reflection does not
+// expose).
+
+import 'package:flutter_scene/src/fmat/fmat_ast.dart';
+
+/// The GLSL uniform block name the runtime binds custom parameters through.
+const String kMaterialParamsBlock = 'MaterialParams';
+
+/// The GLES-fold-safe instance name for [kMaterialParamsBlock].
+const String kMaterialParamsInstance = 'material_params';
+
+/// Emits the fragment shader GLSL for [material].
+String emitFragmentGlsl(FmatMaterial material) {
+  final sb = StringBuffer();
+  final lit = material.shadingModel == FmatShadingModel.lit;
+
+  sb.writeln('// Generated from a .fmat material by flutter_scene. '
+      'Do not edit.');
+  sb.writeln('#include <material_varyings.glsl>');
+  sb.writeln('#include <pbr.glsl>');
+  sb.writeln('#include <texture.glsl>');
+  sb.writeln('#include <normals.glsl>');
+  sb.writeln('#include <material_inputs.glsl>');
+  if (lit) {
+    sb.writeln('#include <material_engine_lighting.glsl>');
+    sb.writeln('#include <material_lighting.glsl>');
+  }
+  sb.writeln();
+
+  final uniforms = material.uniformParameters.toList();
+  if (uniforms.isNotEmpty) {
+    sb.writeln('uniform $kMaterialParamsBlock {');
+    for (final p in uniforms) {
+      sb.writeln('  ${p.type.glslType} ${p.name};');
+    }
+    sb.writeln('}');
+    sb.writeln('$kMaterialParamsInstance;');
+    sb.writeln();
+  }
+
+  final samplers = material.samplerParameters.toList();
+  for (final p in samplers) {
+    sb.writeln('uniform ${p.type.glslType} ${p.name};');
+  }
+  if (samplers.isNotEmpty) sb.writeln();
+
+  // Map compiler errors in the author's code back to the .fmat source line.
+  sb.writeln('#line ${material.fragmentSourceLine}');
+  sb.write(material.fragmentSource);
+  if (!material.fragmentSource.endsWith('\n')) sb.writeln();
+  sb.writeln();
+
+  sb.writeln('void main() {');
+  sb.writeln('  MaterialInputs material = InitMaterialInputs();');
+  sb.writeln('  Surface(material);');
+  if (lit) {
+    sb.writeln('  frag_color = EvaluateLighting(material);');
+  } else {
+    sb.writeln('  // Unlit: output the surface color, premultiplied by alpha.');
+    sb.writeln('  frag_color = vec4(material.base_color.rgb, 1.0) * '
+        'material.base_color.a;');
+  }
+  sb.writeln('}');
+
+  return sb.toString();
+}
+
+/// Builds the JSON-serializable metadata sidecar for [material].
+Map<String, Object?> buildSidecar(FmatMaterial material) {
+  return <String, Object?>{
+    'name': material.name,
+    'shading_model': material.shadingModel.name,
+    'blending': material.blending.name,
+    'culling': material.culling.name,
+    'uniform_block': kMaterialParamsBlock,
+    'parameters': [
+      for (final p in material.uniformParameters)
+        <String, Object?>{
+          'name': p.name,
+          'type': p.type.glslType,
+          if (p.defaultValue != null) 'default': p.defaultValue,
+          if (p.hint != null) 'hint': _hintJson(p.hint!),
+        },
+    ],
+    'samplers': [
+      for (final p in material.samplerParameters)
+        <String, Object?>{
+          'name': p.name,
+          'type': p.type.glslType,
+          if (p.hint != null) 'hint': _hintJson(p.hint!),
+        },
+    ],
+  };
+}
+
+Map<String, Object?> _hintJson(FmatHint hint) {
+  return switch (hint.kind) {
+    FmatHintKind.range => <String, Object?>{
+        'kind': 'range',
+        'min': hint.rangeMin,
+        'max': hint.rangeMax,
+        'step': hint.rangeStep,
+      },
+    FmatHintKind.sourceColor => const {'kind': 'source_color'},
+    FmatHintKind.defaultWhite => const {'kind': 'default_white'},
+    FmatHintKind.defaultBlack => const {'kind': 'default_black'},
+    FmatHintKind.defaultNormal => const {'kind': 'default_normal'},
+    FmatHintKind.defaultTransparent => const {'kind': 'default_transparent'},
+  };
+}

--- a/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
@@ -21,8 +21,10 @@ String emitFragmentGlsl(FmatMaterial material) {
   final sb = StringBuffer();
   final lit = material.shadingModel == FmatShadingModel.lit;
 
-  sb.writeln('// Generated from a .fmat material by flutter_scene. '
-      'Do not edit.');
+  sb.writeln(
+    '// Generated from a .fmat material by flutter_scene. '
+    'Do not edit.',
+  );
   sb.writeln('#include <material_varyings.glsl>');
   sb.writeln('#include <pbr.glsl>');
   sb.writeln('#include <texture.glsl>');
@@ -64,8 +66,10 @@ String emitFragmentGlsl(FmatMaterial material) {
     sb.writeln('  frag_color = EvaluateLighting(material);');
   } else {
     sb.writeln('  // Unlit: output the surface color, premultiplied by alpha.');
-    sb.writeln('  frag_color = vec4(material.base_color.rgb, 1.0) * '
-        'material.base_color.a;');
+    sb.writeln(
+      '  frag_color = vec4(material.base_color.rgb, 1.0) * '
+      'material.base_color.a;',
+    );
   }
   sb.writeln('}');
 
@@ -103,11 +107,11 @@ Map<String, Object?> buildSidecar(FmatMaterial material) {
 Map<String, Object?> _hintJson(FmatHint hint) {
   return switch (hint.kind) {
     FmatHintKind.range => <String, Object?>{
-        'kind': 'range',
-        'min': hint.rangeMin,
-        'max': hint.rangeMax,
-        'step': hint.rangeStep,
-      },
+      'kind': 'range',
+      'min': hint.rangeMin,
+      'max': hint.rangeMax,
+      'step': hint.rangeStep,
+    },
     FmatHintKind.sourceColor => const {'kind': 'source_color'},
     FmatHintKind.defaultWhite => const {'kind': 'default_white'},
     FmatHintKind.defaultBlack => const {'kind': 'default_black'},

--- a/packages/flutter_scene/lib/src/fmat/fmat_parser.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_parser.dart
@@ -1,0 +1,673 @@
+// Parser for the `.fmat` custom-material format.
+//
+// A `.fmat` file has two top-level blocks: a `material { ... }` metadata block
+// in a small JSON-like dialect, and a `fragment { ... }` block of verbatim
+// GLSL. This file extracts the two blocks (brace-matching while skipping
+// comments), lexes and parses the metadata dialect into a generic value tree,
+// then builds and validates an [FmatMaterial].
+
+import 'package:flutter_scene/src/fmat/fmat_ast.dart';
+
+/// Parses [source] into a validated [FmatMaterial]. Throws [FmatException] on
+/// any syntax or validation error.
+FmatMaterial parseFmat(String source, {String? fileName}) {
+  final blocks = _extractBlocks(source, fileName);
+
+  final material = blocks['material'];
+  if (material == null) {
+    throw FmatException('Missing required `material { ... }` block.',
+        fileName: fileName);
+  }
+  final fragment = blocks['fragment'];
+  if (fragment == null) {
+    throw FmatException('Missing required `fragment { ... }` block.',
+        fileName: fileName);
+  }
+
+  final tokens = _Lexer(material.content, fileName, material.startLine).tokenize();
+  final tree = _ValueParser(tokens, fileName).parseObjectBody();
+
+  return _build(tree, fragment, fileName);
+}
+
+// ---------------------------------------------------------------------------
+// Block extraction.
+// ---------------------------------------------------------------------------
+
+class _Block {
+  _Block(this.content, this.startLine);
+  final String content;
+  final int startLine;
+}
+
+/// Walks the top level of [source], returning each `keyword { ... }` block by
+/// keyword. Brace matching skips `//` and `/* */` comments so braces inside
+/// GLSL comments do not throw off the count.
+Map<String, _Block> _extractBlocks(String source, String? fileName) {
+  final blocks = <String, _Block>{};
+  var i = 0;
+  var line = 1;
+
+  ({int i, int line}) skipTrivia(int i, int line) {
+    while (i < source.length) {
+      final c = source[i];
+      if (c == '\n') {
+        line++;
+        i++;
+      } else if (c == ' ' || c == '\t' || c == '\r') {
+        i++;
+      } else if (c == '/' && i + 1 < source.length && source[i + 1] == '/') {
+        while (i < source.length && source[i] != '\n') {
+          i++;
+        }
+      } else if (c == '/' && i + 1 < source.length && source[i + 1] == '*') {
+        i += 2;
+        while (i + 1 < source.length &&
+            !(source[i] == '*' && source[i + 1] == '/')) {
+          if (source[i] == '\n') line++;
+          i++;
+        }
+        i += 2;
+      } else {
+        break;
+      }
+    }
+    return (i: i, line: line);
+  }
+
+  while (true) {
+    final t = skipTrivia(i, line);
+    i = t.i;
+    line = t.line;
+    if (i >= source.length) break;
+
+    // Read a keyword identifier.
+    final keywordStart = i;
+    while (i < source.length && _isIdentChar(source[i])) {
+      i++;
+    }
+    if (i == keywordStart) {
+      throw FmatException(
+          'Expected a top-level block keyword (`material` or `fragment`).',
+          fileName: fileName, line: line);
+    }
+    final keyword = source.substring(keywordStart, i);
+
+    final t2 = skipTrivia(i, line);
+    i = t2.i;
+    line = t2.line;
+    if (i >= source.length || source[i] != '{') {
+      throw FmatException('Expected `{` after `$keyword`.',
+          fileName: fileName, line: line);
+    }
+
+    // Capture the brace-matched content.
+    i++; // past '{'
+    final contentStartLine = line;
+    final contentStart = i;
+    var depth = 1;
+    while (i < source.length && depth > 0) {
+      final c = source[i];
+      if (c == '\n') {
+        line++;
+        i++;
+      } else if (c == '/' && i + 1 < source.length && source[i + 1] == '/') {
+        while (i < source.length && source[i] != '\n') {
+          i++;
+        }
+      } else if (c == '/' && i + 1 < source.length && source[i + 1] == '*') {
+        i += 2;
+        while (i + 1 < source.length &&
+            !(source[i] == '*' && source[i + 1] == '/')) {
+          if (source[i] == '\n') line++;
+          i++;
+        }
+        i += 2;
+      } else {
+        if (c == '{') depth++;
+        if (c == '}') depth--;
+        i++;
+      }
+    }
+    if (depth != 0) {
+      throw FmatException('Unterminated `$keyword { ... }` block.',
+          fileName: fileName, line: contentStartLine);
+    }
+    final content = source.substring(contentStart, i - 1);
+    if (blocks.containsKey(keyword)) {
+      throw FmatException('Duplicate `$keyword` block.',
+          fileName: fileName, line: contentStartLine);
+    }
+    blocks[keyword] = _Block(content, contentStartLine);
+  }
+
+  return blocks;
+}
+
+bool _isIdentChar(String c) {
+  final u = c.codeUnitAt(0);
+  return (u >= 0x30 && u <= 0x39) || // 0-9
+      (u >= 0x41 && u <= 0x5A) || // A-Z
+      (u >= 0x61 && u <= 0x7A) || // a-z
+      u == 0x5F; // _
+}
+
+bool _isIdentStart(String c) {
+  final u = c.codeUnitAt(0);
+  return (u >= 0x41 && u <= 0x5A) || (u >= 0x61 && u <= 0x7A) || u == 0x5F;
+}
+
+// ---------------------------------------------------------------------------
+// Lexer for the metadata dialect.
+// ---------------------------------------------------------------------------
+
+enum _Tok { lbrace, rbrace, lbracket, rbracket, lparen, rparen, colon, comma, ident, number, string, eof }
+
+class _Token {
+  _Token(this.type, this.value, this.line);
+  final _Tok type;
+  final Object? value;
+  final int line;
+}
+
+class _Lexer {
+  _Lexer(this.source, this.fileName, this.baseLine);
+  final String source;
+  final String? fileName;
+  final int baseLine;
+
+  int _i = 0;
+  int _line = 0; // newlines seen within the content
+
+  int get _reportLine => baseLine + _line;
+
+  List<_Token> tokenize() {
+    final tokens = <_Token>[];
+    while (true) {
+      _skipTrivia();
+      if (_i >= source.length) {
+        tokens.add(_Token(_Tok.eof, null, _reportLine));
+        return tokens;
+      }
+      final c = source[_i];
+      final single = _singleCharToken(c);
+      if (single != null) {
+        tokens.add(_Token(single, c, _reportLine));
+        _i++;
+      } else if (c == '"') {
+        tokens.add(_lexString());
+      } else if (c == '-' || _isDigit(c)) {
+        tokens.add(_lexNumber());
+      } else if (_isIdentStart(c)) {
+        tokens.add(_lexIdent());
+      } else {
+        throw FmatException('Unexpected character `$c`.',
+            fileName: fileName, line: _reportLine);
+      }
+    }
+  }
+
+  _Tok? _singleCharToken(String c) => switch (c) {
+        '{' => _Tok.lbrace,
+        '}' => _Tok.rbrace,
+        '[' => _Tok.lbracket,
+        ']' => _Tok.rbracket,
+        '(' => _Tok.lparen,
+        ')' => _Tok.rparen,
+        ':' => _Tok.colon,
+        ',' => _Tok.comma,
+        _ => null,
+      };
+
+  void _skipTrivia() {
+    while (_i < source.length) {
+      final c = source[_i];
+      if (c == '\n') {
+        _line++;
+        _i++;
+      } else if (c == ' ' || c == '\t' || c == '\r') {
+        _i++;
+      } else if (c == '/' && _i + 1 < source.length && source[_i + 1] == '/') {
+        while (_i < source.length && source[_i] != '\n') {
+          _i++;
+        }
+      } else if (c == '/' && _i + 1 < source.length && source[_i + 1] == '*') {
+        _i += 2;
+        while (_i + 1 < source.length &&
+            !(source[_i] == '*' && source[_i + 1] == '/')) {
+          if (source[_i] == '\n') _line++;
+          _i++;
+        }
+        _i += 2;
+      } else {
+        break;
+      }
+    }
+  }
+
+  _Token _lexString() {
+    final startLine = _reportLine;
+    _i++; // opening quote
+    final sb = StringBuffer();
+    while (_i < source.length && source[_i] != '"') {
+      if (source[_i] == '\n') {
+        throw FmatException('Unterminated string.',
+            fileName: fileName, line: startLine);
+      }
+      sb.write(source[_i]);
+      _i++;
+    }
+    if (_i >= source.length) {
+      throw FmatException('Unterminated string.',
+          fileName: fileName, line: startLine);
+    }
+    _i++; // closing quote
+    return _Token(_Tok.string, sb.toString(), startLine);
+  }
+
+  _Token _lexNumber() {
+    final startLine = _reportLine;
+    final start = _i;
+    if (source[_i] == '-') _i++;
+    while (_i < source.length && _isDigit(source[_i])) {
+      _i++;
+    }
+    var isDouble = false;
+    if (_i < source.length && source[_i] == '.') {
+      isDouble = true;
+      _i++;
+      while (_i < source.length && _isDigit(source[_i])) {
+        _i++;
+      }
+    }
+    final text = source.substring(start, _i);
+    final num value = isDouble ? double.parse(text) : int.parse(text);
+    return _Token(_Tok.number, value, startLine);
+  }
+
+  _Token _lexIdent() {
+    final startLine = _reportLine;
+    final start = _i;
+    while (_i < source.length && _isIdentChar(source[_i])) {
+      _i++;
+    }
+    return _Token(_Tok.ident, source.substring(start, _i), startLine);
+  }
+
+  bool _isDigit(String c) {
+    final u = c.codeUnitAt(0);
+    return u >= 0x30 && u <= 0x39;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Generic value tree.
+// ---------------------------------------------------------------------------
+
+/// A bare identifier in the metadata dialect (an enum value or a type name).
+class _Ident {
+  _Ident(this.name, this.line);
+  final String name;
+  final int line;
+}
+
+/// A function-call value, e.g. `range(0, 1, 0.01)`.
+class _Call {
+  _Call(this.name, this.args, this.line);
+  final String name;
+  final List<Object?> args;
+  final int line;
+}
+
+class _ValueParser {
+  _ValueParser(this.tokens, this.fileName);
+  final List<_Token> tokens;
+  final String? fileName;
+  int _p = 0;
+
+  _Token get _cur => tokens[_p];
+  _Token _advance() => tokens[_p++];
+
+  _Token _expect(_Tok type, String what) {
+    if (_cur.type != type) {
+      throw FmatException('Expected $what.',
+          fileName: fileName, line: _cur.line);
+    }
+    return _advance();
+  }
+
+  /// Parses the body of an object (no surrounding braces): `key : value`
+  /// pairs separated by commas, with an optional trailing comma. Used for the
+  /// top-level material block content.
+  Map<String, Object?> parseObjectBody() {
+    final map = _parsePairsUntil(_Tok.eof);
+    _expect(_Tok.eof, 'end of the material block');
+    return map;
+  }
+
+  Map<String, Object?> _parsePairsUntil(_Tok terminator) {
+    final map = <String, Object?>{};
+    while (_cur.type != terminator) {
+      if (_cur.type != _Tok.ident && _cur.type != _Tok.string) {
+        throw FmatException('Expected a key.',
+            fileName: fileName, line: _cur.line);
+      }
+      final key = _advance().value as String;
+      if (map.containsKey(key)) {
+        throw FmatException('Duplicate key `$key`.',
+            fileName: fileName, line: _cur.line);
+      }
+      _expect(_Tok.colon, '`:` after `$key`');
+      map[key] = _parseValue();
+      if (_cur.type == _Tok.comma) {
+        _advance();
+      } else {
+        break;
+      }
+    }
+    return map;
+  }
+
+  Object? _parseValue() {
+    final t = _cur;
+    switch (t.type) {
+      case _Tok.string:
+        _advance();
+        return t.value;
+      case _Tok.number:
+        _advance();
+        return t.value;
+      case _Tok.lbrace:
+        _advance();
+        final map = _parsePairsUntil(_Tok.rbrace);
+        _expect(_Tok.rbrace, '`}`');
+        return map;
+      case _Tok.lbracket:
+        return _parseArray();
+      case _Tok.ident:
+        _advance();
+        if (_cur.type == _Tok.lparen) {
+          return _parseCall(t.value as String, t.line);
+        }
+        return _Ident(t.value as String, t.line);
+      default:
+        throw FmatException('Expected a value.',
+            fileName: fileName, line: t.line);
+    }
+  }
+
+  List<Object?> _parseArray() {
+    _expect(_Tok.lbracket, '`[`');
+    final list = <Object?>[];
+    while (_cur.type != _Tok.rbracket) {
+      list.add(_parseValue());
+      if (_cur.type == _Tok.comma) {
+        _advance();
+      } else {
+        break;
+      }
+    }
+    _expect(_Tok.rbracket, '`]`');
+    return list;
+  }
+
+  _Call _parseCall(String name, int line) {
+    _expect(_Tok.lparen, '`(`');
+    final args = <Object?>[];
+    while (_cur.type != _Tok.rparen) {
+      args.add(_parseValue());
+      if (_cur.type == _Tok.comma) {
+        _advance();
+      } else {
+        break;
+      }
+    }
+    _expect(_Tok.rparen, '`)`');
+    return _Call(name, args, line);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AST builder + validation.
+// ---------------------------------------------------------------------------
+
+const _reservedNames = <String>{
+  'frag_info', 'FragInfo', 'frag_color',
+  'v_position', 'v_normal', 'v_viewvector', 'v_texture_coords', 'v_color',
+  'prefiltered_radiance', 'brdf_lut', 'shadow_map',
+  'MaterialInputs', 'material', 'material_params', 'MaterialParams',
+  'Surface', 'EvaluateLighting', 'InitMaterialInputs', 'PrepareMaterial',
+  'GetWorldPosition', 'GetWorldNormal', 'GetViewDirection', 'GetUV0',
+  'GetVertexColor', 'main',
+};
+
+FmatMaterial _build(
+    Map<String, Object?> tree, _Block fragment, String? fileName) {
+  const knownKeys = {
+    'name', 'shading_model', 'blending', 'culling', 'parameters', 'requires'
+  };
+  for (final key in tree.keys) {
+    if (!knownKeys.contains(key)) {
+      throw FmatException('Unknown material key `$key`.', fileName: fileName);
+    }
+  }
+
+  final name = tree['name'];
+  if (name is! String || name.isEmpty) {
+    throw FmatException('`name` is required and must be a non-empty string.',
+        fileName: fileName);
+  }
+
+  final shadingModel = _enum<FmatShadingModel>(
+      tree['shading_model'], FmatShadingModel.values, 'shading_model',
+      defaultValue: FmatShadingModel.lit, fileName: fileName);
+  final blending = _enum<FmatBlending>(
+      tree['blending'], FmatBlending.values, 'blending',
+      defaultValue: FmatBlending.opaque, fileName: fileName);
+  final culling = _enum<FmatCulling>(
+      tree['culling'], FmatCulling.values, 'culling',
+      defaultValue: FmatCulling.back, fileName: fileName);
+
+  final parameters = _buildParameters(tree['parameters'], fileName);
+
+  // Loose check: the fragment block must define a Surface function. We do not
+  // fully parse GLSL; this catches the common omission with a clear message.
+  if (!RegExp(r'\bvoid\s+Surface\s*\(').hasMatch(fragment.content)) {
+    throw FmatException(
+        'The `fragment` block must define '
+        '`void Surface(inout MaterialInputs material)`.',
+        fileName: fileName, line: fragment.startLine);
+  }
+
+  return FmatMaterial(
+    name: name,
+    shadingModel: shadingModel,
+    blending: blending,
+    culling: culling,
+    parameters: parameters,
+    fragmentSource: fragment.content,
+    fragmentSourceLine: fragment.startLine,
+  );
+}
+
+T _enum<T extends Enum>(
+    Object? value, List<T> values, String key,
+    {required T defaultValue, String? fileName}) {
+  if (value == null) return defaultValue;
+  if (value is! _Ident) {
+    throw FmatException('`$key` must be one of ${values.map((v) => v.name)}.',
+        fileName: fileName);
+  }
+  for (final v in values) {
+    if (v.name == value.name) return v;
+  }
+  throw FmatException(
+      '`$key` is `${value.name}`, expected one of ${values.map((v) => v.name)}.',
+      fileName: fileName, line: value.line);
+}
+
+List<FmatParameter> _buildParameters(Object? raw, String? fileName) {
+  if (raw == null) return const [];
+  if (raw is! List) {
+    throw FmatException('`parameters` must be a list.', fileName: fileName);
+  }
+  final params = <FmatParameter>[];
+  final seen = <String>{};
+  for (final entry in raw) {
+    if (entry is! Map<String, Object?>) {
+      throw FmatException('Each parameter must be an object.',
+          fileName: fileName);
+    }
+    for (final key in entry.keys) {
+      if (!{'type', 'name', 'hint', 'default'}.contains(key)) {
+        throw FmatException('Unknown parameter key `$key`.',
+            fileName: fileName);
+      }
+    }
+
+    final typeTok = entry['type'];
+    if (typeTok is! _Ident) {
+      throw FmatException('Parameter `type` is required.', fileName: fileName);
+    }
+    if (typeTok.name == 'mat3') {
+      throw FmatException(
+          '`mat3` parameters are not supported because of a GLES std140 '
+          'layout bug; use `mat4`.',
+          fileName: fileName, line: typeTok.line);
+    }
+    final type = FmatType.fromToken(typeTok.name);
+    if (type == null) {
+      throw FmatException('Unknown parameter type `${typeTok.name}`.',
+          fileName: fileName, line: typeTok.line);
+    }
+
+    final nameVal = entry['name'];
+    final pname = switch (nameVal) {
+      String s => s,
+      _Ident id => id.name,
+      _ => throw FmatException('Parameter `name` is required.',
+          fileName: fileName),
+    };
+    _validateParamName(pname, fileName);
+    if (!seen.add(pname)) {
+      throw FmatException('Duplicate parameter name `$pname`.',
+          fileName: fileName);
+    }
+
+    final hint = _buildHint(entry['hint'], type, pname, fileName);
+    final defaultValue =
+        _buildDefault(entry['default'], type, pname, fileName);
+
+    params.add(FmatParameter(
+        type: type, name: pname, hint: hint, defaultValue: defaultValue));
+  }
+  return params;
+}
+
+void _validateParamName(String name, String? fileName) {
+  if (name.isEmpty ||
+      !_isIdentStart(name[0]) ||
+      !name.split('').every(_isIdentChar)) {
+    throw FmatException('`$name` is not a valid identifier.',
+        fileName: fileName);
+  }
+  if (name.startsWith('gl_')) {
+    throw FmatException('Parameter names may not start with `gl_`.',
+        fileName: fileName);
+  }
+  if (_reservedNames.contains(name)) {
+    throw FmatException(
+        '`$name` collides with an engine-reserved identifier.',
+        fileName: fileName);
+  }
+}
+
+FmatHint? _buildHint(
+    Object? raw, FmatType type, String pname, String? fileName) {
+  if (raw == null) return null;
+
+  FmatHint colorHint(int line) {
+    if (type != FmatType.vec3 && type != FmatType.vec4) {
+      throw FmatException(
+          '`source_color` on `$pname` requires a vec3 or vec4.',
+          fileName: fileName, line: line);
+    }
+    return const FmatHint(FmatHintKind.sourceColor);
+  }
+
+  FmatHint samplerDefault(FmatHintKind kind, int line) {
+    if (!type.isSampler) {
+      throw FmatException(
+          'A sampler-default hint on `$pname` requires a sampler type.',
+          fileName: fileName, line: line);
+    }
+    return FmatHint(kind);
+  }
+
+  if (raw is _Ident) {
+    return switch (raw.name) {
+      'source_color' => colorHint(raw.line),
+      'default_white' => samplerDefault(FmatHintKind.defaultWhite, raw.line),
+      'default_black' => samplerDefault(FmatHintKind.defaultBlack, raw.line),
+      'default_normal' => samplerDefault(FmatHintKind.defaultNormal, raw.line),
+      'default_transparent' =>
+        samplerDefault(FmatHintKind.defaultTransparent, raw.line),
+      _ => throw FmatException('Unknown hint `${raw.name}` on `$pname`.',
+          fileName: fileName, line: raw.line),
+    };
+  }
+  if (raw is _Call && raw.name == 'range') {
+    if (type != FmatType.float_ && type != FmatType.int_) {
+      throw FmatException('`range` on `$pname` requires a float or int.',
+          fileName: fileName, line: raw.line);
+    }
+    if (raw.args.length != 3 || raw.args.any((a) => a is! num)) {
+      throw FmatException(
+          '`range` takes three numbers: range(min, max, step).',
+          fileName: fileName, line: raw.line);
+    }
+    return FmatHint(FmatHintKind.range,
+        rangeMin: (raw.args[0] as num).toDouble(),
+        rangeMax: (raw.args[1] as num).toDouble(),
+        rangeStep: (raw.args[2] as num).toDouble());
+  }
+  throw FmatException('Invalid hint on `$pname`.', fileName: fileName);
+}
+
+Object? _buildDefault(
+    Object? raw, FmatType type, String pname, String? fileName) {
+  if (raw == null) return null;
+  if (type.isSampler) {
+    throw FmatException(
+        'Samplers take a placeholder via `hint`, not `default` (`$pname`).',
+        fileName: fileName);
+  }
+  if (type == FmatType.float_) {
+    if (raw is! num) {
+      throw FmatException('`default` for `$pname` must be a number.',
+          fileName: fileName);
+    }
+    return raw.toDouble();
+  }
+  if (type == FmatType.int_) {
+    if (raw is! num || raw != raw.toInt()) {
+      throw FmatException('`default` for `$pname` must be an integer.',
+          fileName: fileName);
+    }
+    return raw.toInt();
+  }
+  // Vector / matrix.
+  if (raw is! List || raw.any((e) => e is! num)) {
+    throw FmatException(
+        '`default` for `$pname` must be a list of ${type.componentCount} '
+        'numbers.',
+        fileName: fileName);
+  }
+  if (raw.length != type.componentCount) {
+    throw FmatException(
+        '`default` for `$pname` has ${raw.length} components, '
+        'expected ${type.componentCount}.',
+        fileName: fileName);
+  }
+  return raw.map((e) => (e as num).toDouble()).toList();
+}

--- a/packages/flutter_scene/lib/src/fmat/fmat_parser.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_parser.dart
@@ -15,16 +15,21 @@ FmatMaterial parseFmat(String source, {String? fileName}) {
 
   final material = blocks['material'];
   if (material == null) {
-    throw FmatException('Missing required `material { ... }` block.',
-        fileName: fileName);
+    throw FmatException(
+      'Missing required `material { ... }` block.',
+      fileName: fileName,
+    );
   }
   final fragment = blocks['fragment'];
   if (fragment == null) {
-    throw FmatException('Missing required `fragment { ... }` block.',
-        fileName: fileName);
+    throw FmatException(
+      'Missing required `fragment { ... }` block.',
+      fileName: fileName,
+    );
   }
 
-  final tokens = _Lexer(material.content, fileName, material.startLine).tokenize();
+  final tokens =
+      _Lexer(material.content, fileName, material.startLine).tokenize();
   final tree = _ValueParser(tokens, fileName).parseObjectBody();
 
   return _build(tree, fragment, fileName);
@@ -88,8 +93,10 @@ Map<String, _Block> _extractBlocks(String source, String? fileName) {
     }
     if (i == keywordStart) {
       throw FmatException(
-          'Expected a top-level block keyword (`material` or `fragment`).',
-          fileName: fileName, line: line);
+        'Expected a top-level block keyword (`material` or `fragment`).',
+        fileName: fileName,
+        line: line,
+      );
     }
     final keyword = source.substring(keywordStart, i);
 
@@ -97,8 +104,11 @@ Map<String, _Block> _extractBlocks(String source, String? fileName) {
     i = t2.i;
     line = t2.line;
     if (i >= source.length || source[i] != '{') {
-      throw FmatException('Expected `{` after `$keyword`.',
-          fileName: fileName, line: line);
+      throw FmatException(
+        'Expected `{` after `$keyword`.',
+        fileName: fileName,
+        line: line,
+      );
     }
 
     // Capture the brace-matched content.
@@ -130,13 +140,19 @@ Map<String, _Block> _extractBlocks(String source, String? fileName) {
       }
     }
     if (depth != 0) {
-      throw FmatException('Unterminated `$keyword { ... }` block.',
-          fileName: fileName, line: contentStartLine);
+      throw FmatException(
+        'Unterminated `$keyword { ... }` block.',
+        fileName: fileName,
+        line: contentStartLine,
+      );
     }
     final content = source.substring(contentStart, i - 1);
     if (blocks.containsKey(keyword)) {
-      throw FmatException('Duplicate `$keyword` block.',
-          fileName: fileName, line: contentStartLine);
+      throw FmatException(
+        'Duplicate `$keyword` block.',
+        fileName: fileName,
+        line: contentStartLine,
+      );
     }
     blocks[keyword] = _Block(content, contentStartLine);
   }
@@ -161,7 +177,20 @@ bool _isIdentStart(String c) {
 // Lexer for the metadata dialect.
 // ---------------------------------------------------------------------------
 
-enum _Tok { lbrace, rbrace, lbracket, rbracket, lparen, rparen, colon, comma, ident, number, string, eof }
+enum _Tok {
+  lbrace,
+  rbrace,
+  lbracket,
+  rbracket,
+  lparen,
+  rparen,
+  colon,
+  comma,
+  ident,
+  number,
+  string,
+  eof,
+}
 
 class _Token {
   _Token(this.type, this.value, this.line);
@@ -201,23 +230,26 @@ class _Lexer {
       } else if (_isIdentStart(c)) {
         tokens.add(_lexIdent());
       } else {
-        throw FmatException('Unexpected character `$c`.',
-            fileName: fileName, line: _reportLine);
+        throw FmatException(
+          'Unexpected character `$c`.',
+          fileName: fileName,
+          line: _reportLine,
+        );
       }
     }
   }
 
   _Tok? _singleCharToken(String c) => switch (c) {
-        '{' => _Tok.lbrace,
-        '}' => _Tok.rbrace,
-        '[' => _Tok.lbracket,
-        ']' => _Tok.rbracket,
-        '(' => _Tok.lparen,
-        ')' => _Tok.rparen,
-        ':' => _Tok.colon,
-        ',' => _Tok.comma,
-        _ => null,
-      };
+    '{' => _Tok.lbrace,
+    '}' => _Tok.rbrace,
+    '[' => _Tok.lbracket,
+    ']' => _Tok.rbracket,
+    '(' => _Tok.lparen,
+    ')' => _Tok.rparen,
+    ':' => _Tok.colon,
+    ',' => _Tok.comma,
+    _ => null,
+  };
 
   void _skipTrivia() {
     while (_i < source.length) {
@@ -251,15 +283,21 @@ class _Lexer {
     final sb = StringBuffer();
     while (_i < source.length && source[_i] != '"') {
       if (source[_i] == '\n') {
-        throw FmatException('Unterminated string.',
-            fileName: fileName, line: startLine);
+        throw FmatException(
+          'Unterminated string.',
+          fileName: fileName,
+          line: startLine,
+        );
       }
       sb.write(source[_i]);
       _i++;
     }
     if (_i >= source.length) {
-      throw FmatException('Unterminated string.',
-          fileName: fileName, line: startLine);
+      throw FmatException(
+        'Unterminated string.',
+        fileName: fileName,
+        line: startLine,
+      );
     }
     _i++; // closing quote
     return _Token(_Tok.string, sb.toString(), startLine);
@@ -330,8 +368,11 @@ class _ValueParser {
 
   _Token _expect(_Tok type, String what) {
     if (_cur.type != type) {
-      throw FmatException('Expected $what.',
-          fileName: fileName, line: _cur.line);
+      throw FmatException(
+        'Expected $what.',
+        fileName: fileName,
+        line: _cur.line,
+      );
     }
     return _advance();
   }
@@ -349,13 +390,19 @@ class _ValueParser {
     final map = <String, Object?>{};
     while (_cur.type != terminator) {
       if (_cur.type != _Tok.ident && _cur.type != _Tok.string) {
-        throw FmatException('Expected a key.',
-            fileName: fileName, line: _cur.line);
+        throw FmatException(
+          'Expected a key.',
+          fileName: fileName,
+          line: _cur.line,
+        );
       }
       final key = _advance().value as String;
       if (map.containsKey(key)) {
-        throw FmatException('Duplicate key `$key`.',
-            fileName: fileName, line: _cur.line);
+        throw FmatException(
+          'Duplicate key `$key`.',
+          fileName: fileName,
+          line: _cur.line,
+        );
       }
       _expect(_Tok.colon, '`:` after `$key`');
       map[key] = _parseValue();
@@ -391,8 +438,11 @@ class _ValueParser {
         }
         return _Ident(t.value as String, t.line);
       default:
-        throw FmatException('Expected a value.',
-            fileName: fileName, line: t.line);
+        throw FmatException(
+          'Expected a value.',
+          fileName: fileName,
+          line: t.line,
+        );
     }
   }
 
@@ -432,19 +482,45 @@ class _ValueParser {
 // ---------------------------------------------------------------------------
 
 const _reservedNames = <String>{
-  'frag_info', 'FragInfo', 'frag_color',
-  'v_position', 'v_normal', 'v_viewvector', 'v_texture_coords', 'v_color',
-  'prefiltered_radiance', 'brdf_lut', 'shadow_map',
-  'MaterialInputs', 'material', 'material_params', 'MaterialParams',
-  'Surface', 'EvaluateLighting', 'InitMaterialInputs', 'PrepareMaterial',
-  'GetWorldPosition', 'GetWorldNormal', 'GetViewDirection', 'GetUV0',
-  'GetVertexColor', 'main',
+  'frag_info',
+  'FragInfo',
+  'frag_color',
+  'v_position',
+  'v_normal',
+  'v_viewvector',
+  'v_texture_coords',
+  'v_color',
+  'prefiltered_radiance',
+  'brdf_lut',
+  'shadow_map',
+  'MaterialInputs',
+  'material',
+  'material_params',
+  'MaterialParams',
+  'Surface',
+  'EvaluateLighting',
+  'InitMaterialInputs',
+  'PrepareMaterial',
+  'GetWorldPosition',
+  'GetWorldNormal',
+  'GetViewDirection',
+  'GetUV0',
+  'GetVertexColor',
+  'main',
 };
 
 FmatMaterial _build(
-    Map<String, Object?> tree, _Block fragment, String? fileName) {
+  Map<String, Object?> tree,
+  _Block fragment,
+  String? fileName,
+) {
   const knownKeys = {
-    'name', 'shading_model', 'blending', 'culling', 'parameters', 'requires'
+    'name',
+    'shading_model',
+    'blending',
+    'culling',
+    'parameters',
+    'requires',
   };
   for (final key in tree.keys) {
     if (!knownKeys.contains(key)) {
@@ -454,19 +530,33 @@ FmatMaterial _build(
 
   final name = tree['name'];
   if (name is! String || name.isEmpty) {
-    throw FmatException('`name` is required and must be a non-empty string.',
-        fileName: fileName);
+    throw FmatException(
+      '`name` is required and must be a non-empty string.',
+      fileName: fileName,
+    );
   }
 
   final shadingModel = _enum<FmatShadingModel>(
-      tree['shading_model'], FmatShadingModel.values, 'shading_model',
-      defaultValue: FmatShadingModel.lit, fileName: fileName);
+    tree['shading_model'],
+    FmatShadingModel.values,
+    'shading_model',
+    defaultValue: FmatShadingModel.lit,
+    fileName: fileName,
+  );
   final blending = _enum<FmatBlending>(
-      tree['blending'], FmatBlending.values, 'blending',
-      defaultValue: FmatBlending.opaque, fileName: fileName);
+    tree['blending'],
+    FmatBlending.values,
+    'blending',
+    defaultValue: FmatBlending.opaque,
+    fileName: fileName,
+  );
   final culling = _enum<FmatCulling>(
-      tree['culling'], FmatCulling.values, 'culling',
-      defaultValue: FmatCulling.back, fileName: fileName);
+    tree['culling'],
+    FmatCulling.values,
+    'culling',
+    defaultValue: FmatCulling.back,
+    fileName: fileName,
+  );
 
   final parameters = _buildParameters(tree['parameters'], fileName);
 
@@ -474,9 +564,11 @@ FmatMaterial _build(
   // fully parse GLSL; this catches the common omission with a clear message.
   if (!RegExp(r'\bvoid\s+Surface\s*\(').hasMatch(fragment.content)) {
     throw FmatException(
-        'The `fragment` block must define '
-        '`void Surface(inout MaterialInputs material)`.',
-        fileName: fileName, line: fragment.startLine);
+      'The `fragment` block must define '
+      '`void Surface(inout MaterialInputs material)`.',
+      fileName: fileName,
+      line: fragment.startLine,
+    );
   }
 
   return FmatMaterial(
@@ -491,19 +583,27 @@ FmatMaterial _build(
 }
 
 T _enum<T extends Enum>(
-    Object? value, List<T> values, String key,
-    {required T defaultValue, String? fileName}) {
+  Object? value,
+  List<T> values,
+  String key, {
+  required T defaultValue,
+  String? fileName,
+}) {
   if (value == null) return defaultValue;
   if (value is! _Ident) {
-    throw FmatException('`$key` must be one of ${values.map((v) => v.name)}.',
-        fileName: fileName);
+    throw FmatException(
+      '`$key` must be one of ${values.map((v) => v.name)}.',
+      fileName: fileName,
+    );
   }
   for (final v in values) {
     if (v.name == value.name) return v;
   }
   throw FmatException(
-      '`$key` is `${value.name}`, expected one of ${values.map((v) => v.name)}.',
-      fileName: fileName, line: value.line);
+    '`$key` is `${value.name}`, expected one of ${values.map((v) => v.name)}.',
+    fileName: fileName,
+    line: value.line,
+  );
 }
 
 List<FmatParameter> _buildParameters(Object? raw, String? fileName) {
@@ -515,13 +615,17 @@ List<FmatParameter> _buildParameters(Object? raw, String? fileName) {
   final seen = <String>{};
   for (final entry in raw) {
     if (entry is! Map<String, Object?>) {
-      throw FmatException('Each parameter must be an object.',
-          fileName: fileName);
+      throw FmatException(
+        'Each parameter must be an object.',
+        fileName: fileName,
+      );
     }
     for (final key in entry.keys) {
       if (!{'type', 'name', 'hint', 'default'}.contains(key)) {
-        throw FmatException('Unknown parameter key `$key`.',
-            fileName: fileName);
+        throw FmatException(
+          'Unknown parameter key `$key`.',
+          fileName: fileName,
+        );
       }
     }
 
@@ -531,35 +635,50 @@ List<FmatParameter> _buildParameters(Object? raw, String? fileName) {
     }
     if (typeTok.name == 'mat3') {
       throw FmatException(
-          '`mat3` parameters are not supported because of a GLES std140 '
-          'layout bug; use `mat4`.',
-          fileName: fileName, line: typeTok.line);
+        '`mat3` parameters are not supported because of a GLES std140 '
+        'layout bug; use `mat4`.',
+        fileName: fileName,
+        line: typeTok.line,
+      );
     }
     final type = FmatType.fromToken(typeTok.name);
     if (type == null) {
-      throw FmatException('Unknown parameter type `${typeTok.name}`.',
-          fileName: fileName, line: typeTok.line);
+      throw FmatException(
+        'Unknown parameter type `${typeTok.name}`.',
+        fileName: fileName,
+        line: typeTok.line,
+      );
     }
 
     final nameVal = entry['name'];
     final pname = switch (nameVal) {
       String s => s,
       _Ident id => id.name,
-      _ => throw FmatException('Parameter `name` is required.',
-          fileName: fileName),
+      _ =>
+        throw FmatException(
+          'Parameter `name` is required.',
+          fileName: fileName,
+        ),
     };
     _validateParamName(pname, fileName);
     if (!seen.add(pname)) {
-      throw FmatException('Duplicate parameter name `$pname`.',
-          fileName: fileName);
+      throw FmatException(
+        'Duplicate parameter name `$pname`.',
+        fileName: fileName,
+      );
     }
 
     final hint = _buildHint(entry['hint'], type, pname, fileName);
-    final defaultValue =
-        _buildDefault(entry['default'], type, pname, fileName);
+    final defaultValue = _buildDefault(entry['default'], type, pname, fileName);
 
-    params.add(FmatParameter(
-        type: type, name: pname, hint: hint, defaultValue: defaultValue));
+    params.add(
+      FmatParameter(
+        type: type,
+        name: pname,
+        hint: hint,
+        defaultValue: defaultValue,
+      ),
+    );
   }
   return params;
 }
@@ -568,29 +687,40 @@ void _validateParamName(String name, String? fileName) {
   if (name.isEmpty ||
       !_isIdentStart(name[0]) ||
       !name.split('').every(_isIdentChar)) {
-    throw FmatException('`$name` is not a valid identifier.',
-        fileName: fileName);
+    throw FmatException(
+      '`$name` is not a valid identifier.',
+      fileName: fileName,
+    );
   }
   if (name.startsWith('gl_')) {
-    throw FmatException('Parameter names may not start with `gl_`.',
-        fileName: fileName);
+    throw FmatException(
+      'Parameter names may not start with `gl_`.',
+      fileName: fileName,
+    );
   }
   if (_reservedNames.contains(name)) {
     throw FmatException(
-        '`$name` collides with an engine-reserved identifier.',
-        fileName: fileName);
+      '`$name` collides with an engine-reserved identifier.',
+      fileName: fileName,
+    );
   }
 }
 
 FmatHint? _buildHint(
-    Object? raw, FmatType type, String pname, String? fileName) {
+  Object? raw,
+  FmatType type,
+  String pname,
+  String? fileName,
+) {
   if (raw == null) return null;
 
   FmatHint colorHint(int line) {
     if (type != FmatType.vec3 && type != FmatType.vec4) {
       throw FmatException(
-          '`source_color` on `$pname` requires a vec3 or vec4.',
-          fileName: fileName, line: line);
+        '`source_color` on `$pname` requires a vec3 or vec4.',
+        fileName: fileName,
+        line: line,
+      );
     }
     return const FmatHint(FmatHintKind.sourceColor);
   }
@@ -598,8 +728,10 @@ FmatHint? _buildHint(
   FmatHint samplerDefault(FmatHintKind kind, int line) {
     if (!type.isSampler) {
       throw FmatException(
-          'A sampler-default hint on `$pname` requires a sampler type.',
-          fileName: fileName, line: line);
+        'A sampler-default hint on `$pname` requires a sampler type.',
+        fileName: fileName,
+        line: line,
+      );
     }
     return FmatHint(kind);
   }
@@ -610,64 +742,88 @@ FmatHint? _buildHint(
       'default_white' => samplerDefault(FmatHintKind.defaultWhite, raw.line),
       'default_black' => samplerDefault(FmatHintKind.defaultBlack, raw.line),
       'default_normal' => samplerDefault(FmatHintKind.defaultNormal, raw.line),
-      'default_transparent' =>
-        samplerDefault(FmatHintKind.defaultTransparent, raw.line),
-      _ => throw FmatException('Unknown hint `${raw.name}` on `$pname`.',
-          fileName: fileName, line: raw.line),
+      'default_transparent' => samplerDefault(
+        FmatHintKind.defaultTransparent,
+        raw.line,
+      ),
+      _ =>
+        throw FmatException(
+          'Unknown hint `${raw.name}` on `$pname`.',
+          fileName: fileName,
+          line: raw.line,
+        ),
     };
   }
   if (raw is _Call && raw.name == 'range') {
     if (type != FmatType.float_ && type != FmatType.int_) {
-      throw FmatException('`range` on `$pname` requires a float or int.',
-          fileName: fileName, line: raw.line);
+      throw FmatException(
+        '`range` on `$pname` requires a float or int.',
+        fileName: fileName,
+        line: raw.line,
+      );
     }
     if (raw.args.length != 3 || raw.args.any((a) => a is! num)) {
       throw FmatException(
-          '`range` takes three numbers: range(min, max, step).',
-          fileName: fileName, line: raw.line);
+        '`range` takes three numbers: range(min, max, step).',
+        fileName: fileName,
+        line: raw.line,
+      );
     }
-    return FmatHint(FmatHintKind.range,
-        rangeMin: (raw.args[0] as num).toDouble(),
-        rangeMax: (raw.args[1] as num).toDouble(),
-        rangeStep: (raw.args[2] as num).toDouble());
+    return FmatHint(
+      FmatHintKind.range,
+      rangeMin: (raw.args[0] as num).toDouble(),
+      rangeMax: (raw.args[1] as num).toDouble(),
+      rangeStep: (raw.args[2] as num).toDouble(),
+    );
   }
   throw FmatException('Invalid hint on `$pname`.', fileName: fileName);
 }
 
 Object? _buildDefault(
-    Object? raw, FmatType type, String pname, String? fileName) {
+  Object? raw,
+  FmatType type,
+  String pname,
+  String? fileName,
+) {
   if (raw == null) return null;
   if (type.isSampler) {
     throw FmatException(
-        'Samplers take a placeholder via `hint`, not `default` (`$pname`).',
-        fileName: fileName);
+      'Samplers take a placeholder via `hint`, not `default` (`$pname`).',
+      fileName: fileName,
+    );
   }
   if (type == FmatType.float_) {
     if (raw is! num) {
-      throw FmatException('`default` for `$pname` must be a number.',
-          fileName: fileName);
+      throw FmatException(
+        '`default` for `$pname` must be a number.',
+        fileName: fileName,
+      );
     }
     return raw.toDouble();
   }
   if (type == FmatType.int_) {
     if (raw is! num || raw != raw.toInt()) {
-      throw FmatException('`default` for `$pname` must be an integer.',
-          fileName: fileName);
+      throw FmatException(
+        '`default` for `$pname` must be an integer.',
+        fileName: fileName,
+      );
     }
     return raw.toInt();
   }
   // Vector / matrix.
   if (raw is! List || raw.any((e) => e is! num)) {
     throw FmatException(
-        '`default` for `$pname` must be a list of ${type.componentCount} '
-        'numbers.',
-        fileName: fileName);
+      '`default` for `$pname` must be a list of ${type.componentCount} '
+      'numbers.',
+      fileName: fileName,
+    );
   }
   if (raw.length != type.componentCount) {
     throw FmatException(
-        '`default` for `$pname` has ${raw.length} components, '
-        'expected ${type.componentCount}.',
-        fileName: fileName);
+      '`default` for `$pname` has ${raw.length} components, '
+      'expected ${type.componentCount}.',
+      fileName: fileName,
+    );
   }
   return raw.map((e) => (e as num).toDouble()).toList();
 }

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -1,0 +1,130 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_scene/src/material/environment.dart';
+import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/render/y_flip.dart';
+
+/// Packs the engine lighting half of the shared `FragInfo` uniform block and
+/// binds the image-based-lighting and shadow samplers.
+///
+/// The `FragInfo` block (declared in `shaders/material_engine_lighting.glsl`
+/// and read by `EvaluateLighting` in `material_lighting.glsl`) mixes
+/// material-specific fields with engine lighting / IBL / shadow fields. This
+/// helper owns the lighting fields, which are identical for every lit material;
+/// callers add their own material fields (if any) to the same buffer. Both
+/// [PhysicallyBasedMaterial] and `PreprocessedMaterial` use it so the lighting
+/// packing lives in one place.
+class EngineLightingUniforms {
+  /// The float count of the full `FragInfo` block (608 bytes / 152 floats of
+  /// data, allocated as 156 floats to reach the trailing mat4's 16-byte
+  /// boundary). See the layout map in the implementation.
+  static const fragInfoFloatCount = 156;
+
+  /// Writes the engine lighting / IBL / shadow fields of `FragInfo` into
+  /// [fragInfo] from [lighting] and [env]. Leaves the material-specific fields
+  /// (color, factors, alpha mode) untouched for the caller to fill.
+  static void packInto(
+    Float32List fragInfo,
+    Lighting lighting,
+    EnvironmentMap env,
+  ) {
+    final light = lighting.directionalLight;
+    final cascades =
+        lighting.shadowMap == null
+            ? const <ShadowCascade>[]
+            : lighting.cascades;
+
+    // diffuse_sh0..8 at [8..43] (xyz used).
+    final shCoefficients = env.diffuseSphericalHarmonics;
+    for (var i = 0; i < shCoefficients.length; i++) {
+      fragInfo[8 + i * 4] = shCoefficients[i].x;
+      fragInfo[9 + i * 4] = shCoefficients[i].y;
+      fragInfo[10 + i * 4] = shCoefficients[i].z;
+    }
+    // directional_light_direction [44..47], directional_light_color [48..51].
+    if (light != null) {
+      fragInfo[44] = light.direction.x;
+      fragInfo[45] = light.direction.y;
+      fragInfo[46] = light.direction.z;
+      fragInfo[48] = light.color.x * light.intensity;
+      fragInfo[49] = light.color.y * light.intensity;
+      fragInfo[50] = light.color.z * light.intensity;
+    }
+    // light_space_matrix[4] at [52..115], cascade_box_sizes at [116..119].
+    for (var i = 0; i < cascades.length; i++) {
+      fragInfo.setRange(
+        52 + i * 16,
+        68 + i * 16,
+        cascades[i].lightSpaceMatrix.storage,
+      );
+      fragInfo[116 + i] = cascades[i].boxSize;
+    }
+    fragInfo[126] = lighting.environmentIntensity;
+    fragInfo[127] = light != null ? 1.0 : 0.0;
+    fragInfo[128] = cascades.isEmpty ? 0.0 : 1.0;
+    fragInfo[129] = light?.shadowDepthBias ?? 0.0;
+    fragInfo[130] = light?.shadowNormalBias ?? 0.0;
+    fragInfo[131] = light == null ? 0.0 : 1.0 / light.shadowMapResolution;
+    // render_target_flip_y: flutter_scene stores render-to-texture targets
+    // top-down on every backend, so the top-down sampling value (1.0) is
+    // correct everywhere.
+    fragInfo[132] = 1.0;
+    fragInfo[135] = light?.shadowFadeRange ?? 0.0;
+    fragInfo[136] = light?.shadowSoftness ?? 0.0;
+    fragInfo[137] = cascades.length.toDouble();
+    // prefilter_flip_y: invert the atlas latitude on backends that store
+    // render-to-texture bottom-up (OpenGL ES).
+    fragInfo[138] = backendFlipsRenderTargetY ? 1.0 : 0.0;
+    // environment_transform: a mat4 carrying the 3x3 rotation; std140 mat4
+    // columns are 16 bytes each, at [140], [144], [148], [152].
+    final envTransform = lighting.environmentTransform.storage;
+    for (var col = 0; col < 3; col++) {
+      fragInfo[140 + col * 4] = envTransform[col * 3];
+      fragInfo[141 + col * 4] = envTransform[col * 3 + 1];
+      fragInfo[142 + col * 4] = envTransform[col * 3 + 2];
+    }
+    fragInfo[155] = 1.0; // mat4 column 3 = (0, 0, 0, 1)
+  }
+
+  /// Binds the engine image-based-lighting and shadow samplers
+  /// (`prefiltered_radiance`, `brdf_lut`, `shadow_map`) on [shader].
+  static void bindEngineTextures(
+    gpu.RenderPass pass,
+    gpu.Shader shader,
+    Lighting lighting,
+    EnvironmentMap env,
+  ) {
+    // Specular IBL atlas: horizontal repeat (longitude wraps), vertical clamp
+    // (roughness bands must not bleed).
+    pass.bindTexture(
+      shader.getUniformSlot('prefiltered_radiance'),
+      env.prefilteredRadianceTexture,
+      sampler: gpu.SamplerOptions(
+        minFilter: gpu.MinMagFilter.linear,
+        magFilter: gpu.MinMagFilter.linear,
+        widthAddressMode: gpu.SamplerAddressMode.repeat,
+        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+      ),
+    );
+    pass.bindTexture(
+      shader.getUniformSlot('brdf_lut'),
+      Material.getBrdfLutTexture(),
+      sampler: gpu.SamplerOptions(
+        minFilter: gpu.MinMagFilter.linear,
+        magFilter: gpu.MinMagFilter.linear,
+        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+      ),
+    );
+    pass.bindTexture(
+      shader.getUniformSlot('shadow_map'),
+      Material.whitePlaceholder(lighting.shadowMap),
+      sampler: gpu.SamplerOptions(
+        minFilter: gpu.MinMagFilter.linear,
+        magFilter: gpu.MinMagFilter.linear,
+      ),
+    );
+  }
+}

--- a/packages/flutter_scene/lib/src/material/material_parameters.dart
+++ b/packages/flutter_scene/lib/src/material/material_parameters.dart
@@ -1,0 +1,341 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' show Color;
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/fmat/fmat_ast.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/material/material.dart';
+
+class _ParamSlot {
+  _ParamSlot(this.type, this.offsetBytes, {this.sourceColor = false});
+
+  final FmatType type;
+
+  /// std140 byte offset of this member within the uniform block, from shader
+  /// reflection.
+  final int offsetBytes;
+
+  /// Whether a `source_color` hint applies (sRGB-decode colors on set).
+  final bool sourceColor;
+}
+
+class _SamplerSlot {
+  _SamplerSlot(this.defaultPlaceholder);
+
+  final FmatHintKind? defaultPlaceholder;
+  gpu.Texture? texture;
+  gpu.SamplerOptions? sampler;
+}
+
+/// Type-checked, name-addressed parameters for a custom material.
+///
+/// Parameters are set by name. The declared type comes from the material's
+/// sidecar metadata, and byte offsets come from the compiled shader's
+/// reflection, so callers never compute std140 padding and a wrong-typed value
+/// throws instead of silently corrupting the uniform block. Three tiers of
+/// access share one backing buffer:
+///
+///  * typed setters ([setFloat], [setVec4], [setColor], ...): the safe default;
+///  * the dynamic [operator []=]: dispatches on the declared type and throws on
+///    a mismatch;
+///  * [rawBlock] / [offsetOf]: a raw escape hatch for hot loops.
+class MaterialParameters {
+  MaterialParameters._(
+    this._blockName,
+    this._block,
+    this._layout,
+    this._samplers,
+  );
+
+  /// Builds parameters from a shader's reflection plus a `.fmat` sidecar entry.
+  ///
+  /// Offsets and the block size come from [shader]; types, defaults, and hints
+  /// come from [metadata]. Throws if a parameter named in the metadata is not
+  /// present in the compiled shader block (a stale bundle or metadata).
+  factory MaterialParameters.fromMetadata(
+    gpu.Shader shader,
+    Map<String, Object?> metadata,
+  ) {
+    final blockName =
+        (metadata['uniform_block'] as String?) ?? 'MaterialParams';
+    final slot = shader.getUniformSlot(blockName);
+    final sizeInBytes = slot.sizeInBytes ?? 0;
+
+    final layout = <String, _ParamSlot>{};
+    final defaults = <String, Object>{};
+    for (final raw in (metadata['parameters'] as List?) ?? const []) {
+      final p = (raw as Map).cast<String, Object?>();
+      final name = p['name'] as String;
+      final type = FmatType.fromToken(p['type'] as String);
+      if (type == null) {
+        throw StateError('Unknown parameter type "${p['type']}" for "$name".');
+      }
+      final offset = slot.getMemberOffsetInBytes(name);
+      if (offset == null) {
+        throw StateError(
+          'Material parameter "$name" is not present in the compiled shader '
+          'block "$blockName" (stale bundle or metadata).',
+        );
+      }
+      final hint = (p['hint'] as Map?)?.cast<String, Object?>();
+      layout[name] = _ParamSlot(
+        type,
+        offset,
+        sourceColor: hint?['kind'] == 'source_color',
+      );
+      final defaultValue = p['default'];
+      if (defaultValue != null) defaults[name] = defaultValue;
+    }
+
+    final samplers = <String, _SamplerSlot>{};
+    for (final raw in (metadata['samplers'] as List?) ?? const []) {
+      final s = (raw as Map).cast<String, Object?>();
+      final hint = (s['hint'] as Map?)?.cast<String, Object?>();
+      samplers[s['name'] as String] = _SamplerSlot(
+        _hintKind(hint?['kind'] as String?),
+      );
+    }
+
+    final params = MaterialParameters._(
+      blockName,
+      ByteData(sizeInBytes),
+      layout,
+      samplers,
+    );
+    defaults.forEach(params._applyDefault);
+    return params;
+  }
+
+  /// Builds parameters from an explicit layout, without shader reflection.
+  /// Primarily for tests and advanced callers.
+  @visibleForTesting
+  factory MaterialParameters.withLayout({
+    required String blockName,
+    required int blockSizeBytes,
+    required Map<String, ({FmatType type, int offset, bool sourceColor})>
+    parameters,
+    Map<String, FmatHintKind?> samplers = const {},
+  }) {
+    final layout = {
+      for (final e in parameters.entries)
+        e.key: _ParamSlot(
+          e.value.type,
+          e.value.offset,
+          sourceColor: e.value.sourceColor,
+        ),
+    };
+    final samplerSlots = {
+      for (final e in samplers.entries) e.key: _SamplerSlot(e.value),
+    };
+    return MaterialParameters._(
+      blockName,
+      ByteData(blockSizeBytes),
+      layout,
+      samplerSlots,
+    );
+  }
+
+  final String _blockName;
+  final ByteData _block;
+  final Map<String, _ParamSlot> _layout;
+  final Map<String, _SamplerSlot> _samplers;
+
+  /// The names of the scalar/vector parameters in this material.
+  Iterable<String> get parameterNames => _layout.keys;
+
+  /// The names of the sampler parameters in this material.
+  Iterable<String> get samplerNames => _samplers.keys;
+
+  /// The raw uniform-block bytes, for the hot-loop escape hatch. Pair with
+  /// [offsetOf]; you own correctness (type and std140 layout) here.
+  ByteData get rawBlock => _block;
+
+  /// The std140 byte offset of [name], or throws if it is unknown.
+  int offsetOf(String name) => _slot(name, null).offsetBytes;
+
+  void setFloat(String name, double value) => _block.setFloat32(
+    _slot(name, FmatType.float_).offsetBytes,
+    value,
+    Endian.host,
+  );
+
+  void setInt(String name, int value) => _block.setInt32(
+    _slot(name, FmatType.int_).offsetBytes,
+    value,
+    Endian.host,
+  );
+
+  void setVec2(String name, Vector2 value) =>
+      _writeFloats(_slot(name, FmatType.vec2).offsetBytes, value.storage);
+
+  void setVec3(String name, Vector3 value) =>
+      _writeFloats(_slot(name, FmatType.vec3).offsetBytes, value.storage);
+
+  void setVec4(String name, Vector4 value) =>
+      _writeFloats(_slot(name, FmatType.vec4).offsetBytes, value.storage);
+
+  void setMat4(String name, Matrix4 value) =>
+      _writeFloats(_slot(name, FmatType.mat4).offsetBytes, value.storage);
+
+  /// Sets a vec4 parameter from a [Color]. If the parameter has a
+  /// `source_color` hint, the rgb channels are sRGB-decoded to linear (matching
+  /// the shader's `SRGBToLinear`); alpha is written as-is.
+  void setColor(String name, Color color) {
+    final slot = _slot(name, FmatType.vec4);
+    var r = color.r, g = color.g, b = color.b;
+    if (slot.sourceColor) {
+      r = _srgbToLinear(r);
+      g = _srgbToLinear(g);
+      b = _srgbToLinear(b);
+    }
+    _writeFloats(slot.offsetBytes, [r, g, b, color.a]);
+  }
+
+  void setTexture(
+    String name,
+    gpu.Texture texture, {
+    gpu.SamplerOptions? sampler,
+  }) {
+    final slot = _samplers[name];
+    if (slot == null) {
+      throw ArgumentError('Unknown sampler parameter "$name".');
+    }
+    slot.texture = texture;
+    slot.sampler = sampler;
+  }
+
+  /// Dynamic, type-checked assignment. Dispatches on the parameter's declared
+  /// type and throws if [value]'s runtime type does not match.
+  void operator []=(String name, Object value) {
+    final slot = _layout[name];
+    if (slot != null) {
+      _setDynamic(name, slot.type, value);
+      return;
+    }
+    if (_samplers.containsKey(name)) {
+      if (value is gpu.Texture) {
+        setTexture(name, value);
+        return;
+      }
+      throw ArgumentError('Sampler parameter "$name" requires a gpu.Texture.');
+    }
+    throw ArgumentError('Unknown material parameter "$name".');
+  }
+
+  /// Binds the uniform block and the sampler parameters on [shader] into [pass].
+  void bind(
+    gpu.RenderPass pass,
+    gpu.Shader shader,
+    gpu.HostBuffer transientsBuffer,
+  ) {
+    if (_block.lengthInBytes > 0) {
+      pass.bindUniform(
+        shader.getUniformSlot(_blockName),
+        transientsBuffer.emplace(_block),
+      );
+    }
+    for (final entry in _samplers.entries) {
+      final slot = entry.value;
+      pass.bindTexture(
+        shader.getUniformSlot(entry.key),
+        slot.texture ?? _placeholder(slot.defaultPlaceholder),
+        sampler: slot.sampler ?? gpu.SamplerOptions(),
+      );
+    }
+  }
+
+  _ParamSlot _slot(String name, FmatType? expected) {
+    final slot = _layout[name];
+    if (slot == null) {
+      throw ArgumentError('Unknown material parameter "$name".');
+    }
+    if (expected != null && slot.type != expected) {
+      throw ArgumentError(
+        'Parameter "$name" is ${slot.type.glslType}, but a '
+        '${expected.glslType} value was set.',
+      );
+    }
+    return slot;
+  }
+
+  void _writeFloats(int offset, List<double> values) {
+    for (var i = 0; i < values.length; i++) {
+      _block.setFloat32(offset + i * 4, values[i], Endian.host);
+    }
+  }
+
+  void _setDynamic(String name, FmatType type, Object value) {
+    if (type == FmatType.float_ && value is num) {
+      setFloat(name, value.toDouble());
+      return;
+    }
+    if (type == FmatType.int_ && value is int) {
+      setInt(name, value);
+      return;
+    }
+    if (type == FmatType.vec2 && value is Vector2) {
+      setVec2(name, value);
+      return;
+    }
+    if (type == FmatType.vec3 && value is Vector3) {
+      setVec3(name, value);
+      return;
+    }
+    if (type == FmatType.vec4 && value is Vector4) {
+      setVec4(name, value);
+      return;
+    }
+    if (type == FmatType.vec4 && value is Color) {
+      setColor(name, value);
+      return;
+    }
+    if (type == FmatType.mat4 && value is Matrix4) {
+      setMat4(name, value);
+      return;
+    }
+    throw ArgumentError(
+      'Parameter "$name" is ${type.glslType}; cannot assign a '
+      '${value.runtimeType}.',
+    );
+  }
+
+  void _applyDefault(String name, Object value) {
+    final slot = _layout[name]!;
+    if (slot.type == FmatType.float_) {
+      _block.setFloat32(
+        slot.offsetBytes,
+        (value as num).toDouble(),
+        Endian.host,
+      );
+    } else if (slot.type == FmatType.int_) {
+      _block.setInt32(slot.offsetBytes, (value as num).toInt(), Endian.host);
+    } else if (value is List) {
+      _writeFloats(
+        slot.offsetBytes,
+        value.map((e) => (e as num).toDouble()).toList(),
+      );
+    }
+  }
+
+  gpu.Texture _placeholder(FmatHintKind? kind) => switch (kind) {
+    FmatHintKind.defaultNormal => Material.normalPlaceholder(null),
+    // White is the neutral fallback; dedicated black/transparent
+    // placeholders are a future addition.
+    _ => Material.whitePlaceholder(null),
+  };
+}
+
+// sRGB -> linear matching pbr.glsl's SRGBToLinear, which is pow(color, kGamma)
+// with kGamma = 2.2.
+double _srgbToLinear(double c) => math.pow(c, 2.2).toDouble();
+
+FmatHintKind? _hintKind(String? kind) => switch (kind) {
+  'default_white' => FmatHintKind.defaultWhite,
+  'default_black' => FmatHintKind.defaultBlack,
+  'default_normal' => FmatHintKind.defaultNormal,
+  'default_transparent' => FmatHintKind.defaultTransparent,
+  _ => null,
+};

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material.dart';
-import 'package:flutter_scene/src/render/y_flip.dart';
 import 'package:flutter_scene/src/shaders.dart';
 
 import 'package:flutter_scene/src/importer/flatbuffer.dart' as fb;
@@ -217,43 +217,23 @@ class PhysicallyBasedMaterial extends Material {
     super.bind(pass, transientsBuffer, lighting);
 
     final EnvironmentMap env = environment ?? lighting.environmentMap;
-    final DirectionalLight? light = lighting.directionalLight;
-    final cascades =
-        lighting.shadowMap == null
-            ? const <ShadowCascade>[]
-            : lighting.cascades;
 
-    // FragInfo std140 layout (608 bytes / 152 floats):
+    // FragInfo std140 layout (608 bytes / 152 floats). EngineLightingUniforms
+    // packs the shared engine lighting, image-based-lighting, and shadow
+    // fields (identical for every lit material); this material fills only its
+    // own, disjoint fields:
     //   [0..3]    vec4  color
     //   [4..7]    vec4  emissive_factor
-    //   [8..43]   vec4  diffuse_sh0..8 (xyz used, w padding)
-    //   [44..47]  vec4  directional_light_direction (xyz used)
-    //   [48..51]  vec4  directional_light_color (rgb = color * intensity)
-    //   [52..115] mat4  light_space_matrix[4] (shadow cascades)
-    //   [116..119] vec4 cascade_box_sizes (world-space box size each)
     //   [120]     float vertex_color_weight
     //   [121]     float metallic_factor
     //   [122]     float roughness_factor
     //   [123]     float has_normal_map
     //   [124]     float normal_scale
     //   [125]     float occlusion_strength
-    //   [126]     float environment_intensity
-    //   [127]     float has_directional_light
-    //   [128]     float casts_shadow
-    //   [129]     float shadow_bias
-    //   [130]     float shadow_normal_bias
-    //   [131]     float shadow_texel_size (1 / cascade tile resolution)
-    //   [132]     float render_target_flip_y
     //   [133]     float alpha_mode (0 opaque, 1 mask, 2 blend)
     //   [134]     float alpha_cutoff
-    //   [135]     float shadow_fade (world-space far-edge fade width)
-    //   [136]     float shadow_softness (world-space penumbra radius)
-    //   [137]     float shadow_cascade_count
-    //   [138]     float prefilter_flip_y (OpenGL ES atlas latitude flip)
-    //   [139]     padding to a 16-byte boundary
-    //   [140..155] mat4  environment_transform (3x3 rotation, last col/row
-    //              identity; mat4 not mat3 to dodge a GLES std140-mat3 bug)
-    final fragInfo = Float32List(156);
+    final fragInfo = Float32List(EngineLightingUniforms.fragInfoFloatCount);
+    EngineLightingUniforms.packInto(fragInfo, lighting, env);
     fragInfo[0] = baseColorFactor.r;
     fragInfo[1] = baseColorFactor.g;
     fragInfo[2] = baseColorFactor.b;
@@ -262,69 +242,14 @@ class PhysicallyBasedMaterial extends Material {
     fragInfo[5] = emissiveFactor.g;
     fragInfo[6] = emissiveFactor.b;
     fragInfo[7] = emissiveFactor.a;
-    final shCoefficients = env.diffuseSphericalHarmonics;
-    for (var i = 0; i < shCoefficients.length; i++) {
-      fragInfo[8 + i * 4] = shCoefficients[i].x;
-      fragInfo[9 + i * 4] = shCoefficients[i].y;
-      fragInfo[10 + i * 4] = shCoefficients[i].z;
-    }
-    if (light != null) {
-      fragInfo[44] = light.direction.x;
-      fragInfo[45] = light.direction.y;
-      fragInfo[46] = light.direction.z;
-      fragInfo[48] = light.color.x * light.intensity;
-      fragInfo[49] = light.color.y * light.intensity;
-      fragInfo[50] = light.color.z * light.intensity;
-    }
-    for (var i = 0; i < cascades.length; i++) {
-      fragInfo.setRange(
-        52 + i * 16,
-        68 + i * 16,
-        cascades[i].lightSpaceMatrix.storage,
-      );
-      fragInfo[116 + i] = cascades[i].boxSize;
-    }
     fragInfo[120] = vertexColorWeight;
     fragInfo[121] = metallicFactor;
     fragInfo[122] = roughnessFactor;
     fragInfo[123] = normalTexture != null ? 1.0 : 0.0;
     fragInfo[124] = normalScale;
     fragInfo[125] = occlusionStrength;
-    fragInfo[126] = lighting.environmentIntensity;
-    fragInfo[127] = light != null ? 1.0 : 0.0;
-    fragInfo[128] = cascades.isEmpty ? 0.0 : 1.0;
-    fragInfo[129] = light?.shadowDepthBias ?? 0.0;
-    fragInfo[130] = light?.shadowNormalBias ?? 0.0;
-    fragInfo[131] = light == null ? 0.0 : 1.0 / light.shadowMapResolution;
-    // render_target_flip_y: flips V when sampling render-to-texture targets
-    // (the shadow map, the prefiltered-radiance atlas). flutter_scene now
-    // stores those top-down on every backend (Metal/Vulkan natively; OpenGL
-    // ES via the vertex-stage Y-flip workaround, see y_flip.dart), so the
-    // top-down sampling value (1.0) is correct everywhere.
-    fragInfo[132] = 1.0;
     fragInfo[133] = alphaMode.index.toDouble();
     fragInfo[134] = alphaCutoff;
-    fragInfo[135] = light?.shadowFadeRange ?? 0.0;
-    fragInfo[136] = light?.shadowSoftness ?? 0.0;
-    fragInfo[137] = cascades.length.toDouble();
-    // prefilter_flip_y: invert the atlas latitude when sampling on backends
-    // that store render-to-texture bottom-up (OpenGL ES). See y_flip.dart and
-    // SamplePrefilteredRadiance. Temporary, part of the Y-flip workaround.
-    fragInfo[138] = backendFlipsRenderTargetY ? 1.0 : 0.0;
-    // mat4 environment_transform: the 3x3 rotation in the upper-left, last
-    // row/column identity. A mat4 (not mat3) because Impeller's OpenGL ES
-    // backend mis-reads a std140 mat3 uniform (its padded vec3 columns),
-    // which collapsed the IBL lookup directions to a constant on GLES; a
-    // mat4's columns are tightly-packed vec4s, identical across backends.
-    // std140 mat4 columns are 16 bytes each, landing at [140], [144], [148],
-    // [152]. Matrix3.storage is column-major (3 floats per column).
-    final envTransform = lighting.environmentTransform.storage;
-    for (var col = 0; col < 3; col++) {
-      fragInfo[140 + col * 4] = envTransform[col * 3];
-      fragInfo[141 + col * 4] = envTransform[col * 3 + 1];
-      fragInfo[142 + col * 4] = envTransform[col * 3 + 2];
-    }
-    fragInfo[155] = 1.0; // mat4 column 3 = (0, 0, 0, 1)
     pass.bindUniform(
       fragmentShader.getUniformSlot("FragInfo"),
       transientsBuffer.emplace(ByteData.sublistView(fragInfo)),
@@ -370,43 +295,15 @@ class PhysicallyBasedMaterial extends Material {
         heightAddressMode: gpu.SamplerAddressMode.repeat,
       ),
     );
-    // Specular IBL atlas: horizontal repeat (the panorama wraps in
-    // longitude), vertical clamp (it's a stack of roughness bands;
-    // wrapping V would bleed between them).
-    pass.bindTexture(
-      fragmentShader.getUniformSlot('prefiltered_radiance'),
-      env.prefilteredRadianceTexture,
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
-    );
-    pass.bindTexture(
-      fragmentShader.getUniformSlot('brdf_lut'),
-      Material.getBrdfLutTexture(),
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
-    );
-    // Bilinear + clamp. Linear filtering interpolates the stored depth
-    // between texels, so a flat receiver compares against the smooth
-    // surface rather than a coarse cascade's blocky per-texel depth,
-    // which removes the patchy self-shadow on distant ground. Clamp (not
-    // wrap) keeps out-of-bounds PCF taps from reading another cascade's
-    // tile. When there's no shadow this frame the white placeholder
-    // reads as depth 1.0 (always lit) and casts_shadow is 0 anyway.
-    pass.bindTexture(
-      fragmentShader.getUniformSlot('shadow_map'),
-      Material.whitePlaceholder(lighting.shadowMap),
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-      ),
+    // Image-based-lighting atlas, BRDF LUT, and shadow map. Shared with
+    // PreprocessedMaterial: the sampler choices (radiance repeat/clamp, LUT
+    // clamp/clamp, shadow bilinear/clamp) and the white shadow placeholder
+    // live in EngineLightingUniforms.
+    EngineLightingUniforms.bindEngineTextures(
+      pass,
+      fragmentShader,
+      lighting,
+      env,
     );
   }
 

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -1,0 +1,105 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/fmat/fmat_ast.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_scene/src/material/engine_lighting.dart';
+import 'package:flutter_scene/src/material/environment.dart';
+import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/material/material_parameters.dart';
+import 'package:flutter_scene/src/render/y_flip.dart';
+
+/// A material driven by a `.fmat` custom-material shader and its sidecar
+/// metadata (produced at build time by `buildMaterials`).
+///
+/// Construct one from a shader bundle entry and its metadata, then set
+/// parameters by name through [parameters]:
+///
+/// ```dart
+/// final library = gpu.ShaderLibrary.fromAsset('build/shaderbundles/materials.shaderbundle')!;
+/// final metadata = jsonDecode(await rootBundle.loadString(
+///     'build/shaderbundles/materials.fmat.json')) as Map<String, Object?>;
+/// final toon = PreprocessedMaterial(
+///   fragmentShader: library['Toon']!,
+///   metadata: (metadata['Toon'] as Map).cast<String, Object?>(),
+/// )..parameters.setColor('base_color', const Color(0xff8844ff));
+/// ```
+///
+/// A `lit` material is lit by the engine's physically based pipeline (the
+/// shader's `Surface()` fills the surface description); an `unlit` material
+/// outputs its `base_color` directly. The render state (blending, culling)
+/// comes from the material's metadata.
+class PreprocessedMaterial extends Material {
+  PreprocessedMaterial({
+    required gpu.Shader fragmentShader,
+    required Map<String, Object?> metadata,
+  }) : shadingModel = _parseShadingModel(metadata['shading_model']),
+       _blending = _parseBlending(metadata['blending']),
+       _culling = _parseCulling(metadata['culling']),
+       parameters = MaterialParameters.fromMetadata(fragmentShader, metadata) {
+    setFragmentShader(fragmentShader);
+  }
+
+  /// The material's parameters, set by name. See [MaterialParameters].
+  final MaterialParameters parameters;
+
+  /// Whether the engine runs its lighting ([FmatShadingModel.lit]) or the
+  /// shader's color is output directly ([FmatShadingModel.unlit]).
+  final FmatShadingModel shadingModel;
+
+  final FmatBlending _blending;
+  final FmatCulling _culling;
+
+  /// Per-material image-based-lighting environment, overriding the scene-wide
+  /// environment when set. Only used for [FmatShadingModel.lit] materials.
+  EnvironmentMap? environment;
+
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Lighting lighting,
+  ) {
+    pass.setCullMode(_cullMode(_culling));
+    pass.setWindingOrder(backendWinding(gpu.WindingOrder.counterClockwise));
+
+    if (shadingModel == FmatShadingModel.lit) {
+      final env = environment ?? lighting.environmentMap;
+      final fragInfo = Float32List(EngineLightingUniforms.fragInfoFloatCount);
+      EngineLightingUniforms.packInto(fragInfo, lighting, env);
+      pass.bindUniform(
+        fragmentShader.getUniformSlot('FragInfo'),
+        transientsBuffer.emplace(ByteData.sublistView(fragInfo)),
+      );
+      EngineLightingUniforms.bindEngineTextures(
+        pass,
+        fragmentShader,
+        lighting,
+        env,
+      );
+    }
+
+    parameters.bind(pass, fragmentShader, transientsBuffer);
+  }
+
+  @override
+  bool isOpaque() => _blending == FmatBlending.opaque;
+}
+
+gpu.CullMode _cullMode(FmatCulling culling) => switch (culling) {
+  FmatCulling.back => gpu.CullMode.backFace,
+  FmatCulling.front => gpu.CullMode.frontFace,
+  FmatCulling.none => gpu.CullMode.none,
+};
+
+FmatShadingModel _parseShadingModel(Object? value) =>
+    value == 'unlit' ? FmatShadingModel.unlit : FmatShadingModel.lit;
+
+FmatBlending _parseBlending(Object? value) =>
+    value == 'alpha' ? FmatBlending.alpha : FmatBlending.opaque;
+
+FmatCulling _parseCulling(Object? value) => switch (value) {
+  'front' => FmatCulling.front,
+  'none' => FmatCulling.none,
+  _ => FmatCulling.back,
+};

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -32,7 +32,9 @@ dependencies:
   # falls back to a WebGL2 backend on web.
   flutter_gpu:
     sdk: flutter
-  flutter_gpu_shaders: ^0.4.0
+  # 0.4.4 adds the includeDirectories parameter that buildMaterials uses to put
+  # flutter_scene's framework shaders on impellerc's include path.
+  flutter_gpu_shaders: ^0.4.4
   hooks: ^1.0.0
   image: ^4.5.0
   logging: ^1.2.0

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -90,179 +90,30 @@ out vec4 frag_color;
 #include <normals.glsl>
 #include <pbr.glsl>
 #include <texture.glsl>
+#include <material_inputs.glsl>
+#include <material_lighting.glsl>
 
-// Evaluates the L2 diffuse-irradiance SH polynomial in direction `n`.
-// The coefficients already include the cosine convolution and 1/pi, so
-// the result is E(n)/pi. Must use the same real-SH basis the CPU-side
-// projection in EnvironmentMap.computeDiffuseSphericalHarmonics uses.
-vec3 EvaluateDiffuseSH(vec3 n) {
-  return frag_info.diffuse_sh0.xyz * 0.282095 +
-         frag_info.diffuse_sh1.xyz * (0.488603 * n.y) +
-         frag_info.diffuse_sh2.xyz * (0.488603 * n.z) +
-         frag_info.diffuse_sh3.xyz * (0.488603 * n.x) +
-         frag_info.diffuse_sh4.xyz * (1.092548 * n.x * n.y) +
-         frag_info.diffuse_sh5.xyz * (1.092548 * n.y * n.z) +
-         frag_info.diffuse_sh6.xyz * (0.315392 * (3.0 * n.z * n.z - 1.0)) +
-         frag_info.diffuse_sh7.xyz * (1.092548 * n.x * n.z) +
-         frag_info.diffuse_sh8.xyz * (0.546274 * (n.x * n.x - n.y * n.y));
-}
-
-// One rotated Poisson-disk PCF tap into a cascade's atlas tile. Factored out
-// so the kernel can be unrolled with inline literals at the call site (see the
-// note in SampleCascade); the compiler inlines this.
-float ShadowTap(vec2 p, float ca, float sa, float radius, vec2 uv, int cascade,
-                float inv_count, float receiver_depth) {
-  vec2 offset = vec2(p.x * ca - p.y * sa, p.x * sa + p.y * ca) * radius;
-  // Keep samples a texel inside this cascade's tile, so bilinear filtering of
-  // the atlas never reaches across the tile boundary into a neighbouring
-  // cascade's depths.
-  vec2 cuv = clamp(uv + offset, vec2(frag_info.shadow_texel_size),
-                   vec2(1.0 - frag_info.shadow_texel_size));
-  vec2 atlas_uv = vec2((float(cascade) + cuv.x) * inv_count, cuv.y);
-  // The atlas is a render-to-texture target; flip V to match its sampled Y
-  // orientation (see render_target_flip_y).
-  if (frag_info.render_target_flip_y > 0.5) {
-    atlas_uv.y = 1.0 - atlas_uv.y;
-  }
-  float caster_depth = texture(shadow_map, atlas_uv).r;
-  return receiver_depth <= caster_depth ? 1.0 : 0.0;
-}
-
-// Samples one cascade's tile of the shadow atlas strip with a rotated
-// 16-tap Poisson-disk PCF. `world_pos` and `n` are world-space.
-float SampleCascade(int cascade, vec3 world_pos, vec3 n, int count) {
-  float box = frag_info.cascade_box_sizes[cascade];
-
-  // Normal-offset bias. A soft PCF kernel on a surface tilted relative
-  // to the light straddles a depth gradient and would self-shadow, so
-  // lift the receiver along its normal far enough that the whole kernel
-  // clears the surface. The offset scales with the kernel's world
-  // radius (shadow_softness) and the surface's slope to the light. It
-  // depends only on geometry, not the cascade, so all cascades agree
-  // and there is no banding at their seams.
-  vec3 light_toward = -normalize(frag_info.directional_light_direction.xyz);
-  float ndotl = max(dot(n, light_toward), 0.15);
-  float slope = min(sqrt(max(1.0 - ndotl * ndotl, 0.0)) / (ndotl * ndotl),
-                    8.0);
-  float normal_offset =
-      frag_info.shadow_normal_bias + frag_info.shadow_softness * slope;
-  vec3 biased = world_pos + n * normal_offset;
-
-  vec4 light_clip =
-      frag_info.light_space_matrix[cascade] * vec4(biased, 1.0);
-  vec3 proj = light_clip.xyz / light_clip.w;
-  vec2 uv = proj.xy * 0.5 + 0.5;
-  // The depth bias is world-space; convert it to this cascade's clip-z
-  // (its orthographic depth range is 3 * box) so a caster crosses the
-  // shadow threshold at the same world height in every cascade, with
-  // no discontinuity where cascades meet.
-  float receiver_depth = proj.z - frag_info.shadow_bias / (3.0 * box);
-
-  // World-space penumbra -> this cascade's UV space, floored at a texel.
-  float radius =
-      max(frag_info.shadow_softness / box, frag_info.shadow_texel_size);
-  float inv_count = 1.0 / float(count);
-
-  // A per-fragment rotation hides the 16-tap pattern as a smooth edge.
-  float noise = fract(
-      52.9829189 *
-      fract(dot(gl_FragCoord.xy, vec2(0.06711056, 0.00583715))));
-  float angle = noise * 6.28318530718;
-  float ca = cos(angle);
-  float sa = sin(angle);
-
-  // 16-tap Poisson-disk PCF, unrolled with the kernel as inline literals.
-  //
-  // TODO(flutter_scene): this would naturally loop over a file-scope
-  // `const vec2 kPoissonDisk[16] = vec2[](...)`, but *any* const array (even
-  // one filled element by element, which the SPIR-V optimizer folds back into
-  // a constant) makes impellerc/SPIRV-Cross emit a GLSL array constructor
-  // (`vec2[](...)`) in its `#version 100` GLES output. That is invalid
-  // ES 1.00, so the shader fails to compile on conformant ES drivers
-  // (e.g. Mesa/llvmpipe under headless CI); lenient drivers accept it. Flutter
-  // GPU shaders should compile anywhere Flutter runs, so the real fix belongs
-  // upstream (impellerc should emit valid ES 1.00, or the bundle's GLES stage
-  // should target ES 3.00). Restore the const-array loop once that lands.
-  // See: <upstream issue>.
-#define _SHADOW_TAP(px, py) \
-  ShadowTap(vec2(px, py), ca, sa, radius, uv, cascade, inv_count, \
-            receiver_depth)
-  float lit = 0.0;
-  lit += _SHADOW_TAP(-0.94201624, -0.39906216);
-  lit += _SHADOW_TAP(0.94558609, -0.76890725);
-  lit += _SHADOW_TAP(-0.09418410, -0.92938870);
-  lit += _SHADOW_TAP(0.34495938, 0.29387760);
-  lit += _SHADOW_TAP(-0.91588581, 0.45771432);
-  lit += _SHADOW_TAP(-0.81544232, -0.87912464);
-  lit += _SHADOW_TAP(-0.38277543, 0.27676845);
-  lit += _SHADOW_TAP(0.97484398, 0.75648379);
-  lit += _SHADOW_TAP(0.44323325, -0.97511554);
-  lit += _SHADOW_TAP(0.53742981, -0.47373420);
-  lit += _SHADOW_TAP(-0.26496911, -0.41893023);
-  lit += _SHADOW_TAP(0.79197514, 0.19090188);
-  lit += _SHADOW_TAP(-0.24188840, 0.99706507);
-  lit += _SHADOW_TAP(-0.81409955, 0.91437590);
-  lit += _SHADOW_TAP(0.19984126, 0.78641367);
-  lit += _SHADOW_TAP(0.14383161, -0.14100790);
-#undef _SHADOW_TAP
-  float shadow = lit / 16.0;
-
-  // Only the last cascade has a real outer edge (inner cascades hand
-  // off to the next), so fade just it back to lit at the boundary.
-  if (cascade == count - 1 && frag_info.shadow_fade > 0.0) {
-    float fade = frag_info.shadow_fade / box;
-    vec2 edge = smoothstep(vec2(0.0), vec2(fade), uv) *
-                smoothstep(vec2(0.0), vec2(fade), vec2(1.0) - uv);
-    shadow = mix(1.0, shadow, edge.x * edge.y);
-  }
-  return shadow;
-}
-
-// Soft cascaded-shadow lookup. Returns 1.0 (lit) .. 0.0 (fully
-// shadowed). `world_pos` and `n` are world-space; `n` is the
-// (perturbed) shading normal. Picks the first (highest-resolution)
-// cascade whose box contains the fragment.
-float SampleShadow(vec3 world_pos, vec3 n) {
-  int count = int(frag_info.shadow_cascade_count);
-  for (int c = 0; c < 4; c++) {
-    if (c >= count) {
-      break;
-    }
-    // Containment test with the unbiased position.
-    vec4 light_clip =
-        frag_info.light_space_matrix[c] * vec4(world_pos, 1.0);
-    vec3 proj = light_clip.xyz / light_clip.w;
-    vec2 uv = proj.xy * 0.5 + 0.5;
-    // Require room for the PCF kernel inside the cascade's tile, so its
-    // samples never clamp against the tile edge (which would smear the
-    // edge texel into a thin seam). A fragment closer to the edge than
-    // the kernel radius falls through to the next, larger cascade.
-    float margin =
-        max(frag_info.shadow_softness / frag_info.cascade_box_sizes[c],
-            frag_info.shadow_texel_size);
-    if (uv.x < margin || uv.x > 1.0 - margin || uv.y < margin ||
-        uv.y > 1.0 - margin || proj.z < 0.0 || proj.z > 1.0) {
-      continue;
-    }
-    return SampleCascade(c, world_pos, n, count);
-  }
-  return 1.0;
-}
-
-void main() {
+// Fills the surface description for the standard glTF metallic-roughness
+// material from the FragInfo parameters and the material textures. The shared
+// lighting framework (material_lighting.glsl) consumes it.
+void Surface(inout MaterialInputs material) {
   vec4 vertex_color = mix(vec4(1), v_color, frag_info.vertex_color_weight);
   vec4 base_color_srgb = texture(base_color_texture, v_texture_coords);
   vec3 albedo = SRGBToLinear(base_color_srgb.rgb) * vertex_color.rgb *
                 frag_info.color.rgb;
   float alpha = base_color_srgb.a * vertex_color.a * frag_info.color.a;
   // MASK alpha mode: discard fragments below the cutoff, render the
-  // rest fully opaque (glTF treats MASK output as binary).
+  // rest fully opaque (glTF treats MASK output as binary). Done here, before
+  // the normal-map derivatives, so the discard's effect on screen-space
+  // derivatives matches the original monolithic shader.
   if (frag_info.alpha_mode == 1.0) {
     if (alpha < frag_info.alpha_cutoff) {
       discard;
     }
     alpha = 1.0;
   }
+  material.base_color = vec4(albedo, alpha);
+
   // Note: PerturbNormal needs the non-normalized view vector
   //       (camera_position - vertex_position).
   vec3 normal = normalize(v_normal);
@@ -270,97 +121,28 @@ void main() {
     normal =
         PerturbNormal(normal_texture, normal, v_viewvector, v_texture_coords);
   }
+  material.normal = normal;
 
   vec4 metallic_roughness =
       texture(metallic_roughness_texture, v_texture_coords);
-  float metallic = clamp(metallic_roughness.b * frag_info.metallic_factor, 0.0,
-                         1.0);
-  float roughness =
+  material.metallic = clamp(metallic_roughness.b * frag_info.metallic_factor,
+                            0.0, 1.0);
+  material.roughness =
       clamp(metallic_roughness.g * frag_info.roughness_factor, kMinRoughness,
             1.0);
 
   float occlusion = texture(occlusion_texture, v_texture_coords).r;
-  occlusion = 1.0 - (1.0 - occlusion) * frag_info.occlusion_strength;
+  material.occlusion = 1.0 - (1.0 - occlusion) * frag_info.occlusion_strength;
 
-  vec3 camera_normal = normalize(v_viewvector);
-
-  vec3 reflectance = mix(vec3(0.04), albedo, metallic);
-
-  // 1 when the surface is facing the camera, 0 when it's perpendicular to the
-  // camera.
-  float n_dot_v = max(dot(normal, camera_normal), 0.0);
-
-  // reflect() needs the incident ray (camera -> surface); camera_normal
-  // points surface -> camera, so negate it. Sampling the environment with
-  // the un-negated vector would mirror reflections to the opposite side.
-  vec3 reflection_normal = reflect(-camera_normal, normal);
-
-  // Roughness-dependent Fresnel reflectance for the indirect specular lobe.
-  vec3 k_S = FresnelSchlickRoughness(n_dot_v, reflectance, roughness);
-
-  // The IBL environment can be rotated; transform the lookup directions.
-  mat3 environment_transform = mat3(frag_info.environment_transform);
-  vec3 env_normal = environment_transform * normal;
-  vec3 env_reflection = environment_transform * reflection_normal;
-  vec3 irradiance = max(EvaluateDiffuseSH(env_normal), vec3(0.0)) *
-                    frag_info.environment_intensity;
-  vec3 prefiltered_color =
-      SamplePrefilteredRadiance(prefiltered_radiance, env_reflection, roughness,
-                                frag_info.prefilter_flip_y) *
-      frag_info.environment_intensity;
-
-  // Split-sum DFG terms (Karis '13). The LUT is sampled slightly inside
-  // [0, 1] to avoid edge-tap artifacts.
-  vec2 f_ab = texture(brdf_lut, clamp(vec2(n_dot_v, roughness), 0.0, 0.99)).rg;
-
-  // Single- and multiple-scattering energy compensation (Fdez-Aguera 2019;
-  // see https://bruop.github.io/ibl/). Without the multiscatter term, rough
-  // metals lose noticeable energy.
-  vec3 FssEss = k_S * f_ab.x + f_ab.y;
-  float Ems = 1.0 - (f_ab.x + f_ab.y);
-  vec3 F_avg = reflectance + (1.0 - reflectance) / 21.0;
-  vec3 FmsEms = Ems * FssEss * F_avg / (1.0 - F_avg * Ems);
-  vec3 diffuse_color = albedo * (1.0 - metallic);
-  vec3 k_D = diffuse_color * (1.0 - FssEss + FmsEms);
-
-  vec3 indirect_specular = FssEss * prefiltered_color;
-  vec3 indirect_diffuse = (FmsEms + k_D) * irradiance;
-  vec3 ambient = (indirect_diffuse + indirect_specular) * occlusion;
-
-  // Analytic directional light (Cook-Torrance, layered on top of the IBL
-  // ambient term).
-  vec3 direct = vec3(0.0);
-  if (frag_info.has_directional_light > 0.5) {
-    // surface -> light.
-    vec3 light_vector = -normalize(frag_info.directional_light_direction.xyz);
-    float n_dot_l = max(dot(normal, light_vector), 0.0);
-    if (n_dot_l > 0.0) {
-      vec3 half_vector = normalize(light_vector + camera_normal);
-      float n_dot_v_safe = max(n_dot_v, 1e-4);
-      float distribution = DistributionGGX(normal, half_vector, roughness);
-      float visibility =
-          VisibilitySmithGGXCorrelated(n_dot_v_safe, n_dot_l, roughness);
-      vec3 specular_fresnel =
-          FresnelSchlick(max(dot(half_vector, camera_normal), 0.0), reflectance);
-      // `visibility` already folds in 1 / (4 * NoL * NoV).
-      vec3 specular = distribution * visibility * specular_fresnel;
-      vec3 diffuse = (vec3(1.0) - specular_fresnel) * (1.0 - metallic) *
-                     albedo * (1.0 / kPi);
-      float shadow =
-          frag_info.casts_shadow > 0.5 ? SampleShadow(v_position, normal) : 1.0;
-      direct = (diffuse + specular) * frag_info.directional_light_color.rgb *
-               n_dot_l * shadow;
-    }
-  }
-
-  vec3 emissive =
+  material.emissive =
       SRGBToLinear(texture(emissive_texture, v_texture_coords).rgb) *
       frag_info.emissive_factor.rgb;
 
-  // Linear HDR, premultiplied by alpha. Exposure, the tone-mapping
-  // operator, and the display EOTF are applied later by the tone-mapping
-  // resolve pass (see flutter_scene_resolve.frag), so this writes into a
-  // floating-point scene-color target.
-  vec3 out_color = ambient + direct + emissive;
-  frag_color = vec4(out_color, 1.0) * alpha;
+  PrepareMaterial(material);
+}
+
+void main() {
+  MaterialInputs material = InitMaterialInputs();
+  Surface(material);
+  frag_color = EvaluateLighting(material);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -1,97 +1,16 @@
-uniform FragInfo {
-  vec4 color;
-  vec4 emissive_factor;
-  // Diffuse irradiance L2 spherical-harmonic coefficients (xyz = RGB,
-  // w unused). The cosine convolution (A_l band factors) and the 1/pi
-  // Lambertian term are already folded in, so evaluating the polynomial
-  // yields E(n)/pi, ready to multiply by the diffuse albedo.
-  vec4 diffuse_sh0;
-  vec4 diffuse_sh1;
-  vec4 diffuse_sh2;
-  vec4 diffuse_sh3;
-  vec4 diffuse_sh4;
-  vec4 diffuse_sh5;
-  vec4 diffuse_sh6;
-  vec4 diffuse_sh7;
-  vec4 diffuse_sh8;
-  // Directional light: xyz = direction the light travels (toward the
-  // scene); rgb of the second vector = color premultiplied by intensity.
-  // Active only when has_directional_light > 0.5.
-  vec4 directional_light_direction;
-  vec4 directional_light_color;
-  // World -> light-clip-space matrix per shadow cascade; the first
-  // shadow_cascade_count entries are valid. Used when casts_shadow > 0.5.
-  mat4 light_space_matrix[4];
-  // World-space orthographic box size of each cascade (x..w map to
-  // cascade 0..3), used to scale world-space softness and fade widths
-  // into a cascade's UV space.
-  vec4 cascade_box_sizes;
-  float vertex_color_weight;
-  float metallic_factor;
-  float roughness_factor;
-  float has_normal_map;
-  float normal_scale;
-  float occlusion_strength;
-  float environment_intensity;
-  float has_directional_light;
-  float casts_shadow;
-  float shadow_bias;
-  float shadow_normal_bias;
-  float shadow_texel_size; // 1 / shadow map resolution
-  // 1.0 on backends whose render-to-texture targets sample top-down
-  // (Metal/Vulkan), 0.0 where they sample bottom-up (OpenGL ES). Applied
-  // when sampling the shadow map and the prefiltered-radiance atlas; the
-  // Dart side fills it (Flutter GPU has no backend macro).
-  float render_target_flip_y;
-  // glTF alpha mode: 0 opaque, 1 mask, 2 blend. In mask mode a fragment
-  // whose alpha is below alpha_cutoff is discarded and the rest are
-  // forced fully opaque.
-  float alpha_mode;
-  float alpha_cutoff;
-  // World-space width over which shadowing fades back to lit at the far
-  // cascade's edge, softening the shadow distance limit. 0 disables it.
-  float shadow_fade;
-  // World-space radius of the soft-shadow (PCF) penumbra.
-  float shadow_softness;
-  // Number of valid cascades in light_space_matrix (1 to 4).
-  float shadow_cascade_count;
-  // 1 to invert the prefiltered-radiance atlas latitude when sampling, 0
-  // otherwise. Set on backends that store render-to-texture bottom-up (OpenGL
-  // ES); see SamplePrefilteredRadiance and y_flip.dart. Temporary workaround.
-  float prefilter_flip_y;
-  // Rotates the image-based-lighting environment: the diffuse-SH and
-  // prefiltered-radiance lookup directions are transformed by this before
-  // sampling. Identity leaves the environment unrotated. A mat4 (not mat3)
-  // so the std140 columns are tightly packed vec4s: Impeller's OpenGL ES
-  // backend mis-reads a std140 mat3 uniform (padded vec3 columns), which
-  // collapsed env_normal/env_reflection to a constant on GLES.
-  mat4 environment_transform;
-}
-frag_info;
+#include <material_varyings.glsl>
+#include <normals.glsl>
+#include <pbr.glsl>
+#include <texture.glsl>
+#include <material_engine_lighting.glsl>
+#include <material_inputs.glsl>
+#include <material_lighting.glsl>
 
 uniform sampler2D base_color_texture;
 uniform sampler2D emissive_texture;
 uniform sampler2D metallic_roughness_texture;
 uniform sampler2D normal_texture;
 uniform sampler2D occlusion_texture;
-
-uniform sampler2D prefiltered_radiance; // PMREM-style roughness-band atlas
-uniform sampler2D brdf_lut;
-uniform sampler2D shadow_map;
-
-in vec3 v_position;
-in vec3 v_normal;
-in vec3 v_viewvector; // camera_position - vertex_position
-in vec2 v_texture_coords;
-in vec4 v_color;
-
-out vec4 frag_color;
-
-#include <normals.glsl>
-#include <pbr.glsl>
-#include <texture.glsl>
-#include <material_inputs.glsl>
-#include <material_lighting.glsl>
 
 // Fills the surface description for the standard glTF metallic-roughness
 // material from the FragInfo parameters and the material textures. The shared

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -1,0 +1,81 @@
+// The engine lighting inputs a lit material receives: the FragInfo uniform
+// block (the analytic light, shadow cascades, and image-based-lighting SH and
+// environment data) and the IBL / shadow samplers. material_lighting.glsl
+// reads these to evaluate the lit color. The standard PBR shader and every
+// generated lit `.fmat` material share this single declaration of the engine
+// lighting interface.
+
+uniform FragInfo {
+  vec4 color;
+  vec4 emissive_factor;
+  // Diffuse irradiance L2 spherical-harmonic coefficients (xyz = RGB,
+  // w unused). The cosine convolution (A_l band factors) and the 1/pi
+  // Lambertian term are already folded in, so evaluating the polynomial
+  // yields E(n)/pi, ready to multiply by the diffuse albedo.
+  vec4 diffuse_sh0;
+  vec4 diffuse_sh1;
+  vec4 diffuse_sh2;
+  vec4 diffuse_sh3;
+  vec4 diffuse_sh4;
+  vec4 diffuse_sh5;
+  vec4 diffuse_sh6;
+  vec4 diffuse_sh7;
+  vec4 diffuse_sh8;
+  // Directional light: xyz = direction the light travels (toward the
+  // scene); rgb of the second vector = color premultiplied by intensity.
+  // Active only when has_directional_light > 0.5.
+  vec4 directional_light_direction;
+  vec4 directional_light_color;
+  // World -> light-clip-space matrix per shadow cascade; the first
+  // shadow_cascade_count entries are valid. Used when casts_shadow > 0.5.
+  mat4 light_space_matrix[4];
+  // World-space orthographic box size of each cascade (x..w map to
+  // cascade 0..3), used to scale world-space softness and fade widths
+  // into a cascade's UV space.
+  vec4 cascade_box_sizes;
+  float vertex_color_weight;
+  float metallic_factor;
+  float roughness_factor;
+  float has_normal_map;
+  float normal_scale;
+  float occlusion_strength;
+  float environment_intensity;
+  float has_directional_light;
+  float casts_shadow;
+  float shadow_bias;
+  float shadow_normal_bias;
+  float shadow_texel_size; // 1 / shadow map resolution
+  // 1.0 on backends whose render-to-texture targets sample top-down
+  // (Metal/Vulkan), 0.0 where they sample bottom-up (OpenGL ES). Applied
+  // when sampling the shadow map and the prefiltered-radiance atlas; the
+  // Dart side fills it (Flutter GPU has no backend macro).
+  float render_target_flip_y;
+  // glTF alpha mode: 0 opaque, 1 mask, 2 blend. In mask mode a fragment
+  // whose alpha is below alpha_cutoff is discarded and the rest are
+  // forced fully opaque.
+  float alpha_mode;
+  float alpha_cutoff;
+  // World-space width over which shadowing fades back to lit at the far
+  // cascade's edge, softening the shadow distance limit. 0 disables it.
+  float shadow_fade;
+  // World-space radius of the soft-shadow (PCF) penumbra.
+  float shadow_softness;
+  // Number of valid cascades in light_space_matrix (1 to 4).
+  float shadow_cascade_count;
+  // 1 to invert the prefiltered-radiance atlas latitude when sampling, 0
+  // otherwise. Set on backends that store render-to-texture bottom-up (OpenGL
+  // ES); see SamplePrefilteredRadiance and y_flip.dart. Temporary workaround.
+  float prefilter_flip_y;
+  // Rotates the image-based-lighting environment: the diffuse-SH and
+  // prefiltered-radiance lookup directions are transformed by this before
+  // sampling. Identity leaves the environment unrotated. A mat4 (not mat3)
+  // so the std140 columns are tightly packed vec4s: Impeller's OpenGL ES
+  // backend mis-reads a std140 mat3 uniform (padded vec3 columns), which
+  // collapsed env_normal/env_reflection to a constant on GLES.
+  mat4 environment_transform;
+}
+frag_info;
+
+uniform sampler2D prefiltered_radiance; // PMREM-style roughness-band atlas
+uniform sampler2D brdf_lut;
+uniform sampler2D shadow_map;

--- a/packages/flutter_scene/shaders/material_inputs.glsl
+++ b/packages/flutter_scene/shaders/material_inputs.glsl
@@ -1,0 +1,43 @@
+// The surface description a material's Surface() function fills in, consumed by
+// the engine lighting framework (material_lighting.glsl) to produce the final
+// fragment color. Mirrors Filament's "fill a struct, the engine runs the
+// lighting" contract: a material populates these fields and the shared
+// framework owns the BRDF, IBL, shadows, and output encoding.
+//
+// This file declares only the struct and its helpers and has no dependencies.
+// material_lighting.glsl (which consumes a MaterialInputs) additionally
+// requires the FragInfo block, the standard world-space varyings, the IBL
+// samplers, and pbr.glsl / texture.glsl to be declared before it is included.
+
+struct MaterialInputs {
+  // Linear-space base color in rgb; straight (non-premultiplied) alpha in a.
+  vec4 base_color;
+  // World-space shading normal (perturbed by a normal map if present).
+  vec3 normal;
+  // Linear-space emissive radiance, added after lighting.
+  vec3 emissive;
+  // Metalness in [0, 1]: 0 dielectric, 1 conductor.
+  float metallic;
+  // Perceptual roughness in [0, 1].
+  float roughness;
+  // Ambient occlusion in [0, 1]: 1 unoccluded.
+  float occlusion;
+};
+
+// A MaterialInputs with neutral defaults. A Surface() function that leaves a
+// field unset gets these values.
+MaterialInputs InitMaterialInputs() {
+  MaterialInputs material;
+  material.base_color = vec4(1.0);
+  material.normal = vec3(0.0, 0.0, 1.0);
+  material.emissive = vec3(0.0);
+  material.metallic = 0.0;
+  material.roughness = 1.0;
+  material.occlusion = 1.0;
+  return material;
+}
+
+// Finalization hook a Surface() function calls before returning. Currently a
+// no-op; reserved so the framework can add derived-value setup later without
+// changing the Surface() contract.
+void PrepareMaterial(inout MaterialInputs material) {}

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -1,0 +1,262 @@
+// The engine lighting framework. Takes a MaterialInputs filled by a material's
+// Surface() function and produces the final fragment color: image-based
+// lighting (diffuse SH + prefiltered radiance + split-sum BRDF with
+// multiscatter compensation), a single analytic directional light with
+// cascaded soft shadows, emissive, and the linear-HDR premultiplied-alpha
+// output contract (exposure and tone mapping run later in the resolve pass).
+//
+// Requires, declared before this file is included: the FragInfo uniform block
+// (as `frag_info`), the world-space varyings `v_position` and `v_viewvector`,
+// the `prefiltered_radiance`, `brdf_lut`, and `shadow_map` samplers, the
+// MaterialInputs struct (material_inputs.glsl), and pbr.glsl + texture.glsl.
+
+// Evaluates the L2 diffuse-irradiance SH polynomial in direction `n`.
+// The coefficients already include the cosine convolution and 1/pi, so
+// the result is E(n)/pi. Must use the same real-SH basis the CPU-side
+// projection in EnvironmentMap.computeDiffuseSphericalHarmonics uses.
+vec3 EvaluateDiffuseSH(vec3 n) {
+  return frag_info.diffuse_sh0.xyz * 0.282095 +
+         frag_info.diffuse_sh1.xyz * (0.488603 * n.y) +
+         frag_info.diffuse_sh2.xyz * (0.488603 * n.z) +
+         frag_info.diffuse_sh3.xyz * (0.488603 * n.x) +
+         frag_info.diffuse_sh4.xyz * (1.092548 * n.x * n.y) +
+         frag_info.diffuse_sh5.xyz * (1.092548 * n.y * n.z) +
+         frag_info.diffuse_sh6.xyz * (0.315392 * (3.0 * n.z * n.z - 1.0)) +
+         frag_info.diffuse_sh7.xyz * (1.092548 * n.x * n.z) +
+         frag_info.diffuse_sh8.xyz * (0.546274 * (n.x * n.x - n.y * n.y));
+}
+
+// One rotated Poisson-disk PCF tap into a cascade's atlas tile. Factored out
+// so the kernel can be unrolled with inline literals at the call site (see the
+// note in SampleCascade); the compiler inlines this.
+float ShadowTap(vec2 p, float ca, float sa, float radius, vec2 uv, int cascade,
+                float inv_count, float receiver_depth) {
+  vec2 offset = vec2(p.x * ca - p.y * sa, p.x * sa + p.y * ca) * radius;
+  // Keep samples a texel inside this cascade's tile, so bilinear filtering of
+  // the atlas never reaches across the tile boundary into a neighbouring
+  // cascade's depths.
+  vec2 cuv = clamp(uv + offset, vec2(frag_info.shadow_texel_size),
+                   vec2(1.0 - frag_info.shadow_texel_size));
+  vec2 atlas_uv = vec2((float(cascade) + cuv.x) * inv_count, cuv.y);
+  // The atlas is a render-to-texture target; flip V to match its sampled Y
+  // orientation (see render_target_flip_y).
+  if (frag_info.render_target_flip_y > 0.5) {
+    atlas_uv.y = 1.0 - atlas_uv.y;
+  }
+  float caster_depth = texture(shadow_map, atlas_uv).r;
+  return receiver_depth <= caster_depth ? 1.0 : 0.0;
+}
+
+// Samples one cascade's tile of the shadow atlas strip with a rotated
+// 16-tap Poisson-disk PCF. `world_pos` and `n` are world-space.
+float SampleCascade(int cascade, vec3 world_pos, vec3 n, int count) {
+  float box = frag_info.cascade_box_sizes[cascade];
+
+  // Normal-offset bias. A soft PCF kernel on a surface tilted relative
+  // to the light straddles a depth gradient and would self-shadow, so
+  // lift the receiver along its normal far enough that the whole kernel
+  // clears the surface. The offset scales with the kernel's world
+  // radius (shadow_softness) and the surface's slope to the light. It
+  // depends only on geometry, not the cascade, so all cascades agree
+  // and there is no banding at their seams.
+  vec3 light_toward = -normalize(frag_info.directional_light_direction.xyz);
+  float ndotl = max(dot(n, light_toward), 0.15);
+  float slope = min(sqrt(max(1.0 - ndotl * ndotl, 0.0)) / (ndotl * ndotl),
+                    8.0);
+  float normal_offset =
+      frag_info.shadow_normal_bias + frag_info.shadow_softness * slope;
+  vec3 biased = world_pos + n * normal_offset;
+
+  vec4 light_clip =
+      frag_info.light_space_matrix[cascade] * vec4(biased, 1.0);
+  vec3 proj = light_clip.xyz / light_clip.w;
+  vec2 uv = proj.xy * 0.5 + 0.5;
+  // The depth bias is world-space; convert it to this cascade's clip-z
+  // (its orthographic depth range is 3 * box) so a caster crosses the
+  // shadow threshold at the same world height in every cascade, with
+  // no discontinuity where cascades meet.
+  float receiver_depth = proj.z - frag_info.shadow_bias / (3.0 * box);
+
+  // World-space penumbra -> this cascade's UV space, floored at a texel.
+  float radius =
+      max(frag_info.shadow_softness / box, frag_info.shadow_texel_size);
+  float inv_count = 1.0 / float(count);
+
+  // A per-fragment rotation hides the 16-tap pattern as a smooth edge.
+  float noise = fract(
+      52.9829189 *
+      fract(dot(gl_FragCoord.xy, vec2(0.06711056, 0.00583715))));
+  float angle = noise * 6.28318530718;
+  float ca = cos(angle);
+  float sa = sin(angle);
+
+  // 16-tap Poisson-disk PCF, unrolled with the kernel as inline literals.
+  //
+  // TODO(flutter_scene): this would naturally loop over a file-scope
+  // `const vec2 kPoissonDisk[16] = vec2[](...)`, but *any* const array (even
+  // one filled element by element, which the SPIR-V optimizer folds back into
+  // a constant) makes impellerc/SPIRV-Cross emit a GLSL array constructor
+  // (`vec2[](...)`) in its `#version 100` GLES output. That is invalid
+  // ES 1.00, so the shader fails to compile on conformant ES drivers
+  // (e.g. Mesa/llvmpipe under headless CI); lenient drivers accept it. Flutter
+  // GPU shaders should compile anywhere Flutter runs, so the real fix belongs
+  // upstream (impellerc should emit valid ES 1.00, or the bundle's GLES stage
+  // should target ES 3.00). Restore the const-array loop once that lands.
+  // See: <upstream issue>.
+#define _SHADOW_TAP(px, py) \
+  ShadowTap(vec2(px, py), ca, sa, radius, uv, cascade, inv_count, \
+            receiver_depth)
+  float lit = 0.0;
+  lit += _SHADOW_TAP(-0.94201624, -0.39906216);
+  lit += _SHADOW_TAP(0.94558609, -0.76890725);
+  lit += _SHADOW_TAP(-0.09418410, -0.92938870);
+  lit += _SHADOW_TAP(0.34495938, 0.29387760);
+  lit += _SHADOW_TAP(-0.91588581, 0.45771432);
+  lit += _SHADOW_TAP(-0.81544232, -0.87912464);
+  lit += _SHADOW_TAP(-0.38277543, 0.27676845);
+  lit += _SHADOW_TAP(0.97484398, 0.75648379);
+  lit += _SHADOW_TAP(0.44323325, -0.97511554);
+  lit += _SHADOW_TAP(0.53742981, -0.47373420);
+  lit += _SHADOW_TAP(-0.26496911, -0.41893023);
+  lit += _SHADOW_TAP(0.79197514, 0.19090188);
+  lit += _SHADOW_TAP(-0.24188840, 0.99706507);
+  lit += _SHADOW_TAP(-0.81409955, 0.91437590);
+  lit += _SHADOW_TAP(0.19984126, 0.78641367);
+  lit += _SHADOW_TAP(0.14383161, -0.14100790);
+#undef _SHADOW_TAP
+  float shadow = lit / 16.0;
+
+  // Only the last cascade has a real outer edge (inner cascades hand
+  // off to the next), so fade just it back to lit at the boundary.
+  if (cascade == count - 1 && frag_info.shadow_fade > 0.0) {
+    float fade = frag_info.shadow_fade / box;
+    vec2 edge = smoothstep(vec2(0.0), vec2(fade), uv) *
+                smoothstep(vec2(0.0), vec2(fade), vec2(1.0) - uv);
+    shadow = mix(1.0, shadow, edge.x * edge.y);
+  }
+  return shadow;
+}
+
+// Soft cascaded-shadow lookup. Returns 1.0 (lit) .. 0.0 (fully
+// shadowed). `world_pos` and `n` are world-space; `n` is the
+// (perturbed) shading normal. Picks the first (highest-resolution)
+// cascade whose box contains the fragment.
+float SampleShadow(vec3 world_pos, vec3 n) {
+  int count = int(frag_info.shadow_cascade_count);
+  for (int c = 0; c < 4; c++) {
+    if (c >= count) {
+      break;
+    }
+    // Containment test with the unbiased position.
+    vec4 light_clip =
+        frag_info.light_space_matrix[c] * vec4(world_pos, 1.0);
+    vec3 proj = light_clip.xyz / light_clip.w;
+    vec2 uv = proj.xy * 0.5 + 0.5;
+    // Require room for the PCF kernel inside the cascade's tile, so its
+    // samples never clamp against the tile edge (which would smear the
+    // edge texel into a thin seam). A fragment closer to the edge than
+    // the kernel radius falls through to the next, larger cascade.
+    float margin =
+        max(frag_info.shadow_softness / frag_info.cascade_box_sizes[c],
+            frag_info.shadow_texel_size);
+    if (uv.x < margin || uv.x > 1.0 - margin || uv.y < margin ||
+        uv.y > 1.0 - margin || proj.z < 0.0 || proj.z > 1.0) {
+      continue;
+    }
+    return SampleCascade(c, world_pos, n, count);
+  }
+  return 1.0;
+}
+
+// Lights a surface described by `material` and returns the final fragment
+// color (linear HDR, premultiplied by alpha). This is the engine-owned half of
+// the material contract; a material's Surface() function fills `material` and
+// main() calls this.
+vec4 EvaluateLighting(MaterialInputs material) {
+  vec3 albedo = material.base_color.rgb;
+  float alpha = material.base_color.a;
+  vec3 normal = material.normal;
+  float metallic = material.metallic;
+  float roughness = material.roughness;
+  float occlusion = material.occlusion;
+
+  vec3 camera_normal = normalize(v_viewvector);
+
+  vec3 reflectance = mix(vec3(0.04), albedo, metallic);
+
+  // 1 when the surface is facing the camera, 0 when it's perpendicular to the
+  // camera.
+  float n_dot_v = max(dot(normal, camera_normal), 0.0);
+
+  // reflect() needs the incident ray (camera -> surface); camera_normal
+  // points surface -> camera, so negate it. Sampling the environment with
+  // the un-negated vector would mirror reflections to the opposite side.
+  vec3 reflection_normal = reflect(-camera_normal, normal);
+
+  // Roughness-dependent Fresnel reflectance for the indirect specular lobe.
+  vec3 k_S = FresnelSchlickRoughness(n_dot_v, reflectance, roughness);
+
+  // The IBL environment can be rotated; transform the lookup directions.
+  mat3 environment_transform = mat3(frag_info.environment_transform);
+  vec3 env_normal = environment_transform * normal;
+  vec3 env_reflection = environment_transform * reflection_normal;
+  vec3 irradiance = max(EvaluateDiffuseSH(env_normal), vec3(0.0)) *
+                    frag_info.environment_intensity;
+  vec3 prefiltered_color =
+      SamplePrefilteredRadiance(prefiltered_radiance, env_reflection, roughness,
+                                frag_info.prefilter_flip_y) *
+      frag_info.environment_intensity;
+
+  // Split-sum DFG terms (Karis '13). The LUT is sampled slightly inside
+  // [0, 1] to avoid edge-tap artifacts.
+  vec2 f_ab = texture(brdf_lut, clamp(vec2(n_dot_v, roughness), 0.0, 0.99)).rg;
+
+  // Single- and multiple-scattering energy compensation (Fdez-Aguera 2019;
+  // see https://bruop.github.io/ibl/). Without the multiscatter term, rough
+  // metals lose noticeable energy.
+  vec3 FssEss = k_S * f_ab.x + f_ab.y;
+  float Ems = 1.0 - (f_ab.x + f_ab.y);
+  vec3 F_avg = reflectance + (1.0 - reflectance) / 21.0;
+  vec3 FmsEms = Ems * FssEss * F_avg / (1.0 - F_avg * Ems);
+  vec3 diffuse_color = albedo * (1.0 - metallic);
+  vec3 k_D = diffuse_color * (1.0 - FssEss + FmsEms);
+
+  vec3 indirect_specular = FssEss * prefiltered_color;
+  vec3 indirect_diffuse = (FmsEms + k_D) * irradiance;
+  vec3 ambient = (indirect_diffuse + indirect_specular) * occlusion;
+
+  // Analytic directional light (Cook-Torrance, layered on top of the IBL
+  // ambient term).
+  vec3 direct = vec3(0.0);
+  if (frag_info.has_directional_light > 0.5) {
+    // surface -> light.
+    vec3 light_vector = -normalize(frag_info.directional_light_direction.xyz);
+    float n_dot_l = max(dot(normal, light_vector), 0.0);
+    if (n_dot_l > 0.0) {
+      vec3 half_vector = normalize(light_vector + camera_normal);
+      float n_dot_v_safe = max(n_dot_v, 1e-4);
+      float distribution = DistributionGGX(normal, half_vector, roughness);
+      float visibility =
+          VisibilitySmithGGXCorrelated(n_dot_v_safe, n_dot_l, roughness);
+      vec3 specular_fresnel =
+          FresnelSchlick(max(dot(half_vector, camera_normal), 0.0), reflectance);
+      // `visibility` already folds in 1 / (4 * NoL * NoV).
+      vec3 specular = distribution * visibility * specular_fresnel;
+      vec3 diffuse = (vec3(1.0) - specular_fresnel) * (1.0 - metallic) *
+                     albedo * (1.0 / kPi);
+      float shadow =
+          frag_info.casts_shadow > 0.5 ? SampleShadow(v_position, normal) : 1.0;
+      direct = (diffuse + specular) * frag_info.directional_light_color.rgb *
+               n_dot_l * shadow;
+    }
+  }
+
+  vec3 emissive = material.emissive;
+
+  // Linear HDR, premultiplied by alpha. Exposure, the tone-mapping
+  // operator, and the display EOTF are applied later by the tone-mapping
+  // resolve pass (see flutter_scene_resolve.frag), so this writes into a
+  // floating-point scene-color target.
+  vec3 out_color = ambient + direct + emissive;
+  return vec4(out_color, 1.0) * alpha;
+}

--- a/packages/flutter_scene/shaders/material_varyings.glsl
+++ b/packages/flutter_scene/shaders/material_varyings.glsl
@@ -1,0 +1,27 @@
+// The engine-provided fragment inputs every flutter_scene material shader
+// receives: the interpolated per-vertex outputs (world space) and the color
+// output. Plus convenience accessors a material's Surface() function can call
+// instead of touching the raw varyings.
+
+in vec3 v_position; // world-space position
+in vec3 v_normal; // world-space normal, not normalized
+in vec3 v_viewvector; // camera_position - vertex_position (world space)
+in vec2 v_texture_coords;
+in vec4 v_color;
+
+out vec4 frag_color;
+
+// World-space position of the fragment.
+vec3 GetWorldPosition() { return v_position; }
+
+// Normalized world-space geometric normal (before any normal-map perturbation).
+vec3 GetWorldNormal() { return normalize(v_normal); }
+
+// Normalized direction from the fragment toward the camera.
+vec3 GetViewDirection() { return normalize(v_viewvector); }
+
+// Primary texture coordinates.
+vec2 GetUV0() { return v_texture_coords; }
+
+// Interpolated per-vertex color (white if the mesh has none).
+vec4 GetVertexColor() { return v_color; }

--- a/packages/flutter_scene/test/fmat_test.dart
+++ b/packages/flutter_scene/test/fmat_test.dart
@@ -30,8 +30,13 @@ fragment {
 }
 ''';
 
-Matcher _throwsFmat(String messageSubstring) => throwsA(isA<FmatException>()
-    .having((e) => e.message, 'message', contains(messageSubstring)));
+Matcher _throwsFmat(String messageSubstring) => throwsA(
+  isA<FmatException>().having(
+    (e) => e.message,
+    'message',
+    contains(messageSubstring),
+  ),
+);
 
 void main() {
   group('parse', () {
@@ -43,8 +48,11 @@ void main() {
       expect(m.culling, FmatCulling.none);
       expect(m.parameters.length, 4);
 
-      expect(m.uniformParameters.map((p) => p.name),
-          ['tint', 'strength', 'steps']);
+      expect(m.uniformParameters.map((p) => p.name), [
+        'tint',
+        'strength',
+        'steps',
+      ]);
       expect(m.samplerParameters.map((p) => p.name), ['detail_texture']);
 
       final tint = m.parameters.firstWhere((p) => p.name == 'tint');
@@ -82,10 +90,12 @@ fragment { void Surface(inout MaterialInputs material) {} }
     test('tracks the fragment block source line for #line mapping', () {
       // Explicit newlines so the line count is unambiguous: the fragment
       // block keyword is on line 2.
-      final m = parseFmat('material { name: "x" }\n'
-          'fragment {\n'
-          '  void Surface(inout MaterialInputs material) {}\n'
-          '}');
+      final m = parseFmat(
+        'material { name: "x" }\n'
+        'fragment {\n'
+        '  void Surface(inout MaterialInputs material) {}\n'
+        '}',
+      );
       expect(m.fragmentSourceLine, 2);
     });
   });
@@ -116,8 +126,10 @@ fragment {
 ''');
       expect(c.glsl, isNot(contains('material_lighting.glsl')));
       expect(c.glsl, isNot(contains('EvaluateLighting')));
-      expect(c.glsl,
-          contains('vec4(material.base_color.rgb, 1.0) * material.base_color.a'));
+      expect(
+        c.glsl,
+        contains('vec4(material.base_color.rgb, 1.0) * material.base_color.a'),
+      );
     });
   });
 
@@ -154,77 +166,92 @@ fragment { void Surface(inout MaterialInputs material) {} }
 ''';
 
     test('rejects mat3 with a helpful message', () {
-      expect(() => parseFmat(wrap('{ type: mat3, name: m }')),
-          _throwsFmat('mat3'));
+      expect(
+        () => parseFmat(wrap('{ type: mat3, name: m }')),
+        _throwsFmat('mat3'),
+      );
     });
 
     test('rejects an unknown parameter type', () {
-      expect(() => parseFmat(wrap('{ type: frobnicate, name: x }')),
-          _throwsFmat('Unknown parameter type'));
+      expect(
+        () => parseFmat(wrap('{ type: frobnicate, name: x }')),
+        _throwsFmat('Unknown parameter type'),
+      );
     });
 
     test('rejects duplicate parameter names', () {
       expect(
-          () => parseFmat(
-              wrap('{ type: float, name: a }, { type: float, name: a }')),
-          _throwsFmat('Duplicate parameter name'));
+        () => parseFmat(
+          wrap('{ type: float, name: a }, { type: float, name: a }'),
+        ),
+        _throwsFmat('Duplicate parameter name'),
+      );
     });
 
     test('rejects reserved identifiers', () {
-      expect(() => parseFmat(wrap('{ type: float, name: material }')),
-          _throwsFmat('reserved'));
+      expect(
+        () => parseFmat(wrap('{ type: float, name: material }')),
+        _throwsFmat('reserved'),
+      );
     });
 
     test('rejects a vector default of the wrong length', () {
       expect(
-          () => parseFmat(wrap('{ type: vec4, name: c, default: [1, 2, 3] }')),
-          _throwsFmat('components'));
+        () => parseFmat(wrap('{ type: vec4, name: c, default: [1, 2, 3] }')),
+        _throwsFmat('components'),
+      );
     });
 
     test('rejects source_color on a non-color type', () {
       expect(
-          () =>
-              parseFmat(wrap('{ type: float, name: f, hint: source_color }')),
-          _throwsFmat('source_color'));
+        () => parseFmat(wrap('{ type: float, name: f, hint: source_color }')),
+        _throwsFmat('source_color'),
+      );
     });
 
     test('rejects range on a non-numeric type', () {
       expect(
-          () => parseFmat(
-              wrap('{ type: vec4, name: v, hint: range(0, 1, 0.1) }')),
-          _throwsFmat('range'));
+        () =>
+            parseFmat(wrap('{ type: vec4, name: v, hint: range(0, 1, 0.1) }')),
+        _throwsFmat('range'),
+      );
     });
 
     test('requires a name', () {
       expect(
-          () => parseFmat('''
+        () => parseFmat('''
 material { shading_model: lit }
 fragment { void Surface(inout MaterialInputs material) {} }
 '''),
-          _throwsFmat('name'));
+        _throwsFmat('name'),
+      );
     });
 
     test('requires a fragment block', () {
-      expect(() => parseFmat('material { name: "X" }'),
-          _throwsFmat('fragment'));
+      expect(
+        () => parseFmat('material { name: "X" }'),
+        _throwsFmat('fragment'),
+      );
     });
 
     test('requires a Surface function in the fragment block', () {
       expect(
-          () => parseFmat('''
+        () => parseFmat('''
 material { name: "X" }
 fragment { void NotSurface() {} }
 '''),
-          _throwsFmat('Surface'));
+        _throwsFmat('Surface'),
+      );
     });
 
     test('rejects unknown material keys', () {
       expect(
-          () => parseFmat('''
+        () => parseFmat('''
 material { name: "X", shadingmodel: lit }
 fragment { void Surface(inout MaterialInputs material) {} }
 '''),
-          _throwsFmat('Unknown material key'));
+        _throwsFmat('Unknown material key'),
+      );
     });
   });
 }

--- a/packages/flutter_scene/test/fmat_test.dart
+++ b/packages/flutter_scene/test/fmat_test.dart
@@ -1,0 +1,230 @@
+// CPU unit tests for the .fmat preprocessor: parsing to the AST, GLSL
+// emission, the metadata sidecar, and validation errors. No GPU context is
+// needed; the emitted GLSL is exercised end to end by the example app and the
+// smoke-render golden tests in later stages.
+
+import 'package:flutter_scene/src/fmat/fmat.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _validLit = '''
+material {
+  name: "Test",
+  shading_model: lit,
+  blending: alpha,
+  culling: none,
+  parameters: [
+    { type: vec4, name: tint, hint: source_color, default: [1.0, 0.5, 0.25, 1.0] },
+    { type: float, name: strength, hint: range(0, 1, 0.01), default: 0.5 },
+    { type: int, name: steps, default: 3 },
+    { type: sampler2d, name: detail_texture, hint: default_white },
+  ],
+}
+
+fragment {
+  void Surface(inout MaterialInputs material) {
+    vec4 d = texture(detail_texture, GetUV0());
+    material.base_color = material_params.tint * d * material_params.strength;
+    material.roughness = 0.5;
+    PrepareMaterial(material);
+  }
+}
+''';
+
+Matcher _throwsFmat(String messageSubstring) => throwsA(isA<FmatException>()
+    .having((e) => e.message, 'message', contains(messageSubstring)));
+
+void main() {
+  group('parse', () {
+    test('parses metadata, parameters, hints, and defaults', () {
+      final m = parseFmat(_validLit, fileName: 'test.fmat');
+      expect(m.name, 'Test');
+      expect(m.shadingModel, FmatShadingModel.lit);
+      expect(m.blending, FmatBlending.alpha);
+      expect(m.culling, FmatCulling.none);
+      expect(m.parameters.length, 4);
+
+      expect(m.uniformParameters.map((p) => p.name),
+          ['tint', 'strength', 'steps']);
+      expect(m.samplerParameters.map((p) => p.name), ['detail_texture']);
+
+      final tint = m.parameters.firstWhere((p) => p.name == 'tint');
+      expect(tint.type, FmatType.vec4);
+      expect(tint.hint?.kind, FmatHintKind.sourceColor);
+      expect(tint.defaultValue, [1.0, 0.5, 0.25, 1.0]);
+
+      final strength = m.parameters.firstWhere((p) => p.name == 'strength');
+      expect(strength.hint?.kind, FmatHintKind.range);
+      expect(strength.hint?.rangeMin, 0.0);
+      expect(strength.hint?.rangeMax, 1.0);
+      expect(strength.hint?.rangeStep, 0.01);
+      expect(strength.defaultValue, 0.5);
+
+      final steps = m.parameters.firstWhere((p) => p.name == 'steps');
+      expect(steps.type, FmatType.int_);
+      expect(steps.defaultValue, 3);
+
+      final tex = m.parameters.firstWhere((p) => p.name == 'detail_texture');
+      expect(tex.isSampler, isTrue);
+      expect(tex.hint?.kind, FmatHintKind.defaultWhite);
+    });
+
+    test('applies defaults for omitted shading_model/blending/culling', () {
+      final m = parseFmat('''
+material { name: "D" }
+fragment { void Surface(inout MaterialInputs material) {} }
+''');
+      expect(m.shadingModel, FmatShadingModel.lit);
+      expect(m.blending, FmatBlending.opaque);
+      expect(m.culling, FmatCulling.back);
+      expect(m.parameters, isEmpty);
+    });
+
+    test('tracks the fragment block source line for #line mapping', () {
+      // Explicit newlines so the line count is unambiguous: the fragment
+      // block keyword is on line 2.
+      final m = parseFmat('material { name: "x" }\n'
+          'fragment {\n'
+          '  void Surface(inout MaterialInputs material) {}\n'
+          '}');
+      expect(m.fragmentSourceLine, 2);
+    });
+  });
+
+  group('emit', () {
+    test('lit material composes the lighting framework and main()', () {
+      final c = compileFmat(_validLit, fileName: 'test.fmat');
+      expect(c.glsl, contains('#include <material_lighting.glsl>'));
+      expect(c.glsl, contains('#include <material_engine_lighting.glsl>'));
+      expect(c.glsl, contains('uniform MaterialParams {'));
+      expect(c.glsl, contains('  vec4 tint;'));
+      expect(c.glsl, contains('  int steps;'));
+      expect(c.glsl, contains('material_params;'));
+      expect(c.glsl, contains('uniform sampler2D detail_texture;'));
+      expect(c.glsl, contains('#line ${c.material.fragmentSourceLine}'));
+      expect(c.glsl, contains('frag_color = EvaluateLighting(material);'));
+      expect(c.glsl, contains('Surface(material);'));
+    });
+
+    test('unlit material outputs premultiplied base color, no lighting', () {
+      final c = compileFmat('''
+material { name: "U", shading_model: unlit }
+fragment {
+  void Surface(inout MaterialInputs material) {
+    material.base_color = vec4(1.0);
+  }
+}
+''');
+      expect(c.glsl, isNot(contains('material_lighting.glsl')));
+      expect(c.glsl, isNot(contains('EvaluateLighting')));
+      expect(c.glsl,
+          contains('vec4(material.base_color.rgb, 1.0) * material.base_color.a'));
+    });
+  });
+
+  group('sidecar', () {
+    test('records types, defaults, hints, and samplers', () {
+      final c = compileFmat(_validLit, fileName: 'test.fmat');
+      final s = c.sidecar;
+      expect(s['name'], 'Test');
+      expect(s['shading_model'], 'lit');
+      expect(s['blending'], 'alpha');
+      expect(s['uniform_block'], 'MaterialParams');
+
+      final params = (s['parameters'] as List).cast<Map<String, Object?>>();
+      expect(params.map((p) => p['name']), ['tint', 'strength', 'steps']);
+      final tint = params.firstWhere((p) => p['name'] == 'tint');
+      expect(tint['type'], 'vec4');
+      expect(tint['default'], [1.0, 0.5, 0.25, 1.0]);
+      expect((tint['hint'] as Map)['kind'], 'source_color');
+
+      final samplers = (s['samplers'] as List).cast<Map<String, Object?>>();
+      expect(samplers.single['name'], 'detail_texture');
+      expect((samplers.single['hint'] as Map)['kind'], 'default_white');
+    });
+  });
+
+  group('validation', () {
+    String wrap(String params, {String shadingModel = 'lit'}) => '''
+material {
+  name: "V",
+  shading_model: $shadingModel,
+  parameters: [ $params ],
+}
+fragment { void Surface(inout MaterialInputs material) {} }
+''';
+
+    test('rejects mat3 with a helpful message', () {
+      expect(() => parseFmat(wrap('{ type: mat3, name: m }')),
+          _throwsFmat('mat3'));
+    });
+
+    test('rejects an unknown parameter type', () {
+      expect(() => parseFmat(wrap('{ type: frobnicate, name: x }')),
+          _throwsFmat('Unknown parameter type'));
+    });
+
+    test('rejects duplicate parameter names', () {
+      expect(
+          () => parseFmat(
+              wrap('{ type: float, name: a }, { type: float, name: a }')),
+          _throwsFmat('Duplicate parameter name'));
+    });
+
+    test('rejects reserved identifiers', () {
+      expect(() => parseFmat(wrap('{ type: float, name: material }')),
+          _throwsFmat('reserved'));
+    });
+
+    test('rejects a vector default of the wrong length', () {
+      expect(
+          () => parseFmat(wrap('{ type: vec4, name: c, default: [1, 2, 3] }')),
+          _throwsFmat('components'));
+    });
+
+    test('rejects source_color on a non-color type', () {
+      expect(
+          () =>
+              parseFmat(wrap('{ type: float, name: f, hint: source_color }')),
+          _throwsFmat('source_color'));
+    });
+
+    test('rejects range on a non-numeric type', () {
+      expect(
+          () => parseFmat(
+              wrap('{ type: vec4, name: v, hint: range(0, 1, 0.1) }')),
+          _throwsFmat('range'));
+    });
+
+    test('requires a name', () {
+      expect(
+          () => parseFmat('''
+material { shading_model: lit }
+fragment { void Surface(inout MaterialInputs material) {} }
+'''),
+          _throwsFmat('name'));
+    });
+
+    test('requires a fragment block', () {
+      expect(() => parseFmat('material { name: "X" }'),
+          _throwsFmat('fragment'));
+    });
+
+    test('requires a Surface function in the fragment block', () {
+      expect(
+          () => parseFmat('''
+material { name: "X" }
+fragment { void NotSurface() {} }
+'''),
+          _throwsFmat('Surface'));
+    });
+
+    test('rejects unknown material keys', () {
+      expect(
+          () => parseFmat('''
+material { name: "X", shadingmodel: lit }
+fragment { void Surface(inout MaterialInputs material) {} }
+'''),
+          _throwsFmat('Unknown material key'));
+    });
+  });
+}

--- a/packages/flutter_scene/test/material_parameters_test.dart
+++ b/packages/flutter_scene/test/material_parameters_test.dart
@@ -1,0 +1,128 @@
+// CPU unit tests for the type-checked, name-addressed MaterialParameters. The
+// layout is injected via MaterialParameters.withLayout, so no GPU context or
+// shader reflection is needed; the GPU bind path is exercised by the example
+// app and smoke-render goldens.
+
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' show Color;
+
+import 'package:flutter_scene/src/fmat/fmat_ast.dart';
+import 'package:flutter_scene/src/material/material_parameters.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+MaterialParameters _params() => MaterialParameters.withLayout(
+  blockName: 'MaterialParams',
+  blockSizeBytes: 64,
+  parameters: {
+    'tint': (type: FmatType.vec4, offset: 0, sourceColor: true),
+    'gloss': (type: FmatType.float_, offset: 16, sourceColor: false),
+    'steps': (type: FmatType.int_, offset: 20, sourceColor: false),
+    'dir': (type: FmatType.vec3, offset: 32, sourceColor: false),
+    'plain': (type: FmatType.vec4, offset: 48, sourceColor: false),
+  },
+  samplers: {'detail': FmatHintKind.defaultWhite},
+);
+
+void main() {
+  group('typed setters write at reflected offsets', () {
+    test('float / int', () {
+      final p = _params();
+      p.setFloat('gloss', 0.25);
+      p.setInt('steps', 7);
+      expect(p.rawBlock.getFloat32(16, Endian.host), 0.25);
+      expect(p.rawBlock.getInt32(20, Endian.host), 7);
+    });
+
+    test('vec4 / vec3', () {
+      final p = _params();
+      p.setVec4('tint', Vector4(0.1, 0.2, 0.3, 0.4));
+      p.setVec3('dir', Vector3(1.0, 2.0, 3.0));
+      final b = p.rawBlock;
+      expect(b.getFloat32(0, Endian.host), closeTo(0.1, 1e-6));
+      expect(b.getFloat32(4, Endian.host), closeTo(0.2, 1e-6));
+      expect(b.getFloat32(8, Endian.host), closeTo(0.3, 1e-6));
+      expect(b.getFloat32(12, Endian.host), closeTo(0.4, 1e-6));
+      expect(b.getFloat32(32, Endian.host), closeTo(1.0, 1e-6));
+      expect(b.getFloat32(40, Endian.host), closeTo(3.0, 1e-6));
+    });
+
+    test('offsetOf exposes the reflected offset', () {
+      expect(_params().offsetOf('gloss'), 16);
+    });
+  });
+
+  group('type checking', () {
+    test('wrong-typed setter throws', () {
+      final p = _params();
+      expect(() => p.setFloat('tint', 1.0), throwsArgumentError);
+      expect(() => p.setVec4('gloss', Vector4.zero()), throwsArgumentError);
+    });
+
+    test('unknown parameter throws', () {
+      expect(() => _params().setFloat('nope', 1.0), throwsArgumentError);
+    });
+  });
+
+  group('dynamic operator[]=', () {
+    test('dispatches on the declared type', () {
+      final p = _params();
+      p['gloss'] = 0.5;
+      p['steps'] = 3;
+      p['tint'] = Vector4(1.0, 0.0, 0.0, 1.0);
+      expect(p.rawBlock.getFloat32(16, Endian.host), 0.5);
+      expect(p.rawBlock.getInt32(20, Endian.host), 3);
+      expect(p.rawBlock.getFloat32(0, Endian.host), closeTo(1.0, 1e-6));
+    });
+
+    test('throws on a type mismatch', () {
+      final p = _params();
+      expect(() => p['gloss'] = Vector4.zero(), throwsArgumentError);
+      expect(() => p['tint'] = 'red', throwsArgumentError);
+      expect(() => p['steps'] = 1.5, throwsArgumentError); // not an int
+    });
+
+    test('throws on an unknown name', () {
+      expect(() => _params()['nope'] = 1.0, throwsArgumentError);
+    });
+  });
+
+  group('setColor', () {
+    test('sRGB-decodes rgb for a source_color parameter, alpha as-is', () {
+      final p = _params();
+      p.setColor('tint', const Color(0xff800000)); // r = 0x80/0xff
+      final expected = math.pow(0x80 / 0xff, 2.2).toDouble();
+      expect(p.rawBlock.getFloat32(0, Endian.host), closeTo(expected, 1e-5));
+      expect(p.rawBlock.getFloat32(4, Endian.host), closeTo(0.0, 1e-6));
+      expect(
+        p.rawBlock.getFloat32(12, Endian.host),
+        closeTo(1.0, 1e-6),
+      ); // alpha
+    });
+
+    test('writes raw channels for a non-source_color parameter', () {
+      final p = _params();
+      p.setColor('plain', const Color(0xff800000));
+      expect(
+        p.rawBlock.getFloat32(48, Endian.host),
+        closeTo(0x80 / 0xff, 1e-5),
+      );
+    });
+  });
+
+  group('introspection and samplers', () {
+    test('exposes parameter and sampler names', () {
+      final p = _params();
+      expect(
+        p.parameterNames,
+        containsAll(['tint', 'gloss', 'steps', 'dir', 'plain']),
+      );
+      expect(p.samplerNames, ['detail']);
+    });
+
+    test('assigning a non-texture to a sampler throws', () {
+      expect(() => _params()['detail'] = 5, throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
Work in progress for the Flutter Scene custom-material (`.fmat`) system, tracked in #22. Opened as a draft to run CI and the Argos goldens against the master baseline; not ready to merge, since Stage 4 and beyond are still to come.

Stages so far, one commit each:

- Stage 0: extract a shared material lighting framework (`material_inputs.glsl`, `material_lighting.glsl`) from the standard PBR shader. Behavior-preserving code motion.
- Stage 1: the `.fmat` format and preprocessor (lexer, parser, validator, GLSL emitter, metadata sidecar), pure Dart with unit tests.
- Stage 2a: share the engine fragment interface (`material_varyings.glsl`, `material_engine_lighting.glsl`) between the standard shader and generated materials.
- Stage 2b: the `buildMaterials()` build hook, layered on `flutter_gpu_shaders` 0.4.4's new `includeDirectories` parameter.
- Stage 3: the runtime, `MaterialParameters` (type-checked, name-addressed parameters) and `PreprocessedMaterial`.

The goldens here exercise the Stage 0 and 2a standard-shader refactors through the existing PBR smoke scenes. Custom-material rendering and its own golden scene arrive in Stage 4.
