### PR TITLE
Always encode resolved scene color

### DIFF
--- a/examples/flutter_gpu_shim_smoke/lib/hdr_tab.dart
+++ b/examples/flutter_gpu_shim_smoke/lib/hdr_tab.dart
@@ -122,10 +122,9 @@ class _HdrTabState extends State<HdrTab> {
           offsetInBytes: 0,
           lengthInBytes: verts.lengthInBytes,
         ),
-        3,
       );
       pass.setViewport(gpu.Viewport(x: 0, y: 0, width: _size, height: _size));
-      pass.draw();
+      pass.draw(3);
       pass.clearBindings();
       cmd.submit();
 

--- a/examples/flutter_gpu_shim_smoke/lib/mesh_tab.dart
+++ b/examples/flutter_gpu_shim_smoke/lib/mesh_tab.dart
@@ -127,7 +127,6 @@ class _MeshTabState extends State<MeshTab> {
           offsetInBytes: 0,
           lengthInBytes: verts.lengthInBytes,
         ),
-        4,
       );
       pass.bindIndexBuffer(
         gpu.BufferView(
@@ -136,13 +135,12 @@ class _MeshTabState extends State<MeshTab> {
           lengthInBytes: indices.lengthInBytes,
         ),
         gpu.IndexType.int16,
-        6,
       );
       pass.bindUniform(vert.getUniformSlot('FrameInfo'), frameView);
       pass.bindUniform(frag.getUniformSlot('FragInfo'), fragView);
       pass.bindTexture(frag.getUniformSlot('base_color_texture'), whiteTex);
       pass.setViewport(gpu.Viewport(x: 0, y: 0, width: _size, height: _size));
-      pass.draw();
+      pass.drawIndexed(6);
       pass.clearBindings();
       cmd.submit();
 

--- a/examples/flutter_gpu_shim_smoke/lib/triangle_tab.dart
+++ b/examples/flutter_gpu_shim_smoke/lib/triangle_tab.dart
@@ -111,7 +111,6 @@ class _TriangleTabState extends State<TriangleTab> {
           offsetInBytes: 0,
           lengthInBytes: verts.lengthInBytes,
         ),
-        4,
       );
       pass.bindIndexBuffer(
         gpu.BufferView(
@@ -120,10 +119,9 @@ class _TriangleTabState extends State<TriangleTab> {
           lengthInBytes: indices.lengthInBytes,
         ),
         gpu.IndexType.int16,
-        6,
       );
       pass.setViewport(gpu.Viewport(x: 0, y: 0, width: _size, height: _size));
-      pass.draw();
+      pass.drawIndexed(6);
       pass.clearBindings();
       cmd.submit();
 

--- a/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
@@ -287,7 +287,11 @@ base class RenderPass {
 
   void bindVertexBuffer(BufferView bufferView, {int slot = 0}) {
     if (slot != 0) {
-      throw RangeError.value(slot, 'slot', 'WebGL2 backend only supports slot 0');
+      throw RangeError.value(
+        slot,
+        'slot',
+        'WebGL2 backend only supports slot 0',
+      );
     }
     final gl = _gpuContext._gl;
     final pipeline = _boundPipeline;

--- a/packages/flutter_scene/lib/src/render/resolve_pass.dart
+++ b/packages/flutter_scene/lib/src/render/resolve_pass.dart
@@ -20,7 +20,7 @@ const String kDisplayColorBlackboardKey = 'display_color';
 /// Resolves the linear HDR scene color (a floating-point render target
 /// produced by [ScenePass], read from the blackboard) into the
 /// display-referred image: applies exposure, optional color grading, the
-/// tone mapping operator, and the display EOTF as a single full-screen
+/// tone mapping operator, and display encoding as a single full-screen
 /// pass. Writes into [outputColor] and publishes it on the blackboard.
 class ResolvePass extends RenderGraphPass {
   ResolvePass({

--- a/packages/flutter_scene/shaders/flutter_scene_resolve.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_resolve.frag
@@ -1,7 +1,7 @@
 // Resolve pass: reads the linear HDR scene color (with premultiplied
 // alpha) and produces the display-referred swapchain image. In order it
 // applies chromatic aberration (at sample time), exposure, color grading,
-// a tone mapping operator, the display EOTF, then vignette and film grain.
+// a tone mapping operator, display encoding, then vignette and film grain.
 // Each effect is gated by a flag, so a disabled effect costs only a
 // branch and leaves the image unchanged.
 uniform ResolveInfo {
@@ -166,9 +166,9 @@ void main() {
     mapped = max(mapped + n * resolve_info.grain_intensity, vec3(0.0));
   }
 
-#ifndef IMPELLER_TARGET_METAL
+  // The swapchain texture is a plain UNorm render target, so encode the
+  // resolved linear color before handing it to Texture.asImage().
   mapped = pow(mapped, vec3(1.0 / kGamma));
-#endif
 
   frag_color = vec4(mapped * alpha, alpha);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_unlit.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_unlit.frag
@@ -22,7 +22,7 @@ void main() {
   vec4 base = texture(base_color_texture, v_texture_coords);
   // Linearize the sRGB-encoded base color so what we write to the
   // floating-point scene-color target is linear; the tone-mapping resolve
-  // pass re-applies the display EOTF. Output is premultiplied by alpha.
+  // pass applies display encoding. Output is premultiplied by alpha.
   vec3 rgb = SRGBToLinear(base.rgb) * vertex_color.rgb * frag_info.color.rgb;
   float alpha = base.a * vertex_color.a * frag_info.color.a;
   frag_color = vec4(rgb, 1.0) * alpha;

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -254,7 +254,7 @@ vec4 EvaluateLighting(MaterialInputs material) {
   vec3 emissive = material.emissive;
 
   // Linear HDR, premultiplied by alpha. Exposure, the tone-mapping
-  // operator, and the display EOTF are applied later by the tone-mapping
+  // operator, and display encoding are applied later by the tone-mapping
   // resolve pass (see flutter_scene_resolve.frag), so this writes into a
   // floating-point scene-color target.
   vec3 out_color = ambient + direct + emissive;

--- a/packages/flutter_scene/shaders/tone_mapping.glsl
+++ b/packages/flutter_scene/shaders/tone_mapping.glsl
@@ -1,6 +1,6 @@
 // Tone mapping operators. Each maps a non-negative linear HDR color to a
-// display-referred [0, 1] color (still in linear Rec. 709; the EOTF /
-// gamma is applied separately by the caller where needed).
+// display-referred [0, 1] color (still in linear Rec. 709; display encoding
+// is applied separately by the caller where needed).
 
 // ACES filmic approximation (Stephen Hill fit).
 // source:


### PR DESCRIPTION
- always apply display encoding in the resolve shader
- update tone-mapping comments
- update smoke app draw calls for the latest Flutter GPU API

## Tests
- dart analyze packages examples
- flutter analyze packages/flutter_scene
- flutter build macos --debug