### PR TITLE
Add light and camera components, render layers, and multi-view rendering

### DIFF
--- a/examples/flutter_app/lib/example_physics.dart
+++ b/examples/flutter_app/lib/example_physics.dart
@@ -91,11 +91,15 @@ class ExamplePhysicsState extends State<ExamplePhysics> {
     // A key light that casts shadows across the playfield. Pull the shadow
     // distance in from the default (150) so the cascades concentrate on
     // this compact playground and the cast shadows stay crisp.
-    scene.directionalLight = DirectionalLight(
-      direction: vm.Vector3(-0.6, -1.0, -0.45),
-      intensity: 3.0,
-      castsShadow: true,
-      shadowMaxDistance: 35.0,
+    scene.root.addComponent(
+      DirectionalLightComponent(
+        DirectionalLight(
+          direction: vm.Vector3(-0.6, -1.0, -0.45),
+          intensity: 3.0,
+          castsShadow: true,
+          shadowMaxDistance: 35.0,
+        ),
+      ),
     );
     scene.environmentIntensity = 0.6;
 

--- a/examples/flutter_app/lib/example_settings.dart
+++ b/examples/flutter_app/lib/example_settings.dart
@@ -108,14 +108,27 @@ class ExampleSettings {
         -math.sin(elevation),
         horizontal * math.sin(azimuth),
       );
-      final light = scene.directionalLight ?? DirectionalLight();
+      // Reuse the scene's directional light component, or attach one. The
+      // light's node has no transform, so its world direction is the
+      // direction set here.
+      final existing = scene.root.getComponents<DirectionalLightComponent>();
+      final DirectionalLightComponent component;
+      if (existing.isEmpty) {
+        component = DirectionalLightComponent(DirectionalLight());
+        scene.root.addComponent(component);
+      } else {
+        component = existing.first;
+      }
+      final light = component.light;
       light.direction = direction;
       light.intensity = lightIntensity;
       light.castsShadow = lightCastsShadow;
       light.shadowSoftness = shadowSoftness;
-      scene.directionalLight = light;
     } else {
-      scene.directionalLight = null;
+      for (final component
+          in scene.root.getComponents<DirectionalLightComponent>().toList()) {
+        scene.root.removeComponent(component);
+      }
     }
 
     final wave = waveEffect;

--- a/examples/flutter_app/lib/example_split_screen.dart
+++ b/examples/flutter_app/lib/example_split_screen.dart
@@ -1,0 +1,101 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+
+/// Layer bit for content shown only in the left view.
+const int _leftOnlyLayer = 1 << 1;
+
+/// Renders one scene as split-screen via [Scene.renderViews]: a left half
+/// with an orbiting free [PerspectiveCamera] and a right half driven by a
+/// [CameraComponent] on a node. The right view masks out a node placed on
+/// [_leftOnlyLayer], so that node appears only on the left.
+class ExampleSplitScreen extends StatefulWidget {
+  const ExampleSplitScreen({super.key});
+
+  @override
+  State<ExampleSplitScreen> createState() => _ExampleSplitScreenState();
+}
+
+class _ExampleSplitScreenState extends State<ExampleSplitScreen> {
+  final Scene scene = Scene();
+  late final CameraComponent _rightCamera;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // A ring of debug-colored cuboids, so each view's angle is obvious from
+    // which faces it shows.
+    for (var i = 0; i < 6; i++) {
+      final angle = i / 6 * 2 * pi;
+      scene.add(
+        Node(
+          mesh: Mesh(
+            CuboidGeometry(vm.Vector3(0.8, 0.8, 0.8), debugColors: true),
+            UnlitMaterial(),
+          ),
+          localTransform: vm.Matrix4.translation(
+            vm.Vector3(cos(angle) * 2.5, 0, sin(angle) * 2.5),
+          ),
+        ),
+      );
+    }
+
+    // A tall cuboid at the center, shown only in the left view via its layer.
+    scene.add(
+      Node(
+        mesh: Mesh(
+          CuboidGeometry(vm.Vector3(0.6, 2.0, 0.6), debugColors: true),
+          UnlitMaterial(),
+        ),
+      )..layers = _leftOnlyLayer,
+    );
+
+    // The right view's camera lives on a node: place the node by inverting
+    // the view matrix of an equivalent eye/target/up placement (a static
+    // side view), then drive the view from the node via the component.
+    final placement = PerspectiveCamera(
+      position: vm.Vector3(6, 2, 0),
+      target: vm.Vector3(0, 0, 0),
+    );
+    final cameraNode = Node(
+      localTransform: vm.Matrix4.identity()
+        ..copyInverse(placement.getViewMatrix()),
+    );
+    _rightCamera = CameraComponent();
+    cameraNode.addComponent(_rightCamera);
+    scene.add(cameraNode);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SceneView(
+      scene,
+      viewsBuilder: (elapsed) {
+        final t = elapsed.inMicroseconds / 1e6;
+        final leftCamera = PerspectiveCamera(
+          position: vm.Vector3(sin(t) * 6, 2.5, cos(t) * 6),
+          target: vm.Vector3(0, 0, 0),
+        );
+        return [
+          // Left half: orbiting free camera, sees every layer.
+          RenderView(
+            camera: leftCamera,
+            viewport: const Rect.fromLTWH(0, 0, 0.5, 1),
+          ),
+          // Right half: static node-driven camera, hides the left-only layer.
+          RenderView(
+            camera: _rightCamera.toCamera(),
+            viewport: const Rect.fromLTWH(0.5, 0, 0.5, 1),
+            layerMask: kRenderLayerAll & ~_leftOnlyLayer,
+          ),
+        ];
+      },
+      onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+    );
+  }
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -12,6 +12,7 @@ import 'example_logo.dart';
 import 'example_nav_route.dart';
 import 'example_physics.dart';
 import 'example_settings.dart';
+import 'example_split_screen.dart';
 import 'example_stress_tests.dart';
 import 'example_toon.dart';
 import 'example_toon_fmat.dart';
@@ -62,6 +63,7 @@ class _MyAppState extends State<MyApp> {
           return const ExamplePhysics();
         },
       ),
