### PR TITLE
Add screen-space ambient occlusion

### DIFF
--- a/.github/workflows/smoke_render_jobs.yml
+++ b/.github/workflows/smoke_render_jobs.yml
@@ -146,16 +146,32 @@ jobs:
             (adb shell getprop ro.opengles.version || true) &&
             adb shell svc power stayon true &&
             (adb shell wm dismiss-keyguard || true) &&
+            mkdir -p examples/smoke_render/build/android-diagnostics &&
+            (adb devices -l > examples/smoke_render/build/android-diagnostics/adb_devices_before_${{ matrix.backend }}.txt 2>&1 || true) &&
+            (adb shell getprop > examples/smoke_render/build/android-diagnostics/getprop_${{ matrix.backend }}.txt 2>&1 || true) &&
+            (adb shell dumpsys SurfaceFlinger > examples/smoke_render/build/android-diagnostics/surfaceflinger_${{ matrix.backend }}.txt 2>&1 || true) &&
             adb logcat -c &&
+            (adb logcat -v time > examples/smoke_render/build/android-diagnostics/logcat_${{ matrix.backend }}.txt 2>&1 & echo $! > /tmp/smoke-logcat.pid) &&
             cd examples/smoke_render &&
-            flutter drive
+            (flutter drive
             --flavor ${{ matrix.backend }}
             --driver=test_driver/integration_test.dart
             --target=integration_test/smoke_test.dart
             -d emulator-5554
             --dart-define=SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND=${{ matrix.expected_backend }}
             --enable-impeller
-            --enable-flutter-gpu
+            --enable-flutter-gpu;
+            status=$?;
+            (adb devices -l > build/android-diagnostics/adb_devices_after_${{ matrix.backend }}.txt 2>&1 || true);
+            kill "$(cat /tmp/smoke-logcat.pid)" || true;
+            exit "$status")
+      - name: Upload Android diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-diagnostics-${{ inputs.argos_prefix }}android_${{ matrix.backend }}
+          path: examples/smoke_render/build/android-diagnostics
+          if-no-files-found: ignore
       - name: Upload to Argos
         id: argos
         if: ${{ !cancelled() }}

--- a/examples/flutter_app/lib/example_logo.dart
+++ b/examples/flutter_app/lib/example_logo.dart
@@ -20,13 +20,8 @@ class ExampleLogoState extends State<ExampleLogo> {
 
   @override
   void initState() {
-    // A warm key light (with shadows) on top of the default IBL environment.
-    scene.directionalLight = DirectionalLight(
-      direction: vm.Vector3(0.4, -1.0, 0.3),
-      color: vm.Vector3(1.0, 0.97, 0.9),
-      intensity: 3.0,
-      castsShadow: true,
-    );
+    // The directional key light and shadows are driven by the shared settings
+    // panel via ExampleSettings.applyTo.
 
     // A simple ground plane to catch the logo's shadow.
     final ground = Node(

--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -97,14 +97,8 @@ class ExampleNavRouteState extends State<ExampleNavRoute> {
 
   @override
   void initState() {
-    // A directional "sun" that lights the scene and casts cascaded
-    // shadows. The shadow distance is kept tight to this scene so the
-    // near cascade stays high-resolution under the car.
-    scene.directionalLight = DirectionalLight(
-      direction: vm.Vector3(-0.45, -1.0, -0.35),
-      castsShadow: true,
-      shadowMaxDistance: 60.0,
-    );
+    // The directional "sun" and its cascaded shadows are driven by the shared
+    // settings panel via ExampleSettings.applyTo.
 
     // The ground. A lit material, so it receives the car's shadow.
     scene.add(

--- a/examples/flutter_app/lib/example_settings.dart
+++ b/examples/flutter_app/lib/example_settings.dart
@@ -1,5 +1,8 @@
+import 'dart:math' as math;
+
 import 'package:flutter_scene/gpu.dart' as gpu;
 import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
 
 /// Post-processing settings shared by every example.
 ///
@@ -22,6 +25,28 @@ class ExampleSettings {
 
   /// Bloom shared across the examples.
   final BloomSettings bloom = BloomSettings();
+
+  /// Screen-space ambient occlusion shared across the examples.
+  final AmbientOcclusionSettings ambientOcclusion = AmbientOcclusionSettings();
+
+  /// Whether the shared directional light is attached to the scene.
+  bool directionalLightEnabled = true;
+
+  /// Compass angle of the directional light, in degrees, around the up axis.
+  double lightAzimuthDegrees = 35.0;
+
+  /// Height of the directional light above the horizon, in degrees. `90`
+  /// points straight down.
+  double lightElevationDegrees = 55.0;
+
+  /// Directional light intensity.
+  double lightIntensity = 3.0;
+
+  /// Whether the directional light casts (cascaded) shadows.
+  bool lightCastsShadow = true;
+
+  /// World-space radius of the shadow penumbra. `0` is a hard edge.
+  double shadowSoftness = 0.08;
 
   /// A custom, user-authored effect, built by [loadExampleEffects]. Null
   /// until the example shader bundle finishes loading.
@@ -62,6 +87,36 @@ class ExampleSettings {
     sceneBloom.threshold = bloom.threshold;
     sceneBloom.intensity = bloom.intensity;
     sceneBloom.scatter = bloom.scatter;
+
+    final ao = scene.ambientOcclusion;
+    ao.enabled = ambientOcclusion.enabled;
+    ao.radius = ambientOcclusion.radius;
+    ao.intensity = ambientOcclusion.intensity;
+    ao.bias = ambientOcclusion.bias;
+    ao.sampleCount = ambientOcclusion.sampleCount;
+    ao.halfResolution = ambientOcclusion.halfResolution;
+    ao.specularMode = ambientOcclusion.specularMode;
+
+    if (directionalLightEnabled) {
+      // Derive the travel direction from azimuth/elevation: elevation lifts
+      // the light above the horizon (90 degrees points straight down).
+      final azimuth = lightAzimuthDegrees * math.pi / 180.0;
+      final elevation = lightElevationDegrees * math.pi / 180.0;
+      final horizontal = math.cos(elevation);
+      final direction = Vector3(
+        horizontal * math.cos(azimuth),
+        -math.sin(elevation),
+        horizontal * math.sin(azimuth),
+      );
+      final light = scene.directionalLight ?? DirectionalLight();
+      light.direction = direction;
+      light.intensity = lightIntensity;
+      light.castsShadow = lightCastsShadow;
+      light.shadowSoftness = shadowSoftness;
+      scene.directionalLight = light;
+    } else {
+      scene.directionalLight = null;
+    }
 
     final wave = waveEffect;
     if (wave != null) {

--- a/examples/flutter_app/lib/example_stress_tests.dart
+++ b/examples/flutter_app/lib/example_stress_tests.dart
@@ -493,8 +493,8 @@ class _StressSceneState extends State<_StressScene> {
   @override
   void initState() {
     super.initState();
-    // No analytic light: these scenes are lit purely by the image-based
-    // environment, so the environment menu is what's being evaluated.
+    // Lighting (the directional key light and shadows) is driven by the
+    // shared settings panel via ExampleSettings.applyTo.
     unawaited(_load());
   }
 

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -1,7 +1,8 @@
 import 'package:example_app/example_car.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter_scene/scene.dart' show Scene, PostInsertion;
+import 'package:flutter_scene/scene.dart'
+    show Scene, PostInsertion, SpecularAmbientOcclusionMode;
 import 'package:example_app/example_animation.dart';
 
 import 'example_cuboid.dart';
@@ -230,7 +231,11 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
                 child: SingleChildScrollView(
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
-                    children: [_buildPostProcessing()],
+                    children: [
+                      _buildDirectionalLight(),
+                      _buildAmbientOcclusion(),
+                      _buildPostProcessing(),
+                    ],
                   ),
                 ),
               ),
@@ -253,6 +258,88 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
         _buildVignette(),
         _buildFilmGrain(),
         _buildCustomEffect(),
+      ],
+    );
+  }
+
+  Widget _buildDirectionalLight() {
+    final settings = exampleSettings;
+    return ExpansionTile(
+      title: const Text('Directional light'),
+      initiallyExpanded: true,
+      childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      children: [
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Enabled'),
+          value: settings.directionalLightEnabled,
+          onChanged: (value) =>
+              setState(() => settings.directionalLightEnabled = value),
+        ),
+        _slider('Azimuth', settings.lightAzimuthDegrees, 0, 360, (v) {
+          settings.lightAzimuthDegrees = v;
+        }),
+        _slider('Elevation', settings.lightElevationDegrees, 0, 90, (v) {
+          settings.lightElevationDegrees = v;
+        }),
+        _slider('Intensity', settings.lightIntensity, 0, 10, (v) {
+          settings.lightIntensity = v;
+        }),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Casts shadow'),
+          value: settings.lightCastsShadow,
+          onChanged: (value) =>
+              setState(() => settings.lightCastsShadow = value),
+        ),
+        _slider('Softness', settings.shadowSoftness, 0, 0.3, (v) {
+          settings.shadowSoftness = v;
+        }),
+      ],
+    );
+  }
+
+  Widget _buildAmbientOcclusion() {
+    final settings = exampleSettings.ambientOcclusion;
+    return ExpansionTile(
+      title: const Text('Ambient occlusion'),
+      initiallyExpanded: true,
+      childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      children: [
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Enabled'),
+          value: settings.enabled,
+          onChanged: (value) => setState(() => settings.enabled = value),
+        ),
+        _slider('Radius', settings.radius, 0.05, 2, (v) {
+          settings.radius = v;
+        }),
+        _slider('Intensity', settings.intensity, 0, 3, (v) {
+          settings.intensity = v;
+        }),
+        _slider('Bias', settings.bias, 0, 0.1, (v) {
+          settings.bias = v;
+        }),
+        _slider('Samples', settings.sampleCount.toDouble(), 4, 32, (v) {
+          settings.sampleCount = v.round();
+        }),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Half resolution'),
+          value: settings.halfResolution,
+          onChanged: (value) => setState(() => settings.halfResolution = value),
+        ),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Specular occlusion'),
+          value: settings.specularMode == SpecularAmbientOcclusionMode.simple,
+          onChanged: (value) => setState(() {
+            settings.specularMode = value
+                ? SpecularAmbientOcclusionMode.simple
+                : SpecularAmbientOcclusionMode.none;
+          }),
+        ),
       ],
     );
   }

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+* Added optional screen-space ambient occlusion, configured per scene via
+  `Scene.ambientOcclusion` (off by default). It darkens the indirect
+  (image-based) lighting in creases and contact points for softer, more
+  grounded shading. The implementation is Scalable Ambient Obscurance,
+  evaluated from a camera depth prepass with no normal buffer and no compute,
+  so it works on every backend including the WebGL2 fallback. Settings cover
+  the radius, intensity, bias, sample count, an optional half-resolution mode
+  (on by default) for lower cost, and an optional specular occlusion term.
+  Requires a `PerspectiveCamera`.
+
 ## 0.15.1
 
 * Added a DataAssets-backed `.fmat` material workflow. `buildMaterials` can now

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -42,6 +42,7 @@ export 'src/material/unlit_material.dart';
 export 'src/fmat/material_registry.dart'
     show FmatMaterialRegistry, loadFmatMaterial;
 
