### PR TITLE
Add Android Vulkan smoke render shard

### DIFF
--- a/.github/workflows/smoke_render.yml
+++ b/.github/workflows/smoke_render.yml
@@ -106,17 +106,21 @@ jobs:
           profile: pixel_7
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
-          script: >
-            flutter devices &&
-            adb shell svc power stayon true &&
-            (adb shell wm dismiss-keyguard || true) &&
-            cd examples/smoke_render &&
-            flutter drive
-            --driver=test_driver/integration_test.dart
-            --target=integration_test/smoke_test.dart
-            -d emulator-5554
-            --enable-impeller
-            --enable-flutter-gpu
+          script: |
+            set -euo pipefail
+            flutter devices
+            adb shell svc power stayon true
+            adb shell wm dismiss-keyguard || true
+            adb logcat -c
+            cd examples/smoke_render
+            flutter drive \
+              --flavor gles \
+              --driver=test_driver/integration_test.dart \
+              --target=integration_test/smoke_test.dart \
+              -d emulator-5554 \
+              --dart-define=SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND=opengles \
+              --enable-impeller \
+              --enable-flutter-gpu
       - name: Upload to Argos
         id: argos
         if: ${{ !cancelled() }}
@@ -137,6 +141,75 @@ jobs:
           [ -z "$DISCORD_WEBHOOK_URL" ] && exit 0
           RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           CONTENT="Smoke render failed (android_gles, Flutter master). Run: $RUN_URL"
+          [ -n "$ARGOS_URL" ] && CONTENT="$CONTENT  |  Argos: $ARGOS_URL"
+          curl -sf -H "Content-Type: application/json" \
+            -d "{\"content\": \"$CONTENT\"}" "$DISCORD_WEBHOOK_URL" || true
+
+  android_vulkan:
+    name: android_vulkan (Flutter master)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: master
+      - name: Flutter and engine revision
+        run: flutter --version
+      - run: flutter config --enable-native-assets
+      - run: flutter pub get
+      - name: Enable KVM access
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Render smoke scenes
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_7
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader -no-snapshot -noaudio -no-boot-anim -camera-back none
+          script: |
+            set -euo pipefail
+            flutter devices
+            adb shell getprop ro.hardware.vulkan || true
+            adb shell getprop ro.opengles.version || true
+            adb shell svc power stayon true
+            adb shell wm dismiss-keyguard || true
+            adb logcat -c
+            cd examples/smoke_render
+            flutter drive \
+              --flavor vulkan \
+              --driver=test_driver/integration_test.dart \
+              --target=integration_test/smoke_test.dart \
+              -d emulator-5554 \
+              --dart-define=SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND=vulkan \
+              --enable-impeller \
+              --enable-flutter-gpu
+      - name: Upload to Argos
+        id: argos
+        if: ${{ !cancelled() }}
+        working-directory: examples/smoke_render
+        env:
+          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+        run: |
+          out=$(npx --yes @argos-ci/cli upload build/smoke --build-name android_vulkan 2>&1) || true
+          echo "$out"
+          url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1)
+          echo "build_url=$url" >> "$GITHUB_OUTPUT"
+      - name: Notify Discord on failure
+        if: failure() && github.event_name != 'pull_request'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          ARGOS_URL: ${{ steps.argos.outputs.build_url }}
+        run: |
+          [ -z "$DISCORD_WEBHOOK_URL" ] && exit 0
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          CONTENT="Smoke render failed (android_vulkan, Flutter master). Run: $RUN_URL"
           [ -n "$ARGOS_URL" ] && CONTENT="$CONTENT  |  Argos: $ARGOS_URL"
           curl -sf -H "Content-Type: application/json" \
             -d "{\"content\": \"$CONTENT\"}" "$DISCORD_WEBHOOK_URL" || true

