### PR TITLE
Run Android GLES smoke tests on Flutter master

### DIFF
--- a/.github/workflows/smoke_render.yml
+++ b/.github/workflows/smoke_render.yml
@@ -79,21 +79,14 @@ jobs:
             -d "{\"content\": \"$CONTENT\"}" "$DISCORD_WEBHOOK_URL" || true
 
   android_gles:
-    name: android_gles (Flutter acd5e1a)
+    name: android_gles (Flutter master)
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    env:
-      # Current Flutter master has a GLES Texture.overwrite raster-thread
-      # submission regression after flutter/flutter#185890. Pin Android GLES
-      # smoke goldens before that change until the upstream regression is fixed.
-      FLUTTER_REVISION: acd5e1a75af03247e82bf1cea8a63ae352c3d0b3
     steps:
       - uses: actions/checkout@v4
-      - name: Install pinned Flutter
-        run: |
-          git clone --filter=blob:none https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
-          git -C "$RUNNER_TEMP/flutter" checkout "$FLUTTER_REVISION"
-          echo "$RUNNER_TEMP/flutter/bin" >> "$GITHUB_PATH"
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: master
       - name: Flutter and engine revision
         run: flutter --version
       - run: flutter config --enable-native-assets
@@ -143,7 +136,7 @@ jobs:
         run: |
           [ -z "$DISCORD_WEBHOOK_URL" ] && exit 0
           RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          CONTENT="Smoke render failed (android_gles, Flutter acd5e1a). Run: $RUN_URL"
+          CONTENT="Smoke render failed (android_gles, Flutter master). Run: $RUN_URL"
           [ -n "$ARGOS_URL" ] && CONTENT="$CONTENT  |  Argos: $ARGOS_URL"
           curl -sf -H "Content-Type: application/json" \
             -d "{\"content\": \"$CONTENT\"}" "$DISCORD_WEBHOOK_URL" || true

--- a/examples/smoke_render/integration_test/smoke_test.dart
+++ b/examples/smoke_render/integration_test/smoke_test.dart
@@ -15,10 +15,20 @@ void main() {
 
   for (final smoke in kSmokeScenes) {
     testWidgets('${smoke.id} renders a sane frame', (tester) async {
-      // flutter_scene gates rendering on this future. Wait BEFORE building the
-      // widget: a Geometry/Material ctor (run in SmokeSceneView.initState during
-      // pumpWidget) touches baseShaderLibrary, which throws on web if touched
-      // before initialization completes.
+      // Let Flutter render one ordinary frame before touching flutter_scene.
+      // Android GLES can race GPU context setup if Scene initialization uploads
+      // textures before the first frame has established the backend context.
+      await tester.pumpWidget(
+        const MaterialApp(
+          debugShowCheckedModeBanner: false,
+          home: Scaffold(backgroundColor: kSmokeClear, body: SizedBox.expand()),
+        ),
+      );
+      await tester.pump();
+
+      // flutter_scene gates rendering on this future. Wait before building the
+      // smoke scene: Geometry/Material constructors touch the shader bundle,
+      // which must be loaded before SmokeSceneView constructs them.
       await Scene.initializeStaticResources();
       await loadSmokeMaterials();
 


### PR DESCRIPTION
- switch the Android GLES smoke-render shard from a pinned Flutter revision to Flutter master
- render one ordinary Flutter frame before initializing Flutter Scene in smoke tests so GLES has a backend context before texture uploads

## Validation
- dart format --output none --set-exit-if-changed examples/smoke_render/integration_test/smoke_test.dart
- dart analyze examples/smoke_render/integration_test/smoke_test.dart

CI/Argos should show whether Android GLES on master now renders upright.