+export 'src/ambient_occlusion.dart';
 export 'src/asset_helpers.dart';
 export 'src/camera.dart';
 export 'src/components/component.dart';

--- a/packages/flutter_scene/lib/src/ambient_occlusion.dart
+++ b/packages/flutter_scene/lib/src/ambient_occlusion.dart
@@ -1,0 +1,70 @@
+/// Screen-space ambient occlusion settings for a [Scene].
+///
+/// Reachable through `Scene.ambientOcclusion`. Ambient occlusion darkens
+/// the indirect (image-based) lighting in creases, cavities, and contact
+/// points that the smooth environment term would otherwise leave evenly
+/// lit. The result reads as soft contact shadowing on edges and concave
+/// geometry.
+///
+/// Disabled by default: a fresh scene does no ambient-occlusion work and
+/// adds no render passes. Set [enabled] to turn it on.
+///
+/// The technique is Scalable Ambient Obscurance (McGuire, Mara, and
+/// Luebke 2012,
+/// https://research.nvidia.com/publication/scalable-ambient-obscurance),
+/// evaluated from a camera depth prepass. It takes only a depth buffer
+/// (the per-pixel normal is reconstructed from depth), so it fits a
+/// forward renderer with no normal buffer, and runs as full-screen
+/// fragment passes with no compute.
+class AmbientOcclusionSettings {
+  /// Whether ambient occlusion runs. Off by default. When false the scene
+  /// adds no ambient-occlusion passes and the lighting is unaffected.
+  bool enabled = false;
+
+  /// World-space radius the occlusion is gathered over. Larger values
+  /// darken broader cavities; smaller values keep occlusion to tight
+  /// contact creases.
+  double radius = 0.33;
+
+  /// Strength of the darkening, applied as a power on the occlusion
+  /// factor. `1.0` is the raw estimate; higher values deepen the
+  /// occlusion and `0.0` removes it.
+  double intensity = 1.22;
+
+  /// Distance, in world units, a sampled surface must sit in front of the
+  /// shaded point before it counts as an occluder. Lifts the estimate off
+  /// the surface so a flat plane does not occlude itself.
+  double bias = 0.07;
+
+  /// Number of samples taken per pixel. More samples cut noise at a
+  /// roughly linear cost. Reasonable values are about 8 to 32.
+  int sampleCount = 16;
+
+  /// Evaluates the occlusion buffer at half resolution and bilaterally
+  /// upsamples it, cutting the occlusion pixel work to a quarter at the
+  /// cost of fine detail. Recommended on mobile.
+  bool halfResolution = true;
+
+  /// How indirect specular reflections are occluded. See
+  /// [SpecularAmbientOcclusionMode].
+  SpecularAmbientOcclusionMode specularMode = SpecularAmbientOcclusionMode.none;
+}
+
+/// How [AmbientOcclusionSettings] occludes indirect specular reflections.
+///
+/// Ambient occlusion is fundamentally a diffuse-visibility estimate, so
+/// occluding the specular lobe with the same factor over-darkens glossy
+/// reflections. These modes select how (or whether) the specular lobe is
+/// occluded.
+enum SpecularAmbientOcclusionMode {
+  /// Indirect specular is not occluded by ambient occlusion. Cheapest and
+  /// the default.
+  none,
+
+  /// Indirect specular is occluded by an empirical estimate derived from
+  /// the diffuse occlusion, the view angle, and roughness (Lagarde and de
+  /// Rousiers 2014, "Physically Based Rendering" course notes,
+  /// section 4.10.2). Cheap; tightens reflections in cavities on smoother
+  /// surfaces while leaving rough surfaces unchanged.
+  simple,
+}

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'dart:ui' as ui;
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
@@ -294,6 +295,9 @@ class Lighting {
     this.directionalLight,
     this.shadowMap,
     this.cascades = const [],
+    this.ssaoMap,
+    this.specularOcclusionMode = 0.0,
+    this.viewportSize = ui.Size.zero,
   }) : environmentTransform = environmentTransform ?? Matrix3.identity();
 
   /// The image-based-lighting environment in effect for this draw.