--- a/.github/workflows/smoke_render.yml
+++ b/.github/workflows/smoke_render.yml
@@ -106,21 +106,20 @@ jobs:
           profile: pixel_7
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
-          script: |
-            set -eu
-            flutter devices
-            adb shell svc power stayon true
-            adb shell wm dismiss-keyguard || true
-            adb logcat -c
-            cd examples/smoke_render
-            flutter drive \
-              --flavor gles \
-              --driver=test_driver/integration_test.dart \
-              --target=integration_test/smoke_test.dart \
-              -d emulator-5554 \
-              --dart-define=SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND=opengles \
-              --enable-impeller \
-              --enable-flutter-gpu
+          script: >
+            flutter devices &&
+            adb shell svc power stayon true &&
+            (adb shell wm dismiss-keyguard || true) &&
+            adb logcat -c &&
+            cd examples/smoke_render &&
+            flutter drive
+            --flavor gles
+            --driver=test_driver/integration_test.dart
+            --target=integration_test/smoke_test.dart
+            -d emulator-5554
+            --dart-define=SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND=opengles
+            --enable-impeller
+            --enable-flutter-gpu
       - name: Upload to Argos
         id: argos
         if: ${{ !cancelled() }}
@@ -177,23 +176,22 @@ jobs:
           profile: pixel_7
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader -no-snapshot -noaudio -no-boot-anim -camera-back none
-          script: |
-            set -eu
-            flutter devices
-            adb shell getprop ro.hardware.vulkan || true
-            adb shell getprop ro.opengles.version || true
-            adb shell svc power stayon true
-            adb shell wm dismiss-keyguard || true
-            adb logcat -c
-            cd examples/smoke_render
-            flutter drive \
-              --flavor vulkan \
-              --driver=test_driver/integration_test.dart \
-              --target=integration_test/smoke_test.dart \
-              -d emulator-5554 \
-              --dart-define=SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND=vulkan \
-              --enable-impeller \
-              --enable-flutter-gpu
+          script: >
+            flutter devices &&
+            (adb shell getprop ro.hardware.vulkan || true) &&
+            (adb shell getprop ro.opengles.version || true) &&
+            adb shell svc power stayon true &&
+            (adb shell wm dismiss-keyguard || true) &&
+            adb logcat -c &&
+            cd examples/smoke_render &&
+            flutter drive
+            --flavor vulkan
+            --driver=test_driver/integration_test.dart
+            --target=integration_test/smoke_test.dart
+            -d emulator-5554
+            --dart-define=SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND=vulkan
+            --enable-impeller
+            --enable-flutter-gpu
       - name: Upload to Argos
         id: argos
         if: ${{ !cancelled() }}

--- a/.github/workflows/smoke_render.yml
+++ b/.github/workflows/smoke_render.yml
@@ -107,7 +107,7 @@ jobs:
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
           script: |
-            set -euo pipefail
+            set -eu
             flutter devices
             adb shell svc power stayon true
             adb shell wm dismiss-keyguard || true
@@ -128,6 +128,10 @@ jobs:
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
         run: |
+          if [ ! -d build/smoke ] || ! find build/smoke -type f -name '*.png' | grep -q .; then
+            echo "No smoke screenshots found; skipping Argos upload."
+            exit 0
+          fi
           out=$(npx --yes @argos-ci/cli upload build/smoke --build-name android_gles 2>&1) || true
           echo "$out"
           url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1)
@@ -174,7 +178,7 @@ jobs:
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader -no-snapshot -noaudio -no-boot-anim -camera-back none
           script: |
-            set -euo pipefail
+            set -eu
             flutter devices
             adb shell getprop ro.hardware.vulkan || true
             adb shell getprop ro.opengles.version || true
@@ -197,6 +201,10 @@ jobs:
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
         run: |
+          if [ ! -d build/smoke ] || ! find build/smoke -type f -name '*.png' | grep -q .; then
+            echo "No smoke screenshots found; skipping Argos upload."
+            exit 0
+          fi
           out=$(npx --yes @argos-ci/cli upload build/smoke --build-name android_vulkan 2>&1) || true
           echo "$out"
           url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1)