+      'Split Screen': (context) => const ExampleSplitScreen(),
       'Stress Tests': (context) => const ExampleStressTests(),
     };
     selectedExample = examples.keys.first;

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -101,10 +101,16 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
   // and the lit material's shadow sampling, which the other scenes don't.
   SmokeScene('directional_shadow', () {
     final scene = Scene();
-    scene.directionalLight = DirectionalLight(
-      direction: vm.Vector3(-0.4, -1.0, -0.35),
-      castsShadow: true,
-      shadowMaxDistance: 20.0,
+    scene.add(
+      Node()..addComponent(
+        DirectionalLightComponent(
+          DirectionalLight(
+            direction: vm.Vector3(-0.4, -1.0, -0.35),
+            castsShadow: true,
+            shadowMaxDistance: 20.0,
+          ),
+        ),
+      ),
     );
     // Ground plane (receiver), centered at the origin in the XZ plane.
     scene.add(

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -47,6 +47,7 @@ export 'src/importer/model_registry.dart' show ModelRegistry, loadModel;
 export 'src/ambient_occlusion.dart';
 export 'src/asset_helpers.dart';
 export 'src/camera.dart';
+export 'src/components/camera_component.dart';
 export 'src/components/component.dart';
 export 'src/components/directional_light_component.dart';
 export 'src/components/instanced_mesh_component.dart';

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -54,6 +54,8 @@ export 'src/components/instanced_mesh_component.dart';
 export 'src/components/mesh_component.dart';
 export 'src/instanced_mesh.dart';
 export 'src/light.dart';
+export 'src/render/render_layers.dart';
+export 'src/render_view.dart';
 export 'src/math_extensions.dart';
 export 'src/mesh.dart';
 export 'src/node.dart';

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -48,6 +48,7 @@ export 'src/ambient_occlusion.dart';
 export 'src/asset_helpers.dart';
 export 'src/camera.dart';
 export 'src/components/component.dart';
+export 'src/components/directional_light_component.dart';
 export 'src/components/instanced_mesh_component.dart';
 export 'src/components/mesh_component.dart';
 export 'src/instanced_mesh.dart';

--- a/packages/flutter_scene/lib/src/camera.dart
+++ b/packages/flutter_scene/lib/src/camera.dart
@@ -3,25 +3,80 @@ import 'dart:ui' as ui;
 
 import 'package:vector_math/vector_math.dart';
 
-/// Base class for camera implementations passed to [Scene.render].
+/// A lens projection that maps view-space coordinates into clip space.
 ///
-/// A camera owns the transform that converts world-space coordinates into
-/// clip-space coordinates for a given render target size. Subclasses
-/// configure projection and view conventions; [PerspectiveCamera] is the
-/// built-in option, but applications can subclass [Camera] to implement
-/// orthographic or other custom projections.
+/// The projection is the half of a camera that does not depend on where the
+/// camera is or what it looks at, only on the lens (field of view, clip
+/// planes) and the render target's aspect ratio. Pair one with a view (a
+/// [Camera]'s [Camera.getViewMatrix]) to form a full view-projection
+/// transform. [PerspectiveProjection] is the built-in option; applications
+/// can implement [CameraProjection] for orthographic or other projections.
+abstract class CameraProjection {
+  /// Returns the projection matrix for a render target of the given
+  /// [aspectRatio] (width / height).
+  Matrix4 getProjectionMatrix(double aspectRatio);
+}
+
+/// A standard pinhole perspective projection.
+class PerspectiveProjection extends CameraProjection {
+  /// Creates a [PerspectiveProjection] with a vertical field of view
+  /// [fovRadiansY] and a [near]/[far] clip range.
+  PerspectiveProjection({
+    this.fovRadiansY = 45 * degrees2Radians,
+    this.near = 0.1,
+    this.far = 1000.0,
+  });
+
+  /// Vertical field of view, in radians. The horizontal field of view is
+  /// derived from the render target's aspect ratio at draw time.
+  double fovRadiansY;
+
+  /// Distance to the near clipping plane. Geometry closer is clipped away.
+  double near;
+
+  /// Distance to the far clipping plane. Must be greater than [near].
+  double far;
+
+  @override
+  Matrix4 getProjectionMatrix(double aspectRatio) =>
+      _matrix4Perspective(fovRadiansY, aspectRatio, near, far);
+}
+
+/// A view onto a scene: a world-space eye [position] and orientation paired
+/// with a lens [projection], used by [Scene.render] to map the scene into
+/// clip space.
+///
+/// A camera separates its *view* (where it is and which way it looks, from
+/// [getViewMatrix]) from its *projection* (the lens, a [CameraProjection]).
+/// [PerspectiveCamera] is the built-in free camera, positioned by
+/// eye/target/up. Attach a [CameraComponent] to a [Node] to drive the view
+/// from that node's transform instead.
 abstract class Camera {
-  /// The world-space position of the camera. Used by materials for
-  /// view-dependent shading (e.g. specular reflections).
+  /// The world-space position of the camera (the eye point). Used by
+  /// materials for view-dependent shading (e.g. specular reflections).
   Vector3 get position;
+
+  /// The world-space direction the camera looks along (unit length).
+  Vector3 get forward;
+
+  /// The world-space up direction used to orient the camera around
+  /// [forward].
+  Vector3 get up;
+
+  /// The lens projection paired with this camera's view.
+  CameraProjection get projection;
+
+  /// Returns the world-to-view transform (the view matrix), independent of
+  /// the render target size.
+  Matrix4 getViewMatrix();
 
   /// Returns the combined projection-and-view transform for a render target
   /// of the given [dimensions].
   ///
-  /// Called once per [Scene.render] call. Implementations may read
-  /// [dimensions] (typically to compute aspect ratio) and any subclass
-  /// configuration to build the matrix.
-  Matrix4 getViewTransform(ui.Size dimensions);
+  /// Called once per [Scene.render] call.
+  Matrix4 getViewTransform(ui.Size dimensions) =>
+      projection.getProjectionMatrix(dimensions.width / dimensions.height) *
+      getViewMatrix();
 
   /// Returns the view frustum (six normalized clip planes) for a render
   /// target of the given [dimensions].
@@ -129,6 +184,7 @@ class PerspectiveCamera extends Camera {
 
   /// World-space "up" direction used to orient the camera around the
   /// view vector. Typically `Vector3(0, 1, 0)`.
+  @override
   Vector3 up;
 
   /// Distance to the near clipping plane. Geometry closer than this is
@@ -140,13 +196,15 @@ class PerspectiveCamera extends Camera {
   double fovFar;
 
   @override
-  Matrix4 getViewTransform(ui.Size dimensions) {
-    return _matrix4Perspective(
-          fovRadiansY,
-          dimensions.width / dimensions.height,
-          fovNear,
-          fovFar,
-        ) *
-        _matrix4LookAt(position, target, up);
-  }
+  CameraProjection get projection => PerspectiveProjection(
+    fovRadiansY: fovRadiansY,
+    near: fovNear,
+    far: fovFar,
+  );
+
+  @override
+  Vector3 get forward => (target - position).normalized();
+
+  @override
+  Matrix4 getViewMatrix() => _matrix4LookAt(position, target, up);
 }

--- a/packages/flutter_scene/lib/src/components/camera_component.dart
+++ b/packages/flutter_scene/lib/src/components/camera_component.dart
@@ -1,0 +1,71 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/components/component.dart';
+
+/// An engine [Component] that places a [Camera] in the scene.
+///
+/// The camera's view (eye position and orientation) comes from the owning
+/// node's world transform: the node's translation is the eye, its local
+/// `+Z` axis is the look direction, and its local `+Y` axis is up. The
+/// [projection] (the lens) is configured on the component. Move or rotate
+/// the node to move or aim the camera.
+///
+/// Use [toCamera] to capture a [Camera] for the node's current transform to
+/// pass to `Scene.render`. (The node should not be scaled; a camera node is
+/// expected to carry only rotation and translation.)
+class CameraComponent extends Component {
+  /// Creates a camera component with the given [projection] (a
+  /// [PerspectiveProjection] by default).
+  CameraComponent({CameraProjection? projection})
+    : projection = projection ?? PerspectiveProjection();
+
+  /// The lens projection for this camera.
+  CameraProjection projection;
+
+  /// Returns a [Camera] for the owning node's current world transform.
+  ///
+  /// The returned camera snapshots the transform, so subsequently moving
+  /// the node does not change it; call [toCamera] again for an updated
+  /// view.
+  Camera toCamera() => _NodeCamera(node.globalTransform.clone(), projection);
+}
+
+/// A [Camera] whose view comes from a world transform: the `+Z` axis is the
+/// look direction, `+Y` is up, and the translation is the eye. This is the
+/// inverse of the eye/target/up convention [PerspectiveCamera] builds, so a
+/// node placed at `inverse(camera.getViewMatrix())` yields the same view.
+class _NodeCamera extends Camera {
+  _NodeCamera(this._worldTransform, this.projection);
+
+  final Matrix4 _worldTransform;
+
+  @override
+  final CameraProjection projection;
+
+  @override
+  Vector3 get position => _worldTransform.getTranslation();
+
+  @override
+  Vector3 get forward => Vector3(
+    _worldTransform[8],
+    _worldTransform[9],
+    _worldTransform[10],
+  ).normalized();
+
+  @override
+  Vector3 get up => Vector3(
+    _worldTransform[4],
+    _worldTransform[5],
+    _worldTransform[6],
+  ).normalized();
+
+  @override
+  Matrix4 getViewMatrix() {
+    // The view matrix is the inverse of the camera's world transform.
+    // copyInverse(arg) writes inverse(arg) into the receiver.
+    final view = Matrix4.identity();
+    view.copyInverse(_worldTransform);
+    return view;
+  }
+}

--- a/packages/flutter_scene/lib/src/components/directional_light_component.dart
+++ b/packages/flutter_scene/lib/src/components/directional_light_component.dart
@@ -1,0 +1,53 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/light.dart';
+
+/// An engine [Component] that places a [DirectionalLight] in the scene.
+///
+/// While the owning node is part of a live scene, the component registers
+/// its light with the scene's render layer so the renderer can find it,
+/// and unregisters it when the node leaves the scene.
+///
+/// The light's travel direction is the owning node's world-space
+/// orientation applied to the light's [DirectionalLight.direction] (read
+/// as a node-local direction), so re-orienting the node aims the light.
+/// With an unrotated node the world direction equals the light's own
+/// [DirectionalLight.direction].
+///
+/// The renderer currently shades a single directional light (the first one
+/// registered); additional directional lights are collected but not yet
+/// shaded.
+// TODO(lighting): shade multiple directional lights once the material
+// shader supports more than one.
+class DirectionalLightComponent extends Component {
+  /// Creates a component that lights the scene with [light].
+  DirectionalLightComponent(this.light);
+
+  /// The light this component contributes. Its
+  /// [DirectionalLight.direction] is read in the owning node's local
+  /// space; [worldDirection] is the world-space result.
+  DirectionalLight light;
+
+  @override
+  void onMount() {
+    node.internalRenderScene?.addDirectionalLight(this);
+  }
+
+  @override
+  void onUnmount() {
+    // Guard on attachment, not mount state: Component.unmount clears the
+    // mounted flag before invoking onUnmount, and the owning node's render
+    // scene is still reachable during teardown (mirrors MeshComponent).
+    if (isAttached) {
+      node.internalRenderScene?.removeDirectionalLight(this);
+    }
+  }
+
+  /// The light's world-space travel direction: the owning node's
+  /// world-space rotation applied to the light's local
+  /// [DirectionalLight.direction]. Need not be unit length (the shader and
+  /// the shadow-cascade fit both normalize it).
+  Vector3 get worldDirection =>
+      node.globalTransform.getRotation() * light.direction;
+}

--- a/packages/flutter_scene/lib/src/components/instanced_mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/instanced_mesh_component.dart
@@ -50,6 +50,7 @@ class InstancedMeshComponent extends Component {
     final frustumCulled = node.frustumCulled;
     final frustumCulledChanged = item.frustumCulled != frustumCulled;
     item.frustumCulled = frustumCulled;
+    item.layers = node.layers;
     item.worldTransform.setFrom(node.globalTransform);
     item.windingFlipped = node.windingFlipped;
     item.instanceTransforms = instancedMesh.instances;

--- a/packages/flutter_scene/lib/src/components/mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/mesh_component.dart
@@ -94,10 +94,12 @@ class MeshComponent extends Component {
 
     final renderScene = node.internalRenderScene;
     final frustumCulled = node.frustumCulled;
+    final layers = node.layers;
     for (final item in _renderItems) {
       item.visible = true;
       final frustumCulledChanged = item.frustumCulled != frustumCulled;
       item.frustumCulled = frustumCulled;
+      item.layers = layers;
       item.worldTransform.setFrom(worldTransform);
       item.windingFlipped = windingFlipped;
 

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -22,7 +22,7 @@ import 'package:flutter_scene/src/material/environment.dart';
 /// view distance. The penumbra is a soft Poisson-disk PCF kernel of
 /// radius [shadowSoftness], and shadowing fades back to lit at the far
 /// edge over [shadowFadeRange]. Cascaded shadows require the scene to
-/// render with a [PerspectiveCamera].
+/// render with a perspective projection.
 class DirectionalLight {
   /// Creates a [DirectionalLight].
   ///
@@ -111,12 +111,14 @@ class DirectionalLight {
   /// omitted it falls back to [direction] (the light's own field), which
   /// is correct for a light placed without a node transform.
   List<ShadowCascade> computeCascades(
-    PerspectiveCamera camera,
+    Camera camera,
     double aspectRatio, [
     Vector3? worldDirection,
   ]) {
+    // Cascades fit the camera frustum, which is perspective-specific.
+    final perspective = camera.projection as PerspectiveProjection;
     final count = shadowCascadeCount.clamp(1, 4);
-    final near = camera.fovNear;
+    final near = perspective.near;
     final far = shadowMaxDistance;
 
     // Practical split scheme: a blend of logarithmic and uniform
@@ -133,10 +135,10 @@ class DirectionalLight {
     }
 
     // Camera basis and field-of-view tangents.
-    final forward = (camera.target - camera.position).normalized();
+    final forward = camera.forward;
     final right = camera.up.cross(forward).normalized();
     final up = forward.cross(right).normalized();
-    final tanV = math.tan(camera.fovRadiansY * 0.5);
+    final tanV = math.tan(perspective.fovRadiansY * 0.5);
     final tanH = tanV * aspectRatio;
 
     final effectiveDirection = worldDirection ?? direction;

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -106,10 +106,15 @@ class DirectionalLight {
   /// frustum, so the cascade's projection size stays constant as the
   /// camera rotates; the projection is then texel-snapped so shadow
   /// edges do not shimmer.
+  ///
+  /// [worldDirection] is the light's world-space travel direction. When
+  /// omitted it falls back to [direction] (the light's own field), which
+  /// is correct for a light placed without a node transform.
   List<ShadowCascade> computeCascades(
     PerspectiveCamera camera,
-    double aspectRatio,
-  ) {
+    double aspectRatio, [
+    Vector3? worldDirection,
+  ]) {
     final count = shadowCascadeCount.clamp(1, 4);
     final near = camera.fovNear;
     final far = shadowMaxDistance;
@@ -134,10 +139,11 @@ class DirectionalLight {
     final tanV = math.tan(camera.fovRadiansY * 0.5);
     final tanH = tanV * aspectRatio;
 
-    final lightLength = direction.length;
+    final effectiveDirection = worldDirection ?? direction;
+    final lightLength = effectiveDirection.length;
     final lightDir = lightLength == 0.0
         ? Vector3(0.0, -1.0, 0.0)
-        : direction * (1.0 / lightLength);
+        : effectiveDirection * (1.0 / lightLength);
 
     final cascades = <ShadowCascade>[];
     for (var c = 0; c < count; c++) {
@@ -293,6 +299,7 @@ class Lighting {
     this.environmentIntensity = 1.0,
     Matrix3? environmentTransform,
     this.directionalLight,
+    this.directionalLightDirection,
     this.shadowMap,
     this.cascades = const [],
     this.ssaoMap,
@@ -313,6 +320,11 @@ class Lighting {
 
   /// The scene's directional light, or null when there isn't one.
   final DirectionalLight? directionalLight;
+
+  /// The world-space travel direction of [directionalLight], derived from
+  /// the light node's transform. Null when there is no directional light;
+  /// consumers fall back to [DirectionalLight.direction] in that case.
+  final Vector3? directionalLightDirection;
 
   /// The cascaded shadow map atlas (a depth-in-`.r` texture holding the
   /// cascade tiles as a horizontal strip) for [directionalLight], or

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -44,9 +44,12 @@ class EngineLightingUniforms {
     }
     // directional_light_direction [44..47], directional_light_color [48..51].
     if (light != null) {
-      fragInfo[44] = light.direction.x;
-      fragInfo[45] = light.direction.y;
-      fragInfo[46] = light.direction.z;
+      // The world-space direction comes from the light node's transform;
+      // fall back to the light's own field for a node-less light.
+      final direction = lighting.directionalLightDirection ?? light.direction;
+      fragInfo[44] = direction.x;
+      fragInfo[45] = direction.y;
+      fragInfo[46] = direction.z;
       fragInfo[48] = light.color.x * light.intensity;
       fragInfo[49] = light.color.y * light.intensity;
       fragInfo[50] = light.color.z * light.intensity;

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -14,6 +14,7 @@ import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/material/unlit_material.dart';
 import 'package:flutter_scene/src/mesh.dart';
+import 'package:flutter_scene/src/render/render_layers.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/skin.dart';
 import 'package:flutter_scene/src/importer/flatbuffer.dart' as fb;
@@ -57,6 +58,14 @@ base class Node implements SceneGraph {
   /// computable bounds) are treated as always visible regardless of
   /// this flag.
   bool frustumCulled = true;
+
+  /// The render layers this node occupies, a 32-bit bitmask. A
+  /// [RenderView] renders this node's mesh only when its
+  /// [RenderView.layerMask] intersects these layers
+  /// (`layers & layerMask != 0`). Defaults to [kRenderLayerDefault]
+  /// (layer 0). Each node carries its own layers; the value is not
+  /// inherited by children.
+  int layers = kRenderLayerDefault;
 
   Matrix4 _localTransform;
 

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -6,6 +6,7 @@ import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/render/render_graph.dart';
+import 'package:flutter_scene/src/render/render_layers.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/shaders.dart';
 
@@ -40,17 +41,20 @@ class DepthPrepass extends RenderGraphPass {
     required ui.Size dimensions,
     required Vector3 cameraForward,
     required double farDepth,
+    int layerMask = kRenderLayerAll,
   }) : _camera = camera,
        _renderScene = renderScene,
        _dimensions = dimensions,
        _cameraForward = cameraForward,
-       _farDepth = farDepth;
+       _farDepth = farDepth,
+       _layerMask = layerMask;
 
   final Camera _camera;
   final RenderScene _renderScene;
   final ui.Size _dimensions;
   final Vector3 _cameraForward;
   final double _farDepth;
+  final int _layerMask;
 
   @override
   String get name => 'DepthPrepass';
@@ -103,6 +107,7 @@ class DepthPrepass extends RenderGraphPass {
       _camera.getViewTransform(_dimensions),
       _camera.position,
       _cameraForward,
+      _layerMask,
     );
     _renderScene.cull(encoder.frustum, encoder.submit);
     commandBuffer.submit();
@@ -125,6 +130,7 @@ class _DepthPrepassEncoder {
     this._cameraTransform,
     this._cameraPosition,
     Vector3 cameraForward,
+    this._layerMask,
   ) {
     frustum = Frustum.matrix(_cameraTransform);
     _renderPass.setDepthWriteEnable(true);
@@ -146,6 +152,7 @@ class _DepthPrepassEncoder {
   final gpu.HostBuffer _transientsBuffer;
   final Matrix4 _cameraTransform;
   final Vector3 _cameraPosition;
+  final int _layerMask;
   late final Float32List _depthInfo;
 
   static final gpu.Shader _depthShader =
@@ -166,6 +173,7 @@ class _DepthPrepassEncoder {
   /// contribution), or culled by the camera frustum.
   void submit(RenderItem item) {
     if (!item.visible) return;
+    if ((item.layers & _layerMask) == 0) return;
     if (!item.material.isOpaque()) return;
     if (item.frustumCulled) {
       final bounds = item.cullBounds;

--- a/packages/flutter_scene/lib/src/render/render_layers.dart
+++ b/packages/flutter_scene/lib/src/render/render_layers.dart
@@ -1,0 +1,10 @@
+/// The default layer a [Node] occupies (bit 0).
+///
+/// A node's `layers` is a 32-bit bitmask; a render view renders the node
+/// only when the node's layers intersect the view's layer mask. This lets a
+/// view (a capture, a minimap, an editor overlay) include or exclude
+/// specific nodes.
+const int kRenderLayerDefault = 1;
+
+/// A layer mask that selects every layer (the default render-view mask).
+const int kRenderLayerAll = 0xFFFFFFFF;

--- a/packages/flutter_scene/lib/src/render/render_scene.dart
+++ b/packages/flutter_scene/lib/src/render/render_scene.dart
@@ -1,5 +1,6 @@
 import 'package:vector_math/vector_math.dart';
 
+import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/render/bvh.dart';
@@ -107,6 +108,23 @@ class RenderItem {
 class RenderScene {
   /// Every registered render item, in no particular order.
   final List<RenderItem> items = [];
+
+  /// The directional lights contributed by mounted
+  /// [DirectionalLightComponent]s, in registration order. The renderer
+  /// currently shades the first; the rest are collected for future
+  /// multi-light support.
+  final List<DirectionalLightComponent> directionalLights = [];
+
+  /// Registers [light] as an active directional light. Called by a
+  /// [DirectionalLightComponent] when its owning node mounts.
+  void addDirectionalLight(DirectionalLightComponent light) {
+    directionalLights.add(light);
+  }
+
+  /// Unregisters [light]. Called when its owning node unmounts.
+  void removeDirectionalLight(DirectionalLightComponent light) {
+    directionalLights.remove(light);
+  }
 
   Bvh _bvh = Bvh.build([]);
   final List<RenderItem> _alwaysVisible = [];

--- a/packages/flutter_scene/lib/src/render/render_scene.dart
+++ b/packages/flutter_scene/lib/src/render/render_scene.dart
@@ -4,6 +4,7 @@ import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/render/bvh.dart';
+import 'package:flutter_scene/src/render/render_layers.dart';
 
 /// One drawable primitive in the flat render layer.
 ///
@@ -27,6 +28,11 @@ class RenderItem {
 
   /// Mirrors the owning node's frustum-cull opt-in, refreshed each frame.
   bool frustumCulled = true;
+
+  /// The owning node's render layers (a 32-bit bitmask), refreshed each
+  /// frame. A render pass skips this item when its view's layer mask does
+  /// not intersect (`layers & layerMask == 0`).
+  int layers = kRenderLayerAll;
 
   /// Whether the owning node's transform reverses triangle winding (a mirror
   /// up the chain). Refreshed each frame; the encoder flips cull winding when

--- a/packages/flutter_scene/lib/src/render/scene_pass.dart
+++ b/packages/flutter_scene/lib/src/render/scene_pass.dart
@@ -34,6 +34,7 @@ class ScenePass extends RenderGraphPass {
     Matrix3? environmentTransform,
     required bool enableMsaa,
     DirectionalLight? directionalLight,
+    Vector3? directionalLightDirection,
     List<ShadowCascade> cascades = const [],
     double specularOcclusionMode = 0.0,
   }) : _camera = camera,
@@ -44,6 +45,7 @@ class ScenePass extends RenderGraphPass {
        _environmentTransform = environmentTransform,
        _enableMsaa = enableMsaa,
        _directionalLight = directionalLight,
+       _directionalLightDirection = directionalLightDirection,
        _cascades = cascades,
        _specularOcclusionMode = specularOcclusionMode;
 
@@ -55,6 +57,7 @@ class ScenePass extends RenderGraphPass {
   final Matrix3? _environmentTransform;
   final bool _enableMsaa;
   final DirectionalLight? _directionalLight;
+  final Vector3? _directionalLightDirection;
   final List<ShadowCascade> _cascades;
   final double _specularOcclusionMode;
 
@@ -121,6 +124,7 @@ class ScenePass extends RenderGraphPass {
       environmentIntensity: _environmentIntensity,
       environmentTransform: _environmentTransform,
       directionalLight: _directionalLight,
+      directionalLightDirection: _directionalLightDirection,
       shadowMap: shadowMap,
       cascades: shadowMap == null ? const [] : _cascades,
       ssaoMap: ssaoMap,

--- a/packages/flutter_scene/lib/src/render/scene_pass.dart
+++ b/packages/flutter_scene/lib/src/render/scene_pass.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/render/render_graph.dart';
+import 'package:flutter_scene/src/render/render_layers.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/render/shadow_pass.dart';
 import 'package:flutter_scene/src/render/ssao_pass.dart';
@@ -37,7 +38,9 @@ class ScenePass extends RenderGraphPass {
     Vector3? directionalLightDirection,
     List<ShadowCascade> cascades = const [],
     double specularOcclusionMode = 0.0,
+    int layerMask = kRenderLayerAll,
   }) : _camera = camera,
+       _layerMask = layerMask,
        _renderScene = renderScene,
        _dimensions = dimensions,
        _environmentMap = environmentMap,
@@ -58,6 +61,7 @@ class ScenePass extends RenderGraphPass {
   final bool _enableMsaa;
   final DirectionalLight? _directionalLight;
   final Vector3? _directionalLightDirection;
+  final int _layerMask;
   final List<ShadowCascade> _cascades;
   final double _specularOcclusionMode;
 
@@ -140,6 +144,7 @@ class ScenePass extends RenderGraphPass {
       _camera,
       _dimensions,
       lighting,
+      _layerMask,
     );
     _renderScene.cull(encoder.frustum, encoder.submit);
     encoder.flush();

--- a/packages/flutter_scene/lib/src/render_view.dart
+++ b/packages/flutter_scene/lib/src/render_view.dart
@@ -1,0 +1,37 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/render/render_layers.dart';
+
+/// One view of a `Scene`: a [camera] plus where and how its image is drawn.
+///
+/// A scene can be rendered as a list of views (split-screen, picture-in-
+/// picture, and more). Each view binds a camera to a [viewport]
+/// sub-rectangle of the target, a [layerMask] selecting which nodes it
+/// sees, and an [order] controlling how overlapping views composite.
+class RenderView {
+  /// Creates a render view for [camera].
+  RenderView({
+    required this.camera,
+    this.viewport,
+    this.layerMask = kRenderLayerAll,
+    this.order = 0,
+  });
+
+  /// The camera whose view and projection this view renders.
+  Camera camera;
+
+  /// The sub-rectangle of the render target this view draws into, in
+  /// normalized coordinates (`0..1`, with a top-left origin). `null` fills
+  /// the whole target.
+  ui.Rect? viewport;
+
+  /// A bitmask selecting which `Node` layers this view renders. A node is
+  /// drawn only when `node.layers & layerMask != 0`. Defaults to
+  /// [kRenderLayerAll] (every layer).
+  int layerMask;
+
+  /// The compositing order among views sharing a target: a lower [order]
+  /// renders first, a higher one draws on top.
+  int order;
+}

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -25,6 +25,7 @@ import 'render/scene_pass.dart';
 import 'render/shadow_pass.dart';
 import 'render/ssao_pass.dart';
 import 'render/resolve_pass.dart';
+import 'render_view.dart';
 import 'shaders.dart';
 import 'surface.dart';
 import 'tone_mapping.dart';
@@ -353,13 +354,14 @@ base class Scene implements SceneGraph {
     _tickedThisFrame = true;
   }
 
-  /// Renders the current state of this [Scene] onto the given [ui.Canvas] using the specified [Camera].
+  /// Renders [camera]'s view of this scene onto [canvas].
   ///
-  /// The [Camera] provides the perspective from which the scene is viewed, and the [ui.Canvas]
-  /// is the drawing surface onto which this [Scene] will be rendered.
+  /// The [Camera] provides the perspective from which the scene is viewed,
+  /// and the [ui.Canvas] is the drawing surface onto which this [Scene] is
+  /// rendered.
   ///
-  /// Optionally, a [ui.Rect] can be provided to define a viewport, limiting the rendering area on the canvas.
-  /// If no [ui.Rect] is specified, the entire canvas will be rendered.
+  /// Optionally, a [ui.Rect] [viewport] limits the rendering area on the
+  /// canvas. If none is specified, the entire canvas is rendered.
   ///
   /// [pixelRatio] is the multiplier from logical to physical pixels used
   /// when allocating the offscreen render target. Defaults to the
@@ -367,10 +369,45 @@ base class Scene implements SceneGraph {
   /// so the scene is rasterized at the same density Flutter is
   /// compositing the surrounding UI at. Pass a smaller value to trade
   /// fidelity for performance, or a larger one for supersampling.
+  ///
+  /// This is the single-view convenience over [renderViews].
   void render(
     Camera camera,
     ui.Canvas canvas, {
     ui.Rect? viewport,
+    double? pixelRatio,
+  }) {
+    renderViews(
+      [RenderView(camera: camera)],
+      canvas,
+      region: viewport,
+      pixelRatio: pixelRatio,
+    );
+  }
+
+  /// Renders a list of [views] of this scene onto [canvas].
+  ///
+  /// Each [RenderView] binds a camera to a normalized sub-rectangle of
+  /// [region] (its [RenderView.viewport]), a [RenderView.layerMask], and a
+  /// compositing [RenderView.order]; views are drawn lowest-order first.
+  /// This is how split-screen and picture-in-picture are rendered. [render]
+  /// is the single-view convenience over this.
+  ///
+  /// Each view renders into its own offscreen target (its own swapchain
+  /// texture and transient texture pool), so simultaneous views never share
+  /// a render target within a frame.
+  ///
+  /// [region] is the canvas rectangle the views subdivide; it defaults to
+  /// the canvas clip bounds. [pixelRatio] is the logical-to-physical
+  /// multiplier for the offscreen render targets (defaults to the view's
+  /// device pixel ratio).
+  ///
+  /// The scene is advanced once per call (a single per-frame tick), then
+  /// every view is rendered from that shared scene state.
+  void renderViews(
+    List<RenderView> views,
+    ui.Canvas canvas, {
+    ui.Rect? region,
     double? pixelRatio,
   }) {
     if (!_readyToRender) {
@@ -381,31 +418,17 @@ base class Scene implements SceneGraph {
       return;
     }
 
-    final drawArea = viewport ?? canvas.getLocalClipBounds();
-    if (drawArea.isEmpty) {
+    final drawArea = region ?? canvas.getLocalClipBounds();
+    if (drawArea.isEmpty || views.isEmpty) {
       return;
     }
 
-    // Allocate the offscreen render target at physical-pixel resolution so
-    // the rasterized 3D content matches Flutter's framebuffer density.
-    // Without this, the texture is sized in logical pixels and the
-    // framebuffer compositor upscales it (visible as pixelation on
-    // high-DPI devices). See: https://github.com/bdero/flutter_scene/issues/60
     final dpr =
         pixelRatio ??
         ui.PlatformDispatcher.instance.implicitView?.devicePixelRatio ??
         1.0;
-    final pixelSize = ui.Size(
-      (drawArea.width * dpr).ceilToDouble(),
-      (drawArea.height * dpr).ceilToDouble(),
-    );
 
-    final enableMsaa = _antiAliasingMode == AntiAliasingMode.msaa;
-    final gpu.Texture swapchainColor = surface.getNextSwapchainColorTexture(
-      pixelSize,
-    );
-
-    // Resolve the IBL environment up front (before building the render
+    // Resolve the IBL environment up front (before building any render
     // graph): the default is built lazily here on first use, which submits
     // a one-time prefilter pass that must not be nested inside the frame's
     // render passes. Doing this in the constructor instead would break the
@@ -414,18 +437,107 @@ base class Scene implements SceneGraph {
     final environmentMap = environment ?? Material.getDefaultEnvironmentMap();
 
     // Reuse one host buffer across frames; reset() cycles it to the next
-    // frame's backing storage.
+    // frame's backing storage. Shared by every view this frame.
     final transientsBuffer = _transientsBuffer ??= gpu.gpuContext
         .createHostBuffer();
     transientsBuffer.reset();
 
+    // Advance the scene once per frame (not once per view): tick components
+    // and animations and refresh the flat render list before the passes
+    // iterate it. Skipped when update() already ran the tick this frame.
+    if (!_tickedThisFrame) {
+      final nowMillis = DateTime.now().millisecondsSinceEpoch;
+      final lastMillis = _lastTickMillis ?? nowMillis;
+      _tick((nowMillis - lastMillis) / 1000.0);
+    }
+    _tickedThisFrame = false;
+
+    // Rebuild the spatial culling structure once if the pre-pass changed the
+    // scene, before the views' render passes query it.
+    renderScene.rebuildIfDirty();
+
     // The renderer shades a single directional light: the first one
     // registered in the graph (the [directionalLight] convenience, or a
-    // [DirectionalLightComponent] attached to any node). Its travel
-    // direction comes from the owning node's world transform.
+    // [DirectionalLightComponent] attached to any node).
     final lightComponent = renderScene.directionalLights.isEmpty
         ? null
         : renderScene.directionalLights.first;
+
+    // Composite lower-order views first.
+    final ordered = views.length == 1
+        ? views
+        : (List<RenderView>.of(views)
+            ..sort((a, b) => a.order.compareTo(b.order)));
+
+    for (var i = 0; i < ordered.length; i++) {
+      final view = ordered[i];
+      final viewArea = _viewDrawArea(drawArea, view.viewport);
+      if (viewArea.isEmpty) {
+        continue;
+      }
+      _renderViewToCanvas(
+        view: view,
+        canvas: canvas,
+        drawArea: viewArea,
+        dpr: dpr,
+        viewIndex: i,
+        environmentMap: environmentMap,
+        transientsBuffer: transientsBuffer,
+        lightComponent: lightComponent,
+      );
+    }
+  }
+
+  // Maps a view's normalized viewport rectangle (0..1) into a canvas
+  // sub-rectangle of [area]; a null viewport fills [area].
+  ui.Rect _viewDrawArea(ui.Rect area, ui.Rect? viewport) {
+    if (viewport == null) return area;
+    return ui.Rect.fromLTWH(
+      area.left + viewport.left * area.width,
+      area.top + viewport.top * area.height,
+      viewport.width * area.width,
+      viewport.height * area.height,
+    );
+  }
+
+  // Renders one [view] into [drawArea] on [canvas], using that view's own
+  // swapchain texture and transient texture pool (so simultaneous views in a
+  // frame do not share render targets). The per-frame work (tick, spatial
+  // rebuild, environment resolve, host-buffer reset) is done once by the
+  // caller; this builds and submits one view's render graph and composites
+  // the result.
+  void _renderViewToCanvas({
+    required RenderView view,
+    required ui.Canvas canvas,
+    required ui.Rect drawArea,
+    required double dpr,
+    required int viewIndex,
+    required EnvironmentMap environmentMap,
+    required gpu.HostBuffer transientsBuffer,
+    required DirectionalLightComponent? lightComponent,
+  }) {
+    final camera = view.camera;
+
+    // Allocate the offscreen render target at physical-pixel resolution so
+    // the rasterized 3D content matches Flutter's framebuffer density.
+    // Without this, the texture is sized in logical pixels and the
+    // framebuffer compositor upscales it (visible as pixelation on
+    // high-DPI devices). See: https://github.com/bdero/flutter_scene/issues/60
+    final pixelSize = ui.Size(
+      (drawArea.width * dpr).ceilToDouble(),
+      (drawArea.height * dpr).ceilToDouble(),
+    );
+    if (pixelSize.width < 1 || pixelSize.height < 1) {
+      return;
+    }
+
+    final enableMsaa = _antiAliasingMode == AntiAliasingMode.msaa;
+    final gpu.Texture swapchainColor = surface.getNextSwapchainColorTexture(
+      pixelSize,
+      viewIndex,
+    );
+    final pool = surface.transientTexturePool(viewIndex);
+
     final light = lightComponent?.light;
     final lightDirection = lightComponent?.worldDirection;
     // Cascaded shadows fit the camera frustum, so they require a
@@ -440,20 +552,6 @@ base class Scene implements SceneGraph {
             lightDirection,
           )
         : const <ShadowCascade>[];
-
-    // Walk the graph once to tick components and animations and refresh
-    // the flat render list before the passes iterate it. Skipped when
-    // update() already ran the tick for this frame.
-    if (!_tickedThisFrame) {
-      final nowMillis = DateTime.now().millisecondsSinceEpoch;
-      final lastMillis = _lastTickMillis ?? nowMillis;
-      _tick((nowMillis - lastMillis) / 1000.0);
-    }
-    _tickedThisFrame = false;
-
-    // Rebuild the spatial culling structure if the pre-pass changed the
-    // scene, before the render passes query it.
-    renderScene.rebuildIfDirty();
 
     final graph = RenderGraph();
     if (cascades.isNotEmpty) {
@@ -483,6 +581,7 @@ base class Scene implements SceneGraph {
           dimensions: aoDimensions,
           cameraForward: camera.forward,
           farDepth: perspective.far,
+          layerMask: view.layerMask,
         ),
       );
       graph.addPass(
@@ -511,6 +610,7 @@ base class Scene implements SceneGraph {
         directionalLightDirection: lightDirection,
         cascades: cascades,
         specularOcclusionMode: ambientOcclusion.specularMode.index.toDouble(),
+        layerMask: view.layerMask,
       ),
     );
     // Split custom effects by where they run in the chain.
@@ -527,7 +627,6 @@ base class Scene implements SceneGraph {
       }
     }
 
-    final pool = surface.transientTexturePool;
     final width = pixelSize.width.toInt();
     final height = pixelSize.height.toInt();
     final postTime =
@@ -611,10 +710,7 @@ base class Scene implements SceneGraph {
       );
     }
 
-    graph.execute(
-      transientsBuffer: transientsBuffer,
-      texturePool: surface.transientTexturePool,
-    );
+    graph.execute(transientsBuffer: transientsBuffer, texturePool: pool);
 
     final image = swapchainColor.asImage();
     final srcRect = ui.Rect.fromLTWH(0, 0, pixelSize.width, pixelSize.height);

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart' show Matrix3;
 import 'ambient_occlusion.dart';
 import 'camera.dart';
+import 'components/directional_light_component.dart';
 import 'light.dart';
 import 'material/environment.dart';
 import 'material/material.dart';
@@ -198,9 +199,33 @@ base class Scene implements SceneGraph {
   /// sampled. Identity (the default) leaves the environment unrotated.
   Matrix3 environmentTransform = Matrix3.identity();
 
-  /// Optional analytic directional light (e.g. a sun) layered on top of
+  // The component backing the [directionalLight] convenience: a single
+  // light attached to [root]. Null when no scene-level light is set.
+  DirectionalLightComponent? _directionalLightComponent;
+
+  /// A single analytic directional light (e.g. a sun) layered on top of
   /// the image-based lighting. Null (the default) means IBL only.
-  DirectionalLight? directionalLight;
+  ///
+  /// This is a convenience over attaching a [DirectionalLightComponent] to
+  /// a node: the light is attached to [root] (so its direction is the
+  /// light's own [DirectionalLight.direction], unaffected by any node
+  /// transform). For lights that should move or aim with a node, attach a
+  /// [DirectionalLightComponent] to that node instead. The renderer shades
+  /// the first directional light it finds in the graph.
+  DirectionalLight? get directionalLight => _directionalLightComponent?.light;
+
+  set directionalLight(DirectionalLight? value) {
+    final existing = _directionalLightComponent;
+    if (existing != null) {
+      root.removeComponent(existing);
+      _directionalLightComponent = null;
+    }
+    if (value != null) {
+      final component = DirectionalLightComponent(value);
+      root.addComponent(component);
+      _directionalLightComponent = component;
+    }
+  }
 
   /// Linear exposure multiplier applied to the HDR scene color before
   /// tone mapping. `1.0` (the default) is neutral; see
@@ -394,12 +419,24 @@ base class Scene implements SceneGraph {
         .createHostBuffer();
     transientsBuffer.reset();
 
-    final light = directionalLight;
+    // The renderer shades a single directional light: the first one
+    // registered in the graph (the [directionalLight] convenience, or a
+    // [DirectionalLightComponent] attached to any node). Its travel
+    // direction comes from the owning node's world transform.
+    final lightComponent = renderScene.directionalLights.isEmpty
+        ? null
+        : renderScene.directionalLights.first;
+    final light = lightComponent?.light;
+    final lightDirection = lightComponent?.worldDirection;
     // Cascaded shadows fit the camera frustum, so they require a
     // perspective camera; other camera types render without shadows.
     final cascades =
         light != null && light.castsShadow && camera is PerspectiveCamera
-        ? light.computeCascades(camera, pixelSize.width / pixelSize.height)
+        ? light.computeCascades(
+            camera,
+            pixelSize.width / pixelSize.height,
+            lightDirection,
+          )
         : const <ShadowCascade>[];
 
     // Walk the graph once to tick components and animations and refresh
@@ -468,6 +505,7 @@ base class Scene implements SceneGraph {
         environmentTransform: environmentTransform,
         enableMsaa: enableMsaa,
         directionalLight: light,
+        directionalLightDirection: lightDirection,
         cascades: cascades,
         specularOcclusionMode: ambientOcclusion.specularMode.index.toDouble(),
       ),

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -429,9 +429,11 @@ base class Scene implements SceneGraph {
     final light = lightComponent?.light;
     final lightDirection = lightComponent?.worldDirection;
     // Cascaded shadows fit the camera frustum, so they require a
-    // perspective camera; other camera types render without shadows.
+    // perspective projection; other projections render without shadows.
     final cascades =
-        light != null && light.castsShadow && camera is PerspectiveCamera
+        light != null &&
+            light.castsShadow &&
+            camera.projection is PerspectiveProjection
         ? light.computeCascades(
             camera,
             pixelSize.width / pixelSize.height,
@@ -464,8 +466,9 @@ base class Scene implements SceneGraph {
       );
     }
     // Ambient occlusion is reconstructed from a camera depth prepass, so it
-    // needs a perspective camera (other camera types render without it).
-    if (ambientOcclusion.enabled && camera is PerspectiveCamera) {
+    // needs a perspective projection (others render without it).
+    final perspective = camera.projection;
+    if (ambientOcclusion.enabled && perspective is PerspectiveProjection) {
       // The whole occlusion chain (depth prepass, occlusion, blur) runs at one
       // resolution so depth is sampled 1:1; sampling a full-resolution depth
       // from the half-resolution occlusion pass would alias on fine geometry.
@@ -478,17 +481,17 @@ base class Scene implements SceneGraph {
           camera: camera,
           renderScene: renderScene,
           dimensions: aoDimensions,
-          cameraForward: (camera.target - camera.position).normalized(),
-          farDepth: camera.fovFar,
+          cameraForward: camera.forward,
+          farDepth: perspective.far,
         ),
       );
       graph.addPass(
         SsaoPass(
           dimensions: pixelSize,
           settings: ambientOcclusion,
-          fovRadiansY: camera.fovRadiansY,
-          near: camera.fovNear,
-          far: camera.fovFar,
+          fovRadiansY: perspective.fovRadiansY,
+          near: perspective.near,
+          far: perspective.far,
         ),
       );
       graph.addPass(

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -104,6 +104,7 @@ base class SceneEncoder {
     this._camera,
     ui.Size dimensions,
     this._lighting,
+    this._layerMask,
   ) : _renderPass = renderPass,
       _transientsBuffer = transientsBuffer {
     _cameraTransform = _camera.getViewTransform(dimensions);
@@ -117,6 +118,7 @@ base class SceneEncoder {
 
   final Camera _camera;
   final Lighting _lighting;
+  final int _layerMask;
   final gpu.RenderPass _renderPass;
   final gpu.HostBuffer _transientsBuffer;
   late final Matrix4 _cameraTransform;
@@ -146,6 +148,7 @@ base class SceneEncoder {
   /// instance so each can be depth-sorted independently.
   void submit(RenderItem item) {
     if (!item.visible) return;
+    if ((item.layers & _layerMask) == 0) return;
     if (item.frustumCulled) {
       final bounds = item.cullBounds;
       if (bounds != null) {

--- a/packages/flutter_scene/lib/src/surface.dart
+++ b/packages/flutter_scene/lib/src/surface.dart
@@ -5,45 +5,70 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/render/render_graph.dart';
 
 /// Manages the swapchain color textures a [Scene] composites onto the
-/// Flutter canvas, plus the pool of transient render-graph attachments.
+/// Flutter canvas, plus the pools of transient render-graph attachments.
 ///
-/// Each [Scene] owns one `Surface`. Every frame the renderer asks the
-/// surface for the next swapchain color texture via
-/// [getNextSwapchainColorTexture]; the surface rotates through a small
-/// ring of textures so the GPU isn't asked to overwrite one the
-/// compositor is still reading. The tone-mapping pass renders the final
-/// image into this texture, which is then drawn to the canvas via
-/// `Texture.asImage`. The ring (and the transient texture pool) are
-/// dropped and rebuilt whenever the requested size changes.
+/// Each [Scene] owns one `Surface`. A scene may render several views per
+/// frame (split-screen, picture-in-picture); each view gets its own
+/// swapchain ring and its own transient texture pool, so simultaneous views
+/// never share a render target within a frame. View 0 is the single-view
+/// default.
+///
+/// Every view, every frame, the renderer asks the surface for that view's
+/// next swapchain color texture via [getNextSwapchainColorTexture]; the
+/// surface rotates through a small ring per view so the GPU isn't asked to
+/// overwrite one the compositor is still reading. The tone-mapping pass
+/// renders the final image into this texture, which is then drawn to the
+/// canvas via `Texture.asImage`. Each ring (and the view's transient pool)
+/// is dropped and rebuilt whenever that view's requested size changes.
 ///
 /// Applications typically don't interact with `Surface` directly; it is
-/// driven internally by [Scene.render].
+/// driven internally by [Scene.render] / [Scene.renderViews].
 class Surface {
   // TODO(bdero): There should be a method on the Flutter GPU context to pull
   //              this information.
   static const int _maxFramesInFlight = 2;
 
-  /// Pool of transient textures used as intermediate render targets by
-  /// the render graph (the HDR scene color, MSAA color, depth, shadow
-  /// maps, post-process buffers, ...). Empty until a pass acquires one.
-  final TransientTexturePool transientTexturePool = TransientTexturePool(
-    framesInFlight: _maxFramesInFlight,
+  final List<_ViewSurface> _views = [];
+
+  _ViewSurface _view(int index) {
+    while (_views.length <= index) {
+      _views.add(_ViewSurface());
+    }
+    return _views[index];
+  }
+
+  /// The transient texture pool for view [viewIndex] (the intermediate
+  /// render-graph attachments: HDR scene color, depth, shadow maps,
+  /// post-process buffers). Each view has its own pool so simultaneous
+  /// views in a frame never share an attachment.
+  TransientTexturePool transientTexturePool([int viewIndex = 0]) =>
+      _view(viewIndex).pool;
+
+  /// Returns the next 8-bit swapchain color texture for view [viewIndex] at
+  /// [size], advancing that view's frame. The ring (and the view's
+  /// transient pool) are dropped and rebuilt whenever [size] changes from
+  /// the view's previous call.
+  gpu.Texture getNextSwapchainColorTexture(Size size, [int viewIndex = 0]) =>
+      _view(viewIndex).nextSwapchainColor(size);
+}
+
+/// One view's swapchain color ring plus its transient texture pool. View 0
+/// reproduces the historical single-view behavior exactly.
+class _ViewSurface {
+  final TransientTexturePool pool = TransientTexturePool(
+    framesInFlight: Surface._maxFramesInFlight,
   );
 
   final List<gpu.Texture> _swapchainColors = [];
   int _cursor = 0;
   Size _previousSize = const Size(0, 0);
 
-  /// Returns the next 8-bit color texture in the rotating swapchain ring,
-  /// allocating one when the ring isn't yet full. The ring (and the
-  /// transient texture pool) are dropped and rebuilt whenever [size]
-  /// changes from the previous call.
-  gpu.Texture getNextSwapchainColorTexture(Size size) {
-    transientTexturePool.beginFrame();
+  gpu.Texture nextSwapchainColor(Size size) {
+    pool.beginFrame();
     if (size != _previousSize) {
       _cursor = 0;
       _swapchainColors.clear();
-      transientTexturePool.clear();
+      pool.clear();
       _previousSize = size;
     }
     if (_cursor == _swapchainColors.length) {
@@ -59,7 +84,7 @@ class Surface {
       );
     }
     final result = _swapchainColors[_cursor];
-    _cursor = (_cursor + 1) % _maxFramesInFlight;
+    _cursor = (_cursor + 1) % Surface._maxFramesInFlight;
     return result;
   }
 }

--- a/packages/flutter_scene/lib/src/widgets/scene_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/hot_reload/hot_reload_coordinator.dart';
+import 'package:flutter_scene/src/render_view.dart';
 import 'package:flutter_scene/src/scene.dart';
 
 /// Builds a [Camera] for the current frame from the [elapsed] time since the
@@ -11,6 +12,12 @@ import 'package:flutter_scene/src/scene.dart';
 /// orbiting view); pass a fixed [SceneView.camera] instead when the camera does
 /// not change over time.
 typedef SceneCameraBuilder = Camera Function(Duration elapsed);
+
+/// Builds the list of [RenderView]s to render for the current frame from the
+/// [elapsed] time since the view started ticking. Use this for multi-view
+/// rendering (split-screen, picture-in-picture); pass a single
+/// [SceneView.camera] or [SceneView.cameraBuilder] for one view.
+typedef SceneViewsBuilder = List<RenderView> Function(Duration elapsed);
 
 /// Called once per frame with the total [elapsed] time and the [deltaSeconds]
 /// since the previous tick. Drive per-frame app logic here, or advance the
@@ -56,29 +63,40 @@ typedef SceneTickCallback =
 class SceneView extends StatefulWidget {
   /// Renders [scene], driving a repaint each frame.
   ///
-  /// Exactly one of [camera] or [cameraBuilder] must be provided.
+  /// Exactly one of [camera], [cameraBuilder], or [viewsBuilder] must be
+  /// provided.
   const SceneView(
     this.scene, {
     super.key,
     this.camera,
     this.cameraBuilder,
+    this.viewsBuilder,
     this.autoTick = true,
     this.pixelRatio,
     this.onTick,
   }) : assert(
-         (camera == null) != (cameraBuilder == null),
-         'Provide exactly one of camera or cameraBuilder.',
+         (camera != null ? 1 : 0) +
+                 (cameraBuilder != null ? 1 : 0) +
+                 (viewsBuilder != null ? 1 : 0) ==
+             1,
+         'Provide exactly one of camera, cameraBuilder, or viewsBuilder.',
        );
 
   /// The scene to render. Owned and mutated by the application.
   final Scene scene;
 
-  /// A fixed camera. Mutually exclusive with [cameraBuilder].
+  /// A fixed camera. Mutually exclusive with [cameraBuilder] and
+  /// [viewsBuilder].
   final Camera? camera;
 
   /// Builds the camera each frame from the elapsed time. Mutually exclusive
-  /// with [camera].
+  /// with [camera] and [viewsBuilder].
   final SceneCameraBuilder? cameraBuilder;
+
+  /// Builds the list of views to render each frame (split-screen,
+  /// picture-in-picture). Mutually exclusive with [camera] and
+  /// [cameraBuilder].
+  final SceneViewsBuilder? viewsBuilder;
 
   /// Whether to drive a repaint every frame with an internal [Ticker].
   ///
@@ -144,6 +162,8 @@ class _SceneViewState extends State<SceneView>
   Camera _cameraForFrame() =>
       widget.camera ?? widget.cameraBuilder!(_elapsed.value);
 
+  List<RenderView> _viewsForFrame() => widget.viewsBuilder!(_elapsed.value);
+
   @override
   void reassemble() {
     super.reassemble();
@@ -174,7 +194,8 @@ class _SceneViewState extends State<SceneView>
         size: Size.infinite,
         painter: _ScenePainter(
           scene: widget.scene,
-          cameraForFrame: _cameraForFrame,
+          cameraForFrame: widget.viewsBuilder == null ? _cameraForFrame : null,
+          viewsForFrame: widget.viewsBuilder == null ? null : _viewsForFrame,
           pixelRatio: widget.pixelRatio,
           repaint: _repaint,
         ),
@@ -187,28 +208,41 @@ class _ScenePainter extends CustomPainter {
   _ScenePainter({
     required this.scene,
     required this.cameraForFrame,
+    required this.viewsForFrame,
     required this.pixelRatio,
     required Listenable repaint,
   }) : super(repaint: repaint);
 
   final Scene scene;
-  final Camera Function() cameraForFrame;
+  final Camera Function()? cameraForFrame;
+  final List<RenderView> Function()? viewsForFrame;
   final double? pixelRatio;
 
   @override
   void paint(Canvas canvas, Size size) {
-    scene.render(
-      cameraForFrame(),
-      canvas,
-      viewport: Offset.zero & size,
-      pixelRatio: pixelRatio,
-    );
+    final views = viewsForFrame;
+    if (views != null) {
+      scene.renderViews(
+        views(),
+        canvas,
+        region: Offset.zero & size,
+        pixelRatio: pixelRatio,
+      );
+    } else {
+      scene.render(
+        cameraForFrame!(),
+        canvas,
+        viewport: Offset.zero & size,
+        pixelRatio: pixelRatio,
+      );
+    }
   }
 
   @override
   bool shouldRepaint(covariant _ScenePainter oldDelegate) =>
       scene != oldDelegate.scene ||
       cameraForFrame != oldDelegate.cameraForFrame ||
+      viewsForFrame != oldDelegate.viewsForFrame ||
       pixelRatio != oldDelegate.pixelRatio;
 }
 

--- a/packages/flutter_scene/test/camera_component_test.dart
+++ b/packages/flutter_scene/test/camera_component_test.dart
@@ -1,0 +1,63 @@
+// Covers CameraComponent: a camera whose view is derived from the owning
+// node's world transform should match an equivalent free PerspectiveCamera.
+
+import 'dart:ui' show Size;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  group('CameraComponent', () {
+    test('derives a view matching an equivalent PerspectiveCamera', () {
+      final reference = PerspectiveCamera(
+        position: Vector3(3.0, 4.0, 5.0),
+        target: Vector3(-1.0, 0.5, 2.0),
+        up: Vector3(0.0, 1.0, 0.0),
+        fovRadiansY: 0.9,
+        fovNear: 0.2,
+        fovFar: 500.0,
+      );
+
+      // Place a camera node where the reference camera sits: the node's
+      // world transform is the inverse of the reference view matrix.
+      final world = Matrix4.identity()..copyInverse(reference.getViewMatrix());
+      final node = Node(localTransform: world);
+      final component = CameraComponent(projection: reference.projection);
+      node.addComponent(component);
+      final camera = component.toCamera();
+
+      const size = Size(800.0, 600.0);
+      final expected = reference.getViewTransform(size);
+      final actual = camera.getViewTransform(size);
+      for (var i = 0; i < 16; i++) {
+        expect(
+          actual.storage[i],
+          closeTo(expected.storage[i], 1e-5),
+          reason: 'view-projection element $i',
+        );
+      }
+
+      expect(camera.position.x, closeTo(reference.position.x, 1e-5));
+      expect(camera.position.y, closeTo(reference.position.y, 1e-5));
+      expect(camera.position.z, closeTo(reference.position.z, 1e-5));
+
+      final refForward = reference.forward;
+      expect(camera.forward.x, closeTo(refForward.x, 1e-5));
+      expect(camera.forward.y, closeTo(refForward.y, 1e-5));
+      expect(camera.forward.z, closeTo(refForward.z, 1e-5));
+    });
+
+    test('captures the node transform at the time toCamera is called', () {
+      final node = Node();
+      final component = CameraComponent();
+      node.addComponent(component);
+
+      node.localTransform = Matrix4.translation(Vector3(1.0, 2.0, 3.0));
+      final camera = component.toCamera();
+      expect(camera.position.x, closeTo(1.0, 1e-6));
+      expect(camera.position.y, closeTo(2.0, 1e-6));
+      expect(camera.position.z, closeTo(3.0, 1e-6));
+    });
+  });
+}


### PR DESCRIPTION
Move directional lighting and cameras onto per-node components, and add multi-view rendering.

Lighting and cameras:
- `DirectionalLightComponent` attaches a directional light to a node. The renderer collects directional lights from the scene graph and shades the first one, with the light's travel direction taken from the owning node's world transform. `Scene.directionalLight` stays as a convenience that attaches a component to the scene root, so existing code is unchanged.
- Cameras are split into a `CameraProjection` (the lens, `PerspectiveProjection` today) and a view. `PerspectiveCamera` stays the free camera positioned by eye/target/up. The new `CameraComponent` derives the view from its node's world transform, so a camera can live in the scene graph.

Views and layers:
- `RenderView` binds a camera to a target sub-rectangle, a layer mask, and a compositing order. Nodes carry a `layers` bitmask, and a view renders a node only when their masks intersect.
- `Scene.renderViews` draws a list of views in one frame (split-screen, picture-in-picture), each into its own canvas sub-rectangle with its own camera and layer mask. `Scene.render` is the single-view convenience over it. Each view renders into its own offscreen target, so simultaneous views never share a render target within a frame. `SceneView` gains a `viewsBuilder`.

The example apps migrate to the component APIs, and a split-screen example is added.