@@ -318,4 +322,18 @@ class Lighting {
   /// The shadow cascades matching [shadowMap], near-to-far, or empty
   /// when there is no shadow map this frame.
   final List<ShadowCascade> cascades;
+
+  /// The screen-space ambient-occlusion texture for this frame (occlusion
+  /// factor in `.r`), or null when occlusion is off. When set, it modulates
+  /// indirect lighting in the shader.
+  final gpu.Texture? ssaoMap;
+
+  /// How indirect specular is occluded: `0` leaves it on the diffuse
+  /// occlusion factor, `1` derives a dedicated specular occlusion. Mirrors
+  /// `SpecularAmbientOcclusionMode.index`.
+  final double specularOcclusionMode;
+
+  /// The color-pass render-target size, used to map `gl_FragCoord` into the
+  /// occlusion texture's UV. Zero when occlusion is off.
+  final ui.Size viewportSize;
 }

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -16,11 +16,11 @@ import 'package:flutter_scene/src/material/material.dart';
 /// [PhysicallyBasedMaterial] and `PreprocessedMaterial` use it so the lighting
 /// packing lives in one place.
 class EngineLightingUniforms {
-  /// The float count of the full `FragInfo` block (624 bytes / 156 floats:
-  /// the trailing mat4 `environment_transform` ends at float 155, with three
-  /// floats of std140 padding before it). See the layout map in the
+  /// The float count of the full `FragInfo` block (640 bytes / 160 floats:
+  /// the mat4 `environment_transform` ends at float 155, followed by the
+  /// `ssao_params` vec4 at floats 156..159). See the layout map in the
   /// implementation.
-  static const fragInfoFloatCount = 156;
+  static const fragInfoFloatCount = 160;
 
   /// Writes the engine lighting / IBL / shadow fields of `FragInfo` into
   /// [fragInfo] from [lighting] and [env]. Leaves the material-specific fields
@@ -78,6 +78,14 @@ class EngineLightingUniforms {
       fragInfo[142 + col * 4] = envTransform[col * 3 + 2];
     }
     fragInfo[155] = 1.0; // mat4 column 3 = (0, 0, 0, 1)
+    // ssao_params at [156..159]: occlusion enabled, specular occlusion
+    // enabled, and the reciprocal render-target size (for the gl_FragCoord
+    // to occlusion-UV mapping).
+    fragInfo[156] = lighting.ssaoMap != null ? 1.0 : 0.0;
+    fragInfo[157] = lighting.specularOcclusionMode;
+    final viewport = lighting.viewportSize;
+    fragInfo[158] = viewport.width > 0 ? 1.0 / viewport.width : 0.0;
+    fragInfo[159] = viewport.height > 0 ? 1.0 / viewport.height : 0.0;
   }
 
   /// Binds the engine image-based-lighting and shadow samplers
@@ -120,6 +128,20 @@ class EngineLightingUniforms {
       sampler: gpu.SamplerOptions(
         minFilter: gpu.MinMagFilter.nearest,
         magFilter: gpu.MinMagFilter.nearest,
+      ),
+    );
+    // Screen-space ambient occlusion. Bilinear so a half-resolution
+    // occlusion buffer upsamples smoothly; a white placeholder makes the
+    // sample a no-op when occlusion is off. The shader gates it on
+    // ssao_params.x regardless.
+    pass.bindTexture(
+      shader.getUniformSlot('ssao_texture'),
+      Material.whitePlaceholder(lighting.ssaoMap),
+      sampler: gpu.SamplerOptions(
+        minFilter: gpu.MinMagFilter.linear,
+        magFilter: gpu.MinMagFilter.linear,
+        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
       ),
     );
   }

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -1,0 +1,227 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/render/render_graph.dart';
+import 'package:flutter_scene/src/render/render_scene.dart';
+import 'package:flutter_scene/src/shaders.dart';
+
+/// Render-graph blackboard key under which [DepthPrepass] publishes the
+/// camera linear-depth texture: planar view-space depth (world units) in
+/// the red channel, with the far value where no geometry was drawn.
+const String kLinearDepthBlackboardKey = 'linear_depth';
+
+/// Process-lifetime cache of depth-prepass render pipelines, keyed by
+/// vertex shader. The fragment shader is constant, so only the (skinned /
+/// unskinned) vertex shader varies; the engine loads each shader once, so
+/// the prepass only ever needs two pipelines. Caching them avoids
+/// rebuilding a pipeline per draw, every frame.
+final Map<gpu.Shader, gpu.RenderPipeline> _depthPipelineCache = {};
+
+/// Renders the opaque scene's depth from the camera into a linear-depth
+/// color target and publishes it on the render-graph blackboard.
+///
+/// Screen-space effects (ambient occlusion today, and depth-aware effects
+/// later) read this to reconstruct view-space positions. The prepass also
+/// primes early-Z for the following color pass.
+///
+/// Planar view-space depth is written into the red channel of a
+/// floating-point color target (rather than relying on a shader-readable
+/// depth-stencil texture), mirroring how the shadow pass stores depth in a
+/// color attachment. That keeps the texture sampleable identically on
+/// every backend.
+class DepthPrepass extends RenderGraphPass {
+  DepthPrepass({
+    required Camera camera,
+    required RenderScene renderScene,
+    required ui.Size dimensions,
+    required Vector3 cameraForward,
+    required double farDepth,
+  }) : _camera = camera,
+       _renderScene = renderScene,
+       _dimensions = dimensions,
+       _cameraForward = cameraForward,
+       _farDepth = farDepth;
+
+  final Camera _camera;
+  final RenderScene _renderScene;
+  final ui.Size _dimensions;
+  final Vector3 _cameraForward;
+  final double _farDepth;
+
+  @override
+  String get name => 'DepthPrepass';
+
+  @override
+  void execute(RenderGraphContext context) {
+    final width = _dimensions.width.toInt();
+    final height = _dimensions.height.toInt();
+
+    // fp32 (not fp16): the occlusion pass reconstructs view-space positions
+    // and normals from this depth, and fp16's ~11-bit mantissa quantizes it
+    // into visibly banded steps (the same reason the shadow map is fp32).
+    // Only the red channel is used.
+    // TODO(flutter_scene): use a single-channel r32Float once Flutter GPU
+    // exposes it, to drop the three unused channels' bandwidth.
+    final linearDepth = context.texturePool.acquire(
+      TransientTextureDescriptor.color(
+        width: width,
+        height: height,
+        format: gpu.PixelFormat.r32g32b32a32Float,
+        debugName: 'linear_depth',
+      ),
+    );
+    final depth = context.texturePool.acquire(
+      TransientTextureDescriptor.depth(
+        width: width,
+        height: height,
+        format: gpu.gpuContext.defaultDepthStencilFormat,
+        debugName: 'depth_prepass_depth',
+      ),
+    );
+    final target = gpu.RenderTarget.singleColor(
+      gpu.ColorAttachment(
+        texture: linearDepth,
+        // Background texels (no geometry) read as the far plane, i.e. fully
+        // unoccluded for any consumer.
+        clearValue: Vector4(_farDepth, 0.0, 0.0, 1.0),
+      ),
+      depthStencilAttachment: gpu.DepthStencilAttachment(
+        texture: depth,
+        depthClearValue: 1.0,
+      ),
+    );
+
+    final commandBuffer = gpu.gpuContext.createCommandBuffer();
+    final renderPass = commandBuffer.createRenderPass(target);
+    final encoder = _DepthPrepassEncoder(
+      renderPass,
+      context.transientsBuffer,
+      _camera.getViewTransform(_dimensions),
+      _camera.position,
+      _cameraForward,
+    );
+    _renderScene.cull(encoder.frustum, encoder.submit);
+    commandBuffer.submit();
+
+    context.blackboard.set(kLinearDepthBlackboardKey, linearDepth);
+  }
+}
+
+/// Records each opaque object's planar view-space depth into the prepass
+/// render pass, from the camera's point of view.
+///
+/// Mirrors `ShadowEncoder`: it reuses the engine's standard vertex shaders
+/// (so unskinned and skinned geometry are both covered) paired with the
+/// `LinearDepthFragment` shader, and supplies the camera view-projection in
+/// place of the light-space matrix. Translucent objects do not write depth.
+class _DepthPrepassEncoder {
+  _DepthPrepassEncoder(
+    this._renderPass,
+    this._transientsBuffer,
+    this._cameraTransform,
+    this._cameraPosition,
+    Vector3 cameraForward,
+  ) {
+    frustum = Frustum.matrix(_cameraTransform);
+    _renderPass.setDepthWriteEnable(true);
+    _renderPass.setColorBlendEnable(false);
+    _renderPass.setDepthCompareOperation(gpu.CompareFunction.lessEqual);
+    // Match the standard materials' winding / culling so the same faces
+    // that are visible contribute depth.
+    _renderPass.setCullMode(gpu.CullMode.backFace);
+    _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
+    // The camera forward axis is constant across the pass. Pack it once and
+    // rebind it per draw (clearBindings drops it between draws).
+    _depthInfo = Float32List(4)
+      ..[0] = cameraForward.x
+      ..[1] = cameraForward.y
+      ..[2] = cameraForward.z;
+  }
+
+  final gpu.RenderPass _renderPass;
+  final gpu.HostBuffer _transientsBuffer;
+  final Matrix4 _cameraTransform;
+  final Vector3 _cameraPosition;
+  late final Float32List _depthInfo;
+
+  static final gpu.Shader _depthShader =
+      baseShaderLibrary['LinearDepthFragment']!;
+
+  /// Frustum of the camera view-projection, used for per-item culling.
+  late final Frustum frustum;
+
+  /// Reusable AABB for the per-item cull check.
+  final Aabb3 cullScratchAabb = Aabb3();
+
+  /// The pipeline currently bound on the render pass, or null before the
+  /// first draw. `clearBindings` leaves the pipeline in place, so
+  /// consecutive objects that share one only bind it once.
+  gpu.RenderPipeline? _boundPipeline;
+
+  /// Records [item]'s depth, unless it is hidden, translucent (no depth
+  /// contribution), or culled by the camera frustum.
+  void submit(RenderItem item) {
+    if (!item.visible) return;
+    if (!item.material.isOpaque()) return;
+    if (item.frustumCulled) {
+      final bounds = item.cullBounds;
+      if (bounds != null) {
+        cullScratchAabb
+          ..copyFrom(bounds)
+          ..transform(item.worldTransform);
+        if (!frustum.intersectsWithAabb3(cullScratchAabb)) return;
+      }
+    }
+    _renderPass.clearBindings();
+    final pipeline = _depthPipelineCache[item.geometry.vertexShader] ??= gpu
+        .gpuContext
+        .createRenderPipeline(item.geometry.vertexShader, _depthShader);
+    if (!identical(_boundPipeline, pipeline)) {
+      _renderPass.bindPipeline(pipeline);
+      _boundPipeline = pipeline;
+    }
+    _renderPass.setPrimitiveType(item.geometry.primitiveType);
+    _renderPass.bindUniform(
+      _depthShader.getUniformSlot('DepthInfo'),
+      _transientsBuffer.emplace(ByteData.sublistView(_depthInfo)),
+    );
+
+    final instances = item.instanceTransforms;
+    if (instances != null) {
+      for (final instanceTransform in instances) {
+        item.geometry.bind(
+          _renderPass,
+          _transientsBuffer,
+          item.worldTransform * instanceTransform,
+          _cameraTransform,
+          _cameraPosition,
+        );
+        final flip =
+            item.windingFlipped != (instanceTransform.determinant() < 0);
+        _renderPass.setWindingOrder(
+          flip ? gpu.WindingOrder.clockwise : gpu.WindingOrder.counterClockwise,
+        );
+        item.geometry.draw(_renderPass);
+      }
+      return;
+    }
+
+    item.geometry.bind(
+      _renderPass,
+      _transientsBuffer,
+      item.worldTransform,
+      _cameraTransform,
+      _cameraPosition,
+    );
+    _renderPass.setWindingOrder(
+      item.windingFlipped
+          ? gpu.WindingOrder.clockwise
+          : gpu.WindingOrder.counterClockwise,
+    );
+    item.geometry.draw(_renderPass);
+  }
+}