--- a/examples/smoke_render/android/app/build.gradle.kts
+++ b/examples/smoke_render/android/app/build.gradle.kts
@@ -24,6 +24,20 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        manifestPlaceholders["impellerBackend"] = "opengles"
+    }
+
+    flavorDimensions += "impellerBackend"
+
+    productFlavors {
+        create("gles") {
+            dimension = "impellerBackend"
+            manifestPlaceholders["impellerBackend"] = "opengles"
+        }
+        create("vulkan") {
+            dimension = "impellerBackend"
+            manifestPlaceholders["impellerBackend"] = "vulkan"
+        }
     }
 
     buildTypes {

--- a/examples/smoke_render/android/app/src/main/AndroidManifest.xml
+++ b/examples/smoke_render/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
             android:value="true" />
         <meta-data
             android:name="io.flutter.embedding.android.ImpellerBackend"
-            android:value="opengles" />
+            android:value="${impellerBackend}" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/examples/smoke_render/android/app/src/main/kotlin/dev/bdero/smoke_render/MainActivity.kt
+++ b/examples/smoke_render/android/app/src/main/kotlin/dev/bdero/smoke_render/MainActivity.kt
@@ -1,5 +1,45 @@
 package dev.bdero.smoke_render
 
+import android.content.pm.PackageManager
+import android.os.Build
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "dev.bdero.smoke_render/android_manifest",
+        ).setMethodCallHandler { call, result ->
+            if (call.method != "getApplicationMetadataValue") {
+                result.notImplemented()
+                return@setMethodCallHandler
+            }
+
+            val name = call.arguments as? String
+            if (name == null) {
+                result.error("bad-argument", "Expected metadata key string.", null)
+                return@setMethodCallHandler
+            }
+
+            result.success(applicationMetadataValue(name))
+        }
+    }
+
+    private fun applicationMetadataValue(name: String): String? {
+        val applicationInfo =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                packageManager.getApplicationInfo(
+                    packageName,
+                    PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong()),
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            }
+        return applicationInfo.metaData?.get(name)?.toString()
+    }
+}

--- a/examples/smoke_render/integration_test/smoke_test.dart
+++ b/examples/smoke_render/integration_test/smoke_test.dart
@@ -1,17 +1,39 @@
 import 'dart:convert';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:smoke_render/smoke_scenes.dart';
 
+const _expectedAndroidImpellerBackend = String.fromEnvironment(
+  'SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND',
+);
+const _androidManifestChannel = MethodChannel(
+  'dev.bdero.smoke_render/android_manifest',
+);
+
 void main() {
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   final captures = <String, String>{};
+
+  if (_expectedAndroidImpellerBackend.isNotEmpty) {
+    testWidgets('Android requests the expected Impeller backend', (_) async {
+      expect(defaultTargetPlatform, TargetPlatform.android);
+      expect(kIsWeb, isFalse);
+
+      final backend = await _androidManifestChannel.invokeMethod<String>(
+        'getApplicationMetadataValue',
+        'io.flutter.embedding.android.ImpellerBackend',
+      );
+
+      expect(backend, _expectedAndroidImpellerBackend);
+    });
+  }
 
   for (final smoke in kSmokeScenes) {
     testWidgets('${smoke.id} renders a sane frame', (tester) async {


### PR DESCRIPTION
Adds an Android Vulkan smoke-render shard on Flutter master alongside the existing Android GLES shard. The smoke app now has `gles` and `vulkan` Android flavors, with the Impeller backend selected through the Android manifest metadata that Flutter reads on startup.

The Android smoke test also verifies the requested backend metadata at runtime through a small Android-only platform channel. The GLES and Vulkan workflow jobs pass matching dart-defines so CI fails if the wrong flavored APK is installed.

Validation run locally on the connected Pixel 10 Pro:
- `flutter analyze examples/smoke_render`
- `flutter drive --flavor vulkan --driver=test_driver/integration_test.dart --target=integration_test/smoke_test.dart -d 57211FDCH005Z2 --dart-define=SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND=vulkan --enable-impeller --enable-flutter-gpu`
- `flutter drive --flavor gles --driver=test_driver/integration_test.dart --target=integration_test/smoke_test.dart -d 57211FDCH005Z2 --dart-define=SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND=opengles --enable-impeller --enable-flutter-gpu`