--- a/packages/flutter_scene/lib/src/render/scene_pass.dart
+++ b/packages/flutter_scene/lib/src/render/scene_pass.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/render/shadow_pass.dart';
+import 'package:flutter_scene/src/render/ssao_pass.dart';
 import 'package:flutter_scene/src/scene_encoder.dart';
 
 /// Render-graph blackboard key for the current scene-color texture.
@@ -34,6 +35,7 @@ class ScenePass extends RenderGraphPass {
     required bool enableMsaa,
     DirectionalLight? directionalLight,
     List<ShadowCascade> cascades = const [],
+    double specularOcclusionMode = 0.0,
   }) : _camera = camera,
        _renderScene = renderScene,
        _dimensions = dimensions,
@@ -42,7 +44,8 @@ class ScenePass extends RenderGraphPass {
        _environmentTransform = environmentTransform,
        _enableMsaa = enableMsaa,
        _directionalLight = directionalLight,
-       _cascades = cascades;
+       _cascades = cascades,
+       _specularOcclusionMode = specularOcclusionMode;
 
   final Camera _camera;
   final RenderScene _renderScene;
@@ -53,6 +56,7 @@ class ScenePass extends RenderGraphPass {
   final bool _enableMsaa;
   final DirectionalLight? _directionalLight;
   final List<ShadowCascade> _cascades;
+  final double _specularOcclusionMode;
 
   static const gpu.PixelFormat _hdrFormat = gpu.PixelFormat.r16g16b16a16Float;
 
@@ -109,6 +113,9 @@ class ScenePass extends RenderGraphPass {
     final shadowMap = context.blackboard.get<gpu.Texture>(
       kShadowMapBlackboardKey,
     );
+    final ssaoMap = context.blackboard.get<gpu.Texture>(
+      kSsaoTextureBlackboardKey,
+    );
     final lighting = Lighting(
       environmentMap: _environmentMap,
       environmentIntensity: _environmentIntensity,
@@ -116,6 +123,9 @@ class ScenePass extends RenderGraphPass {
       directionalLight: _directionalLight,
       shadowMap: shadowMap,
       cascades: shadowMap == null ? const [] : _cascades,
+      ssaoMap: ssaoMap,
+      specularOcclusionMode: ssaoMap == null ? 0.0 : _specularOcclusionMode,
+      viewportSize: _dimensions,
     );
 
     final commandBuffer = gpu.gpuContext.createCommandBuffer();

--- a/packages/flutter_scene/lib/src/render/ssao_pass.dart
+++ b/packages/flutter_scene/lib/src/render/ssao_pass.dart
@@ -1,0 +1,258 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
+
+import 'package:flutter_scene/src/ambient_occlusion.dart';
+import 'package:flutter_scene/src/render/depth_prepass.dart';
+import 'package:flutter_scene/src/render/render_graph.dart';
+import 'package:flutter_scene/src/shaders.dart';
+
+/// Render-graph blackboard key under which [SsaoBlurPass] publishes the
+/// final ambient-occlusion texture (occlusion factor in `.r`, 1 =
+/// unoccluded). The scene pass reads it to modulate indirect lighting.
+const String kSsaoTextureBlackboardKey = 'ssao_texture';
+
+// Intermediate key: the raw (unblurred) occlusion [SsaoPass] hands to
+// [SsaoBlurPass].
+const String _kSsaoRawBlackboardKey = 'ssao_raw';
+
+// Single-channel, filterable, and color-renderable on every backend, which
+// is all the occlusion factor needs.
+const gpu.PixelFormat _aoFormat = gpu.PixelFormat.r8UNormInt;
+
+/// The render size of the ambient-occlusion chain for a full-resolution
+/// target of [dimensions], halved (floored, minimum 1) when
+/// [AmbientOcclusionSettings.halfResolution] is set.
+///
+/// The depth prepass, occlusion pass, and blur all run at this resolution so
+/// the depth texture is sampled 1:1 (sampling a full-resolution depth from a
+/// half-resolution pass would alias on detailed geometry).
+ui.Size ambientOcclusionTargetSize(
+  ui.Size dimensions,
+  AmbientOcclusionSettings settings,
+) {
+  if (!settings.halfResolution) {
+    return dimensions;
+  }
+  return ui.Size(
+    math.max(1, (dimensions.width / 2).floor()).toDouble(),
+    math.max(1, (dimensions.height / 2).floor()).toDouble(),
+  );
+}
+
+// Two triangles of NDC positions covering the screen (6 vec2s), shared by
+// the occlusion passes.
+gpu.BufferView _fullscreenQuad() {
+  return _quadView ??= () {
+    final buffer = gpu.gpuContext.createDeviceBufferWithCopy(
+      ByteData.sublistView(
+        Float32List.fromList(<double>[
+          -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, //
+          -1.0, 1.0, 1.0, -1.0, 1.0, 1.0, //
+        ]),
+      ),
+    );
+    return gpu.BufferView(buffer, offsetInBytes: 0, lengthInBytes: 6 * 2 * 4);
+  }();
+}
+
+gpu.BufferView? _quadView;
+
+final gpu.SamplerOptions _linearClamp = gpu.SamplerOptions(
+  minFilter: gpu.MinMagFilter.linear,
+  magFilter: gpu.MinMagFilter.linear,
+  widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+);
+
+// Linear depth is fp32. GLES / WebGL2 devices may not filter float textures
+// (no OES_texture_float_linear), and depth must not be interpolated across
+// edges anyway, so it is always sampled with nearest filtering.
+final gpu.SamplerOptions _nearestClamp = gpu.SamplerOptions(
+  minFilter: gpu.MinMagFilter.nearest,
+  magFilter: gpu.MinMagFilter.nearest,
+  widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+);
+
+/// Evaluates Scalable Ambient Obscurance over the camera linear-depth
+/// target and publishes the raw (unblurred) occlusion for [SsaoBlurPass].
+///
+/// A single full-screen fragment pass, no compute. See
+/// `flutter_scene_ssao.frag` for the algorithm.
+class SsaoPass extends RenderGraphPass {
+  SsaoPass({
+    required ui.Size dimensions,
+    required AmbientOcclusionSettings settings,
+    required double fovRadiansY,
+    required double near,
+    required double far,
+  }) : _dimensions = dimensions,
+       _settings = settings,
+       _fovRadiansY = fovRadiansY,
+       _near = near,
+       _far = far;
+
+  final ui.Size _dimensions;
+  final AmbientOcclusionSettings _settings;
+  final double _fovRadiansY;
+  final double _near;
+  final double _far;
+
+  static final gpu.Shader _vertexShader =
+      baseShaderLibrary['FullscreenVertex']!;
+  static final gpu.Shader _fragmentShader = baseShaderLibrary['SsaoFragment']!;
+
+  @override
+  String get name => 'SsaoPass';
+
+  @override
+  void execute(RenderGraphContext context) {
+    final linearDepth = context.blackboard.require<gpu.Texture>(
+      kLinearDepthBlackboardKey,
+    );
+
+    final aoSize = ambientOcclusionTargetSize(_dimensions, _settings);
+    final aoWidth = aoSize.width.toInt();
+    final aoHeight = aoSize.height.toInt();
+    final occlusion = context.texturePool.acquire(
+      TransientTextureDescriptor.color(
+        width: aoWidth,
+        height: aoHeight,
+        format: _aoFormat,
+        debugName: 'ssao_raw',
+      ),
+    );
+
+    final commandBuffer = gpu.gpuContext.createCommandBuffer();
+    final renderPass = commandBuffer.createRenderPass(
+      gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: occlusion)),
+    );
+    renderPass.bindPipeline(
+      gpu.gpuContext.createRenderPipeline(_vertexShader, _fragmentShader),
+    );
+    renderPass.setColorBlendEnable(false);
+    bindVertexBufferCompat(renderPass, _fullscreenQuad(), 6);
+
+    final tanHalfFovY = math.tan(_fovRadiansY * 0.5);
+    final aspect = _dimensions.width / _dimensions.height;
+    final tanHalfFovX = tanHalfFovY * aspect;
+    // Pixels per world unit at depth 1, used to project the world radius to a
+    // screen-space disk. Based on the occlusion target's own height.
+    final projScale = aoHeight / (2.0 * tanHalfFovY);
+
+    final info = Float32List(16)
+      ..[0] = aoWidth.toDouble()
+      ..[1] = aoHeight.toDouble()
+      ..[2] = 1.0 / aoWidth
+      ..[3] = 1.0 / aoHeight
+      ..[4] = tanHalfFovX
+      ..[5] = tanHalfFovY
+      ..[6] = _near
+      ..[7] = _far
+      ..[8] = _settings.radius
+      ..[9] = _settings.bias
+      ..[10] = _settings.intensity
+      ..[11] = projScale
+      ..[12] = _settings.sampleCount.toDouble();
+    renderPass.bindUniform(
+      _fragmentShader.getUniformSlot('SsaoInfo'),
+      context.transientsBuffer.emplace(ByteData.sublistView(info)),
+    );
+    renderPass.bindTexture(
+      _fragmentShader.getUniformSlot('linear_depth'),
+      linearDepth,
+      sampler: _nearestClamp,
+    );
+    drawCompat(renderPass, 6);
+    commandBuffer.submit();
+
+    context.blackboard.set(_kSsaoRawBlackboardKey, occlusion);
+  }
+}
+
+/// Denoises the raw occlusion with a 2D depth-aware (bilateral) blur and
+/// publishes the result under [kSsaoTextureBlackboardKey].
+///
+/// See `flutter_scene_ssao_blur.frag`.
+class SsaoBlurPass extends RenderGraphPass {
+  SsaoBlurPass({
+    required ui.Size dimensions,
+    required AmbientOcclusionSettings settings,
+  }) : _dimensions = dimensions,
+       _settings = settings;
+
+  final ui.Size _dimensions;
+  final AmbientOcclusionSettings _settings;
+
+  static final gpu.Shader _vertexShader =
+      baseShaderLibrary['FullscreenVertex']!;
+  static final gpu.Shader _fragmentShader =
+      baseShaderLibrary['SsaoBlurFragment']!;
+
+  @override
+  String get name => 'SsaoBlurPass';
+
+  @override
+  void execute(RenderGraphContext context) {
+    final raw = context.blackboard.require<gpu.Texture>(_kSsaoRawBlackboardKey);
+    final linearDepth = context.blackboard.require<gpu.Texture>(
+      kLinearDepthBlackboardKey,
+    );
+
+    final aoSize = ambientOcclusionTargetSize(_dimensions, _settings);
+    final aoWidth = aoSize.width.toInt();
+    final aoHeight = aoSize.height.toInt();
+
+    // The bilateral depth weight falls off over roughly the occlusion radius,
+    // so neighbours on the same (even steeply slanted) surface still average
+    // while a real depth step at a silhouette, far larger than the radius,
+    // cuts the blur.
+    final depthScale = math.max(_settings.radius, 1e-3);
+
+    final blurred = context.texturePool.acquire(
+      TransientTextureDescriptor.color(
+        width: aoWidth,
+        height: aoHeight,
+        format: _aoFormat,
+        debugName: 'ssao_blurred',
+      ),
+    );
+
+    final commandBuffer = gpu.gpuContext.createCommandBuffer();
+    final renderPass = commandBuffer.createRenderPass(
+      gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: blurred)),
+    );
+    renderPass.bindPipeline(
+      gpu.gpuContext.createRenderPipeline(_vertexShader, _fragmentShader),
+    );
+    renderPass.setColorBlendEnable(false);
+    bindVertexBufferCompat(renderPass, _fullscreenQuad(), 6);
+
+    final info = Float32List(4)
+      ..[0] = 1.0 / aoWidth
+      ..[1] = 1.0 / aoHeight
+      ..[2] = depthScale;
+    renderPass.bindUniform(
+      _fragmentShader.getUniformSlot('BlurInfo'),
+      context.transientsBuffer.emplace(ByteData.sublistView(info)),
+    );
+    renderPass.bindTexture(
+      _fragmentShader.getUniformSlot('ao_texture'),
+      raw,
+      sampler: _linearClamp,
+    );
+    renderPass.bindTexture(
+      _fragmentShader.getUniformSlot('linear_depth'),
+      linearDepth,
+      sampler: _nearestClamp,
+    );
+    drawCompat(renderPass, 6);
+    commandBuffer.submit();
+
+    context.blackboard.set(kSsaoTextureBlackboardKey, blurred);
+  }
+}

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart' show Matrix3;
+import 'ambient_occlusion.dart';
 import 'camera.dart';
 import 'light.dart';
 import 'material/environment.dart';
@@ -14,11 +15,13 @@ import 'node.dart';
 import 'post_process/post_effect.dart';
 import 'post_process/post_process.dart';
 import 'render/bloom_pass.dart';
+import 'render/depth_prepass.dart';
 import 'render/post_effect_pass.dart';
 import 'render/render_graph.dart';
 import 'render/render_scene.dart';
 import 'render/scene_pass.dart';
 import 'render/shadow_pass.dart';
+import 'render/ssao_pass.dart';
 import 'render/resolve_pass.dart';
 import 'shaders.dart';
 import 'surface.dart';
@@ -211,6 +214,12 @@ base class Scene implements SceneGraph {
   /// effect is off by default.
   final PostProcessSettings postProcess = PostProcessSettings();
 
+  /// Screen-space ambient occlusion settings. Off by default; set
+  /// [AmbientOcclusionSettings.enabled] to turn it on. Requires a
+  /// [PerspectiveCamera] (the occlusion is reconstructed from the camera's
+  /// perspective depth); it is skipped for other camera types.
+  final AmbientOcclusionSettings ambientOcclusion = AmbientOcclusionSettings();
+
   @override
   void add(Node child) {
     root.add(child);
@@ -359,6 +368,38 @@ base class Scene implements SceneGraph {
         ),
       );
     }
+    // Ambient occlusion is reconstructed from a camera depth prepass, so it
+    // needs a perspective camera (other camera types render without it).
+    if (ambientOcclusion.enabled && camera is PerspectiveCamera) {
+      // The whole occlusion chain (depth prepass, occlusion, blur) runs at one
+      // resolution so depth is sampled 1:1; sampling a full-resolution depth
+      // from the half-resolution occlusion pass would alias on fine geometry.
+      final aoDimensions = ambientOcclusionTargetSize(
+        pixelSize,
+        ambientOcclusion,
+      );
+      graph.addPass(
+        DepthPrepass(
+          camera: camera,
+          renderScene: renderScene,
+          dimensions: aoDimensions,
+          cameraForward: (camera.target - camera.position).normalized(),
+          farDepth: camera.fovFar,
+        ),
+      );
+      graph.addPass(
+        SsaoPass(
+          dimensions: pixelSize,
+          settings: ambientOcclusion,
+          fovRadiansY: camera.fovRadiansY,
+          near: camera.fovNear,
+          far: camera.fovFar,
+        ),
+      );
+      graph.addPass(
+        SsaoBlurPass(dimensions: pixelSize, settings: ambientOcclusion),
+      );
+    }
     graph.addPass(
       ScenePass(
         camera: camera,
@@ -370,6 +411,7 @@ base class Scene implements SceneGraph {
         enableMsaa: enableMsaa,
         directionalLight: light,
         cascades: cascades,
+        specularOcclusionMode: ambientOcclusion.specularMode.index.toDouble(),
       ),
     );
     // Split custom effects by where they run in the chain.

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -19,6 +19,18 @@
         "type": "fragment",
         "file": "shaders/flutter_scene_depth_only.frag"
     },
+    "LinearDepthFragment": {
+        "type": "fragment",
+        "file": "shaders/flutter_scene_linear_depth.frag"
+    },
+    "SsaoFragment": {
+        "type": "fragment",
+        "file": "shaders/flutter_scene_ssao.frag"
+    },
+    "SsaoBlurFragment": {
+        "type": "fragment",
+        "file": "shaders/flutter_scene_ssao_blur.frag"
+    },
     "FullscreenVertex": {
         "type": "vertex",
         "file": "shaders/flutter_scene_fullscreen.vert"

--- a/packages/flutter_scene/shaders/flutter_scene_linear_depth.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_linear_depth.frag
@@ -1,0 +1,30 @@
+// Fragment shader for the camera depth prepass.
+//
+// Pairs with the engine's standard vertex shaders (UnskinnedVertex /
+// SkinnedVertex), driven with the camera view-projection. Writes planar
+// view-space depth (the distance from the camera plane along the view
+// direction, in world units) into the red channel of a floating-point
+// color target, so screen-space passes such as ambient occlusion can
+// reconstruct view-space positions from it. A transient depth attachment
+// backs the depth test; the other standard vertex outputs are unused.
+//
+// View-space depth is computed from the world-space view vector rather
+// than by linearizing gl_FragCoord.z, so it does not depend on the
+// backend's clip-space depth-range convention.
+
+#include <material_varyings.glsl>
+
+uniform DepthInfo {
+  // xyz: normalized world-space camera forward (from the eye into the
+  // scene). w: unused.
+  vec4 camera_forward;
+}
+depth_info;
+
+void main() {
+  // v_viewvector is (camera_position - world_position), so negating it and
+  // projecting onto the forward axis gives the planar view-space depth
+  // (positive in front of the camera).
+  float view_depth = -dot(v_viewvector, depth_info.camera_forward.xyz);
+  frag_color = vec4(view_depth, 0.0, 0.0, 1.0);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_ssao.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssao.frag
@@ -1,0 +1,145 @@
+// Screen-space ambient occlusion, evaluated from the camera linear-depth
+// prepass.
+//
+// Implements Scalable Ambient Obscurance (McGuire, Mara, and Luebke 2012,
+// https://research.nvidia.com/publication/scalable-ambient-obscurance): it
+// reconstructs each pixel's view-space position and a face normal from
+// depth alone (no normal buffer), then estimates obscurance from a spiral
+// of neighbour samples. The output is a single occlusion factor in the red
+// channel: 1 is unoccluded, 0 is fully occluded. A bilateral blur pass
+// cleans up the per-pixel noise afterwards.
+
+uniform sampler2D linear_depth;
+
+uniform SsaoInfo {
+  // x, y: occlusion target size in pixels. z, w: its reciprocal.
+  vec4 viewport;
+  // x: tan(fovX / 2). y: tan(fovY / 2). z: near plane. w: far plane.
+  vec4 proj;
+  // x: radius (world units). y: bias (world units). z: intensity (final
+  // contrast power). w: projection scale (pixels per world unit at depth 1).
+  vec4 params;
+  // x: sample count.
+  vec4 params2;
+}
+ssao;
+
+in vec2 v_uv;
+out vec4 frag_color;
+
+// Static loop bound so the sample loop is constant-bounded for the GLES
+// 1.00 shader output (a uniform-bounded loop is rejected by conformant ES
+// drivers); the dynamic sample count breaks out early.
+#define MAX_SSAO_SAMPLES 32
+
+const float kPi = 3.14159265359;
+const float kEpsilon = 0.0001;
+// Golden angle, for the Vogel-disk sample distribution.
+const float kGoldenAngle = 2.39996323;
+// Widest screen-edge occlusion fade, as a fraction of the viewport. Keeps the
+// fade a thin border even for near, large-radius geometry.
+const float kEdgeFadeMax = 0.04;
+
+// Reconstructs a view-space position from a depth-buffer UV. Camera space
+// places the eye at the origin looking down +Z (the convention the depth
+// prepass writes), so the stored planar depth is the view-space Z and the
+// X/Y follow from the projection tangents.
+vec3 ViewPositionAt(vec2 uv) {
+  float z = texture(linear_depth, uv).r;
+  // NDC from the full-screen UV (V runs downward in the UV).
+  vec2 ndc = vec2(2.0 * uv.x - 1.0, 1.0 - 2.0 * uv.y);
+  return vec3(ndc.x * z * ssao.proj.x, ndc.y * z * ssao.proj.y, z);
+}
+
+void main() {
+  float radius = ssao.params.x;
+  float bias = ssao.params.y;
+  float intensity = ssao.params.z;
+  float proj_scale = ssao.params.w;
+  int sample_count = int(ssao.params2.x);
+  float far = ssao.proj.w;
+
+  vec3 origin = ViewPositionAt(v_uv);
+
+  // Background texels (no geometry) are unoccluded.
+  if (origin.z >= far) {
+    frag_color = vec4(1.0, 1.0, 1.0, 1.0);
+    return;
+  }
+
+  // Face normal from the screen-space gradient of the reconstructed
+  // position. With precise (fp32) depth this is smooth across surfaces; the
+  // single-pixel errors at silhouettes are removed by the bilateral blur
+  // (see the SAO paper). A per-axis "nearest depth neighbour" reconstruction
+  // is sharper at edges but compares near-equal depth steps on smooth
+  // surfaces, which flips per pixel and injects normal noise, so the plain
+  // gradient is preferred here. Oriented toward the camera (the eye is at
+  // the origin, so the view direction is -origin).
+  vec3 normal = normalize(cross(dFdx(origin), dFdy(origin)));
+  if (dot(normal, origin) > 0.0) {
+    normal = -normal;
+  }
+
+  // Screen-space disk radius: the world radius projected to this depth.
+  float screen_radius = proj_scale * radius / origin.z;
+  // TODO(flutter_scene): SAO keeps large radii cache-friendly by sampling a
+  // MIP chain of the depth buffer (selecting a level per sample by screen
+  // radius). A single level is enough for typical radii; add the chain (like
+  // the bloom downsample chain) if large-radius occlusion shows cache cost.
+
+  // Interleaved rotation: 16 well-separated angles tiled over a 4x4 screen
+  // block (the golden-ratio sequence spreads them, and neighbours differ
+  // sharply). The matching 4x4 box blur that follows averages all 16, which
+  // resolves uniform regions to a smooth result without temporal
+  // accumulation. Per-pixel random rotation instead leaves screen-locked
+  // grain the blur cannot fully remove.
+  vec2 tile = mod(gl_FragCoord.xy, 4.0);
+  float rotation_index = tile.y * 4.0 + tile.x;
+  float rotation = fract(rotation_index * 0.61803399) * 2.0 * kPi;
+
+  float radius2 = radius * radius;
+  float sum = 0.0;
+  for (int i = 0; i < MAX_SSAO_SAMPLES; i++) {
+    if (i >= sample_count) {
+      break;
+    }
+    // Vogel disk: a near-uniform area distribution for any sample count. The
+    // sqrt radius spreads samples evenly (rather than clustering toward the
+    // center like a linear spiral, whose clusters alias into screen-axis
+    // streaks on receding surfaces).
+    float sample_radius = sqrt((float(i) + 0.5) / float(sample_count));
+    float theta = float(i) * kGoldenAngle + rotation;
+    vec2 offset = vec2(cos(theta), sin(theta)) * (sample_radius * screen_radius);
+    vec2 sample_uv = v_uv + offset * ssao.viewport.zw;
+
+    vec3 q = ViewPositionAt(sample_uv);
+    vec3 v = q - origin;
+    float vv = dot(v, v);
+    float vn = dot(v, normal);
+
+    // SAO falloff: (radius^2 - vv)^3 weights nearer occluders and clamps
+    // anything beyond the world radius to zero.
+    float f = max(radius2 - vv, 0.0);
+    sum += f * f * f * max((vn - bias) / (kEpsilon + vv), 0.0);
+  }
+
+  // Empirical normalisation (the constant follows the SAO reference); the
+  // user intensity is applied as a final contrast power.
+  float ao = max(
+      0.0,
+      1.0 - 5.0 * sum / (float(sample_count) * radius2 * radius2 * radius2));
+  ao = pow(clamp(ao, 0.0, 1.0), intensity);
+
+  // Fade occlusion toward unoccluded in a thin band at the screen edge, so an
+  // occluder crossing the edge (whose samples leave the viewport and have no
+  // depth to read) ramps out smoothly instead of popping. The band is the
+  // sample-disk reach, capped to a small fraction of the screen so near or
+  // large-radius geometry does not fade a large region.
+  vec2 reach = min(vec2(screen_radius) * ssao.viewport.zw, vec2(kEdgeFadeMax));
+  vec2 edge = clamp(min(v_uv, 1.0 - v_uv) / max(reach, vec2(kEpsilon)),
+                    0.0, 1.0);
+  float edge_fade = smoothstep(0.0, 1.0, edge.x) * smoothstep(0.0, 1.0, edge.y);
+  ao = mix(1.0, ao, edge_fade);
+
+  frag_color = vec4(ao, ao, ao, 1.0);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_ssao_blur.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssao_blur.frag
@@ -1,0 +1,61 @@
+// Depth-aware (bilateral) blur for the screen-space ambient occlusion
+// buffer. Removes the per-pixel variation of the occlusion estimate while
+// preserving edges at depth discontinuities, so occlusion does not bleed
+// across silhouettes.
+//
+// The kernel is a 4x4 box matching the occlusion pass's 4x4 interleaved
+// rotation tile: averaging one full tile period sees all 16 rotations, which
+// is what turns the interleaved pattern into a smooth result. A separable or
+// Gaussian-weighted kernel would not average the rotations evenly and would
+// leave residual structure.
+//
+// The bilateral weight is plane-aware: it subtracts the surface's own
+// screen-space depth gradient before testing the difference, so a slanted or
+// detailed (but continuous) surface still blurs, while a real depth step at a
+// silhouette, far larger than the local gradient, still cuts the blur.
+
+uniform sampler2D ao_texture;
+uniform sampler2D linear_depth;
+
+uniform BlurInfo {
+  // xy: texel size (reciprocal of the occlusion target size). z: depth
+  // falloff scale (world units) for the bilateral weight. w: unused.
+  vec4 texel;
+}
+blur;
+
+in vec2 v_uv;
+out vec4 frag_color;
+
+// Offsets span one 4x4 tile period (-2..1) so every interleaved rotation is
+// covered exactly once. Constant bounds for the GLES 1.00 shader output.
+#define BLUR_LO -2
+#define BLUR_HI 1
+
+const float kEpsilon = 0.0001;
+
+void main() {
+  float center_depth = texture(linear_depth, v_uv).r;
+  float depth_scale = max(blur.texel.z, kEpsilon);
+  // Per-pixel depth gradient, clamped so a silhouette (huge gradient) does not
+  // open the bilateral up enough to bleed across it.
+  float gradient = min(fwidth(center_depth), depth_scale);
+
+  float ao_sum = 0.0;
+  float weight_sum = 0.0;
+  for (int y = BLUR_LO; y <= BLUR_HI; y++) {
+    for (int x = BLUR_LO; x <= BLUR_HI; x++) {
+      vec2 uv = v_uv + vec2(float(x), float(y)) * blur.texel.xy;
+      float depth = texture(linear_depth, uv).r;
+      // Depth difference beyond what the smooth surface gradient predicts.
+      float expected = gradient * length(vec2(float(x), float(y)));
+      float delta = max(abs(depth - center_depth) - expected, 0.0);
+      float weight = exp(-delta / depth_scale);
+      ao_sum += texture(ao_texture, uv).r * weight;
+      weight_sum += weight;
+    }
+  }
+
+  float ao = ao_sum / max(weight_sum, kEpsilon);
+  frag_color = vec4(ao, ao, ao, 1.0);
+}

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -64,9 +64,18 @@ uniform FragInfo {
   // backend mis-reads a std140 mat3 uniform (padded vec3 columns), which
   // collapsed env_normal/env_reflection to a constant on GLES.
   mat4 environment_transform;
+  // Screen-space ambient occlusion controls. x: occlusion enabled (sampled
+  // from ssao_texture when > 0.5). y: specular occlusion enabled. zw:
+  // reciprocal of the render-target size, to turn gl_FragCoord into the
+  // occlusion-texture UV.
+  vec4 ssao_params;
 }
 frag_info;
 
 uniform sampler2D prefiltered_radiance; // PMREM-style roughness-band atlas
 uniform sampler2D brdf_lut;
 uniform sampler2D shadow_map;
+// Screen-space ambient occlusion (occlusion factor in .r). A white
+// placeholder is bound when occlusion is disabled, so the sample is a
+// no-op; frag_info.ssao_params.x gates it regardless.
+uniform sampler2D ssao_texture;

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -168,6 +168,19 @@ float SampleShadow(vec3 world_pos, vec3 n) {
   return 1.0;
 }
 
+// Empirical specular occlusion derived from the diffuse occlusion factor,
+// the view angle, and roughness (Lagarde and de Rousiers 2014, "Physically
+// Based Rendering" course notes). Rough surfaces are returned unchanged;
+// smoother surfaces lose indirect specular at normal incidence. Applied
+// only to indirect specular.
+float ComputeSpecularOcclusion(float n_dot_v, float occlusion,
+                               float roughness) {
+  return clamp(
+      pow(n_dot_v + occlusion, exp2(-16.0 * roughness - 1.0)) - 1.0 +
+          occlusion,
+      0.0, 1.0);
+}
+
 // Lights a surface described by `material` and returns the final fragment
 // color (linear HDR, premultiplied by alpha). This is the engine-owned half of
 // the material contract; a material's Surface() function fills `material` and
@@ -178,7 +191,20 @@ vec4 EvaluateLighting(MaterialInputs material) {
   vec3 normal = material.normal;
   float metallic = material.metallic;
   float roughness = material.roughness;
+
+  // Diffuse occlusion: the material's (baked) occlusion modulated by the
+  // screen-space ambient occlusion when it is enabled. Occlusion only ever
+  // affects indirect lighting, never the analytic direct light below.
   float occlusion = material.occlusion;
+  if (frag_info.ssao_params.x > 0.5) {
+    vec2 screen_uv = gl_FragCoord.xy * frag_info.ssao_params.zw;
+    // TODO(flutter_scene): the occlusion target is stored top-down like the
+    // other render-to-texture targets, which matches gl_FragCoord here. If a
+    // backend reports gl_FragCoord with a flipped origin, this sample needs
+    // screen_uv.y = 1.0 - screen_uv.y; verify against the depth prepass on
+    // each backend.
+    occlusion *= texture(ssao_texture, screen_uv).r;
+  }
 
   vec3 camera_normal = normalize(v_viewvector);
 
@@ -223,7 +249,15 @@ vec4 EvaluateLighting(MaterialInputs material) {
 
   vec3 indirect_specular = FssEss * prefiltered_color;
   vec3 indirect_diffuse = (FmsEms + k_D) * irradiance;
-  vec3 ambient = (indirect_diffuse + indirect_specular) * occlusion;
+  // Occluding indirect specular with the diffuse factor over-darkens glossy
+  // reflections, so derive a dedicated specular occlusion when it is
+  // enabled; otherwise the specular lobe uses the same occlusion (the
+  // historical behavior).
+  float specular_occlusion = frag_info.ssao_params.y > 0.5
+      ? ComputeSpecularOcclusion(n_dot_v, occlusion, roughness)
+      : occlusion;
+  vec3 ambient =
+      indirect_diffuse * occlusion + indirect_specular * specular_occlusion;
 
   // Analytic directional light (Cook-Torrance, layered on top of the IBL
   // ambient term).


### PR DESCRIPTION
Adds optional screen-space ambient occlusion, configured per scene via `Scene.ambientOcclusion` (off by default). It darkens indirect (image-based) lighting in creases, cavities, and contact points for softer, more grounded shading, and never affects direct lighting.

<img width="1142" height="719" alt="image" src="https://github.com/user-attachments/assets/47cf0bdb-7c0b-43fd-bb3b-a82c2e84ddc2" />


## Technique

Scalable Ambient Obscurance (McGuire, Mara, and Luebke 2012). It needs only a depth buffer, which fits the forward renderer with no normal G-buffer, and runs entirely as full-screen fragment passes (no compute), so it works on every backend including the WebGL2 fallback.

The chain (all at half resolution by default):

1. A camera depth prepass writes planar view-space depth into a color target. Depth is fp32 and sampled with nearest filtering (fp16 banded, and fp32 linear filtering is not guaranteed on GLES/WebGL2). The whole chain runs at one resolution so depth is sampled 1:1.
2. The occlusion pass reconstructs each pixel's view-space position and a face normal from depth, then estimates obscurance from a Vogel-disk sample set.
3. A 4x4 interleaved rotation paired with a matching plane-aware bilateral box blur removes the per-pixel noise without temporal accumulation.
4. Occlusion fades out within a thin screen-edge band so occluders leaving the viewport ramp out instead of popping.

## Lighting integration

Occlusion modulates indirect diffuse only (combined with any baked `occlusionTexture`), never the analytic direct light. Indirect specular keeps the diffuse factor unless the specular mode is enabled, which derives a dedicated specular occlusion from the occlusion factor, view angle, and roughness (Lagarde and de Rousiers 2014).

Requires a `PerspectiveCamera`; other camera types render without it. When disabled, no passes are added and the lit shader's occlusion sample is a no-op.

## Settings

`AmbientOcclusionSettings`: `enabled`, `radius`, `intensity`, `bias`, `sampleCount`, `halfResolution`, and `specularMode`. Defaults are tuned for a balanced look.

## Example app

The shared settings sidebar gains an Ambient occlusion section, plus a Directional light section (azimuth, elevation, intensity, casts shadow, softness) that now drives the light uniformly across every example (the per-scene lights were removed in favour of the shared panel).

## Follow-up

Per-draw CPU overhead (uncached fullscreen-pass pipelines, per-draw sampler/uniform allocations) becomes more noticeable with the extra geometry passes shadows and AO add. Memoizing that is planned as a separate change.