### PR TITLE
Add the .fscene / .fsceneb serialized scene format

### DIFF
--- a/examples/flutter_app/hook/build.dart
+++ b/examples/flutter_app/hook/build.dart
@@ -4,17 +4,26 @@ import 'package:flutter_scene/build_hooks.dart';
 
 void main(List<String> args) {
   build(args, (config, output) async {
+    // Reference the shared corpus through the in-package `assets_src` symlink
+    // so each asset is keyed by a path relative to the package root.
+    const corpus = [
+      'assets_src/two_triangles.glb',
+      'assets_src/flutter_logo_baked.glb',
+      'assets_src/dash.glb',
+      'assets_src/fcar.glb',
+    ];
     buildModels(
       buildInput: config,
       buildOutput: output,
-      // Reference the shared corpus through the in-package `assets_src` symlink
-      // so each model is keyed by a path relative to the package root.
-      inputFilePaths: [
-        'assets_src/two_triangles.glb',
-        'assets_src/flutter_logo_baked.glb',
-        'assets_src/dash.glb',
-        'assets_src/fcar.glb',
-      ],
+      inputFilePaths: corpus,
+      assetMode: ModelAssetMode.dataAssetsIfAvailable,
+    );
+    // The same corpus as `.fsceneb` packages, loaded by source path through
+    // loadScene (the "fscene (import)" example).
+    buildScenes(
+      buildInput: config,
+      buildOutput: output,
+      inputFilePaths: corpus,
       assetMode: ModelAssetMode.dataAssetsIfAvailable,
     );
     await buildShaderBundleJson(

--- a/examples/flutter_app/lib/example_fscene.dart
+++ b/examples/flutter_app/lib/example_fscene.dart
@@ -13,12 +13,15 @@ import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_settings.dart';
 
-/// Builds a scene as an `.fscene` document in code, writes it to a `.fsceneb`
-/// binary container, reads it back, and realizes it into a live node graph.
-/// This exercises the full round-trip: document model -> binary package ->
-/// live scene, with procedural geometry, a payload-backed mesh (interleaved
-/// vertex/index chunks, the shape an imported model takes), parameter
-/// materials, and a directional light.
+/// Builds a scene as an `.fscene` document in code and runs it through the
+/// whole format pipeline both ways: document -> `.fsceneb` -> live graph
+/// (realize), then live graph -> document (serialize) -> `.fsceneb` -> live
+/// graph again. The twice-realized scene is what renders, so anything that
+/// fails to survive serialization (payload geometry, textures, materials,
+/// the light) would visibly drop out. It exercises procedural geometry, a
+/// payload-backed mesh (interleaved vertex/index chunks, the shape an imported
+/// model takes), an image-payload texture, parameter materials, and a
+/// directional light.
 class ExampleFscene extends StatefulWidget {
   const ExampleFscene({super.key});
 
@@ -32,8 +35,11 @@ class _ExampleFsceneState extends State<ExampleFscene> {
   @override
   void initState() {
     super.initState();
-    final bytes = writeFsceneb(_buildDocument());
-    scene.add(loadFscenebBytes(bytes));
+    // Realize the authored document, serialize the live graph back to a
+    // document, then realize that. What renders is the round-tripped scene.
+    final realized = loadFscenebBytes(writeFsceneb(_buildDocument()));
+    final roundTripped = serializeScene(realized);
+    scene.add(loadFscenebBytes(writeFsceneb(roundTripped)));
   }
 
   @override

--- a/examples/flutter_app/lib/example_fscene.dart
+++ b/examples/flutter_app/lib/example_fscene.dart
@@ -3,14 +3,21 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/fscene.dart';
 import 'package:flutter_scene/scene.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/geometry/primitives.dart'
+    show buildCuboidArrays;
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_settings.dart';
 
-/// Builds a scene as an `.fscene` document in code, writes it to `.fscene`
-/// text, reads it back, and realizes it into a live node graph. This
-/// exercises the full round-trip: document model -> JSON -> live scene, with
-/// procedural geometry, parameter materials, and a directional light.
+/// Builds a scene as an `.fscene` document in code, writes it to a `.fsceneb`
+/// binary container, reads it back, and realizes it into a live node graph.
+/// This exercises the full round-trip: document model -> binary package ->
+/// live scene, with procedural geometry, a payload-backed mesh (interleaved
+/// vertex/index chunks, the shape an imported model takes), parameter
+/// materials, and a directional light.
 class ExampleFscene extends StatefulWidget {
   const ExampleFscene({super.key});
 
@@ -24,8 +31,8 @@ class _ExampleFsceneState extends State<ExampleFscene> {
   @override
   void initState() {
     super.initState();
-    final text = writeFscene(_buildDocument());
-    scene.add(loadFsceneString(text));
+    final bytes = writeFsceneb(_buildDocument());
+    scene.add(loadFscenebBytes(bytes));
   }
 
   @override
@@ -134,5 +141,68 @@ SceneDocument _buildDocument() {
     );
   }
 
+  // A payload-backed mesh: its geometry lives in binary vertex/index chunks
+  // (the same interleaved layout an imported model produces) rather than a
+  // procedural descriptor. It rides above the ring so it is easy to pick out.
+  final green = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'physicallyBased',
+      properties: {
+        'baseColor': const ColorValue(0.2, 0.8, 0.3, 1.0),
+        'roughness': const DoubleValue(0.5),
+      },
+    ),
+  );
+  final payloadCube = _payloadCuboid(doc, vm.Vector3(1.4, 1.4, 1.4));
+  doc.createNode(
+    name: 'payloadCube',
+    root: true,
+    transform: TrsTransform(translation: vm.Vector3(0, 1.6, 0)),
+    components: [
+      ComponentSpec(
+        'mesh',
+        properties: {
+          'geometry': ResourceRefValue(payloadCube.id),
+          'material': ResourceRefValue(green.id),
+        },
+      ),
+    ],
+  );
+
   return doc;
+}
+
+/// Builds a cuboid as payload-backed geometry: the interleaved vertex buffer
+/// and index buffer are packed into binary chunks and referenced by a
+/// [GeometryResource], the way the importer will emit imported meshes.
+GeometryResource _payloadCuboid(SceneDocument doc, vm.Vector3 extents) {
+  final arrays = buildCuboidArrays(extents);
+  final vertexBytes = InterleavedLayoutAdapter.packUnskinned(
+    positions: arrays.positions,
+    vertexCount: arrays.positions.length ~/ 3,
+    normals: arrays.normals,
+    texCoords: arrays.texCoords,
+  );
+  final packedIndices = InterleavedLayoutAdapter.packIndices(arrays.indices);
+
+  final vertices = doc.addPayload(
+    PayloadSpec(
+      doc.newId(),
+      encoding: PayloadEncoding.vertexBuffer,
+      layout: 'unskinned',
+      bytes: vertexBytes,
+    ),
+  );
+  final indices = doc.addPayload(
+    PayloadSpec(
+      doc.newId(),
+      encoding: PayloadEncoding.indexBuffer,
+      format: packedIndices.is32Bit ? 'uint32' : 'uint16',
+      bytes: packedIndices.bytes,
+    ),
+  );
+  return doc.addResource(
+    GeometryResource(doc.newId(), vertices: vertices.id, indices: indices.id),
+  );
 }

--- a/examples/flutter_app/lib/example_fscene.dart
+++ b/examples/flutter_app/lib/example_fscene.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/fscene.dart';
@@ -170,7 +171,61 @@ SceneDocument _buildDocument() {
     ],
   );
 
+  // A textured cube: its material samples a checkerboard image carried as an
+  // rgba8 payload chunk (the shape an imported texture takes). Unlit so the
+  // pattern reads directly.
+  final checker = _checkerTexture(doc);
+  final tiles = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'unlit',
+      properties: {'baseColorTexture': ResourceRefValue(checker.id)},
+    ),
+  );
+  doc.createNode(
+    name: 'texturedCube',
+    root: true,
+    transform: TrsTransform(translation: vm.Vector3(0, 0.5, 3.6)),
+    components: [
+      ComponentSpec(
+        'mesh',
+        properties: {
+          'geometry': ResourceRefValue(cubeGeometry.id),
+          'material': ResourceRefValue(tiles.id),
+        },
+      ),
+    ],
+  );
+
   return doc;
+}
+
+/// Builds a high-contrast checkerboard as an rgba8 image payload referenced by
+/// a [TextureResource], the way an imported texture is carried.
+TextureResource _checkerTexture(SceneDocument doc) {
+  const size = 16;
+  final pixels = Uint8List(size * size * 4);
+  for (var y = 0; y < size; y++) {
+    for (var x = 0; x < size; x++) {
+      final i = (y * size + x) * 4;
+      final lit = ((x ~/ 2) + (y ~/ 2)).isEven;
+      pixels[i] = lit ? 235 : 25;
+      pixels[i + 1] = lit ? 235 : 25;
+      pixels[i + 2] = lit ? 235 : 25;
+      pixels[i + 3] = 255;
+    }
+  }
+  final payload = doc.addPayload(
+    PayloadSpec(
+      doc.newId(),
+      encoding: PayloadEncoding.image,
+      format: 'rgba8',
+      width: size,
+      height: size,
+      bytes: pixels,
+    ),
+  );
+  return doc.addResource(TextureResource(doc.newId(), payload: payload.id));
 }
 
 /// Builds a cuboid as payload-backed geometry: the interleaved vertex buffer

--- a/examples/flutter_app/lib/example_fscene.dart
+++ b/examples/flutter_app/lib/example_fscene.dart
@@ -1,0 +1,138 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+
+/// Builds a scene as an `.fscene` document in code, writes it to `.fscene`
+/// text, reads it back, and realizes it into a live node graph. This
+/// exercises the full round-trip: document model -> JSON -> live scene, with
+/// procedural geometry, parameter materials, and a directional light.
+class ExampleFscene extends StatefulWidget {
+  const ExampleFscene({super.key});
+
+  @override
+  State<ExampleFscene> createState() => _ExampleFsceneState();
+}
+
+class _ExampleFsceneState extends State<ExampleFscene> {
+  final Scene scene = Scene();
+
+  @override
+  void initState() {
+    super.initState();
+    final text = writeFscene(_buildDocument());
+    scene.add(loadFsceneString(text));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SceneView(
+      scene,
+      cameraBuilder: (elapsed) {
+        final t = elapsed.inMicroseconds / 1e6;
+        return PerspectiveCamera(
+          position: vm.Vector3(sin(t) * 6, 3, cos(t) * 6),
+          target: vm.Vector3(0, 0, 0),
+        );
+      },
+      onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+    );
+  }
+}
+
+SceneDocument _buildDocument() {
+  final doc = SceneDocument();
+
+  // A sun, pitched down toward the scene.
+  doc.createNode(
+    name: 'sun',
+    root: true,
+    transform: TrsTransform(
+      rotation: vm.Quaternion.axisAngle(vm.Vector3(1, 0, 0), -1.0),
+    ),
+    components: [
+      ComponentSpec(
+        'directionalLight',
+        properties: {
+          'intensity': const DoubleValue(3.0),
+          'castsShadow': const BoolValue(true),
+        },
+      ),
+    ],
+  );
+
+  final red = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'physicallyBased',
+      properties: {
+        'baseColor': const ColorValue(0.9, 0.2, 0.2, 1.0),
+        'roughness': const DoubleValue(0.4),
+      },
+    ),
+  );
+  final blue = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'physicallyBased',
+      properties: {
+        'baseColor': const ColorValue(0.2, 0.4, 0.9, 1.0),
+        'metallic': const DoubleValue(0.8),
+        'roughness': const DoubleValue(0.3),
+      },
+    ),
+  );
+
+  final planeGeometry = doc.addResource(
+    GeometryResource(
+      doc.newId(),
+      procedural: PlaneGeometrySpec(width: 10, depth: 10),
+    ),
+  );
+  doc.createNode(
+    name: 'ground',
+    root: true,
+    transform: TrsTransform(translation: vm.Vector3(0, -1, 0)),
+    components: [
+      ComponentSpec(
+        'mesh',
+        properties: {
+          'geometry': ResourceRefValue(planeGeometry.id),
+          'material': ResourceRefValue(blue.id),
+        },
+      ),
+    ],
+  );
+
+  final cubeGeometry = doc.addResource(
+    GeometryResource(
+      doc.newId(),
+      procedural: CuboidGeometrySpec(extents: vm.Vector3(1, 1, 1)),
+    ),
+  );
+  for (var i = 0; i < 5; i++) {
+    final angle = i / 5 * 2 * pi;
+    doc.createNode(
+      name: 'cube$i',
+      root: true,
+      transform: TrsTransform(
+        translation: vm.Vector3(cos(angle) * 2.5, 0, sin(angle) * 2.5),
+      ),
+      components: [
+        ComponentSpec(
+          'mesh',
+          properties: {
+            'geometry': ResourceRefValue(cubeGeometry.id),
+            'material': ResourceRefValue(i.isEven ? red.id : blue.id),
+          },
+        ),
+      ],
+    );
+  }
+
+  return doc;
+}

--- a/examples/flutter_app/lib/example_fscene.dart
+++ b/examples/flutter_app/lib/example_fscene.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_scene/fscene.dart';
 import 'package:flutter_scene/scene.dart';
 // ignore: implementation_imports
@@ -17,11 +18,11 @@ import 'example_settings.dart';
 /// whole format pipeline both ways: document -> `.fsceneb` -> live graph
 /// (realize), then live graph -> document (serialize) -> `.fsceneb` -> live
 /// graph again. The twice-realized scene is what renders, so anything that
-/// fails to survive serialization (payload geometry, textures, materials,
-/// the light) would visibly drop out. It exercises procedural geometry, a
-/// payload-backed mesh (interleaved vertex/index chunks, the shape an imported
-/// model takes), an image-payload texture, parameter materials, and a
-/// directional light.
+/// fails to survive serialization would visibly drop out. It exercises
+/// procedural geometry, a payload-backed mesh, parameter materials, a
+/// directional light, and the asynchronously-loaded resources: an embedded
+/// `rgba8` texture, an external image-asset texture, an encoded (PNG) image
+/// payload, and an `fmat` custom material.
 class ExampleFscene extends StatefulWidget {
   const ExampleFscene({super.key});
 
@@ -35,11 +36,27 @@ class _ExampleFsceneState extends State<ExampleFscene> {
   @override
   void initState() {
     super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    // An encoded image to carry as a PNG payload chunk (decoded at load).
+    final pano = await rootBundle.load('assets/little_paris_eiffel_tower.png');
+    final pngBytes = pano.buffer.asUint8List(
+      pano.offsetInBytes,
+      pano.lengthInBytes,
+    );
+
     // Realize the authored document, serialize the live graph back to a
     // document, then realize that. What renders is the round-tripped scene.
-    final realized = loadFscenebBytes(writeFsceneb(_buildDocument()));
+    // The async loader preloads external assets, encoded payloads, and fmat
+    // materials before realizing.
+    final realized = await loadFscenebBytesAsync(
+      writeFsceneb(_buildDocument(pngBytes)),
+    );
     final roundTripped = serializeScene(realized);
-    scene.add(loadFscenebBytes(writeFsceneb(roundTripped)));
+    if (!mounted) return;
+    scene.add(await loadFscenebBytesAsync(writeFsceneb(roundTripped)));
   }
 
   @override
@@ -49,8 +66,8 @@ class _ExampleFsceneState extends State<ExampleFscene> {
       cameraBuilder: (elapsed) {
         final t = elapsed.inMicroseconds / 1e6;
         return PerspectiveCamera(
-          position: vm.Vector3(sin(t) * 6, 3, cos(t) * 6),
-          target: vm.Vector3(0, 0, 0),
+          position: vm.Vector3(sin(t) * 10, 5, cos(t) * 10),
+          target: vm.Vector3(0, 1.5, 0),
         );
       },
       onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
@@ -58,7 +75,7 @@ class _ExampleFsceneState extends State<ExampleFscene> {
   }
 }
 
-SceneDocument _buildDocument() {
+SceneDocument _buildDocument(Uint8List pngBytes) {
   final doc = SceneDocument();
 
   // A sun, pitched down toward the scene.
@@ -203,7 +220,99 @@ SceneDocument _buildDocument() {
     ],
   );
 
+  // A row of asynchronously-loaded resources above the ring.
+  // 1. An external image-asset texture (referenced by path, not embedded).
+  final assetTexture = doc.addResource(
+    TextureResource(
+      doc.newId(),
+      asset: const AssetRef('assets/little_paris_eiffel_tower.png'),
+    ),
+  );
+  _meshNode(
+    doc,
+    name: 'assetTextureCube',
+    position: vm.Vector3(-3, 3, 0),
+    geometry: cubeGeometry.id,
+    material: doc
+        .addResource(
+          MaterialResource(
+            doc.newId(),
+            type: 'unlit',
+            properties: {'baseColorTexture': ResourceRefValue(assetTexture.id)},
+          ),
+        )
+        .id,
+  );
+
+  // 2. The same image as an encoded (PNG) payload chunk, decoded at load.
+  final pngPayload = doc.addPayload(
+    PayloadSpec(
+      doc.newId(),
+      encoding: PayloadEncoding.image,
+      format: 'png',
+      bytes: pngBytes,
+    ),
+  );
+  final pngTexture = doc.addResource(
+    TextureResource(doc.newId(), payload: pngPayload.id),
+  );
+  _meshNode(
+    doc,
+    name: 'encodedTextureCube',
+    position: vm.Vector3(0, 3, 0),
+    geometry: cubeGeometry.id,
+    material: doc
+        .addResource(
+          MaterialResource(
+            doc.newId(),
+            type: 'unlit',
+            properties: {'baseColorTexture': ResourceRefValue(pngTexture.id)},
+          ),
+        )
+        .id,
+  );
+
+  // 3. An `fmat` custom material, loaded by source path.
+  _meshNode(
+    doc,
+    name: 'fmatCube',
+    position: vm.Vector3(3, 3, 0),
+    geometry: cubeGeometry.id,
+    material: doc
+        .addResource(
+          MaterialResource(
+            doc.newId(),
+            type: 'fmat',
+            asset: const AssetRef('assets/toon.fmat'),
+          ),
+        )
+        .id,
+  );
+
   return doc;
+}
+
+void _meshNode(
+  SceneDocument doc, {
+  required String name,
+  required vm.Vector3 position,
+  required LocalId geometry,
+  required LocalId material,
+}) {
+  doc.createNode(
+    name: name,
+    root: true,
+    transform: TrsTransform(translation: position),
+    components: [
+      ComponentSpec(
+        'mesh',
+        properties: {
+          'geometry': ResourceRefValue(geometry),
+          'material': ResourceRefValue(material),
+        },
+      ),
+    ],
+  );
 }
 
 /// Builds a high-contrast checkerboard as an rgba8 image payload referenced by

--- a/examples/flutter_app/lib/example_fscene_animated.dart
+++ b/examples/flutter_app/lib/example_fscene_animated.dart
@@ -1,0 +1,85 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/importer/in_memory_import.dart'
+    show importGlbToFscenebBytes;
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+
+/// Imports a skinned, animated `.glb` at runtime through the glTF -> `.fsceneb`
+/// importer, then realizes it (binding the skin and parsing the animations)
+/// and plays a looping clip. Exercises the whole skinned/animated path through
+/// the `.fscene` pipeline.
+class ExampleFsceneAnimated extends StatefulWidget {
+  const ExampleFsceneAnimated({super.key});
+
+  @override
+  State<ExampleFsceneAnimated> createState() => _ExampleFsceneAnimatedState();
+}
+
+class _ExampleFsceneAnimatedState extends State<ExampleFsceneAnimated> {
+  final Scene scene = Scene();
+  bool loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final glb = await rootBundle.load('assets_src/dash.glb');
+    final container = importGlbToFscenebBytes(
+      glb.buffer.asUint8List(glb.offsetInBytes, glb.lengthInBytes),
+    );
+    final dash = loadFscenebBytes(container)..name = 'Dash';
+    if (!mounted) return;
+
+    // Play a clearly-moving clip, looping (falls back to the first animation).
+    final animation =
+        dash.findAnimationByName('Walk') ??
+        (dash.parsedAnimations.isNotEmpty ? dash.parsedAnimations.first : null);
+    if (animation != null) {
+      dash.createAnimationClip(animation)
+        ..loop = true
+        ..play();
+    }
+
+    scene.add(dash);
+    setState(() => loaded = true);
+  }
+
+  @override
+  void dispose() {
+    scene.removeAll();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!loaded) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return SceneView(
+      scene,
+      cameraBuilder: (elapsed) {
+        final rotation = elapsed.inMicroseconds / 1e6 * 0.5;
+        const distance = 6.0;
+        return PerspectiveCamera(
+          position: vm.Vector3(
+            sin(rotation) * distance,
+            2,
+            cos(rotation) * distance,
+          ),
+          target: vm.Vector3(0, 1.5, 0),
+        );
+      },
+      onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+    );
+  }
+}

--- a/examples/flutter_app/lib/example_fscene_import.dart
+++ b/examples/flutter_app/lib/example_fscene_import.dart
@@ -1,20 +1,14 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
-import 'package:flutter_scene/fscene.dart';
 import 'package:flutter_scene/scene.dart';
-// ignore: implementation_imports
-import 'package:flutter_scene/src/importer/in_memory_import.dart'
-    show importGlbToFscenebBytes;
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_settings.dart';
 
-/// Imports a real `.glb` at runtime through the glTF -> `.fsceneb` importer,
-/// then realizes and renders it. The geometry is packed exactly as the
-/// `.model` path packs it, but it travels through the `.fscene` pipeline:
-/// glTF -> SceneDocument -> binary container -> live node graph.
+/// Loads a `.fsceneb` scene by source path through [loadScene]. The build hook
+/// (`buildScenes`) imported `assets_src/fcar.glb` into a `.fsceneb` DataAsset;
+/// this resolves and realizes it, the `.fscene` analog of `loadModel`.
 class ExampleFsceneImport extends StatefulWidget {
   const ExampleFsceneImport({super.key});
 
@@ -33,11 +27,7 @@ class _ExampleFsceneImportState extends State<ExampleFsceneImport> {
   }
 
   Future<void> _load() async {
-    final glb = await rootBundle.load('assets_src/fcar.glb');
-    final container = importGlbToFscenebBytes(
-      glb.buffer.asUint8List(glb.offsetInBytes, glb.lengthInBytes),
-    );
-    final car = loadFscenebBytes(container)..name = 'Car';
+    final car = (await loadScene('assets_src/fcar.glb'))..name = 'Car';
     final environment = await EnvironmentMap.fromAssets(
       radianceImagePath: 'assets/little_paris_eiffel_tower.png',
     );

--- a/examples/flutter_app/lib/example_fscene_import.dart
+++ b/examples/flutter_app/lib/example_fscene_import.dart
@@ -1,0 +1,74 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/importer/in_memory_import.dart'
+    show importGlbToFscenebBytes;
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+
+/// Imports a real `.glb` at runtime through the glTF -> `.fsceneb` importer,
+/// then realizes and renders it. The geometry is packed exactly as the
+/// `.model` path packs it, but it travels through the `.fscene` pipeline:
+/// glTF -> SceneDocument -> binary container -> live node graph.
+class ExampleFsceneImport extends StatefulWidget {
+  const ExampleFsceneImport({super.key});
+
+  @override
+  State<ExampleFsceneImport> createState() => _ExampleFsceneImportState();
+}
+
+class _ExampleFsceneImportState extends State<ExampleFsceneImport> {
+  final Scene scene = Scene();
+  bool loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final glb = await rootBundle.load('assets_src/fcar.glb');
+    final container = importGlbToFscenebBytes(
+      glb.buffer.asUint8List(glb.offsetInBytes, glb.lengthInBytes),
+    );
+    final car = loadFscenebBytes(container)..name = 'Car';
+    final environment = await EnvironmentMap.fromAssets(
+      radianceImagePath: 'assets/little_paris_eiffel_tower.png',
+    );
+    if (!mounted) return;
+    scene.add(car);
+    scene.environment = environment;
+    scene.exposure = 2.5;
+    setState(() => loaded = true);
+  }
+
+  @override
+  void dispose() {
+    scene.removeAll();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!loaded) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return SceneView(
+      scene,
+      cameraBuilder: (elapsed) {
+        final rotation = elapsed.inMicroseconds / 1e6 * 0.2;
+        return PerspectiveCamera(
+          position: vm.Vector3(sin(rotation) * 5, 2, cos(rotation) * 5) * 2,
+          target: vm.Vector3(0, 0, 0),
+        );
+      },
+      onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+    );
+  }
+}

--- a/examples/flutter_app/lib/example_fscene_prefab.dart
+++ b/examples/flutter_app/lib/example_fscene_prefab.dart
@@ -1,0 +1,204 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+
+/// Demonstrates the prefab composer: one prefab document (a two-cube "robot")
+/// instantiated several times in a row, each instance recoloring the body and
+/// rotating the head through per-instance overrides. The host document is
+/// composed (instances expanded, ids remapped, deltas applied) and then
+/// realized.
+class ExampleFscenePrefab extends StatefulWidget {
+  const ExampleFscenePrefab({super.key});
+
+  @override
+  State<ExampleFscenePrefab> createState() => _ExampleFscenePrefabState();
+}
+
+class _ExampleFscenePrefabState extends State<ExampleFscenePrefab> {
+  final Scene scene = Scene();
+
+  @override
+  void initState() {
+    super.initState();
+    final prefab = _robotPrefab();
+    final host = _hostScene(prefab);
+    final composed = composeScene(host, resolve: (_) => prefab);
+    scene.add(realizeScene(composed));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SceneView(
+      scene,
+      cameraBuilder: (elapsed) {
+        final t = elapsed.inMicroseconds / 1e6 * 0.3;
+        return PerspectiveCamera(
+          position: vm.Vector3(sin(t) * 12, 6, cos(t) * 12),
+          target: vm.Vector3(0, 1, 0),
+        );
+      },
+      onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+    );
+  }
+}
+
+// A single-root prefab: 'body' (a cube) with a smaller 'head' cube on top.
+// Both share one grey material.
+SceneDocument _robotPrefab() {
+  final doc = SceneDocument();
+  final material = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'physicallyBased',
+      properties: {
+        'baseColor': const ColorValue(0.7, 0.7, 0.7, 1.0),
+        'roughness': const DoubleValue(0.5),
+      },
+    ),
+  );
+  final bodyGeometry = doc.addResource(
+    GeometryResource(
+      doc.newId(),
+      procedural: CuboidGeometrySpec(extents: vm.Vector3(1, 1.4, 1)),
+    ),
+  );
+  final headGeometry = doc.addResource(
+    GeometryResource(
+      doc.newId(),
+      procedural: CuboidGeometrySpec(extents: vm.Vector3(0.7, 0.7, 0.7)),
+    ),
+  );
+  final body = doc.createNode(
+    name: 'body',
+    root: true,
+    components: [
+      ComponentSpec(
+        'mesh',
+        properties: {
+          'geometry': ResourceRefValue(bodyGeometry.id),
+          'material': ResourceRefValue(material.id),
+        },
+      ),
+    ],
+  );
+  final head = doc.createNode(
+    name: 'head',
+    transform: TrsTransform(translation: vm.Vector3(0, 1.1, 0)),
+    components: [
+      ComponentSpec(
+        'mesh',
+        properties: {
+          'geometry': ResourceRefValue(headGeometry.id),
+          'material': ResourceRefValue(material.id),
+        },
+      ),
+    ],
+  );
+  body.children.add(head.id);
+  return doc;
+}
+
+SceneDocument _hostScene(SceneDocument prefab) {
+  // The host authors overrides against the prefab's own node ids.
+  final bodyId = prefab.rootNodes.single.id;
+  final headId = prefab.rootNodes.single.children.single;
+
+  final doc = SceneDocument();
+  doc.createNode(
+    name: 'sun',
+    root: true,
+    transform: TrsTransform(
+      rotation: vm.Quaternion.axisAngle(vm.Vector3(1, 0, 0), -1.0),
+    ),
+    components: [
+      ComponentSpec(
+        'directionalLight',
+        properties: {
+          'intensity': const DoubleValue(4.0),
+          'castsShadow': const BoolValue(true),
+        },
+      ),
+    ],
+  );
+
+  final groundGeometry = doc.addResource(
+    GeometryResource(
+      doc.newId(),
+      procedural: PlaneGeometrySpec(width: 16, depth: 8),
+    ),
+  );
+  final groundMaterial = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'physicallyBased',
+      properties: {'baseColor': const ColorValue(0.3, 0.35, 0.4, 1.0)},
+    ),
+  );
+  doc.createNode(
+    name: 'ground',
+    root: true,
+    transform: TrsTransform(translation: vm.Vector3(0, -0.7, 0)),
+    components: [
+      ComponentSpec(
+        'mesh',
+        properties: {
+          'geometry': ResourceRefValue(groundGeometry.id),
+          'material': ResourceRefValue(groundMaterial.id),
+        },
+      ),
+    ],
+  );
+
+  const colors = [
+    ColorValue(0.9, 0.3, 0.3, 1.0),
+    ColorValue(0.9, 0.7, 0.2, 1.0),
+    ColorValue(0.3, 0.8, 0.4, 1.0),
+    ColorValue(0.3, 0.5, 0.9, 1.0),
+    ColorValue(0.7, 0.4, 0.9, 1.0),
+  ];
+  for (var i = 0; i < colors.length; i++) {
+    // A per-instance body material in this color.
+    final bodyMaterial = doc.addResource(
+      MaterialResource(
+        doc.newId(),
+        type: 'physicallyBased',
+        properties: {
+          'baseColor': colors[i],
+          'roughness': const DoubleValue(0.4),
+        },
+      ),
+    );
+    doc
+        .createNode(
+          name: 'robot$i',
+          root: true,
+          transform: TrsTransform(
+            translation: vm.Vector3((i - 2) * 2.6, 0.7, 0),
+          ),
+        )
+        .instance = PrefabInstanceSpec(
+      source: const AssetRef('robot.fscene'),
+      overrides: [
+        // Recolor the body, and tilt each head differently.
+        PropertyOverride(
+          target: bodyId,
+          path: 'components.mesh.material',
+          value: ResourceRefValue(bodyMaterial.id),
+        ),
+        PropertyOverride(
+          target: headId,
+          path: 'transform.trs.r',
+          value: QuaternionValue(
+            vm.Quaternion.axisAngle(vm.Vector3(0, 1, 0), (i - 2) * 0.4),
+          ),
+        ),
+      ],
+    );
+  }
+  return doc;
+}

--- a/examples/flutter_app/lib/example_fscene_stream.dart
+++ b/examples/flutter_app/lib/example_fscene_stream.dart
@@ -1,0 +1,201 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+
+/// Demonstrates lazy-subtree streaming: a row of `LoadPolicy.lazy` tree
+/// placeholders that realize empty, then load and unload their prefab content
+/// on demand via [loadSubtree] / [unloadSubtree]. The "tree" prefab is loaded
+/// from an in-memory document.
+class ExampleFsceneStream extends StatefulWidget {
+  const ExampleFsceneStream({super.key});
+
+  @override
+  State<ExampleFsceneStream> createState() => _ExampleFsceneStreamState();
+}
+
+class _ExampleFsceneStreamState extends State<ExampleFsceneStream> {
+  final Scene scene = Scene();
+  final SceneDocument _prefab = _treePrefab();
+  final List<Node> _placeholders = [];
+  bool _loaded = false;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final root = realizeScene(_hostScene());
+    _collectPlaceholders(root);
+    scene.add(root);
+  }
+
+  void _collectPlaceholders(Node node) {
+    if (isLazySubtree(node)) _placeholders.add(node);
+    for (final child in node.children) {
+      _collectPlaceholders(child);
+    }
+  }
+
+  Future<void> _toggle() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    if (_loaded) {
+      for (final placeholder in _placeholders) {
+        unloadSubtree(placeholder);
+      }
+    } else {
+      for (final placeholder in _placeholders) {
+        await loadSubtree(placeholder, load: (_) async => _prefab);
+      }
+    }
+    if (!mounted) return;
+    setState(() {
+      _loaded = !_loaded;
+      _busy = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: SceneView(
+            scene,
+            cameraBuilder: (elapsed) {
+              final t = elapsed.inMicroseconds / 1e6 * 0.25;
+              return PerspectiveCamera(
+                position: vm.Vector3(sin(t) * 11, 5, cos(t) * 11),
+                target: vm.Vector3(0, 0.5, 0),
+              );
+            },
+            onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+          ),
+        ),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: FilledButton(
+              onPressed: _busy ? null : _toggle,
+              child: Text(_loaded ? 'Unload subtrees' : 'Load subtrees'),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+ComponentSpec _mesh(LocalId geometry, LocalId material) => ComponentSpec(
+  'mesh',
+  properties: {
+    'geometry': ResourceRefValue(geometry),
+    'material': ResourceRefValue(material),
+  },
+);
+
+// A single-root "tree" prefab: a trunk with foliage on top.
+SceneDocument _treePrefab() {
+  final doc = SceneDocument();
+  final trunkMaterial = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'physicallyBased',
+      properties: {
+        'baseColor': const ColorValue(0.4, 0.26, 0.13, 1.0),
+        'roughness': const DoubleValue(0.8),
+      },
+    ),
+  );
+  final foliageMaterial = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'physicallyBased',
+      properties: {
+        'baseColor': const ColorValue(0.22, 0.6, 0.27, 1.0),
+        'roughness': const DoubleValue(0.7),
+      },
+    ),
+  );
+  final trunkGeometry = doc.addResource(
+    GeometryResource(
+      doc.newId(),
+      procedural: CuboidGeometrySpec(extents: vm.Vector3(0.3, 1.2, 0.3)),
+    ),
+  );
+  final foliageGeometry = doc.addResource(
+    GeometryResource(doc.newId(), procedural: SphereGeometrySpec(radius: 0.75)),
+  );
+  final trunk = doc.createNode(
+    name: 'trunk',
+    root: true,
+    components: [_mesh(trunkGeometry.id, trunkMaterial.id)],
+  );
+  final foliage = doc.createNode(
+    name: 'foliage',
+    transform: TrsTransform(translation: vm.Vector3(0, 1.2, 0)),
+    components: [_mesh(foliageGeometry.id, foliageMaterial.id)],
+  );
+  trunk.children.add(foliage.id);
+  return doc;
+}
+
+SceneDocument _hostScene() {
+  final doc = SceneDocument();
+  doc.createNode(
+    name: 'sun',
+    root: true,
+    transform: TrsTransform(
+      rotation: vm.Quaternion.axisAngle(vm.Vector3(1, 0, 0), -1.0),
+    ),
+    components: [
+      ComponentSpec(
+        'directionalLight',
+        properties: {
+          'intensity': const DoubleValue(4.0),
+          'castsShadow': const BoolValue(true),
+        },
+      ),
+    ],
+  );
+
+  final groundGeometry = doc.addResource(
+    GeometryResource(
+      doc.newId(),
+      procedural: PlaneGeometrySpec(width: 16, depth: 8),
+    ),
+  );
+  final groundMaterial = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'physicallyBased',
+      properties: {'baseColor': const ColorValue(0.32, 0.38, 0.3, 1.0)},
+    ),
+  );
+  doc.createNode(
+    name: 'ground',
+    root: true,
+    transform: TrsTransform(translation: vm.Vector3(0, -0.6, 0)),
+    components: [_mesh(groundGeometry.id, groundMaterial.id)],
+  );
+
+  // A row of lazy tree placeholders.
+  for (var i = 0; i < 5; i++) {
+    doc
+        .createNode(
+          name: 'slot$i',
+          root: true,
+          transform: TrsTransform(translation: vm.Vector3((i - 2) * 2.2, 0, 0)),
+        )
+        .instance = PrefabInstanceSpec(
+      source: const AssetRef('tree'),
+      load: LoadPolicy.lazy,
+    );
+  }
+  return doc;
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:example_app/example_animation.dart';
 
 import 'example_cuboid.dart';
 import 'example_fscene.dart';
+import 'example_fscene_animated.dart';
 import 'example_fscene_import.dart';
 import 'example_instancing.dart';
 import 'example_logo.dart';
@@ -67,6 +68,7 @@ class _MyAppState extends State<MyApp> {
       ),
       'fscene': (context) => const ExampleFscene(),
       'fscene (import)': (context) => const ExampleFsceneImport(),
+      'fscene (animated)': (context) => const ExampleFsceneAnimated(),
       'Split Screen': (context) => const ExampleSplitScreen(),
       'Stress Tests': (context) => const ExampleStressTests(),
     };

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene_rapier/flutter_scene_rapier.dart'
 import 'package:example_app/example_animation.dart';
 
 import 'example_cuboid.dart';
+import 'example_fscene.dart';
 import 'example_instancing.dart';
 import 'example_logo.dart';
 import 'example_nav_route.dart';
@@ -63,6 +64,7 @@ class _MyAppState extends State<MyApp> {
           return const ExamplePhysics();
         },
       ),
+      'fscene': (context) => const ExampleFscene(),
       'Split Screen': (context) => const ExampleSplitScreen(),
       'Stress Tests': (context) => const ExampleStressTests(),
     };

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:example_app/example_animation.dart';
 
 import 'example_cuboid.dart';
 import 'example_fscene.dart';
+import 'example_fscene_import.dart';
 import 'example_instancing.dart';
 import 'example_logo.dart';
 import 'example_nav_route.dart';
@@ -65,6 +66,7 @@ class _MyAppState extends State<MyApp> {
         },
       ),
       'fscene': (context) => const ExampleFscene(),
+      'fscene (import)': (context) => const ExampleFsceneImport(),
       'Split Screen': (context) => const ExampleSplitScreen(),
       'Stress Tests': (context) => const ExampleStressTests(),
     };

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -10,6 +10,7 @@ import 'example_cuboid.dart';
 import 'example_fscene.dart';
 import 'example_fscene_animated.dart';
 import 'example_fscene_import.dart';
+import 'example_fscene_prefab.dart';
 import 'example_instancing.dart';
 import 'example_logo.dart';
 import 'example_nav_route.dart';
@@ -69,6 +70,7 @@ class _MyAppState extends State<MyApp> {
       'fscene': (context) => const ExampleFscene(),
       'fscene (import)': (context) => const ExampleFsceneImport(),
       'fscene (animated)': (context) => const ExampleFsceneAnimated(),
+      'fscene (prefab)': (context) => const ExampleFscenePrefab(),
       'Split Screen': (context) => const ExampleSplitScreen(),
       'Stress Tests': (context) => const ExampleStressTests(),
     };

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -11,6 +11,7 @@ import 'example_fscene.dart';
 import 'example_fscene_animated.dart';
 import 'example_fscene_import.dart';
 import 'example_fscene_prefab.dart';
+import 'example_fscene_stream.dart';
 import 'example_instancing.dart';
 import 'example_logo.dart';
 import 'example_nav_route.dart';
@@ -71,6 +72,7 @@ class _MyAppState extends State<MyApp> {
       'fscene (import)': (context) => const ExampleFsceneImport(),
       'fscene (animated)': (context) => const ExampleFsceneAnimated(),
       'fscene (prefab)': (context) => const ExampleFscenePrefab(),
+      'fscene (stream)': (context) => const ExampleFsceneStream(),
       'Split Screen': (context) => const ExampleSplitScreen(),
       'Stress Tests': (context) => const ExampleStressTests(),
     };

--- a/packages/flutter_scene/lib/build_hooks.dart
+++ b/packages/flutter_scene/lib/build_hooks.dart
@@ -29,7 +29,7 @@ library;
 // package WASM-compatible. Build hooks only ever run on the native host.
 export 'src/importer/build_hooks.dart'
     if (dart.library.js_interop) 'src/importer/build_hooks_unsupported.dart'
-    show ModelAssetMode, buildModels;
+    show ModelAssetMode, buildModels, buildScenes;
 export 'src/fmat/build_materials.dart'
     if (dart.library.js_interop) 'src/fmat/build_materials_unsupported.dart'
     show MaterialAssetMode, buildMaterials;

--- a/packages/flutter_scene/lib/fscene.dart
+++ b/packages/flutter_scene/lib/fscene.dart
@@ -34,3 +34,5 @@ export 'src/fscene/realize/realize.dart';
 export 'src/fscene/realize/resource_realizer.dart';
 export 'src/fscene/scene_document.dart';
 export 'src/fscene/specs.dart';
+export 'src/fscene/stream/stream.dart'
+    show loadSubtree, unloadSubtree, isLazySubtree, isSubtreeLoaded;

--- a/packages/flutter_scene/lib/fscene.dart
+++ b/packages/flutter_scene/lib/fscene.dart
@@ -10,6 +10,7 @@ library;
 
 export 'src/fscene/binary/fsceneb.dart'
     show writeFsceneb, readFsceneb, kFscenebVersion, FscenebFormatException;
+export 'src/fscene/compose/compose.dart' show composeScene, PrefabResolver;
 export 'src/fscene/id.dart'
     show DocumentId, LocalId, IdAllocator, encodeBase32, decodeBase32;
 export 'src/fscene/json/fscene_json.dart'

--- a/packages/flutter_scene/lib/fscene.dart
+++ b/packages/flutter_scene/lib/fscene.dart
@@ -8,6 +8,8 @@
 /// with a [FsceneComponentRegistry].
 library;
 
+export 'src/fscene/binary/fsceneb.dart'
+    show writeFsceneb, readFsceneb, kFscenebVersion, FscenebFormatException;
 export 'src/fscene/id.dart'
     show DocumentId, LocalId, IdAllocator, encodeBase32, decodeBase32;
 export 'src/fscene/json/fscene_json.dart'

--- a/packages/flutter_scene/lib/fscene.dart
+++ b/packages/flutter_scene/lib/fscene.dart
@@ -25,6 +25,8 @@ export 'src/fscene/json/fscene_json.dart'
         FsceneUnsupportedFeatureException;
 export 'src/fscene/property_value.dart';
 export 'src/fscene/realize/builtin_codecs.dart';
+export 'src/fscene/reload/diff.dart' show diffScene, SceneDiff, NodeChange;
+export 'src/fscene/reload/reload.dart' show reloadScene;
 export 'src/fscene/realize/component_codec.dart';
 export 'src/fscene/realize/loader.dart';
 export 'src/fscene/realize/property_read.dart';

--- a/packages/flutter_scene/lib/fscene.dart
+++ b/packages/flutter_scene/lib/fscene.dart
@@ -1,0 +1,30 @@
+/// The `.fscene` serialized scene format: an in-memory document model, JSON
+/// read/write, and realization to and from a live `Node` graph.
+///
+/// Load a scene with [loadFsceneAsset] (or build a [SceneDocument] in code,
+/// write it with [writeFscene], and read it back with [readFscene]). Realize
+/// a document into a node graph with [realizeScene], or serialize a live
+/// graph back with [serializeScene]. Register app-defined component types
+/// with a [FsceneComponentRegistry].
+library;
+
+export 'src/fscene/id.dart'
+    show DocumentId, LocalId, IdAllocator, encodeBase32, decodeBase32;
+export 'src/fscene/json/fscene_json.dart'
+    show
+        writeFscene,
+        readFscene,
+        currentFsceneVersion,
+        supportedFeatures,
+        FsceneFormatException,
+        FsceneVersionException,
+        FsceneUnsupportedFeatureException;
+export 'src/fscene/property_value.dart';
+export 'src/fscene/realize/builtin_codecs.dart';
+export 'src/fscene/realize/component_codec.dart';
+export 'src/fscene/realize/loader.dart';
+export 'src/fscene/realize/property_read.dart';
+export 'src/fscene/realize/realize.dart';
+export 'src/fscene/realize/resource_realizer.dart';
+export 'src/fscene/scene_document.dart';
+export 'src/fscene/specs.dart';

--- a/packages/flutter_scene/lib/fscene.dart
+++ b/packages/flutter_scene/lib/fscene.dart
@@ -10,7 +10,8 @@ library;
 
 export 'src/fscene/binary/fsceneb.dart'
     show writeFsceneb, readFsceneb, kFscenebVersion, FscenebFormatException;
-export 'src/fscene/compose/compose.dart' show composeScene, PrefabResolver;
+export 'src/fscene/compose/compose.dart'
+    show composeScene, composeSceneAsync, PrefabResolver, AsyncPrefabLoader;
 export 'src/fscene/id.dart'
     show DocumentId, LocalId, IdAllocator, encodeBase32, decodeBase32;
 export 'src/fscene/json/fscene_json.dart'

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -43,6 +43,7 @@ export 'src/fmat/material_registry.dart'
     show FmatMaterialRegistry, loadFmatMaterial;
 export 'src/hot_reload/hot_reload_coordinator.dart' show ModelReloadCallback;
 export 'src/importer/model_registry.dart' show ModelRegistry, loadModel;
+export 'src/importer/scene_registry.dart' show SceneRegistry, loadScene;
 
 export 'src/ambient_occlusion.dart';
 export 'src/asset_helpers.dart';

--- a/packages/flutter_scene/lib/src/asset_helpers.dart
+++ b/packages/flutter_scene/lib/src/asset_helpers.dart
@@ -33,12 +33,23 @@ Future<gpu.Texture> gpuTextureFromImage(ui.Image image) async {
 ///
 /// Uses `dart:ui`'s built-in image codecs (PNG, JPEG, etc.). Throws if
 /// the asset is not present in the bundle or cannot be decoded.
-Future<ui.Image> imageFromAsset(String assetPath) async {
+Future<ui.Image> imageFromAsset(String assetPath, {AssetBundle? bundle}) async {
   // Load resource from the asset bundle. Throws exception if the asset couldn't
   // be found in the bundle.
-  final buffer = await rootBundle.loadBuffer(assetPath);
+  final buffer = await (bundle ?? rootBundle).loadBuffer(assetPath);
 
   // Decode the image.
+  final codec = await ui.instantiateImageCodecFromBuffer(buffer);
+  final frame = await codec.getNextFrame();
+  return frame.image;
+}
+
+/// Decodes an encoded image (PNG, JPEG, etc.) from raw [bytes].
+///
+/// Uses `dart:ui`'s built-in image codecs. Throws if the bytes can't be
+/// decoded as an image.
+Future<ui.Image> imageFromBytes(Uint8List bytes) async {
+  final buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
   final codec = await ui.instantiateImageCodecFromBuffer(buffer);
   final frame = await codec.getNextFrame();
   return frame.image;

--- a/packages/flutter_scene/lib/src/fscene/binary/fsceneb.dart
+++ b/packages/flutter_scene/lib/src/fscene/binary/fsceneb.dart
@@ -1,0 +1,200 @@
+/// The `.fsceneb` binary container: a single self-contained file holding a
+/// document's JSON manifest plus its binary payload chunks, concatenated like
+/// a `.glb`.
+///
+/// The manifest chunk is the exact canonical JSON a bare `.fscene` text file
+/// would carry (so the two forms share one codec); the payload chunks hold the
+/// heavy binary the JSON references by id (vertex/index buffers, images,
+/// matrices). Chunks are uncompressed and chunk-aligned so the container stays
+/// cheap to read.
+///
+/// Layout (all integers little-endian):
+///
+/// ```text
+/// Header (16 bytes):
+///   [0..4)   magic           ASCII "FSCB"
+///   [4..8)   version         uint32 (kFscenebVersion)
+///   [8..12)  totalByteLength  uint32 (the whole container)
+///   [12..16) reserved        uint32 (0)
+/// Chunks (repeat until totalByteLength), each 8-byte aligned:
+///   [0..4)   dataByteLength  uint32 (unpadded)
+///   [4..8)   chunkType       4 ASCII bytes ("JSON" or "BLOB")
+///   [8..)    data            dataByteLength bytes
+///   padding  zero bytes to the next 8-byte boundary
+/// ```
+///
+/// The first chunk is the sole "JSON" chunk (UTF-8 document text). Each "BLOB"
+/// chunk carries one payload, its data being `[uint32 idByteLength][id token
+/// UTF-8][payload bytes]`. An unrecognized chunk type is skipped, so the format
+/// can grow new chunk kinds without breaking older readers.
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+
+/// The current `.fsceneb` container version this build reads and writes.
+const int kFscenebVersion = 1;
+
+const List<int> _magic = [0x46, 0x53, 0x43, 0x42]; // "FSCB"
+const String _chunkJson = 'JSON';
+const String _chunkBlob = 'BLOB';
+const int _headerByteLength = 16;
+const int _alignment = 8;
+
+/// Thrown when a `.fsceneb` container is malformed.
+class FscenebFormatException implements Exception {
+  /// Creates a container-format exception with the given [message].
+  const FscenebFormatException(this.message);
+
+  /// What is wrong with the container.
+  final String message;
+
+  @override
+  String toString() => 'FscenebFormatException: $message';
+}
+
+/// Serializes [document] to a `.fsceneb` container: the document's JSON
+/// manifest followed by one chunk per payload.
+///
+/// Every payload in the document must carry its [PayloadSpec.bytes]; a
+/// manifest-only payload (no bytes) cannot be embedded and throws a
+/// [FscenebFormatException]. Payloads referenced by external `ref` rather than
+/// an embedded chunk are not payloads, so they are unaffected.
+Uint8List writeFsceneb(SceneDocument document) {
+  final body = BytesBuilder();
+
+  void addChunk(String type, Uint8List data) {
+    final preamble = ByteData(8)..setUint32(0, data.length, Endian.little);
+    final typeBytes = ascii.encode(type);
+    for (var i = 0; i < 4; i++) {
+      preamble.setUint8(4 + i, typeBytes[i]);
+    }
+    body.add(preamble.buffer.asUint8List());
+    body.add(data);
+    final remainder = data.length % _alignment;
+    if (remainder != 0) body.add(Uint8List(_alignment - remainder));
+  }
+
+  addChunk(_chunkJson, utf8.encode(writeFscene(document)));
+
+  // Emit payloads in a deterministic (id-sorted) order, matching the JSON
+  // manifest's enumeration so two writes of the same document are identical.
+  final payloads = document.payloads.entries.toList()
+    ..sort((a, b) => a.key.toToken().compareTo(b.key.toToken()));
+  for (final entry in payloads) {
+    final bytes = entry.value.bytes;
+    if (bytes == null) {
+      throw FscenebFormatException(
+        'Payload ${entry.key.toToken()} has no bytes to embed',
+      );
+    }
+    addChunk(_chunkBlob, _encodeBlob(entry.key, bytes));
+  }
+
+  final bodyBytes = body.toBytes();
+  final total = _headerByteLength + bodyBytes.length;
+  final out = Uint8List(total);
+  for (var i = 0; i < 4; i++) {
+    out[i] = _magic[i];
+  }
+  ByteData.sublistView(out)
+    ..setUint32(4, kFscenebVersion, Endian.little)
+    ..setUint32(8, total, Endian.little)
+    ..setUint32(12, 0, Endian.little);
+  out.setRange(_headerByteLength, total, bodyBytes);
+  return out;
+}
+
+/// Parses a `.fsceneb` container from [bytes] into a [SceneDocument] with each
+/// embedded payload's [PayloadSpec.bytes] attached.
+///
+/// Tolerates the same JSONC superset and runs the same version migration as
+/// [readFscene] for the manifest. Throws a [FscenebFormatException] on a bad
+/// magic, an unsupported container version, or a missing manifest.
+SceneDocument readFsceneb(Uint8List bytes) {
+  if (bytes.length < _headerByteLength) {
+    throw const FscenebFormatException('Truncated container (no header)');
+  }
+  for (var i = 0; i < 4; i++) {
+    if (bytes[i] != _magic[i]) {
+      throw const FscenebFormatException(
+        'Not a .fsceneb container (bad magic)',
+      );
+    }
+  }
+  final view = ByteData.sublistView(bytes);
+  final version = view.getUint32(4, Endian.little);
+  if (version > kFscenebVersion) {
+    throw FscenebFormatException(
+      'Container version $version is newer than supported $kFscenebVersion',
+    );
+  }
+  final total = view.getUint32(8, Endian.little);
+  if (total > bytes.length) {
+    throw const FscenebFormatException('Container length exceeds the data');
+  }
+
+  String? manifest;
+  final blobs = <LocalId, Uint8List>{};
+  var offset = _headerByteLength;
+  while (offset + 8 <= total) {
+    final dataLength = view.getUint32(offset, Endian.little);
+    final type = ascii.decode(
+      Uint8List.sublistView(bytes, offset + 4, offset + 8),
+    );
+    final dataStart = offset + 8;
+    final dataEnd = dataStart + dataLength;
+    if (dataEnd > total) {
+      throw const FscenebFormatException('Chunk extends past the container');
+    }
+    final data = Uint8List.sublistView(bytes, dataStart, dataEnd);
+    switch (type) {
+      case _chunkJson:
+        manifest = utf8.decode(data);
+      case _chunkBlob:
+        final (id, payload) = _decodeBlob(data);
+        blobs[id] = payload;
+      default:
+        break; // Skip unrecognized chunk types.
+    }
+    final padded = dataLength + ((-dataLength) & (_alignment - 1));
+    offset = dataStart + padded;
+  }
+
+  if (manifest == null) {
+    throw const FscenebFormatException('Container has no JSON manifest chunk');
+  }
+  final document = readFscene(manifest);
+  blobs.forEach((id, payload) {
+    document.payload(id)?.bytes = payload;
+  });
+  return document;
+}
+
+Uint8List _encodeBlob(LocalId id, Uint8List payload) {
+  final token = ascii.encode(id.toToken());
+  final out = Uint8List(4 + token.length + payload.length);
+  ByteData.sublistView(out).setUint32(0, token.length, Endian.little);
+  out.setRange(4, 4 + token.length, token);
+  out.setRange(4 + token.length, out.length, payload);
+  return out;
+}
+
+(LocalId, Uint8List) _decodeBlob(Uint8List data) {
+  if (data.length < 4) {
+    throw const FscenebFormatException('Truncated payload chunk');
+  }
+  final idLength = ByteData.sublistView(data).getUint32(0, Endian.little);
+  final tokenEnd = 4 + idLength;
+  if (tokenEnd > data.length) {
+    throw const FscenebFormatException('Payload chunk id runs past its data');
+  }
+  final token = ascii.decode(Uint8List.sublistView(data, 4, tokenEnd));
+  // Copy so the payload does not retain a view onto the whole container buffer.
+  final payload = Uint8List.fromList(Uint8List.sublistView(data, tokenEnd));
+  return (LocalId.parse(token), payload);
+}

--- a/packages/flutter_scene/lib/src/fscene/compose/compose.dart
+++ b/packages/flutter_scene/lib/src/fscene/compose/compose.dart
@@ -1,0 +1,365 @@
+/// Prefab composition: expands a document's prefab instances into a flat,
+/// fully-realized document.
+///
+/// A [NodeSpec] whose [NodeSpec.instance] is set is a prefab instance: a
+/// reference to another `.fscene` plus a per-instance delta (overrides, added
+/// and removed nodes/components). [composeScene] resolves each reference,
+/// recursively composes the referenced prefab, remaps its document-local id
+/// space into fresh ids (so two instances of one prefab are distinct,
+/// Bevy-style), inlines it, and applies the delta. The result has no instance
+/// nodes left and feeds straight into `realizeScene`.
+///
+/// Pure Dart and GPU-free. Resolution of a prefab reference is delegated to a
+/// caller-supplied `resolve` (a runtime wrapper loads the referenced document
+/// from the asset bundle; tests pass an in-memory map).
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+
+/// Resolves a prefab [AssetRef] to its (uncomposed) [SceneDocument].
+typedef PrefabResolver = SceneDocument Function(AssetRef ref);
+
+/// Expands every prefab instance in [document], returning a new document with
+/// no instance nodes. A document with no instances is returned unchanged.
+///
+/// [resolve] loads a referenced prefab document. A cyclic reference (a prefab
+/// that instantiates itself, directly or transitively) is broken with a
+/// warning rather than recursing forever.
+SceneDocument composeScene(
+  SceneDocument document, {
+  required PrefabResolver resolve,
+}) => _compose(document, resolve, <String>{});
+
+SceneDocument _compose(
+  SceneDocument document,
+  PrefabResolver resolve,
+  Set<String> visiting,
+) {
+  if (document.nodes.values.every((node) => node.instance == null)) {
+    return document;
+  }
+
+  final out = SceneDocument(
+    documentId: document.documentId,
+    allocator: IdAllocator(excludedSessions: document.usedSessions()),
+    stage: _copyStage(document.stage),
+  );
+  out.formatVersion = document.formatVersion;
+  out.generator = document.generator;
+  out.featuresUsed.addAll(document.featuresUsed);
+  out.featuresRequired.addAll(document.featuresRequired);
+
+  // Copy the host's own content verbatim (ids preserved); instances are
+  // expanded below.
+  LocalId identity(LocalId id) => id;
+  for (final resource in document.resources.values) {
+    out.addResource(_remapResource(resource, identity));
+  }
+  for (final payload in document.payloads.values) {
+    out.addPayload(_remapPayload(payload, identity));
+  }
+  for (final skin in document.skins.values) {
+    out.addSkin(_remapSkin(skin, identity));
+  }
+  for (final animation in document.animations.values) {
+    out.addAnimation(_remapAnimation(animation, identity));
+  }
+  for (final node in document.nodes.values) {
+    out.addNode(_remapNode(node, identity, keepInstance: true));
+  }
+  out.roots.addAll(document.roots);
+
+  for (final instance
+      in out.nodes.values.where((node) => node.instance != null).toList()) {
+    _expandInstance(out, instance, resolve, visiting);
+  }
+  return out;
+}
+
+void _expandInstance(
+  SceneDocument out,
+  NodeSpec instance,
+  PrefabResolver resolve,
+  Set<String> visiting,
+) {
+  final spec = instance.instance!;
+  instance.instance = null; // mark expanded regardless of outcome
+  final sourceKey = spec.source.key;
+  if (visiting.contains(sourceKey)) {
+    debugPrint('fscene: cyclic prefab reference to "$sourceKey"; skipping');
+    return;
+  }
+
+  visiting.add(sourceKey);
+  final prefab = _compose(resolve(spec.source), resolve, visiting);
+  visiting.remove(sourceKey);
+
+  // Fresh id for every prefab id; a single-root prefab merges its root into
+  // the instance node (so the instance node "is" the prefab root, which is
+  // what overrides and added/removed components target).
+  final singleRoot = prefab.roots.length == 1 ? prefab.roots.single : null;
+  final remap = <LocalId, LocalId>{};
+  for (final id in _allIds(prefab)) {
+    remap[id] = id == singleRoot ? instance.id : out.newId();
+  }
+  LocalId remapId(LocalId id) => remap[id] ?? id;
+
+  for (final resource in prefab.resources.values) {
+    out.addResource(_remapResource(resource, remapId));
+  }
+  for (final payload in prefab.payloads.values) {
+    out.addPayload(_remapPayload(payload, remapId));
+  }
+  for (final skin in prefab.skins.values) {
+    out.addSkin(_remapSkin(skin, remapId));
+  }
+  for (final animation in prefab.animations.values) {
+    out.addAnimation(_remapAnimation(animation, remapId));
+  }
+  for (final node in prefab.nodes.values) {
+    if (node.id == singleRoot) {
+      // Merge the prefab root into the instance node, keeping the instance's
+      // own transform, name, and layers (its placement in the host).
+      instance.components.addAll([
+        for (final c in node.components) _remapComponent(c, remapId),
+      ]);
+      instance.children.addAll([for (final c in node.children) remapId(c)]);
+      instance.skin ??= node.skin == null ? null : remapId(node.skin!);
+    } else {
+      out.addNode(_remapNode(node, remapId, keepInstance: false));
+    }
+  }
+  if (singleRoot == null) {
+    instance.children.addAll([for (final r in prefab.roots) remapId(r)]);
+  }
+
+  _applyDelta(out, instance, spec, remapId);
+}
+
+void _applyDelta(
+  SceneDocument out,
+  NodeSpec instance,
+  PrefabInstanceSpec spec,
+  LocalId Function(LocalId) remapId,
+) {
+  for (final override in spec.overrides) {
+    final node = out.node(remapId(override.target));
+    if (node == null) {
+      debugPrint('fscene: override target ${override.target} not found');
+      continue;
+    }
+    _setProperty(node, override.path, override.value);
+  }
+  for (final removed in spec.removedNodes) {
+    _removeNode(out, remapId(removed));
+  }
+  // Added nodes keep their authored ids; subtree roots (those not referenced as
+  // another added node's child) parent under the instance node.
+  final addedChildren = {for (final n in spec.addedNodes) ...n.children};
+  for (final node in spec.addedNodes) {
+    out.addNode(node);
+    if (!addedChildren.contains(node.id)) instance.children.add(node.id);
+  }
+  instance.components.addAll(spec.addedComponents);
+  if (spec.removedComponentTypes.isNotEmpty) {
+    instance.components.removeWhere(
+      (c) => spec.removedComponentTypes.contains(c.type),
+    );
+  }
+}
+
+// ---- property-path override application ----
+
+void _setProperty(NodeSpec node, String path, PropertyValue value) {
+  final parts = path.split('.');
+  if (parts.length == 1) {
+    if (parts[0] == 'name' && value is StringValue) {
+      node.name = value.value;
+      return;
+    }
+    if (parts[0] == 'layers' && value is IntValue) {
+      node.layers = value.value;
+      return;
+    }
+  }
+  if (parts.length >= 2 && parts[0] == 'transform') {
+    if (parts[1] == 'matrix' && value is Matrix4Value) {
+      node.transform = MatrixTransform(value.value.clone());
+      return;
+    }
+    if (parts[1] == 'trs' && parts.length == 3) {
+      _setTrs(node, parts[2], value);
+      return;
+    }
+  }
+  if (parts.length == 3 && parts[0] == 'components') {
+    for (final component in node.components) {
+      if (component.type == parts[1]) {
+        component.properties[parts[2]] = value;
+        return;
+      }
+    }
+    debugPrint('fscene: override "$path" found no "${parts[1]}" component');
+    return;
+  }
+  debugPrint('fscene: unsupported override path "$path"');
+}
+
+void _setTrs(NodeSpec node, String component, PropertyValue value) {
+  final current = node.transform;
+  var translation = Vector3.zero();
+  var rotation = Quaternion.identity();
+  var scale = Vector3(1, 1, 1);
+  if (current is TrsTransform) {
+    translation = current.translation.clone();
+    rotation = current.rotation.clone();
+    scale = current.scale.clone();
+  }
+  switch (component) {
+    case 't' when value is Vec3Value:
+      translation = value.value.clone();
+    case 'r' when value is QuaternionValue:
+      rotation = value.value.clone();
+    case 's' when value is Vec3Value:
+      scale = value.value.clone();
+    default:
+      debugPrint('fscene: bad transform override "trs.$component"');
+      return;
+  }
+  node.transform = TrsTransform(
+    translation: translation,
+    rotation: rotation,
+    scale: scale,
+  );
+}
+
+void _removeNode(SceneDocument out, LocalId id) {
+  out.nodes.remove(id);
+  out.roots.remove(id);
+  for (final node in out.nodes.values) {
+    node.children.remove(id);
+  }
+}
+
+// ---- id-remapping copies ----
+
+Iterable<LocalId> _allIds(SceneDocument doc) sync* {
+  yield* doc.nodes.keys;
+  yield* doc.resources.keys;
+  yield* doc.payloads.keys;
+  yield* doc.skins.keys;
+  yield* doc.animations.keys;
+}
+
+NodeSpec _remapNode(
+  NodeSpec node,
+  LocalId Function(LocalId) remap, {
+  required bool keepInstance,
+}) => NodeSpec(
+  id: remap(node.id),
+  name: node.name,
+  transform: node.transform,
+  children: [for (final c in node.children) remap(c)],
+  components: [for (final c in node.components) _remapComponent(c, remap)],
+  layers: node.layers,
+  skin: node.skin == null ? null : remap(node.skin!),
+  instance: keepInstance ? node.instance : null,
+);
+
+ComponentSpec _remapComponent(
+  ComponentSpec c,
+  LocalId Function(LocalId) remap,
+) => ComponentSpec(c.type, properties: _remapProperties(c.properties, remap));
+
+Map<String, PropertyValue> _remapProperties(
+  Map<String, PropertyValue> props,
+  LocalId Function(LocalId) remap,
+) => {for (final e in props.entries) e.key: _remapValue(e.value, remap)};
+
+PropertyValue _remapValue(PropertyValue v, LocalId Function(LocalId) remap) =>
+    switch (v) {
+      ResourceRefValue(:final id) => ResourceRefValue(remap(id)),
+      NodeRefValue(:final id) => NodeRefValue(remap(id)),
+      ListValue(:final values) => ListValue([
+        for (final e in values) _remapValue(e, remap),
+      ]),
+      MapValue(:final values) => MapValue({
+        for (final e in values.entries) e.key: _remapValue(e.value, remap),
+      }),
+      _ => v,
+    };
+
+ResourceSpec _remapResource(ResourceSpec r, LocalId Function(LocalId) remap) =>
+    switch (r) {
+      GeometryResource() => GeometryResource(
+        remap(r.id),
+        vertices: r.vertices == null ? null : remap(r.vertices!),
+        indices: r.indices == null ? null : remap(r.indices!),
+        procedural: r.procedural,
+        bounds: r.bounds,
+      ),
+      TextureResource() => TextureResource(
+        remap(r.id),
+        payload: r.payload == null ? null : remap(r.payload!),
+        asset: r.asset,
+      ),
+      MaterialResource() => MaterialResource(
+        remap(r.id),
+        type: r.type,
+        properties: _remapProperties(r.properties, remap),
+        asset: r.asset,
+      ),
+    };
+
+PayloadSpec _remapPayload(PayloadSpec p, LocalId Function(LocalId) remap) =>
+    PayloadSpec(
+      remap(p.id),
+      encoding: p.encoding,
+      layout: p.layout,
+      format: p.format,
+      width: p.width,
+      height: p.height,
+      length: p.length,
+      bytes: p.bytes,
+    );
+
+SkinSpec _remapSkin(SkinSpec s, LocalId Function(LocalId) remap) => SkinSpec(
+  remap(s.id),
+  joints: [for (final j in s.joints) remap(j)],
+  inverseBindMatrices: remap(s.inverseBindMatrices),
+  skeleton: s.skeleton == null ? null : remap(s.skeleton!),
+);
+
+AnimationSpec _remapAnimation(
+  AnimationSpec a,
+  LocalId Function(LocalId) remap,
+) => AnimationSpec(
+  remap(a.id),
+  name: a.name,
+  channels: [
+    for (final ch in a.channels)
+      AnimationChannelSpec(
+        target: remap(ch.target),
+        targetName: ch.targetName,
+        property: ch.property,
+        timeline: remap(ch.timeline),
+        keyframes: remap(ch.keyframes),
+      ),
+  ],
+);
+
+StageMetadata _copyStage(StageMetadata s) => StageMetadata(
+  upAxis: s.upAxis,
+  handedness: s.handedness,
+  unitsPerMeter: s.unitsPerMeter,
+  environment: s.environment,
+  environmentIntensity: s.environmentIntensity,
+  exposure: s.exposure,
+  toneMapping: s.toneMapping,
+);

--- a/packages/flutter_scene/lib/src/fscene/compose/compose.dart
+++ b/packages/flutter_scene/lib/src/fscene/compose/compose.dart
@@ -71,16 +71,20 @@ Future<SceneDocument> composeSceneAsync(
   );
 }
 
-Iterable<AssetRef> _prefabRefs(SceneDocument doc) => doc.nodes.values
-    .where((node) => node.instance != null)
-    .map((node) => node.instance!.source);
+Iterable<AssetRef> _prefabRefs(SceneDocument doc) =>
+    doc.nodes.values.where(_isEager).map((node) => node.instance!.source);
+
+bool _isEager(NodeSpec node) =>
+    node.instance != null && node.instance!.load == LoadPolicy.eager;
 
 SceneDocument _compose(
   SceneDocument document,
   PrefabResolver resolve,
   Set<String> visiting,
 ) {
-  if (document.nodes.values.every((node) => node.instance == null)) {
+  // Only eager instances are expanded here; lazy instances pass through as
+  // placeholders for the streaming layer to load on demand.
+  if (!document.nodes.values.any(_isEager)) {
     return document;
   }
 
@@ -114,8 +118,7 @@ SceneDocument _compose(
   }
   out.roots.addAll(document.roots);
 
-  for (final instance
-      in out.nodes.values.where((node) => node.instance != null).toList()) {
+  for (final instance in out.nodes.values.where(_isEager).toList()) {
     _expandInstance(out, instance, resolve, visiting);
   }
   return out;

--- a/packages/flutter_scene/lib/src/fscene/compose/compose.dart
+++ b/packages/flutter_scene/lib/src/fscene/compose/compose.dart
@@ -18,12 +18,16 @@ import 'package:flutter/foundation.dart';
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
 import 'package:flutter_scene/src/fscene/property_value.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 
 /// Resolves a prefab [AssetRef] to its (uncomposed) [SceneDocument].
 typedef PrefabResolver = SceneDocument Function(AssetRef ref);
+
+/// Asynchronously loads a prefab [AssetRef]'s (uncomposed) [SceneDocument].
+typedef AsyncPrefabLoader = Future<SceneDocument> Function(AssetRef ref);
 
 /// Expands every prefab instance in [document], returning a new document with
 /// no instance nodes. A document with no instances is returned unchanged.
@@ -35,6 +39,41 @@ SceneDocument composeScene(
   SceneDocument document, {
   required PrefabResolver resolve,
 }) => _compose(document, resolve, <String>{});
+
+/// Loads every prefab document [document] references (transitively, breadth
+/// first, each source loaded once) via [load], then composes synchronously.
+///
+/// The async counterpart of [composeScene]: the asset loaders call this so a
+/// scene that references prefab files by source path is expanded before
+/// realizing. A reference that fails to load throws.
+Future<SceneDocument> composeSceneAsync(
+  SceneDocument document, {
+  required AsyncPrefabLoader load,
+}) async {
+  final loaded = <String, SceneDocument>{};
+  final queue = [..._prefabRefs(document)];
+  while (queue.isNotEmpty) {
+    final ref = queue.removeLast();
+    if (loaded.containsKey(ref.key)) continue;
+    final prefab = await load(ref);
+    loaded[ref.key] = prefab;
+    queue.addAll(_prefabRefs(prefab));
+  }
+  return composeScene(
+    document,
+    resolve: (ref) {
+      final prefab = loaded[ref.key];
+      if (prefab == null) {
+        throw FsceneFormatException('Unresolved prefab "${ref.key}"');
+      }
+      return prefab;
+    },
+  );
+}
+
+Iterable<AssetRef> _prefabRefs(SceneDocument doc) => doc.nodes.values
+    .where((node) => node.instance != null)
+    .map((node) => node.instance!.source);
 
 SceneDocument _compose(
   SceneDocument document,

--- a/packages/flutter_scene/lib/src/fscene/id.dart
+++ b/packages/flutter_scene/lib/src/fscene/id.dart
@@ -1,0 +1,169 @@
+/// Identity for the `.fscene` document model.
+///
+/// A document carries one global [DocumentId] (128-bit, minted once) plus
+/// compact, document-scoped [LocalId]s for its nodes, resources, skins,
+/// animations, and payloads. A cross-document reference is the
+/// `(DocumentId, LocalId)` pair; within a document the [DocumentId] is
+/// implicit and only the [LocalId] is stored. Ids are stored, never derived
+/// from names or paths, so a rename or reparent never changes an id.
+///
+/// The representation is web-safe: ids are kept in 8-bit and 32-bit pieces
+/// and never rely on 64-bit integer arithmetic (which `dart2js` cannot do
+/// losslessly).
+library;
+
+import 'dart:math';
+import 'dart:typed_data';
+
+/// The Crockford base32 alphabet (no `I`, `L`, `O`, `U`), used for the
+/// case-insensitive, dictatable text form of ids.
+const String _base32Alphabet = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+/// Encodes [bytes] as an unpadded Crockford base32 string, most significant
+/// bit first. Stays web-safe by never accumulating more than ~13 bits.
+String encodeBase32(Uint8List bytes) {
+  final out = StringBuffer();
+  var buffer = 0;
+  var bitsLeft = 0;
+  for (final b in bytes) {
+    buffer = (buffer << 8) | b;
+    bitsLeft += 8;
+    while (bitsLeft >= 5) {
+      bitsLeft -= 5;
+      out.write(_base32Alphabet[(buffer >> bitsLeft) & 0x1F]);
+    }
+    // Drop the bits already emitted so `buffer` stays small.
+    buffer &= (1 << bitsLeft) - 1;
+  }
+  if (bitsLeft > 0) {
+    out.write(_base32Alphabet[(buffer << (5 - bitsLeft)) & 0x1F]);
+  }
+  return out.toString();
+}
+
+// A uniformly random 32-bit value, assembled from two 16-bit draws to stay
+// within `Random.nextInt`'s range and web-safe integer bounds.
+int _random32(Random random) =>
+    (random.nextInt(0x10000) << 16) | random.nextInt(0x10000);
+
+/// A 128-bit document identifier, minted once when a document is created.
+///
+/// Stored as 16 bytes; the text form is Crockford base32. The high bits are
+/// stamped UUIDv4 (random) so the id is a well-formed UUID, but the bytes are
+/// the identity, not the UUID fields.
+class DocumentId {
+  /// Wraps the given 16 [bytes].
+  DocumentId(this.bytes)
+    : assert(bytes.length == 16, 'A DocumentId is 16 bytes');
+
+  /// The 16 identity bytes.
+  final Uint8List bytes;
+
+  /// Mints a new random document id (UUIDv4 layout). Pass a seeded [random]
+  /// for deterministic tests; the default is cryptographically random.
+  factory DocumentId.generate([Random? random]) {
+    final rng = random ?? Random.secure();
+    final b = Uint8List(16);
+    for (var i = 0; i < 16; i++) {
+      b[i] = rng.nextInt(0x100);
+    }
+    b[6] = (b[6] & 0x0F) | 0x40; // version 4
+    b[8] = (b[8] & 0x3F) | 0x80; // variant 1
+    return DocumentId(b);
+  }
+
+  /// The canonical text form: 26-character Crockford base32.
+  String toToken() => encodeBase32(bytes);
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! DocumentId) return false;
+    for (var i = 0; i < 16; i++) {
+      if (bytes[i] != other.bytes[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hashAll(bytes);
+
+  @override
+  String toString() => 'DocumentId(${toToken()})';
+}
+
+/// A compact, document-scoped identifier for a node, resource, skin,
+/// animation, or payload.
+///
+/// A local id is a `(session, index)` pair: [session] is the 32-bit random
+/// salt of the [IdAllocator] that minted it, and [index] is that allocator's
+/// monotonic counter. The salt makes ids minted on different machines or
+/// branches collision-free without a coordinator (a merge is a set union, no
+/// renumbering); the counter is never reused. Both halves are 32-bit, so the
+/// pair is web-safe and a fast map key.
+class LocalId {
+  /// Wraps an explicit [session] salt and [index] counter. Prefer
+  /// [IdAllocator.mint] to allocate fresh ids.
+  const LocalId(this.session, this.index);
+
+  /// The 32-bit session salt of the minting allocator.
+  final int session;
+
+  /// The monotonic counter within that session.
+  final int index;
+
+  /// The canonical text token: Crockford base32 of the 8 id bytes (the
+  /// big-endian [session] followed by the big-endian [index]).
+  String toToken() {
+    final b = Uint8List(8);
+    ByteData.view(b.buffer)
+      ..setUint32(0, session, Endian.big)
+      ..setUint32(4, index, Endian.big);
+    return encodeBase32(b);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is LocalId && other.session == session && other.index == index;
+
+  @override
+  int get hashCode => Object.hash(session, index);
+
+  @override
+  String toString() => 'LocalId(${toToken()})';
+}
+
+/// Mints fresh [LocalId]s for one editing session of a document.
+///
+/// Each allocator draws one random 32-bit [session] salt and hands out
+/// monotonically increasing indices, so every id it mints is unique and
+/// never reused. Continuing to edit a loaded document uses a new allocator
+/// with a new session salt (pass [excludedSessions] to guarantee it differs
+/// from sessions already present in the document), so newly minted ids never
+/// collide with existing ones.
+class IdAllocator {
+  /// Creates an allocator. Pass an explicit [session] to resume a known
+  /// session, or [excludedSessions] (the salts already used in a loaded
+  /// document) to draw a fresh salt that avoids them. [random] is seedable
+  /// for deterministic tests.
+  IdAllocator({int? session, Set<int>? excludedSessions, Random? random})
+    : session =
+          session ?? _drawSession(random ?? Random.secure(), excludedSessions);
+
+  static int _drawSession(Random random, Set<int>? excluded) {
+    var s = _random32(random);
+    if (excluded != null) {
+      while (excluded.contains(s)) {
+        s = _random32(random);
+      }
+    }
+    return s;
+  }
+
+  /// This allocator's 32-bit session salt; every minted id carries it.
+  final int session;
+
+  int _nextIndex = 0;
+
+  /// Mints the next unique [LocalId] for this session.
+  LocalId mint() => LocalId(session, _nextIndex++);
+}

--- a/packages/flutter_scene/lib/src/fscene/id.dart
+++ b/packages/flutter_scene/lib/src/fscene/id.dart
@@ -41,6 +41,49 @@ String encodeBase32(Uint8List bytes) {
   return out.toString();
 }
 
+// The 5-bit value of a base32 character, normalizing case and the Crockford
+// ambiguous letters (I, L -> 1; O -> 0). Throws on an invalid character.
+int _base32Value(int code) {
+  var c = code;
+  if (c >= 0x61 && c <= 0x7A) c -= 0x20; // a-z -> A-Z
+  if (c == 0x49 || c == 0x4C) c = 0x31; // I, L -> 1
+  if (c == 0x4F) c = 0x30; // O -> 0
+  final idx = _base32Alphabet.indexOf(String.fromCharCode(c));
+  if (idx < 0) {
+    throw FormatException(
+      'Invalid base32 character: ${String.fromCharCode(code)}',
+    );
+  }
+  return idx;
+}
+
+/// Decodes a Crockford base32 [token] to bytes (most significant bit first),
+/// the inverse of [encodeBase32]. Case-insensitive; trailing bits that do not
+/// fill a byte are dropped. Throws a [FormatException] on an invalid
+/// character.
+Uint8List decodeBase32(String token) {
+  final out = <int>[];
+  var buffer = 0;
+  var bits = 0;
+  for (final code in token.codeUnits) {
+    buffer = (buffer << 5) | _base32Value(code);
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      out.add((buffer >> bits) & 0xFF);
+      buffer &= (1 << bits) - 1;
+    }
+  }
+  return Uint8List.fromList(out);
+}
+
+// Strips a leading readability prefix (everything up to and including the
+// last ':') from an id token, so `n:ABC` and `ABC` both parse.
+String _stripIdPrefix(String token) {
+  final colon = token.lastIndexOf(':');
+  return colon < 0 ? token : token.substring(colon + 1);
+}
+
 // A uniformly random 32-bit value, assembled from two 16-bit draws to stay
 // within `Random.nextInt`'s range and web-safe integer bounds.
 int _random32(Random random) =>
@@ -70,6 +113,17 @@ class DocumentId {
     b[6] = (b[6] & 0x0F) | 0x40; // version 4
     b[8] = (b[8] & 0x3F) | 0x80; // variant 1
     return DocumentId(b);
+  }
+
+  /// Parses a document id from its base32 [token] (the inverse of
+  /// [toToken]). Throws a [FormatException] if it does not decode to 16
+  /// bytes.
+  factory DocumentId.parse(String token) {
+    final bytes = decodeBase32(_stripIdPrefix(token));
+    if (bytes.length != 16) {
+      throw FormatException('A DocumentId token decodes to 16 bytes: $token');
+    }
+    return DocumentId(bytes);
   }
 
   /// The canonical text form: 26-character Crockford base32.
@@ -104,6 +158,21 @@ class LocalId {
   /// Wraps an explicit [session] salt and [index] counter. Prefer
   /// [IdAllocator.mint] to allocate fresh ids.
   const LocalId(this.session, this.index);
+
+  /// Parses a local id from its [token] (the inverse of [toToken]), ignoring
+  /// any leading readability prefix (`n:`, `geo:`, ...). Throws a
+  /// [FormatException] if it does not decode to 8 bytes.
+  factory LocalId.parse(String token) {
+    final bytes = decodeBase32(_stripIdPrefix(token));
+    if (bytes.length != 8) {
+      throw FormatException('A LocalId token decodes to 8 bytes: $token');
+    }
+    final view = ByteData.view(bytes.buffer, bytes.offsetInBytes, 8);
+    return LocalId(
+      view.getUint32(0, Endian.big),
+      view.getUint32(4, Endian.big),
+    );
+  }
 
   /// The 32-bit session salt of the minting allocator.
   final int session;

--- a/packages/flutter_scene/lib/src/fscene/json/canonical.dart
+++ b/packages/flutter_scene/lib/src/fscene/json/canonical.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+
+/// Thrown when a value cannot be encoded to canonical `.fscene` JSON.
+class FsceneEncodeException implements Exception {
+  /// Creates an encode exception with the given [message].
+  FsceneEncodeException(this.message);
+
+  /// What went wrong.
+  final String message;
+
+  @override
+  String toString() => 'FsceneEncodeException: $message';
+}
+
+/// Writes [value] (a JSON tree of maps, lists, and primitives) as canonical
+/// `.fscene` text.
+///
+/// The output is deterministic for a given tree: maps keep the encoder's key
+/// order, objects and object-arrays are pretty-printed with [indent], and
+/// arrays of numbers and booleans (vectors, matrices, colors) are kept inline
+/// on one line so diffs stay tight. Doubles are written with a decimal or
+/// exponent so they round-trip back to doubles; non-finite numbers are
+/// rejected and `-0.0` is normalized to `0.0`.
+String canonicalJson(Object? value, {String indent = '  '}) {
+  final sb = StringBuffer();
+  _write(sb, value, indent, 0);
+  sb.write('\n');
+  return sb.toString();
+}
+
+void _write(StringBuffer sb, Object? v, String indent, int depth) {
+  if (v == null) {
+    sb.write('null');
+  } else if (v is bool) {
+    sb.write(v ? 'true' : 'false');
+  } else if (v is int) {
+    sb.write(v.toString());
+  } else if (v is double) {
+    sb.write(_formatDouble(v));
+  } else if (v is String) {
+    sb.write(jsonEncode(v));
+  } else if (v is List) {
+    _writeList(sb, v, indent, depth);
+  } else if (v is Map) {
+    _writeMap(sb, v, indent, depth);
+  } else {
+    throw FsceneEncodeException('Cannot encode value of type ${v.runtimeType}');
+  }
+}
+
+String _formatDouble(double d) {
+  if (d.isNaN || d.isInfinite) {
+    throw FsceneEncodeException('Cannot encode non-finite number: $d');
+  }
+  if (d == 0.0) return '0.0'; // normalizes -0.0
+  final s = d.toString();
+  // Dart prints whole doubles as `1.0`; ensure a decimal or exponent so the
+  // value decodes back to a double rather than an int.
+  return s.contains('.') || s.contains('e') || s.contains('E') ? s : '$s.0';
+}
+
+bool _isScalar(Object? v) => v == null || v is num || v is bool;
+
+void _writeList(StringBuffer sb, List<Object?> v, String indent, int depth) {
+  if (v.isEmpty) {
+    sb.write('[]');
+    return;
+  }
+  if (v.every(_isScalar)) {
+    sb.write('[');
+    for (var i = 0; i < v.length; i++) {
+      if (i > 0) sb.write(', ');
+      _write(sb, v[i], indent, depth);
+    }
+    sb.write(']');
+    return;
+  }
+  final pad = indent * (depth + 1);
+  sb.write('[\n');
+  for (var i = 0; i < v.length; i++) {
+    sb.write(pad);
+    _write(sb, v[i], indent, depth + 1);
+    if (i < v.length - 1) sb.write(',');
+    sb.write('\n');
+  }
+  sb
+    ..write(indent * depth)
+    ..write(']');
+}
+
+void _writeMap(
+  StringBuffer sb,
+  Map<Object?, Object?> v,
+  String indent,
+  int depth,
+) {
+  if (v.isEmpty) {
+    sb.write('{}');
+    return;
+  }
+  final pad = indent * (depth + 1);
+  sb.write('{\n');
+  final keys = v.keys.toList();
+  for (var i = 0; i < keys.length; i++) {
+    final k = keys[i];
+    sb
+      ..write(pad)
+      ..write(jsonEncode(k.toString()))
+      ..write(': ');
+    _write(sb, v[k], indent, depth + 1);
+    if (i < keys.length - 1) sb.write(',');
+    sb.write('\n');
+  }
+  sb
+    ..write(indent * depth)
+    ..write('}');
+}

--- a/packages/flutter_scene/lib/src/fscene/json/fscene_json.dart
+++ b/packages/flutter_scene/lib/src/fscene/json/fscene_json.dart
@@ -215,10 +215,16 @@ Map<String, dynamic> _encodeStage(StageMetadata s) => {
 
 Object _encodeResource(ResourceSpec r, String Function(LocalId) idKey) {
   switch (r) {
-    case GeometryResource(:final payload, :final procedural, :final bounds):
+    case GeometryResource(
+      :final vertices,
+      :final indices,
+      :final procedural,
+      :final bounds,
+    ):
       return {
         'kind': 'geometry',
-        if (payload != null) 'payload': idKey(payload),
+        if (vertices != null) 'vertices': idKey(vertices),
+        if (indices != null) 'indices': idKey(indices),
         if (procedural != null) 'procedural': _encodeProcedural(procedural),
         if (bounds != null)
           'bounds': {
@@ -510,8 +516,11 @@ ResourceSpec _decodeResource(LocalId id, Map<String, dynamic> json) {
     case 'geometry':
       return GeometryResource(
         id,
-        payload: json['payload'] != null
-            ? LocalId.parse(json['payload'] as String)
+        vertices: json['vertices'] != null
+            ? LocalId.parse(json['vertices'] as String)
+            : null,
+        indices: json['indices'] != null
+            ? LocalId.parse(json['indices'] as String)
             : null,
         procedural: json['procedural'] != null
             ? _decodeProcedural(

--- a/packages/flutter_scene/lib/src/fscene/json/fscene_json.dart
+++ b/packages/flutter_scene/lib/src/fscene/json/fscene_json.dart
@@ -1,0 +1,614 @@
+import 'dart:convert';
+
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/json/canonical.dart';
+import 'package:flutter_scene/src/fscene/json/jsonc.dart';
+import 'package:flutter_scene/src/fscene/json/property_json.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+
+/// The current `.fscene` format version this build reads and writes.
+const int currentFsceneVersion = 1;
+
+/// The format feature flags this build understands. A document that lists a
+/// feature outside this set in its `featuresRequired` is refused.
+const Set<String> supportedFeatures = {
+  'skinning',
+  'prefabInstances',
+  'streaming',
+};
+
+/// Upgrades a raw decoded document one version forward (version `N` to
+/// `N + 1`). Indexed by source version in the migration list.
+typedef FsceneMigration =
+    Map<String, dynamic> Function(Map<String, dynamic> json);
+
+// The built-in migration chain. Empty at v1 (the first version); a future
+// breaking change appends a `vN -> vN+1` step here.
+const List<FsceneMigration> _builtInMigrations = [];
+
+/// Thrown when a `.fscene` document is malformed.
+class FsceneFormatException implements Exception {
+  /// Creates a format exception with the given [message].
+  const FsceneFormatException(this.message);
+
+  /// What is wrong with the document.
+  final String message;
+
+  @override
+  String toString() => 'FsceneFormatException: $message';
+}
+
+/// Thrown when a document's version cannot be loaded (newer than supported,
+/// or missing a migration step).
+class FsceneVersionException implements Exception {
+  /// Creates a version exception with the given [message].
+  const FsceneVersionException(this.message);
+
+  /// What went wrong with the version.
+  final String message;
+
+  @override
+  String toString() => 'FsceneVersionException: $message';
+}
+
+/// Thrown when a document requires a format feature this build does not
+/// support.
+class FsceneUnsupportedFeatureException implements Exception {
+  /// Creates an exception naming the unsupported [feature].
+  const FsceneUnsupportedFeatureException(this.feature);
+
+  /// The required feature this build does not support.
+  final String feature;
+
+  @override
+  String toString() =>
+      'FsceneUnsupportedFeatureException: required feature "$feature" '
+      'is not supported';
+}
+
+/// Serializes [doc] to canonical `.fscene` JSON text.
+String writeFscene(SceneDocument doc) => canonicalJson(encodeDocument(doc));
+
+/// Parses a `.fscene` document from [source].
+///
+/// Accepts a JSONC superset on read (`//` and `/* */` comments, trailing
+/// commas), runs the version migration chain, then decodes. Pass [migrations]
+/// to override the built-in chain (for tests). Unknown fields are ignored.
+SceneDocument readFscene(String source, {List<FsceneMigration>? migrations}) {
+  final decoded = jsonDecode(stripJsonc(source));
+  if (decoded is! Map) {
+    throw const FsceneFormatException('Top-level value must be an object');
+  }
+  final migrated = migrateFscene(
+    Map<String, dynamic>.from(decoded),
+    migrations: migrations,
+  );
+  return decodeDocument(migrated);
+}
+
+/// Runs the version migration chain over a raw decoded [json] document,
+/// upgrading it to [currentFsceneVersion]. Throws [FsceneVersionException]
+/// for a newer-than-supported version or a missing migration step.
+Map<String, dynamic> migrateFscene(
+  Map<String, dynamic> json, {
+  List<FsceneMigration>? migrations,
+}) {
+  final steps = migrations ?? _builtInMigrations;
+  var version = json['fscene'] as int? ?? currentFsceneVersion;
+  if (version > currentFsceneVersion) {
+    throw FsceneVersionException(
+      'Document version $version is newer than supported $currentFsceneVersion',
+    );
+  }
+  while (version < currentFsceneVersion) {
+    if (version >= steps.length) {
+      throw FsceneVersionException('No migration from version $version');
+    }
+    json = steps[version](json);
+    version++;
+    json['fscene'] = version;
+  }
+  return json;
+}
+
+//-----------------------------------------------------------------------------
+// Encode
+//-----------------------------------------------------------------------------
+
+/// Encodes [doc] as a JSON tree (maps, lists, and primitives).
+Map<String, dynamic> encodeDocument(SceneDocument doc) {
+  final prefixes = _buildPrefixMap(doc);
+  String idKey(LocalId id) => '${prefixes[id] ?? 'id'}:${id.toToken()}';
+
+  final json = <String, dynamic>{
+    'fscene': doc.formatVersion,
+    'documentId': doc.documentId.toToken(),
+  };
+  if (doc.featuresUsed.isNotEmpty) {
+    json['featuresUsed'] = doc.featuresUsed.toList()..sort();
+  }
+  if (doc.featuresRequired.isNotEmpty) {
+    json['featuresRequired'] = doc.featuresRequired.toList()..sort();
+  }
+  if (doc.generator != null) json['generator'] = doc.generator;
+  json['stage'] = _encodeStage(doc.stage);
+  if (doc.resources.isNotEmpty) {
+    json['resources'] = _encodeIdMap(
+      doc.resources,
+      idKey,
+      (r) => _encodeResource(r, idKey),
+    );
+  }
+  json['nodes'] = _encodeIdMap(doc.nodes, idKey, (n) => _encodeNode(n, idKey));
+  json['roots'] = [for (final id in doc.roots) idKey(id)];
+  if (doc.skins.isNotEmpty) {
+    json['skins'] = _encodeIdMap(
+      doc.skins,
+      idKey,
+      (s) => _encodeSkin(s, idKey),
+    );
+  }
+  if (doc.animations.isNotEmpty) {
+    json['animations'] = _encodeIdMap(
+      doc.animations,
+      idKey,
+      (a) => _encodeAnimation(a, idKey),
+    );
+  }
+  if (doc.payloads.isNotEmpty) {
+    json['payloads'] = _encodeIdMap(doc.payloads, idKey, _encodePayload);
+  }
+  return json;
+}
+
+Map<LocalId, String> _buildPrefixMap(SceneDocument doc) {
+  final prefixes = <LocalId, String>{};
+  for (final id in doc.nodes.keys) {
+    prefixes[id] = 'n';
+  }
+  for (final r in doc.resources.values) {
+    prefixes[r.id] = switch (r) {
+      GeometryResource() => 'geo',
+      MaterialResource() => 'mat',
+      TextureResource() => 'tex',
+    };
+  }
+  for (final id in doc.skins.keys) {
+    prefixes[id] = 'skin';
+  }
+  for (final id in doc.animations.keys) {
+    prefixes[id] = 'anim';
+  }
+  for (final id in doc.payloads.keys) {
+    prefixes[id] = 'chunk';
+  }
+  return prefixes;
+}
+
+Map<String, dynamic> _encodeIdMap<V>(
+  Map<LocalId, V> map,
+  String Function(LocalId) idKey,
+  Object Function(V) encode,
+) {
+  final entries = map.entries.toList()
+    ..sort((a, b) => a.key.toToken().compareTo(b.key.toToken()));
+  return {for (final e in entries) idKey(e.key): encode(e.value)};
+}
+
+Map<String, dynamic> _encodeStage(StageMetadata s) => {
+  'upAxis': s.upAxis.name,
+  'handedness': s.handedness.name,
+  'unitsPerMeter': s.unitsPerMeter,
+  'environment': switch (s.environment) {
+    StudioEnvironment() => {'type': 'studio'},
+    AssetEnvironment(:final asset) => {'type': 'asset', 'ref': asset.key},
+    EmptyEnvironment() => {'type': 'empty'},
+  },
+  'environmentIntensity': s.environmentIntensity,
+  'exposure': s.exposure,
+  'toneMapping': s.toneMapping,
+};
+
+Object _encodeResource(ResourceSpec r, String Function(LocalId) idKey) {
+  switch (r) {
+    case GeometryResource(:final payload, :final bounds):
+      return {
+        'kind': 'geometry',
+        'payload': idKey(payload),
+        if (bounds != null)
+          'bounds': {
+            'min': [bounds.min.x, bounds.min.y, bounds.min.z],
+            'max': [bounds.max.x, bounds.max.y, bounds.max.z],
+          },
+      };
+    case TextureResource(:final payload, :final asset):
+      return {
+        'kind': 'texture',
+        if (payload != null) 'payload': idKey(payload),
+        if (asset != null) 'ref': asset.key,
+      };
+    case MaterialResource(:final type, :final properties, :final asset):
+      return {
+        'kind': 'material',
+        'type': type,
+        if (asset != null) 'ref': asset.key,
+        if (properties.isNotEmpty)
+          'properties': {
+            for (final e in properties.entries)
+              e.key: encodePropertyValue(e.value, idKey),
+          },
+      };
+  }
+}
+
+Map<String, dynamic> _encodeNode(NodeSpec n, String Function(LocalId) idKey) {
+  return {
+    if (n.name.isNotEmpty) 'name': n.name,
+    'transform': _encodeTransform(n.transform),
+    if (n.children.isNotEmpty)
+      'children': [for (final c in n.children) idKey(c)],
+    if (n.components.isNotEmpty)
+      'components': [for (final c in n.components) _encodeComponent(c, idKey)],
+    if (n.layers != 1) 'layers': n.layers,
+    if (n.skin != null) 'skin': idKey(n.skin!),
+    if (n.instance != null) 'instance': _encodeInstance(n.instance!, idKey),
+  };
+}
+
+Map<String, dynamic> _encodeTransform(TransformSpec t) => switch (t) {
+  MatrixTransform(:final matrix) => {'matrix': matrix.storage.toList()},
+  TrsTransform(:final translation, :final rotation, :final scale) => {
+    'trs': {
+      't': [translation.x, translation.y, translation.z],
+      'r': [rotation.x, rotation.y, rotation.z, rotation.w],
+      's': [scale.x, scale.y, scale.z],
+    },
+  },
+};
+
+Map<String, dynamic> _encodeComponent(
+  ComponentSpec c,
+  String Function(LocalId) idKey,
+) => {
+  'type': c.type,
+  if (c.properties.isNotEmpty)
+    'properties': {
+      for (final e in c.properties.entries)
+        e.key: encodePropertyValue(e.value, idKey),
+    },
+};
+
+Map<String, dynamic> _encodeInstance(
+  PrefabInstanceSpec p,
+  String Function(LocalId) idKey,
+) => {
+  'source': p.source.key,
+  if (p.load != LoadPolicy.eager) 'load': p.load.name,
+  if (p.overrides.isNotEmpty)
+    'overrides': [
+      for (final o in p.overrides)
+        {
+          'target': idKey(o.target),
+          'path': o.path,
+          'value': encodePropertyValue(o.value, idKey),
+        },
+    ],
+  if (p.addedNodes.isNotEmpty)
+    'addedNodes': {
+      for (final n in p.addedNodes) idKey(n.id): _encodeNode(n, idKey),
+    },
+  if (p.removedNodes.isNotEmpty)
+    'removedNodes': [for (final id in p.removedNodes) idKey(id)],
+  if (p.addedComponents.isNotEmpty)
+    'addedComponents': [
+      for (final c in p.addedComponents) _encodeComponent(c, idKey),
+    ],
+  if (p.removedComponentTypes.isNotEmpty)
+    'removedComponentTypes': p.removedComponentTypes,
+};
+
+Map<String, dynamic> _encodeSkin(SkinSpec s, String Function(LocalId) idKey) =>
+    {
+      'joints': [for (final j in s.joints) idKey(j)],
+      'inverseBindMatrices': idKey(s.inverseBindMatrices),
+      if (s.skeleton != null) 'skeleton': idKey(s.skeleton!),
+    };
+
+Map<String, dynamic> _encodeAnimation(
+  AnimationSpec a,
+  String Function(LocalId) idKey,
+) => {
+  if (a.name.isNotEmpty) 'name': a.name,
+  'channels': [
+    for (final ch in a.channels)
+      {
+        'target': idKey(ch.target),
+        if (ch.targetName != null) 'targetName': ch.targetName,
+        'property': ch.property.name,
+        'timeline': idKey(ch.timeline),
+        'keyframes': idKey(ch.keyframes),
+      },
+  ],
+};
+
+Map<String, dynamic> _encodePayload(PayloadSpec p) => {
+  'encoding': p.encoding.name,
+  if (p.layout != null) 'layout': p.layout,
+  if (p.format != null) 'format': p.format,
+  if (p.width != null) 'width': p.width,
+  if (p.height != null) 'height': p.height,
+  if (p.length != null) 'length': p.length,
+};
+
+//-----------------------------------------------------------------------------
+// Decode
+//-----------------------------------------------------------------------------
+
+/// Decodes a [SceneDocument] from a raw JSON tree (already migrated to the
+/// current version). Throws on an unsupported required feature.
+SceneDocument decodeDocument(Map<String, dynamic> json) {
+  final version = json['fscene'] as int? ?? currentFsceneVersion;
+  if (version != currentFsceneVersion) {
+    throw FsceneVersionException(
+      'Document is version $version; expected $currentFsceneVersion '
+      '(run migrateFscene first)',
+    );
+  }
+
+  final required =
+      (json['featuresRequired'] as List?)?.cast<String>() ?? const <String>[];
+  for (final feature in required) {
+    if (!supportedFeatures.contains(feature)) {
+      throw FsceneUnsupportedFeatureException(feature);
+    }
+  }
+
+  final documentId = DocumentId.parse(json['documentId'] as String);
+
+  final nodes = _decodeIdMap(json['nodes'], _decodeNode);
+  final resources = _decodeIdMap(json['resources'], _decodeResource);
+  final skins = _decodeIdMap(json['skins'], _decodeSkin);
+  final animations = _decodeIdMap(json['animations'], _decodeAnimation);
+  final payloads = _decodeIdMap(json['payloads'], _decodePayload);
+  final roots = [
+    for (final id in (json['roots'] as List? ?? const []))
+      LocalId.parse(id as String),
+  ];
+
+  // Mint future ids with a fresh session that avoids every session already
+  // present in the document, so new edits cannot collide with loaded ids.
+  final usedSessions = <int>{};
+  void collect(LocalId id) => usedSessions.add(id.session);
+  nodes.keys.forEach(collect);
+  resources.keys.forEach(collect);
+  skins.keys.forEach(collect);
+  animations.keys.forEach(collect);
+  payloads.keys.forEach(collect);
+
+  final doc = SceneDocument(
+    documentId: documentId,
+    allocator: IdAllocator(excludedSessions: usedSessions),
+    stage: _decodeStage(json['stage'] as Map<String, dynamic>),
+  );
+  doc.formatVersion = version;
+  doc.generator = json['generator'] as String?;
+  doc.featuresUsed.addAll(
+    (json['featuresUsed'] as List?)?.cast<String>() ?? const [],
+  );
+  doc.featuresRequired.addAll(required);
+  doc.nodes.addAll(nodes);
+  doc.roots.addAll(roots);
+  doc.resources.addAll(resources);
+  doc.skins.addAll(skins);
+  doc.animations.addAll(animations);
+  doc.payloads.addAll(payloads);
+  return doc;
+}
+
+Map<LocalId, V> _decodeIdMap<V>(
+  Object? json,
+  V Function(LocalId id, Map<String, dynamic> value) decode,
+) {
+  if (json == null) return {};
+  final out = <LocalId, V>{};
+  for (final e in (json as Map).entries) {
+    final id = LocalId.parse(e.key as String);
+    out[id] = decode(id, Map<String, dynamic>.from(e.value as Map));
+  }
+  return out;
+}
+
+NodeSpec _decodeNode(LocalId id, Map<String, dynamic> json) => NodeSpec(
+  id: id,
+  name: json['name'] as String? ?? '',
+  transform: _decodeTransform(json['transform'] as Map<String, dynamic>),
+  children: [
+    for (final c in (json['children'] as List? ?? const []))
+      LocalId.parse(c as String),
+  ],
+  components: [
+    for (final c in (json['components'] as List? ?? const []))
+      _decodeComponent(Map<String, dynamic>.from(c as Map)),
+  ],
+  layers: json['layers'] as int? ?? 1,
+  skin: json['skin'] != null ? LocalId.parse(json['skin'] as String) : null,
+  instance: json['instance'] != null
+      ? _decodeInstance(Map<String, dynamic>.from(json['instance'] as Map))
+      : null,
+);
+
+TransformSpec _decodeTransform(Map<String, dynamic> json) {
+  final matrix = json['matrix'];
+  if (matrix != null) {
+    return MatrixTransform(
+      Matrix4.fromList([for (final e in matrix as List) _d(e)]),
+    );
+  }
+  final trs = json['trs'] as Map<String, dynamic>;
+  final t = trs['t'] as List;
+  final r = trs['r'] as List;
+  final s = trs['s'] as List;
+  return TrsTransform(
+    translation: Vector3(_d(t[0]), _d(t[1]), _d(t[2])),
+    rotation: Quaternion(_d(r[0]), _d(r[1]), _d(r[2]), _d(r[3])),
+    scale: Vector3(_d(s[0]), _d(s[1]), _d(s[2])),
+  );
+}
+
+ComponentSpec _decodeComponent(Map<String, dynamic> json) => ComponentSpec(
+  json['type'] as String,
+  properties: _decodeProperties(json['properties']),
+);
+
+Map<String, PropertyValue> _decodeProperties(Object? json) => {
+  if (json != null)
+    for (final e in (json as Map).entries)
+      e.key as String: decodePropertyValue(e.value),
+};
+
+PrefabInstanceSpec _decodeInstance(Map<String, dynamic> json) =>
+    PrefabInstanceSpec(
+      source: AssetRef(json['source'] as String),
+      load: json['load'] == 'lazy' ? LoadPolicy.lazy : LoadPolicy.eager,
+      overrides: [
+        for (final o in (json['overrides'] as List? ?? const []))
+          _decodeOverride(Map<String, dynamic>.from(o as Map)),
+      ],
+      addedNodes: [
+        for (final e in (json['addedNodes'] as Map? ?? const {}).entries)
+          _decodeNode(
+            LocalId.parse(e.key as String),
+            Map<String, dynamic>.from(e.value as Map),
+          ),
+      ],
+      removedNodes: [
+        for (final id in (json['removedNodes'] as List? ?? const []))
+          LocalId.parse(id as String),
+      ],
+      addedComponents: [
+        for (final c in (json['addedComponents'] as List? ?? const []))
+          _decodeComponent(Map<String, dynamic>.from(c as Map)),
+      ],
+      removedComponentTypes:
+          (json['removedComponentTypes'] as List?)?.cast<String>() ?? const [],
+    );
+
+PropertyOverride _decodeOverride(Map<String, dynamic> json) => PropertyOverride(
+  target: LocalId.parse(json['target'] as String),
+  path: json['path'] as String,
+  value: decodePropertyValue(json['value']),
+);
+
+ResourceSpec _decodeResource(LocalId id, Map<String, dynamic> json) {
+  final kind = json['kind'] as String;
+  switch (kind) {
+    case 'geometry':
+      return GeometryResource(
+        id,
+        payload: LocalId.parse(json['payload'] as String),
+        bounds: _decodeBounds(json['bounds']),
+      );
+    case 'texture':
+      return TextureResource(
+        id,
+        payload: json['payload'] != null
+            ? LocalId.parse(json['payload'] as String)
+            : null,
+        asset: json['ref'] != null ? AssetRef(json['ref'] as String) : null,
+      );
+    case 'material':
+      return MaterialResource(
+        id,
+        type: json['type'] as String,
+        asset: json['ref'] != null ? AssetRef(json['ref'] as String) : null,
+        properties: _decodeProperties(json['properties']),
+      );
+    default:
+      throw FsceneFormatException('Unknown resource kind: $kind');
+  }
+}
+
+BoundsSpec? _decodeBounds(Object? json) {
+  if (json == null) return null;
+  final m = json as Map;
+  final min = m['min'] as List;
+  final max = m['max'] as List;
+  return BoundsSpec(
+    min: Vector3(_d(min[0]), _d(min[1]), _d(min[2])),
+    max: Vector3(_d(max[0]), _d(max[1]), _d(max[2])),
+  );
+}
+
+SkinSpec _decodeSkin(LocalId id, Map<String, dynamic> json) => SkinSpec(
+  id,
+  joints: [
+    for (final j in (json['joints'] as List? ?? const []))
+      LocalId.parse(j as String),
+  ],
+  inverseBindMatrices: LocalId.parse(json['inverseBindMatrices'] as String),
+  skeleton: json['skeleton'] != null
+      ? LocalId.parse(json['skeleton'] as String)
+      : null,
+);
+
+AnimationSpec _decodeAnimation(LocalId id, Map<String, dynamic> json) =>
+    AnimationSpec(
+      id,
+      name: json['name'] as String? ?? '',
+      channels: [
+        for (final ch in (json['channels'] as List? ?? const []))
+          _decodeChannel(Map<String, dynamic>.from(ch as Map)),
+      ],
+    );
+
+AnimationChannelSpec _decodeChannel(Map<String, dynamic> json) =>
+    AnimationChannelSpec(
+      target: LocalId.parse(json['target'] as String),
+      targetName: json['targetName'] as String?,
+      property: AnimationProperty.values.byName(json['property'] as String),
+      timeline: LocalId.parse(json['timeline'] as String),
+      keyframes: LocalId.parse(json['keyframes'] as String),
+    );
+
+PayloadSpec _decodePayload(LocalId id, Map<String, dynamic> json) =>
+    PayloadSpec(
+      id,
+      encoding: PayloadEncoding.values.byName(json['encoding'] as String),
+      layout: json['layout'] as String?,
+      format: json['format'] as String?,
+      width: json['width'] as int?,
+      height: json['height'] as int?,
+      length: json['length'] as int?,
+    );
+
+StageMetadata _decodeStage(Map<String, dynamic> json) => StageMetadata(
+  upAxis: UpAxis.values.byName(json['upAxis'] as String? ?? 'y'),
+  handedness: Handedness.values.byName(
+    json['handedness'] as String? ?? 'right',
+  ),
+  unitsPerMeter: _d(json['unitsPerMeter'] ?? 1.0),
+  environment: _decodeEnvironment(json['environment']),
+  environmentIntensity: _d(json['environmentIntensity'] ?? 1.0),
+  exposure: _d(json['exposure'] ?? 1.0),
+  toneMapping: json['toneMapping'] as String? ?? 'pbrNeutral',
+);
+
+EnvironmentSpec _decodeEnvironment(Object? json) {
+  if (json == null) return const StudioEnvironment();
+  final m = json as Map;
+  switch (m['type']) {
+    case 'asset':
+      return AssetEnvironment(AssetRef(m['ref'] as String));
+    case 'empty':
+      return const EmptyEnvironment();
+    case 'studio':
+    default:
+      return const StudioEnvironment();
+  }
+}
+
+double _d(Object? v) => (v as num).toDouble();

--- a/packages/flutter_scene/lib/src/fscene/json/fscene_json.dart
+++ b/packages/flutter_scene/lib/src/fscene/json/fscene_json.dart
@@ -215,10 +215,11 @@ Map<String, dynamic> _encodeStage(StageMetadata s) => {
 
 Object _encodeResource(ResourceSpec r, String Function(LocalId) idKey) {
   switch (r) {
-    case GeometryResource(:final payload, :final bounds):
+    case GeometryResource(:final payload, :final procedural, :final bounds):
       return {
         'kind': 'geometry',
-        'payload': idKey(payload),
+        if (payload != null) 'payload': idKey(payload),
+        if (procedural != null) 'procedural': _encodeProcedural(procedural),
         if (bounds != null)
           'bounds': {
             'min': [bounds.min.x, bounds.min.y, bounds.min.z],
@@ -509,7 +510,14 @@ ResourceSpec _decodeResource(LocalId id, Map<String, dynamic> json) {
     case 'geometry':
       return GeometryResource(
         id,
-        payload: LocalId.parse(json['payload'] as String),
+        payload: json['payload'] != null
+            ? LocalId.parse(json['payload'] as String)
+            : null,
+        procedural: json['procedural'] != null
+            ? _decodeProcedural(
+                Map<String, dynamic>.from(json['procedural'] as Map),
+              )
+            : null,
         bounds: _decodeBounds(json['bounds']),
       );
     case 'texture':
@@ -529,6 +537,60 @@ ResourceSpec _decodeResource(LocalId id, Map<String, dynamic> json) {
       );
     default:
       throw FsceneFormatException('Unknown resource kind: $kind');
+  }
+}
+
+Map<String, dynamic> _encodeProcedural(ProceduralGeometry p) => switch (p) {
+  CuboidGeometrySpec(:final extents, :final debugColors) => {
+    'shape': 'cuboid',
+    'extents': [extents.x, extents.y, extents.z],
+    if (debugColors) 'debugColors': true,
+  },
+  PlaneGeometrySpec(
+    :final width,
+    :final depth,
+    :final segmentsX,
+    :final segmentsZ,
+  ) =>
+    {
+      'shape': 'plane',
+      'width': width,
+      'depth': depth,
+      'segmentsX': segmentsX,
+      'segmentsZ': segmentsZ,
+    },
+  SphereGeometrySpec(:final radius, :final segments, :final rings) => {
+    'shape': 'sphere',
+    'radius': radius,
+    'segments': segments,
+    'rings': rings,
+  },
+};
+
+ProceduralGeometry _decodeProcedural(Map<String, dynamic> json) {
+  final shape = json['shape'] as String;
+  switch (shape) {
+    case 'cuboid':
+      final e = json['extents'] as List;
+      return CuboidGeometrySpec(
+        extents: Vector3(_d(e[0]), _d(e[1]), _d(e[2])),
+        debugColors: json['debugColors'] as bool? ?? false,
+      );
+    case 'plane':
+      return PlaneGeometrySpec(
+        width: _d(json['width'] ?? 1.0),
+        depth: _d(json['depth'] ?? 1.0),
+        segmentsX: json['segmentsX'] as int? ?? 1,
+        segmentsZ: json['segmentsZ'] as int? ?? 1,
+      );
+    case 'sphere':
+      return SphereGeometrySpec(
+        radius: _d(json['radius'] ?? 0.5),
+        segments: json['segments'] as int? ?? 32,
+        rings: json['rings'] as int? ?? 16,
+      );
+    default:
+      throw FsceneFormatException('Unknown procedural geometry shape: $shape');
   }
 }
 

--- a/packages/flutter_scene/lib/src/fscene/json/jsonc.dart
+++ b/packages/flutter_scene/lib/src/fscene/json/jsonc.dart
@@ -1,0 +1,95 @@
+/// Strips JSONC niceties so a hand-edited `.fscene` parses with the strict
+/// JSON decoder.
+///
+/// Removes `//` line comments and `/* ... */` block comments, then drops
+/// trailing commas before `}` and `]`. Comment characters and commas inside
+/// string literals are preserved. The canonical written form is strict JSON;
+/// this only loosens the read path.
+String stripJsonc(String source) =>
+    _stripTrailingCommas(_stripComments(source));
+
+String _stripComments(String s) {
+  final out = StringBuffer();
+  final n = s.length;
+  var i = 0;
+  var inString = false;
+  while (i < n) {
+    final c = s[i];
+    if (inString) {
+      out.write(c);
+      if (c == r'\' && i + 1 < n) {
+        out.write(s[i + 1]);
+        i += 2;
+        continue;
+      }
+      if (c == '"') inString = false;
+      i++;
+      continue;
+    }
+    if (c == '"') {
+      inString = true;
+      out.write(c);
+      i++;
+      continue;
+    }
+    if (c == '/' && i + 1 < n && s[i + 1] == '/') {
+      i += 2;
+      while (i < n && s[i] != '\n') {
+        i++;
+      }
+      continue;
+    }
+    if (c == '/' && i + 1 < n && s[i + 1] == '*') {
+      i += 2;
+      while (i + 1 < n && !(s[i] == '*' && s[i + 1] == '/')) {
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    out.write(c);
+    i++;
+  }
+  return out.toString();
+}
+
+String _stripTrailingCommas(String s) {
+  final out = StringBuffer();
+  final n = s.length;
+  var i = 0;
+  var inString = false;
+  while (i < n) {
+    final c = s[i];
+    if (inString) {
+      out.write(c);
+      if (c == r'\' && i + 1 < n) {
+        out.write(s[i + 1]);
+        i += 2;
+        continue;
+      }
+      if (c == '"') inString = false;
+      i++;
+      continue;
+    }
+    if (c == '"') {
+      inString = true;
+      out.write(c);
+      i++;
+      continue;
+    }
+    if (c == ',') {
+      var j = i + 1;
+      while (j < n &&
+          (s[j] == ' ' || s[j] == '\t' || s[j] == '\n' || s[j] == '\r')) {
+        j++;
+      }
+      if (j < n && (s[j] == '}' || s[j] == ']')) {
+        i++; // drop the trailing comma
+        continue;
+      }
+    }
+    out.write(c);
+    i++;
+  }
+  return out.toString();
+}

--- a/packages/flutter_scene/lib/src/fscene/json/property_json.dart
+++ b/packages/flutter_scene/lib/src/fscene/json/property_json.dart
@@ -1,0 +1,123 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+
+/// Resolves a referenced [LocalId] to the text token written for it (a
+/// kind-prefixed token such as `geo:7A3F...` for readability). The decoder
+/// strips the prefix, so any resolver that produces a parseable token works.
+typedef IdTokenResolver = String Function(LocalId id);
+
+/// Encodes [value] as a self-describing JSON tree (a single-key tagged
+/// object), using [idToken] to render any referenced ids.
+///
+/// The tag form round-trips the generic typed model without a per-component
+/// schema. Component codecs may later emit a cleaner schema-driven form for
+/// known types; this is the general fallback.
+Object encodePropertyValue(PropertyValue value, IdTokenResolver idToken) {
+  switch (value) {
+    case BoolValue(:final value):
+      return {'b': value};
+    case IntValue(:final value):
+      return {'i': value};
+    case DoubleValue(:final value):
+      return {'d': value};
+    case StringValue(:final value):
+      return {'s': value};
+    case Vec2Value(:final value):
+      return {
+        'v2': [value.x, value.y],
+      };
+    case Vec3Value(:final value):
+      return {
+        'v3': [value.x, value.y, value.z],
+      };
+    case Vec4Value(:final value):
+      return {
+        'v4': [value.x, value.y, value.z, value.w],
+      };
+    case QuaternionValue(:final value):
+      return {
+        'q': [value.x, value.y, value.z, value.w],
+      };
+    case Matrix4Value(:final value):
+      return {'m4': value.storage.toList()};
+    case ColorValue(:final r, :final g, :final b, :final a):
+      return {
+        'c': [r, g, b, a],
+      };
+    case ResourceRefValue(:final id):
+      return {'rref': idToken(id)};
+    case NodeRefValue(:final id):
+      return {'nref': idToken(id)};
+    case ListValue(:final values):
+      return {
+        'list': [for (final v in values) encodePropertyValue(v, idToken)],
+      };
+    case MapValue(:final values):
+      return {
+        'map': {
+          for (final e in values.entries)
+            e.key: encodePropertyValue(e.value, idToken),
+        },
+      };
+  }
+}
+
+/// Decodes a [PropertyValue] from a tagged JSON tree produced by
+/// [encodePropertyValue]. Referenced ids are parsed with [LocalId.parse],
+/// which ignores any readability prefix.
+PropertyValue decodePropertyValue(Object? json) {
+  if (json is! Map || json.length != 1) {
+    throw FormatException('Expected a single-key tagged value, got $json');
+  }
+  final tag = json.keys.first as String;
+  final payload = json.values.first;
+  switch (tag) {
+    case 'b':
+      return BoolValue(payload as bool);
+    case 'i':
+      return IntValue(payload as int);
+    case 'd':
+      return DoubleValue((payload as num).toDouble());
+    case 's':
+      return StringValue(payload as String);
+    case 'v2':
+      final l = payload as List;
+      return Vec2Value(Vector2(_d(l[0]), _d(l[1])));
+    case 'v3':
+      final l = payload as List;
+      return Vec3Value(Vector3(_d(l[0]), _d(l[1]), _d(l[2])));
+    case 'v4':
+      final l = payload as List;
+      return Vec4Value(Vector4(_d(l[0]), _d(l[1]), _d(l[2]), _d(l[3])));
+    case 'q':
+      final l = payload as List;
+      return QuaternionValue(
+        Quaternion(_d(l[0]), _d(l[1]), _d(l[2]), _d(l[3])),
+      );
+    case 'm4':
+      final l = payload as List;
+      return Matrix4Value(Matrix4.fromList([for (final e in l) _d(e)]));
+    case 'c':
+      final l = payload as List;
+      return ColorValue(_d(l[0]), _d(l[1]), _d(l[2]), _d(l[3]));
+    case 'rref':
+      return ResourceRefValue(LocalId.parse(payload as String));
+    case 'nref':
+      return NodeRefValue(LocalId.parse(payload as String));
+    case 'list':
+      return ListValue([
+        for (final e in payload as List) decodePropertyValue(e),
+      ]);
+    case 'map':
+      return MapValue({
+        for (final e in (payload as Map).entries)
+          e.key as String: decodePropertyValue(e.value),
+      });
+    default:
+      throw FormatException('Unknown property value tag: $tag');
+  }
+}
+
+double _d(Object? v) => (v as num).toDouble();

--- a/packages/flutter_scene/lib/src/fscene/property_value.dart
+++ b/packages/flutter_scene/lib/src/fscene/property_value.dart
@@ -1,0 +1,126 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/fscene/id.dart';
+
+/// A reference to an external asset by its source-path key.
+///
+/// The path is the same stable key the build hook and the hot-reload
+/// coordinator use (for example `assets/dash.glb` or `assets/toon.fmat`),
+/// resolved at load time. Wrapping it gives the format a single seam to
+/// later swap filesystem paths for content-addressed or uid-backed
+/// resolution.
+class AssetRef {
+  /// References the asset at the given source-path [key].
+  const AssetRef(this.key);
+
+  /// The source-path key, relative to the owning package's root.
+  final String key;
+
+  @override
+  bool operator ==(Object other) => other is AssetRef && other.key == key;
+
+  @override
+  int get hashCode => key.hashCode;
+
+  @override
+  String toString() => 'AssetRef($key)';
+}
+
+/// A typed value carried by a component field, a material parameter, or a
+/// prefab override.
+///
+/// The taxonomy is closed (a `sealed` hierarchy) so encoders, the component
+/// codec registry, and the prefab composer can exhaustively switch over it.
+/// References to other document entities are first-class:
+/// [ResourceRefValue] points at a resource, [NodeRefValue] at a node.
+sealed class PropertyValue {
+  const PropertyValue();
+}
+
+/// A boolean value.
+class BoolValue extends PropertyValue {
+  const BoolValue(this.value);
+  final bool value;
+}
+
+/// An integer value.
+class IntValue extends PropertyValue {
+  const IntValue(this.value);
+  final int value;
+}
+
+/// A floating-point scalar value.
+class DoubleValue extends PropertyValue {
+  const DoubleValue(this.value);
+  final double value;
+}
+
+/// A string value.
+class StringValue extends PropertyValue {
+  const StringValue(this.value);
+  final String value;
+}
+
+/// A 2-component vector.
+class Vec2Value extends PropertyValue {
+  Vec2Value(this.value);
+  final Vector2 value;
+}
+
+/// A 3-component vector.
+class Vec3Value extends PropertyValue {
+  Vec3Value(this.value);
+  final Vector3 value;
+}
+
+/// A 4-component vector.
+class Vec4Value extends PropertyValue {
+  Vec4Value(this.value);
+  final Vector4 value;
+}
+
+/// A rotation quaternion (`x, y, z, w`).
+class QuaternionValue extends PropertyValue {
+  QuaternionValue(this.value);
+  final Quaternion value;
+}
+
+/// A 4x4 matrix.
+class Matrix4Value extends PropertyValue {
+  Matrix4Value(this.value);
+  final Matrix4 value;
+}
+
+/// A linear RGBA color.
+class ColorValue extends PropertyValue {
+  const ColorValue(this.r, this.g, this.b, this.a);
+  final double r;
+  final double g;
+  final double b;
+  final double a;
+}
+
+/// A reference to a resource (geometry, material, texture, ...) in the same
+/// document, by its [LocalId].
+class ResourceRefValue extends PropertyValue {
+  const ResourceRefValue(this.id);
+  final LocalId id;
+}
+
+/// A reference to another node in the same document, by its [LocalId].
+class NodeRefValue extends PropertyValue {
+  const NodeRefValue(this.id);
+  final LocalId id;
+}
+
+/// An ordered list of values.
+class ListValue extends PropertyValue {
+  ListValue(this.values);
+  final List<PropertyValue> values;
+}
+
+/// A string-keyed map of values (a nested property bag).
+class MapValue extends PropertyValue {
+  MapValue(this.values);
+  final Map<String, PropertyValue> values;
+}

--- a/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
@@ -1,0 +1,113 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/components/camera_component.dart';
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/components/directional_light_component.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/light.dart';
+
+/// Registers the component codecs the format ships with (directional light,
+/// camera) into [registry].
+void registerBuiltinComponentCodecs(FsceneComponentRegistry registry) {
+  registry
+    ..register(DirectionalLightCodec())
+    ..register(CameraCodec());
+}
+
+/// Codec for [DirectionalLightComponent]: serializes the light's parameters,
+/// including its local direction (the node transform orients it at render
+/// time).
+class DirectionalLightCodec extends ComponentCodec {
+  @override
+  String get type => 'directionalLight';
+
+  @override
+  Component realize(ComponentSpec spec, RealizeContext context) {
+    final p = spec.properties;
+    return DirectionalLightComponent(
+      DirectionalLight(
+        direction: readVec3(p, 'direction', Vector3(-0.3, -1.0, -0.2)),
+        color: readVec3(p, 'color', Vector3(1, 1, 1)),
+        intensity: readDouble(p, 'intensity', 3.0),
+        castsShadow: readBool(p, 'castsShadow', false),
+        shadowFadeRange: readDouble(p, 'shadowFadeRange', 2.0),
+        shadowSoftness: readDouble(p, 'shadowSoftness', 0.08),
+        shadowCascadeCount: readInt(p, 'shadowCascadeCount', 4),
+        shadowMaxDistance: readDouble(p, 'shadowMaxDistance', 150.0),
+        shadowCascadeSplitLambda: readDouble(
+          p,
+          'shadowCascadeSplitLambda',
+          0.6,
+        ),
+        shadowMapResolution: readInt(p, 'shadowMapResolution', 1024),
+        shadowDepthBias: readDouble(p, 'shadowDepthBias', 0.02),
+        shadowNormalBias: readDouble(p, 'shadowNormalBias', 0.02),
+      ),
+    );
+  }
+
+  @override
+  ComponentSpec? serialize(Component component, SerializeContext context) {
+    if (component is! DirectionalLightComponent) return null;
+    final l = component.light;
+    return ComponentSpec(
+      type,
+      properties: {
+        'direction': Vec3Value(l.direction.clone()),
+        'color': Vec3Value(l.color.clone()),
+        'intensity': DoubleValue(l.intensity),
+        'castsShadow': BoolValue(l.castsShadow),
+        'shadowFadeRange': DoubleValue(l.shadowFadeRange),
+        'shadowSoftness': DoubleValue(l.shadowSoftness),
+        'shadowCascadeCount': IntValue(l.shadowCascadeCount),
+        'shadowMaxDistance': DoubleValue(l.shadowMaxDistance),
+        'shadowCascadeSplitLambda': DoubleValue(l.shadowCascadeSplitLambda),
+        'shadowMapResolution': IntValue(l.shadowMapResolution),
+        'shadowDepthBias': DoubleValue(l.shadowDepthBias),
+        'shadowNormalBias': DoubleValue(l.shadowNormalBias),
+      },
+    );
+  }
+}
+
+/// Codec for [CameraComponent]. Handles perspective projections; the node
+/// transform supplies the view.
+// TODO(fscene): serialize orthographic and off-axis projections once they
+// exist on CameraProjection.
+class CameraCodec extends ComponentCodec {
+  @override
+  String get type => 'camera';
+
+  @override
+  Component realize(ComponentSpec spec, RealizeContext context) {
+    final p = spec.properties;
+    return CameraComponent(
+      projection: PerspectiveProjection(
+        fovRadiansY: readDouble(p, 'fovRadiansY', 45 * degrees2Radians),
+        near: readDouble(p, 'near', 0.1),
+        far: readDouble(p, 'far', 1000.0),
+      ),
+    );
+  }
+
+  @override
+  ComponentSpec? serialize(Component component, SerializeContext context) {
+    if (component is! CameraComponent) return null;
+    final proj = component.projection;
+    if (proj is! PerspectiveProjection) {
+      return ComponentSpec(type);
+    }
+    return ComponentSpec(
+      type,
+      properties: {
+        'projection': const StringValue('perspective'),
+        'fovRadiansY': DoubleValue(proj.fovRadiansY),
+        'near': DoubleValue(proj.near),
+        'far': DoubleValue(proj.far),
+      },
+    );
+  }
+}

--- a/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
@@ -1,20 +1,61 @@
+import 'package:flutter/foundation.dart';
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/components/camera_component.dart';
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/components/directional_light_component.dart';
+import 'package:flutter_scene/src/components/mesh_component.dart';
 import 'package:flutter_scene/src/fscene/property_value.dart';
 import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/realize/property_read.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_scene/src/mesh.dart';
 
-/// Registers the component codecs the format ships with (directional light,
-/// camera) into [registry].
+/// Registers the component codecs the format ships with (mesh, directional
+/// light, camera) into [registry].
 void registerBuiltinComponentCodecs(FsceneComponentRegistry registry) {
   registry
+    ..register(MeshCodec())
     ..register(DirectionalLightCodec())
     ..register(CameraCodec());
+}
+
+/// Codec for [MeshComponent]. Realizes a mesh from `geometry` and `material`
+/// resource references via the context's resource realizer.
+// TODO(fscene): serialize meshes back to resources. A live geometry is opaque
+// GPU buffers, so this needs a tracked source resource id or payload
+// extraction (alongside the binary package format).
+class MeshCodec extends ComponentCodec {
+  @override
+  String get type => 'mesh';
+
+  @override
+  Component? realize(ComponentSpec spec, RealizeContext context) {
+    final realizer = context.resources;
+    if (realizer == null) {
+      debugPrint('fscene: mesh component skipped (no resource realizer)');
+      return null;
+    }
+    final geometry = spec.properties['geometry'];
+    final material = spec.properties['material'];
+    if (geometry is! ResourceRefValue || material is! ResourceRefValue) {
+      debugPrint('fscene: mesh component missing geometry/material references');
+      return null;
+    }
+    return MeshComponent(
+      Mesh(realizer.geometry(geometry.id), realizer.material(material.id)),
+    );
+  }
+
+  @override
+  ComponentSpec? serialize(Component component, SerializeContext context) {
+    if (component is MeshComponent) {
+      debugPrint('fscene: mesh serialization is not implemented yet');
+    }
+    return null;
+  }
 }
 
 /// Codec for [DirectionalLightComponent]: serializes the light's parameters,

--- a/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
@@ -6,9 +6,13 @@ import 'package:flutter_scene/src/components/camera_component.dart';
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/components/mesh_component.dart';
+import 'package:flutter_scene/src/fscene/id.dart';
 import 'package:flutter_scene/src/fscene/property_value.dart';
 import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
 import 'package:flutter_scene/src/fscene/realize/property_read.dart';
+import 'package:flutter_scene/src/fscene/realize/resource_copy.dart';
+import 'package:flutter_scene/src/fscene/realize/resource_origin.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/mesh.dart';
@@ -22,11 +26,13 @@ void registerBuiltinComponentCodecs(FsceneComponentRegistry registry) {
     ..register(CameraCodec());
 }
 
-/// Codec for [MeshComponent]. Realizes a mesh from `geometry` and `material`
-/// resource references via the context's resource realizer.
-// TODO(fscene): serialize meshes back to resources. A live geometry is opaque
-// GPU buffers, so this needs a tracked source resource id or payload
-// extraction (alongside the binary package format).
+/// Codec for [MeshComponent]. Realizes a mesh from geometry/material resource
+/// references through the context's resource realizer, and serializes a mesh
+/// back by recovering the resources it was realized from.
+///
+/// A single primitive is carried as `geometry` and `material` references; a
+/// multi-primitive mesh uses a `primitives` list of `{geometry, material}`
+/// entries.
 class MeshCodec extends ComponentCodec {
   @override
   String get type => 'mesh';
@@ -38,23 +44,101 @@ class MeshCodec extends ComponentCodec {
       debugPrint('fscene: mesh component skipped (no resource realizer)');
       return null;
     }
-    final geometry = spec.properties['geometry'];
-    final material = spec.properties['material'];
-    if (geometry is! ResourceRefValue || material is! ResourceRefValue) {
-      debugPrint('fscene: mesh component missing geometry/material references');
+    final pairs = _primitivePairs(spec);
+    if (pairs.isEmpty) {
+      debugPrint('fscene: mesh component has no geometry/material references');
       return null;
     }
     return MeshComponent(
-      Mesh(realizer.geometry(geometry.id), realizer.material(material.id)),
+      Mesh.primitives(
+        primitives: [
+          for (final (geometryId, materialId) in pairs)
+            MeshPrimitive(
+              realizer.geometry(geometryId),
+              realizer.material(materialId),
+            ),
+        ],
+      ),
     );
   }
 
   @override
   ComponentSpec? serialize(Component component, SerializeContext context) {
-    if (component is MeshComponent) {
-      debugPrint('fscene: mesh serialization is not implemented yet');
+    if (component is! MeshComponent) return null;
+    final dest = context.document;
+    final pairs = <(LocalId, LocalId)>[];
+    for (final primitive in component.mesh.primitives) {
+      final geometryId = _serializeResource(primitive.geometry, dest);
+      final materialId = _serializeResource(primitive.material, dest);
+      if (geometryId == null || materialId == null) {
+        debugPrint(
+          'fscene: mesh primitive not serialized; its geometry or material '
+          'was not produced by the realizer',
+        );
+        continue;
+      }
+      pairs.add((geometryId, materialId));
+    }
+    if (pairs.isEmpty) return null;
+    if (pairs.length == 1) {
+      return ComponentSpec(
+        type,
+        properties: {
+          'geometry': ResourceRefValue(pairs.first.$1),
+          'material': ResourceRefValue(pairs.first.$2),
+        },
+      );
+    }
+    return ComponentSpec(
+      type,
+      properties: {
+        'primitives': ListValue([
+          for (final (geometryId, materialId) in pairs)
+            MapValue({
+              'geometry': ResourceRefValue(geometryId),
+              'material': ResourceRefValue(materialId),
+            }),
+        ]),
+      },
+    );
+  }
+
+  // Reads the mesh's primitive references, accepting both the single-primitive
+  // shorthand (`geometry`/`material`) and the `primitives` list.
+  List<(LocalId, LocalId)> _primitivePairs(ComponentSpec spec) {
+    final primitives = spec.properties['primitives'];
+    if (primitives is ListValue) {
+      final out = <(LocalId, LocalId)>[];
+      for (final entry in primitives.values) {
+        if (entry is MapValue) {
+          final pair = _pair(entry.values);
+          if (pair != null) out.add(pair);
+        }
+      }
+      return out;
+    }
+    final pair = _pair(spec.properties);
+    return pair == null ? const [] : [pair];
+  }
+
+  (LocalId, LocalId)? _pair(Map<String, PropertyValue> props) {
+    final geometry = props['geometry'];
+    final material = props['material'];
+    if (geometry is ResourceRefValue && material is ResourceRefValue) {
+      return (geometry.id, material.id);
     }
     return null;
+  }
+
+  // Recovers the source resource a live geometry or material was realized from
+  // and copies it into [dest], returning its id. Returns null for an object the
+  // realizer did not produce.
+  // TODO(fscene): serialize hand-built geometry/materials (re-pack a
+  // MeshGeometry's CPU streams; read back material factor fields).
+  LocalId? _serializeResource(Object live, SceneDocument dest) {
+    final origin = resourceOrigin(live);
+    if (origin == null) return null;
+    return copyResourceInto(dest, origin.document, origin.resourceId);
   }
 }
 

--- a/packages/flutter_scene/lib/src/fscene/realize/component_codec.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/component_codec.dart
@@ -1,19 +1,23 @@
-import 'package:vector_math/vector_math.dart';
-
 import 'package:flutter_scene/src/components/component.dart';
-import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/realize/resource_realizer.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 
 /// Context handed to a [ComponentCodec] when realizing a [ComponentSpec] into
-/// a live [Component]. Carries the source [document] so a codec can resolve
-/// referenced resources or nodes.
+/// a live [Component]. Carries the source [document] and a [resources]
+/// realizer so a codec (for example a mesh) can resolve referenced geometry
+/// and materials.
 class RealizeContext {
-  /// Creates a realize context over [document].
-  RealizeContext(this.document);
+  /// Creates a realize context over [document], optionally with a [resources]
+  /// realizer.
+  RealizeContext(this.document, {this.resources});
 
   /// The document being realized.
   final SceneDocument document;
+
+  /// Realizes referenced geometry/material resources, or null when resource
+  /// realization is unavailable (a codec needing it should return null).
+  final ResourceRealizer? resources;
 }
 
 /// Context handed to a [ComponentCodec] when serializing a live [Component]
@@ -38,8 +42,10 @@ abstract class ComponentCodec {
   /// `directionalLight`).
   String get type;
 
-  /// Builds a live component from [spec].
-  Component realize(ComponentSpec spec, RealizeContext context);
+  /// Builds a live component from [spec], or returns null when it cannot be
+  /// realized in the given context (for example a mesh with no resource
+  /// realizer).
+  Component? realize(ComponentSpec spec, RealizeContext context);
 
   /// Serializes [component] to a [ComponentSpec], or returns null if this
   /// codec does not handle that component instance.
@@ -74,50 +80,4 @@ class FsceneComponentRegistry {
     }
     return null;
   }
-}
-
-/// Reads a `double` property, accepting an int too, or returns [fallback].
-double readDouble(
-  Map<String, PropertyValue> props,
-  String key,
-  double fallback,
-) {
-  final v = props[key];
-  return switch (v) {
-    DoubleValue(:final value) => value,
-    IntValue(:final value) => value.toDouble(),
-    _ => fallback,
-  };
-}
-
-/// Reads an `int` property, or returns [fallback].
-int readInt(Map<String, PropertyValue> props, String key, int fallback) {
-  final v = props[key];
-  return v is IntValue ? v.value : fallback;
-}
-
-/// Reads a `bool` property, or returns [fallback].
-bool readBool(Map<String, PropertyValue> props, String key, bool fallback) {
-  final v = props[key];
-  return v is BoolValue ? v.value : fallback;
-}
-
-/// Reads a [Vector3] property, or returns [fallback].
-Vector3 readVec3(
-  Map<String, PropertyValue> props,
-  String key,
-  Vector3 fallback,
-) {
-  final v = props[key];
-  return v is Vec3Value ? v.value.clone() : fallback.clone();
-}
-
-/// Reads a string property, or returns [fallback].
-String readString(
-  Map<String, PropertyValue> props,
-  String key,
-  String fallback,
-) {
-  final v = props[key];
-  return v is StringValue ? v.value : fallback;
 }

--- a/packages/flutter_scene/lib/src/fscene/realize/component_codec.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/component_codec.dart
@@ -1,0 +1,123 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+
+/// Context handed to a [ComponentCodec] when realizing a [ComponentSpec] into
+/// a live [Component]. Carries the source [document] so a codec can resolve
+/// referenced resources or nodes.
+class RealizeContext {
+  /// Creates a realize context over [document].
+  RealizeContext(this.document);
+
+  /// The document being realized.
+  final SceneDocument document;
+}
+
+/// Context handed to a [ComponentCodec] when serializing a live [Component]
+/// into a [ComponentSpec]. Carries the destination [document] so a codec can
+/// register resources or mint ids.
+class SerializeContext {
+  /// Creates a serialize context over [document].
+  SerializeContext(this.document);
+
+  /// The document being written into.
+  final SceneDocument document;
+}
+
+/// Translates between a serialized [ComponentSpec] and a live [Component] of
+/// one type.
+///
+/// Codecs are registered in a [FsceneComponentRegistry]; the realizer and
+/// serializer dispatch through it. This is the seam that lets the format
+/// carry component types the core does not know about.
+abstract class ComponentCodec {
+  /// The serialized component type name this codec handles (for example
+  /// `directionalLight`).
+  String get type;
+
+  /// Builds a live component from [spec].
+  Component realize(ComponentSpec spec, RealizeContext context);
+
+  /// Serializes [component] to a [ComponentSpec], or returns null if this
+  /// codec does not handle that component instance.
+  ComponentSpec? serialize(Component component, SerializeContext context);
+}
+
+/// A registry of [ComponentCodec]s, keyed by component type name.
+///
+/// Realization looks a codec up by [ComponentSpec.type]; serialization tries
+/// each codec until one claims the component. Unknown components are skipped
+/// (with the caller deciding how to report it) rather than failing the load.
+class FsceneComponentRegistry {
+  final Map<String, ComponentCodec> _byType = {};
+
+  /// Registers [codec], replacing any existing codec for its type.
+  void register(ComponentCodec codec) => _byType[codec.type] = codec;
+
+  /// The codec for [type], or null when none is registered.
+  ComponentCodec? codecFor(String type) => _byType[type];
+
+  /// Realizes [spec] into a live component, or returns null when no codec is
+  /// registered for its type.
+  Component? realize(ComponentSpec spec, RealizeContext context) =>
+      _byType[spec.type]?.realize(spec, context);
+
+  /// Serializes [component] using the first codec that claims it, or returns
+  /// null when none does.
+  ComponentSpec? serialize(Component component, SerializeContext context) {
+    for (final codec in _byType.values) {
+      final spec = codec.serialize(component, context);
+      if (spec != null) return spec;
+    }
+    return null;
+  }
+}
+
+/// Reads a `double` property, accepting an int too, or returns [fallback].
+double readDouble(
+  Map<String, PropertyValue> props,
+  String key,
+  double fallback,
+) {
+  final v = props[key];
+  return switch (v) {
+    DoubleValue(:final value) => value,
+    IntValue(:final value) => value.toDouble(),
+    _ => fallback,
+  };
+}
+
+/// Reads an `int` property, or returns [fallback].
+int readInt(Map<String, PropertyValue> props, String key, int fallback) {
+  final v = props[key];
+  return v is IntValue ? v.value : fallback;
+}
+
+/// Reads a `bool` property, or returns [fallback].
+bool readBool(Map<String, PropertyValue> props, String key, bool fallback) {
+  final v = props[key];
+  return v is BoolValue ? v.value : fallback;
+}
+
+/// Reads a [Vector3] property, or returns [fallback].
+Vector3 readVec3(
+  Map<String, PropertyValue> props,
+  String key,
+  Vector3 fallback,
+) {
+  final v = props[key];
+  return v is Vec3Value ? v.value.clone() : fallback.clone();
+}
+
+/// Reads a string property, or returns [fallback].
+String readString(
+  Map<String, PropertyValue> props,
+  String key,
+  String fallback,
+) {
+  final v = props[key];
+  return v is StringValue ? v.value : fallback;
+}

--- a/packages/flutter_scene/lib/src/fscene/realize/lazy_subtree.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/lazy_subtree.dart
@@ -1,0 +1,26 @@
+/// Marks a realized live [Node] as a lazy prefab placeholder: its prefab
+/// content has not been loaded yet (level streaming). `loadSubtree` expands it
+/// on demand and `unloadSubtree` releases it again.
+///
+/// The placeholder carries the [PrefabInstanceSpec] it was realized from (via
+/// an [Expando]) so the streaming layer knows what to instantiate when the
+/// subtree is loaded.
+library;
+
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/node.dart';
+
+final Expando<PrefabInstanceSpec> _lazyInstances = Expando<PrefabInstanceSpec>(
+  'fscene.lazyInstance',
+);
+
+/// Marks [node] as the placeholder for the lazy prefab instance [spec], and
+/// returns it.
+Node tagLazyInstance(Node node, PrefabInstanceSpec spec) {
+  _lazyInstances[node] = spec;
+  return node;
+}
+
+/// The lazy prefab instance [node] is a placeholder for, or null if it is not a
+/// lazy placeholder.
+PrefabInstanceSpec? lazyInstanceOf(Node node) => _lazyInstances[node];

--- a/packages/flutter_scene/lib/src/fscene/realize/loader.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/loader.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:flutter/services.dart' show rootBundle;
 
+import 'package:flutter_scene/src/fscene/binary/fsceneb.dart';
 import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
 import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
 import 'package:flutter_scene/src/fscene/realize/realize.dart';
@@ -25,4 +28,29 @@ Future<Node> loadFsceneAsset(
 }) async {
   final source = await rootBundle.loadString(assetPath);
   return loadFsceneString(source, registry: registry);
+}
+
+/// Parses and realizes a `.fsceneb` binary container from [bytes] into a live
+/// node graph.
+///
+/// Unlike the text form, the container carries embedded payload chunks, so
+/// payload-backed geometry and image textures realize. Realizing meshes builds
+/// GPU resources, so call this after the engine's static resources are ready.
+Node loadFscenebBytes(Uint8List bytes, {FsceneComponentRegistry? registry}) =>
+    realizeScene(readFsceneb(bytes), registry: registry);
+
+/// Loads a `.fsceneb` binary asset by [assetPath] and realizes it into a live
+/// node graph.
+///
+/// Mirrors `loadModel`: returns a root node to add to a scene. Pass a custom
+/// [registry] to realize app-defined component types.
+Future<Node> loadFscenebAsset(
+  String assetPath, {
+  FsceneComponentRegistry? registry,
+}) async {
+  final data = await rootBundle.load(assetPath);
+  return loadFscenebBytes(
+    data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+    registry: registry,
+  );
 }

--- a/packages/flutter_scene/lib/src/fscene/realize/loader.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/loader.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/services.dart' show rootBundle;
+
+import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
+import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/realize/realize.dart';
+import 'package:flutter_scene/src/node.dart';
+
+/// Parses and realizes a `.fscene` document from [source] text into a live
+/// node graph.
+///
+/// The returned root carries the document's handedness (see [realizeScene]);
+/// add it to a scene. Realizing meshes builds GPU geometry and materials, so
+/// call this after the engine's static resources are ready.
+Node loadFsceneString(String source, {FsceneComponentRegistry? registry}) =>
+    realizeScene(readFscene(source), registry: registry);
+
+/// Loads a `.fscene` text asset by [assetPath] and realizes it into a live
+/// node graph.
+///
+/// Mirrors `loadModel`: returns a root node to add to a scene. Pass a custom
+/// [registry] to realize app-defined component types.
+Future<Node> loadFsceneAsset(
+  String assetPath, {
+  FsceneComponentRegistry? registry,
+}) async {
+  final source = await rootBundle.loadString(assetPath);
+  return loadFsceneString(source, registry: registry);
+}

--- a/packages/flutter_scene/lib/src/fscene/realize/loader.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/loader.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter/services.dart' show AssetBundle, rootBundle;
 
 import 'package:flutter_scene/src/fscene/binary/fsceneb.dart';
 import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
@@ -9,48 +9,68 @@ import 'package:flutter_scene/src/fscene/realize/realize.dart';
 import 'package:flutter_scene/src/node.dart';
 
 /// Parses and realizes a `.fscene` document from [source] text into a live
-/// node graph.
+/// node graph (synchronously).
 ///
 /// The returned root carries the document's handedness (see [realizeScene]);
 /// add it to a scene. Realizing meshes builds GPU geometry and materials, so
-/// call this after the engine's static resources are ready.
+/// call this after the engine's static resources are ready. A document that
+/// references external image assets or `fmat` materials needs [loadFsceneAsset]
+/// (or [realizeSceneAsync]); the synchronous path uses placeholders for those.
 Node loadFsceneString(String source, {FsceneComponentRegistry? registry}) =>
     realizeScene(readFscene(source), registry: registry);
 
 /// Loads a `.fscene` text asset by [assetPath] and realizes it into a live
-/// node graph.
+/// node graph, loading any external assets / `fmat` materials it references.
 ///
 /// Mirrors `loadModel`: returns a root node to add to a scene. Pass a custom
 /// [registry] to realize app-defined component types.
 Future<Node> loadFsceneAsset(
   String assetPath, {
   FsceneComponentRegistry? registry,
+  AssetBundle? bundle,
 }) async {
-  final source = await rootBundle.loadString(assetPath);
-  return loadFsceneString(source, registry: registry);
+  final source = await (bundle ?? rootBundle).loadString(assetPath);
+  return realizeSceneAsync(
+    readFscene(source),
+    registry: registry,
+    bundle: bundle,
+  );
 }
 
 /// Parses and realizes a `.fsceneb` binary container from [bytes] into a live
-/// node graph.
+/// node graph (synchronously).
 ///
-/// Unlike the text form, the container carries embedded payload chunks, so
-/// payload-backed geometry and image textures realize. Realizing meshes builds
-/// GPU resources, so call this after the engine's static resources are ready.
+/// The container carries embedded payload chunks, so payload-backed geometry
+/// and embedded `rgba8` textures realize. For external assets, encoded image
+/// payloads, or `fmat` materials, use [loadFscenebBytesAsync] (or
+/// [realizeSceneAsync]); the synchronous path uses placeholders for those.
 Node loadFscenebBytes(Uint8List bytes, {FsceneComponentRegistry? registry}) =>
     realizeScene(readFsceneb(bytes), registry: registry);
 
+/// Parses a `.fsceneb` container from [bytes] and realizes it, first loading
+/// any external assets, encoded image payloads, and `fmat` materials it
+/// references (from [bundle], default `rootBundle`).
+Future<Node> loadFscenebBytesAsync(
+  Uint8List bytes, {
+  FsceneComponentRegistry? registry,
+  AssetBundle? bundle,
+}) => realizeSceneAsync(readFsceneb(bytes), registry: registry, bundle: bundle);
+
 /// Loads a `.fsceneb` binary asset by [assetPath] and realizes it into a live
-/// node graph.
+/// node graph, loading any external assets / `fmat` materials it references.
 ///
 /// Mirrors `loadModel`: returns a root node to add to a scene. Pass a custom
 /// [registry] to realize app-defined component types.
 Future<Node> loadFscenebAsset(
   String assetPath, {
   FsceneComponentRegistry? registry,
+  AssetBundle? bundle,
 }) async {
-  final data = await rootBundle.load(assetPath);
-  return loadFscenebBytes(
+  final resolvedBundle = bundle ?? rootBundle;
+  final data = await resolvedBundle.load(assetPath);
+  return loadFscenebBytesAsync(
     data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
     registry: registry,
+    bundle: bundle,
   );
 }

--- a/packages/flutter_scene/lib/src/fscene/realize/node_identity.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/node_identity.dart
@@ -1,0 +1,22 @@
+/// Associates a realized live [Node] with the document-local id it was built
+/// from, so scene-structure hot reload can find the live node for a given
+/// document node by id (the stable key a structural diff patches against).
+///
+/// The id lives on the object via an [Expando], so it survives for as long as
+/// the node does and adds nothing to [Node]'s own surface.
+library;
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/node.dart';
+
+final Expando<LocalId> _nodeIds = Expando<LocalId>('fscene.nodeId');
+
+/// Stamps [node] with the document [id] it was realized from, and returns it.
+Node tagNodeId(Node node, LocalId id) {
+  _nodeIds[node] = id;
+  return node;
+}
+
+/// The document id [node] was realized from, or null if it was not realized by
+/// the fscene realizer.
+LocalId? nodeFsceneId(Node node) => _nodeIds[node];

--- a/packages/flutter_scene/lib/src/fscene/realize/property_read.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/property_read.dart
@@ -1,0 +1,59 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/fscene/property_value.dart';
+
+/// Typed readers over a component or material property bag, with fallbacks
+/// for missing or mistyped values. Shared by component codecs and the
+/// resource realizer.
+
+/// Reads a `double` property, accepting an int too, or returns [fallback].
+double readDouble(
+  Map<String, PropertyValue> props,
+  String key,
+  double fallback,
+) {
+  final v = props[key];
+  return switch (v) {
+    DoubleValue(:final value) => value,
+    IntValue(:final value) => value.toDouble(),
+    _ => fallback,
+  };
+}
+
+/// Reads an `int` property, or returns [fallback].
+int readInt(Map<String, PropertyValue> props, String key, int fallback) {
+  final v = props[key];
+  return v is IntValue ? v.value : fallback;
+}
+
+/// Reads a `bool` property, or returns [fallback].
+bool readBool(Map<String, PropertyValue> props, String key, bool fallback) {
+  final v = props[key];
+  return v is BoolValue ? v.value : fallback;
+}
+
+/// Reads a [Vector3] property (a copy), or returns a copy of [fallback].
+Vector3 readVec3(
+  Map<String, PropertyValue> props,
+  String key,
+  Vector3 fallback,
+) {
+  final v = props[key];
+  return v is Vec3Value ? v.value.clone() : fallback.clone();
+}
+
+/// Reads a [ColorValue] as a [Vector4] (RGBA), or returns [fallback].
+Vector4? readColor(Map<String, PropertyValue> props, String key) {
+  final v = props[key];
+  return v is ColorValue ? Vector4(v.r, v.g, v.b, v.a) : null;
+}
+
+/// Reads a string property, or returns [fallback].
+String readString(
+  Map<String, PropertyValue> props,
+  String key,
+  String fallback,
+) {
+  final v = props[key];
+  return v is StringValue ? v.value : fallback;
+}

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -6,6 +6,7 @@ import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/fscene/id.dart';
 import 'package:flutter_scene/src/fscene/realize/builtin_codecs.dart';
 import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/realize/lazy_subtree.dart';
 import 'package:flutter_scene/src/fscene/realize/node_identity.dart';
 import 'package:flutter_scene/src/fscene/realize/resource_realizer.dart';
 import 'package:flutter_scene/src/fscene/realize/skin_animation.dart';
@@ -72,17 +73,25 @@ Node _realizeWith(
   // First pass: a bare node per spec (no children, no components yet).
   final nodes = <LocalId, Node>{};
   for (final spec in document.nodes.values) {
-    if (spec.instance != null) {
-      debugPrint(
-        'fscene: node ${spec.id} is an unexpanded prefab instance; run '
-        'composeScene (or load via loadScene) before realizing',
-      );
-    }
-    nodes[spec.id] = tagNodeId(
+    final node = tagNodeId(
       Node(name: spec.name, localTransform: spec.transform.toMatrix4())
         ..layers = spec.layers,
       spec.id,
     );
+    final instance = spec.instance;
+    if (instance != null) {
+      if (instance.load == LoadPolicy.lazy) {
+        // A streamed placeholder: its prefab content loads later via
+        // loadSubtree.
+        tagLazyInstance(node, instance);
+      } else {
+        debugPrint(
+          'fscene: node ${spec.id} is an unexpanded eager prefab instance; '
+          'run composeScene (or load via loadScene) before realizing',
+        );
+      }
+    }
+    nodes[spec.id] = node;
   }
 
   // Second pass: wire children and realize components now that every node

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -26,9 +26,9 @@ FsceneComponentRegistry defaultComponentRegistry() {
 /// [registry] (the built-ins by default); a component whose type has no codec
 /// is skipped with a debug warning.
 ///
-/// Mesh components are realized from procedural geometry and parameter
-/// materials. Payload-backed geometry and image textures are not yet realized
-/// (they need the binary package format); see [ResourceRealizer].
+/// Mesh components are realized from procedural or payload-backed geometry and
+/// parameter materials; payload chunks come from a `.fsceneb` container. Image
+/// textures are not yet realized; see [ResourceRealizer].
 Node realizeScene(SceneDocument document, {FsceneComponentRegistry? registry}) {
   final reg = registry ?? defaultComponentRegistry();
   final context = RealizeContext(

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/foundation.dart';
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/realize/builtin_codecs.dart';
+import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/node.dart';
+
+/// Returns a registry preloaded with the built-in component codecs.
+FsceneComponentRegistry defaultComponentRegistry() {
+  final registry = FsceneComponentRegistry();
+  registerBuiltinComponentCodecs(registry);
+  return registry;
+}
+
+/// Realizes [document] into a live [Node] graph.
+///
+/// Returns a synthesized root node that carries the handedness convention
+/// from the document's stage (a `scale(1, 1, -1)` mirror with winding parity
+/// excluded for a right-handed document, matching the model importers); the
+/// document's own root nodes are its children. Components are built through
+/// [registry] (the built-ins by default); a component whose type has no codec
+/// is skipped with a debug warning.
+///
+/// Mesh and other resource-backed components are not realized here yet (they
+/// need the geometry/texture payloads); that is the renderer-facing seam the
+/// loader will fill.
+// TODO(fscene): realize mesh components from geometry/material/texture
+// resources once payloads are loaded (P5) and a resource realizer is wired.
+Node realizeScene(SceneDocument document, {FsceneComponentRegistry? registry}) {
+  final reg = registry ?? defaultComponentRegistry();
+  final context = RealizeContext(document);
+
+  // First pass: a bare node per spec (no children, no components yet).
+  final nodes = <LocalId, Node>{};
+  for (final spec in document.nodes.values) {
+    nodes[spec.id] = Node(
+      name: spec.name,
+      localTransform: spec.transform.toMatrix4(),
+    )..layers = spec.layers;
+  }
+
+  // Second pass: wire children and realize components now that every node
+  // exists.
+  for (final spec in document.nodes.values) {
+    final node = nodes[spec.id]!;
+    for (final childId in spec.children) {
+      final child = nodes[childId];
+      if (child == null) {
+        debugPrint('fscene: node ${spec.id} references missing child $childId');
+        continue;
+      }
+      node.add(child);
+    }
+    for (final componentSpec in spec.components) {
+      final component = reg.realize(componentSpec, context);
+      if (component == null) {
+        debugPrint(
+          'fscene: no codec for component "${componentSpec.type}"; skipping',
+        );
+        continue;
+      }
+      node.addComponent(component);
+    }
+  }
+
+  final root = Node(
+    name: 'root',
+    localTransform: _handednessTransform(document),
+  )..excludeFromWindingParity = true;
+  for (final rootId in document.roots) {
+    final node = nodes[rootId];
+    if (node == null) {
+      debugPrint('fscene: missing root node $rootId');
+      continue;
+    }
+    root.add(node);
+  }
+  return root;
+}
+
+Matrix4 _handednessTransform(SceneDocument document) =>
+    document.stage.handedness == Handedness.right
+    ? Matrix4.diagonal3Values(1.0, 1.0, -1.0)
+    : Matrix4.identity();
+
+/// Serializes the live [Node] graph rooted at [root] into a new
+/// [SceneDocument].
+///
+/// [root] is treated as the synthesized realization root (as returned by
+/// [realizeScene]): its handedness is read back into the stage, and its
+/// children become the document's root nodes. Components are serialized
+/// through [registry] (the built-ins by default); a component no codec claims
+/// (for example a mesh) is skipped with a debug warning.
+SceneDocument serializeScene(Node root, {FsceneComponentRegistry? registry}) {
+  final reg = registry ?? defaultComponentRegistry();
+  final document = SceneDocument();
+  document.stage.handedness = root.localTransform.determinant() < 0
+      ? Handedness.right
+      : Handedness.left;
+  final context = SerializeContext(document);
+
+  for (final child in root.children) {
+    final spec = _serializeNode(child, document, reg, context);
+    document.addNode(spec, root: true);
+  }
+  return document;
+}
+
+NodeSpec _serializeNode(
+  Node node,
+  SceneDocument document,
+  FsceneComponentRegistry registry,
+  SerializeContext context,
+) {
+  final components = <ComponentSpec>[];
+  for (final component in node.getComponents<Component>()) {
+    final spec = registry.serialize(component, context);
+    if (spec == null) {
+      debugPrint(
+        'fscene: no codec for ${component.runtimeType}; not serialized',
+      );
+      continue;
+    }
+    components.add(spec);
+  }
+
+  final spec = NodeSpec(
+    id: document.newId(),
+    name: node.name,
+    transform: MatrixTransform(node.localTransform.clone()),
+    components: components,
+    layers: node.layers,
+  );
+  document.addNode(spec);
+
+  for (final child in node.children) {
+    final childSpec = _serializeNode(child, document, registry, context);
+    spec.children.add(childSpec.id);
+  }
+  return spec;
+}

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -6,6 +6,7 @@ import 'package:flutter_scene/src/fscene/id.dart';
 import 'package:flutter_scene/src/fscene/realize/builtin_codecs.dart';
 import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
 import 'package:flutter_scene/src/fscene/realize/resource_realizer.dart';
+import 'package:flutter_scene/src/fscene/realize/skin_animation.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/node.dart';
@@ -81,6 +82,11 @@ Node realizeScene(SceneDocument document, {FsceneComponentRegistry? registry}) {
     }
     root.add(node);
   }
+
+  // Bind skins and attach animations now that every node exists under the
+  // root (animations resolve their targets by node name within the tree).
+  realizeSkinsAndAnimations(document, root, nodes);
+
   return root;
 }
 

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/fscene/id.dart';
 import 'package:flutter_scene/src/fscene/realize/builtin_codecs.dart';
 import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/realize/resource_realizer.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/node.dart';
@@ -25,14 +26,15 @@ FsceneComponentRegistry defaultComponentRegistry() {
 /// [registry] (the built-ins by default); a component whose type has no codec
 /// is skipped with a debug warning.
 ///
-/// Mesh and other resource-backed components are not realized here yet (they
-/// need the geometry/texture payloads); that is the renderer-facing seam the
-/// loader will fill.
-// TODO(fscene): realize mesh components from geometry/material/texture
-// resources once payloads are loaded (P5) and a resource realizer is wired.
+/// Mesh components are realized from procedural geometry and parameter
+/// materials. Payload-backed geometry and image textures are not yet realized
+/// (they need the binary package format); see [ResourceRealizer].
 Node realizeScene(SceneDocument document, {FsceneComponentRegistry? registry}) {
   final reg = registry ?? defaultComponentRegistry();
-  final context = RealizeContext(document);
+  final context = RealizeContext(
+    document,
+    resources: ResourceRealizer(document),
+  );
 
   // First pass: a bare node per spec (no children, no components yet).
   final nodes = <LocalId, Node>{};

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -71,6 +71,12 @@ Node _realizeWith(
   // First pass: a bare node per spec (no children, no components yet).
   final nodes = <LocalId, Node>{};
   for (final spec in document.nodes.values) {
+    if (spec.instance != null) {
+      debugPrint(
+        'fscene: node ${spec.id} is an unexpanded prefab instance; run '
+        'composeScene (or load via loadScene) before realizing',
+      );
+    }
     nodes[spec.id] = Node(
       name: spec.name,
       localTransform: spec.transform.toMatrix4(),

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -6,6 +6,7 @@ import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/fscene/id.dart';
 import 'package:flutter_scene/src/fscene/realize/builtin_codecs.dart';
 import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/realize/node_identity.dart';
 import 'package:flutter_scene/src/fscene/realize/resource_realizer.dart';
 import 'package:flutter_scene/src/fscene/realize/skin_animation.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
@@ -77,10 +78,11 @@ Node _realizeWith(
         'composeScene (or load via loadScene) before realizing',
       );
     }
-    nodes[spec.id] = Node(
-      name: spec.name,
-      localTransform: spec.transform.toMatrix4(),
-    )..layers = spec.layers;
+    nodes[spec.id] = tagNodeId(
+      Node(name: spec.name, localTransform: spec.transform.toMatrix4())
+        ..layers = spec.layers,
+      spec.id,
+    );
   }
 
   // Second pass: wire children and realize components now that every node

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show AssetBundle;
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/components/component.dart';
@@ -28,14 +29,44 @@ FsceneComponentRegistry defaultComponentRegistry() {
 /// is skipped with a debug warning.
 ///
 /// Mesh components are realized from procedural or payload-backed geometry and
-/// parameter materials; payload chunks come from a `.fsceneb` container. Image
-/// textures are not yet realized; see [ResourceRealizer].
+/// parameter materials; embedded `rgba8` textures realize here too. External
+/// image assets, encoded image payloads, and `fmat` materials need
+/// [realizeSceneAsync] (which preloads them); the synchronous path falls back
+/// to placeholders. See [ResourceRealizer].
 Node realizeScene(SceneDocument document, {FsceneComponentRegistry? registry}) {
-  final reg = registry ?? defaultComponentRegistry();
-  final context = RealizeContext(
+  return _realizeWith(
     document,
-    resources: ResourceRealizer(document),
+    registry ?? defaultComponentRegistry(),
+    ResourceRealizer(document),
   );
+}
+
+/// Realizes [document] into a live [Node] graph, first asynchronously loading
+/// any external image assets, encoded image payloads, and `fmat` materials it
+/// references (from [bundle], default `rootBundle`).
+///
+/// Use this (over [realizeScene]) when a document may reference such
+/// resources; the `.fscene` / `.fsceneb` asset loaders do.
+Future<Node> realizeSceneAsync(
+  SceneDocument document, {
+  FsceneComponentRegistry? registry,
+  AssetBundle? bundle,
+}) async {
+  final resources = ResourceRealizer(document, bundle: bundle);
+  await resources.preload();
+  return _realizeWith(
+    document,
+    registry ?? defaultComponentRegistry(),
+    resources,
+  );
+}
+
+Node _realizeWith(
+  SceneDocument document,
+  FsceneComponentRegistry reg,
+  ResourceRealizer resources,
+) {
+  final context = RealizeContext(document, resources: resources);
 
   // First pass: a bare node per spec (no children, no components yet).
   final nodes = <LocalId, Node>{};

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_copy.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_copy.dart
@@ -1,0 +1,91 @@
+/// Copies a resource (and the payload chunks it references) from one document
+/// into another, preserving ids. Used by the scene serializer to rebuild a
+/// document's resource pool from the resources a live graph was realized from.
+///
+/// This layer is GPU-free: it moves [ResourceSpec]s and [PayloadSpec]s (bytes
+/// included), not live GPU objects.
+library;
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+
+/// Copies resource [resourceId] from [source] into [dest], keeping its id, and
+/// returns that id. Idempotent: a resource (or payload) already present in
+/// [dest] is left as is, so a resource shared by several meshes copies once.
+///
+/// Referenced payload chunks are copied with their bytes, and a material's
+/// referenced texture resources are copied recursively.
+LocalId copyResourceInto(
+  SceneDocument dest,
+  SceneDocument source,
+  LocalId resourceId,
+) {
+  if (dest.resource(resourceId) != null) return resourceId;
+  final res = source.resource(resourceId);
+  if (res == null) {
+    throw FsceneFormatException('Source has no resource $resourceId to copy');
+  }
+  switch (res) {
+    case GeometryResource(
+      :final vertices,
+      :final indices,
+      :final procedural,
+      :final bounds,
+    ):
+      if (vertices != null) _copyPayload(dest, source, vertices);
+      if (indices != null) _copyPayload(dest, source, indices);
+      dest.addResource(
+        GeometryResource(
+          resourceId,
+          vertices: vertices,
+          indices: indices,
+          procedural: procedural,
+          bounds: bounds,
+        ),
+      );
+    case TextureResource(:final payload, :final asset):
+      if (payload != null) _copyPayload(dest, source, payload);
+      dest.addResource(
+        TextureResource(resourceId, payload: payload, asset: asset),
+      );
+    case MaterialResource(:final type, :final properties, :final asset):
+      for (final value in properties.values) {
+        if (value is ResourceRefValue &&
+            source.resource(value.id) is TextureResource) {
+          copyResourceInto(dest, source, value.id);
+        }
+      }
+      dest.addResource(
+        MaterialResource(
+          resourceId,
+          type: type,
+          properties: Map<String, PropertyValue>.of(properties),
+          asset: asset,
+        ),
+      );
+  }
+  return resourceId;
+}
+
+void _copyPayload(SceneDocument dest, SceneDocument source, LocalId id) {
+  if (dest.payload(id) != null) return;
+  final p = source.payload(id);
+  if (p == null) {
+    throw FsceneFormatException('Source has no payload $id to copy');
+  }
+  dest.addPayload(
+    PayloadSpec(
+      id,
+      encoding: p.encoding,
+      layout: p.layout,
+      format: p.format,
+      width: p.width,
+      height: p.height,
+      length: p.length,
+      bytes: p.bytes,
+    ),
+  );
+}

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_origin.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_origin.dart
@@ -1,0 +1,44 @@
+/// Tracks where a live, GPU-backed resource was realized from, so the scene
+/// serializer can recover the originating resource (and its payload chunks)
+/// without reading bytes back off the GPU.
+///
+/// When the [ResourceRealizer] builds a [Geometry], [Material], or texture, it
+/// stamps the live object with the source document and resource id. The mesh
+/// codec reads that stamp back at serialize time and copies the resource into
+/// the destination document. The stamp lives on the object itself (via an
+/// [Expando]), so it survives for as long as the realized object does.
+library;
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+
+/// The document and resource id a live object was realized from.
+class ResourceOrigin {
+  /// Records that a live object came from [resourceId] in [document].
+  ResourceOrigin(this.document, this.resourceId);
+
+  /// The document the resource was realized from.
+  final SceneDocument document;
+
+  /// The realized resource's id within [document].
+  final LocalId resourceId;
+}
+
+final Expando<ResourceOrigin> _origins = Expando<ResourceOrigin>(
+  'fscene.resourceOrigin',
+);
+
+/// Stamps [live] (a realized geometry, material, or texture) with the
+/// [document] and [resourceId] it was built from, and returns it.
+T tagResourceOrigin<T extends Object>(
+  T live,
+  SceneDocument document,
+  LocalId resourceId,
+) {
+  _origins[live] = ResourceOrigin(document, resourceId);
+  return live;
+}
+
+/// The origin stamped on [live] by [tagResourceOrigin], or null if it was not
+/// produced by the realizer.
+ResourceOrigin? resourceOrigin(Object live) => _origins[live];

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -19,11 +19,11 @@ import 'package:flutter_scene/src/material/unlit_material.dart';
 /// [Material] objects, memoizing each so a resource shared by many nodes is
 /// realized once.
 ///
-/// Procedural and payload-backed geometry, and parameter-only materials, are
-/// realized here. Image textures and `fmat` materials are the renderer-facing
-/// seams still to fill.
-// TODO(fscene): realize image textures (async asset or embedded payload) and
-// fmat materials.
+/// Procedural and payload-backed geometry, parameter materials, and image
+/// textures from embedded payloads are realized here. External image assets
+/// (async) and `fmat` materials are the renderer-facing seams still to fill.
+// TODO(fscene): realize external image-asset textures (async) and fmat
+// materials.
 class ResourceRealizer {
   /// Creates a realizer over [document].
   ResourceRealizer(this.document);
@@ -33,12 +33,16 @@ class ResourceRealizer {
 
   final Map<LocalId, Geometry> _geometries = {};
   final Map<LocalId, Material> _materials = {};
+  final Map<LocalId, gpu.Texture> _textures = {};
 
   /// The live geometry for resource [id], realized and memoized on first use.
   Geometry geometry(LocalId id) => _geometries[id] ??= _buildGeometry(id);
 
   /// The live material for resource [id], realized and memoized on first use.
   Material material(LocalId id) => _materials[id] ??= _buildMaterial(id);
+
+  /// The live texture for resource [id], realized and memoized on first use.
+  gpu.Texture texture(LocalId id) => _textures[id] ??= _buildTexture(id);
 
   Geometry _buildGeometry(LocalId id) {
     final res = document.resource(id);
@@ -159,10 +163,68 @@ class ResourceRealizer {
     }
   }
 
+  gpu.Texture _buildTexture(LocalId id) {
+    final res = document.resource(id);
+    if (res is! TextureResource) {
+      throw FsceneFormatException('Resource $id is not a texture');
+    }
+    final payloadId = res.payload;
+    if (payloadId == null) {
+      // External image assets need an async load path; only embedded payloads
+      // realize here.
+      // TODO(fscene): async-load external image-asset textures
+      // (TextureResource.asset).
+      throw FsceneFormatException(
+        'Texture $id references an external asset; only embedded image '
+        'payloads are realized',
+      );
+    }
+    final payload = document.payload(payloadId);
+    final bytes = payload?.bytes;
+    if (payload == null || bytes == null) {
+      throw FsceneFormatException(
+        'Image payload $payloadId has no bytes; load the document from a '
+        '.fsceneb container so its chunks are attached',
+      );
+    }
+    if (payload.encoding != PayloadEncoding.image) {
+      throw FsceneFormatException('Payload $payloadId is not an image');
+    }
+    final width = payload.width;
+    final height = payload.height;
+    if (width == null || height == null) {
+      throw FsceneFormatException(
+        'Image payload $payloadId is missing its width/height',
+      );
+    }
+    if (payload.format != 'rgba8') {
+      // Encoded images (png/jpg) would need an async decode step.
+      // TODO(fscene): decode encoded image payloads via instantiateImageCodec.
+      throw FsceneFormatException(
+        'Image payload format "${payload.format}" is not supported; expected '
+        'rgba8',
+      );
+    }
+    final texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      width,
+      height,
+    );
+    texture.overwrite(ByteData.sublistView(bytes));
+    return texture;
+  }
+
+  gpu.Texture? _textureRef(Map<String, PropertyValue> p, String key) {
+    final v = p[key];
+    return v is ResourceRefValue ? texture(v.id) : null;
+  }
+
   UnlitMaterial _unlit(Map<String, PropertyValue> p) {
     final m = UnlitMaterial();
     final base = readColor(p, 'baseColor');
     if (base != null) m.baseColorFactor = base;
+    final baseColorTexture = _textureRef(p, 'baseColorTexture');
+    if (baseColorTexture != null) m.baseColorTexture = baseColorTexture;
     return m;
   }
 
@@ -179,6 +241,18 @@ class ResourceRealizer {
       'occlusionStrength',
       m.occlusionStrength,
     );
+    final baseColorTexture = _textureRef(p, 'baseColorTexture');
+    if (baseColorTexture != null) m.baseColorTexture = baseColorTexture;
+    final metallicRoughnessTexture = _textureRef(p, 'metallicRoughnessTexture');
+    if (metallicRoughnessTexture != null) {
+      m.metallicRoughnessTexture = metallicRoughnessTexture;
+    }
+    final normalTexture = _textureRef(p, 'normalTexture');
+    if (normalTexture != null) m.normalTexture = normalTexture;
+    final occlusionTexture = _textureRef(p, 'occlusionTexture');
+    if (occlusionTexture != null) m.occlusionTexture = occlusionTexture;
+    final emissiveTexture = _textureRef(p, 'emissiveTexture');
+    if (emissiveTexture != null) m.emissiveTexture = emissiveTexture;
     return m;
   }
 }

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/realize/property_read.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/geometry/geometry.dart';
+import 'package:flutter_scene/src/geometry/primitives.dart';
+import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/material/physically_based_material.dart';
+import 'package:flutter_scene/src/material/unlit_material.dart';
+
+/// Turns a document's resources into live, GPU-backed [Geometry] and
+/// [Material] objects, memoizing each so a resource shared by many nodes is
+/// realized once.
+///
+/// Procedural geometry and parameter-only materials are realized here.
+/// Payload-backed geometry, image textures, and `fmat` materials are the
+/// renderer-facing seams the loader fills as those payloads become
+/// available.
+// TODO(fscene): realize payload-backed geometry, image textures (async asset
+// or embedded payload), and fmat materials.
+class ResourceRealizer {
+  /// Creates a realizer over [document].
+  ResourceRealizer(this.document);
+
+  /// The document whose resources are realized.
+  final SceneDocument document;
+
+  final Map<LocalId, Geometry> _geometries = {};
+  final Map<LocalId, Material> _materials = {};
+
+  /// The live geometry for resource [id], realized and memoized on first use.
+  Geometry geometry(LocalId id) => _geometries[id] ??= _buildGeometry(id);
+
+  /// The live material for resource [id], realized and memoized on first use.
+  Material material(LocalId id) => _materials[id] ??= _buildMaterial(id);
+
+  Geometry _buildGeometry(LocalId id) {
+    final res = document.resource(id);
+    if (res is! GeometryResource) {
+      throw FsceneFormatException('Resource $id is not a geometry');
+    }
+    final procedural = res.procedural;
+    if (procedural != null) return _buildProcedural(procedural);
+    throw UnimplementedError(
+      'Payload-backed geometry needs the binary package format',
+    );
+  }
+
+  Geometry _buildProcedural(ProceduralGeometry p) => switch (p) {
+    CuboidGeometrySpec(:final extents, :final debugColors) => CuboidGeometry(
+      extents,
+      debugColors: debugColors,
+    ),
+    PlaneGeometrySpec(
+      :final width,
+      :final depth,
+      :final segmentsX,
+      :final segmentsZ,
+    ) =>
+      PlaneGeometry(
+        width: width,
+        depth: depth,
+        segmentsX: segmentsX,
+        segmentsZ: segmentsZ,
+      ),
+    SphereGeometrySpec(:final radius, :final segments, :final rings) =>
+      SphereGeometry(radius: radius, segments: segments, rings: rings),
+  };
+
+  Material _buildMaterial(LocalId id) {
+    final res = document.resource(id);
+    if (res is! MaterialResource) {
+      throw FsceneFormatException('Resource $id is not a material');
+    }
+    switch (res.type) {
+      case 'unlit':
+        return _unlit(res.properties);
+      case 'physicallyBased':
+        return _pbr(res.properties);
+      default:
+        debugPrint(
+          'fscene: material type "${res.type}" not realized; using unlit',
+        );
+        return _unlit(res.properties);
+    }
+  }
+
+  UnlitMaterial _unlit(Map<String, PropertyValue> p) {
+    final m = UnlitMaterial();
+    final base = readColor(p, 'baseColor');
+    if (base != null) m.baseColorFactor = base;
+    return m;
+  }
+
+  PhysicallyBasedMaterial _pbr(Map<String, PropertyValue> p) {
+    final m = PhysicallyBasedMaterial();
+    final base = readColor(p, 'baseColor');
+    if (base != null) m.baseColorFactor = base;
+    final emissive = readColor(p, 'emissive');
+    if (emissive != null) m.emissiveFactor = emissive;
+    m.metallicFactor = readDouble(p, 'metallic', m.metallicFactor);
+    m.roughnessFactor = readDouble(p, 'roughness', m.roughnessFactor);
+    m.occlusionStrength = readDouble(
+      p,
+      'occlusionStrength',
+      m.occlusionStrength,
+    );
+    return m;
+  }
+}

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show AssetBundle, rootBundle;
 import 'package:vector_math/vector_math.dart';
 
+import 'package:flutter_scene/src/asset_helpers.dart';
 import 'package:flutter_scene/src/fscene/id.dart';
 import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
 import 'package:flutter_scene/src/fscene/property_value.dart';
@@ -8,6 +10,7 @@ import 'package:flutter_scene/src/fscene/realize/property_read.dart';
 import 'package:flutter_scene/src/fscene/realize/resource_origin.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/fmat/material_registry.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/geometry/primitives.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
@@ -20,17 +23,22 @@ import 'package:flutter_scene/src/material/unlit_material.dart';
 /// [Material] objects, memoizing each so a resource shared by many nodes is
 /// realized once.
 ///
-/// Procedural and payload-backed geometry, parameter materials, and image
-/// textures from embedded payloads are realized here. External image assets
-/// (async) and `fmat` materials are the renderer-facing seams still to fill.
-// TODO(fscene): realize external image-asset textures (async) and fmat
-// materials.
+/// Procedural and payload-backed geometry, parameter materials, and embedded
+/// `rgba8` textures realize synchronously. External image assets, encoded
+/// (PNG/JPEG) image payloads, and `fmat` materials need decoding or asset
+/// loading, so they are resolved by [preload] (await it before realizing);
+/// the synchronous path falls back to a placeholder for them.
 class ResourceRealizer {
-  /// Creates a realizer over [document].
-  ResourceRealizer(this.document);
+  /// Creates a realizer over [document]. [bundle] (default [rootBundle])
+  /// resolves external image assets and `fmat` materials during [preload].
+  ResourceRealizer(this.document, {AssetBundle? bundle})
+    : bundle = bundle ?? rootBundle;
 
   /// The document whose resources are realized.
   final SceneDocument document;
+
+  /// The asset bundle external assets and `fmat` materials load from.
+  final AssetBundle bundle;
 
   final Map<LocalId, Geometry> _geometries = {};
   final Map<LocalId, Material> _materials = {};
@@ -48,6 +56,90 @@ class ResourceRealizer {
   /// The live texture for resource [id], realized and memoized on first use.
   gpu.Texture texture(LocalId id) =>
       _textures[id] ??= tagResourceOrigin(_buildTexture(id), document, id);
+
+  /// Resolves the resources that need asynchronous work (external image
+  /// assets, encoded image payloads, and `fmat` materials), caching them so
+  /// the synchronous realize path finds them ready.
+  ///
+  /// Await this before realizing a document that may reference such resources
+  /// (the async loaders do). A resource that fails to load degrades to a
+  /// placeholder (textures) or an unlit material (`fmat`) with a warning,
+  /// rather than failing the whole scene.
+  Future<void> preload() async {
+    final pending = <Future<void>>[];
+    for (final resource in document.resources.values) {
+      if (resource is TextureResource && _needsAsyncTexture(resource)) {
+        pending.add(_preloadTexture(resource));
+      } else if (resource is MaterialResource && resource.type == 'fmat') {
+        pending.add(_preloadFmat(resource));
+      }
+    }
+    await Future.wait(pending);
+  }
+
+  bool _needsAsyncTexture(TextureResource res) {
+    if (res.asset != null) return true;
+    final payload = res.payload;
+    return payload != null && document.payload(payload)?.format != 'rgba8';
+  }
+
+  Future<void> _preloadTexture(TextureResource res) async {
+    try {
+      final asset = res.asset;
+      final image = asset != null
+          ? await imageFromAsset(asset.key, bundle: bundle)
+          : await imageFromBytes(_payloadBytes(res.payload!, 'image'));
+      _textures[res.id] = tagResourceOrigin(
+        await gpuTextureFromImage(image),
+        document,
+        res.id,
+      );
+    } catch (e) {
+      debugPrint('fscene: failed to load texture ${res.id}: $e; placeholder');
+      _textures[res.id] = _placeholderTexture();
+    }
+  }
+
+  Future<void> _preloadFmat(MaterialResource res) async {
+    final asset = res.asset;
+    if (asset == null) {
+      debugPrint('fscene: fmat material ${res.id} has no asset; using unlit');
+      _materials[res.id] = tagResourceOrigin(
+        _unlit(res.properties),
+        document,
+        res.id,
+      );
+      return;
+    }
+    try {
+      // TODO(fscene): apply MaterialResource.properties as fmat parameter
+      // overrides (scalars and sampler bindings) once exposed.
+      _materials[res.id] = tagResourceOrigin(
+        await loadFmatMaterial(asset.key, bundle: bundle),
+        document,
+        res.id,
+      );
+    } catch (e) {
+      debugPrint('fscene: failed to load fmat ${res.id} ("${asset.key}"): $e');
+      _materials[res.id] = tagResourceOrigin(
+        _unlit(res.properties),
+        document,
+        res.id,
+      );
+    }
+  }
+
+  gpu.Texture _placeholderTexture() {
+    final texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      1,
+      1,
+    );
+    texture.overwrite(
+      ByteData.sublistView(Uint8List.fromList(const [255, 255, 255, 255])),
+    );
+    return texture;
+  }
 
   Geometry _buildGeometry(LocalId id) {
     final res = document.resource(id);
@@ -160,6 +252,10 @@ class ResourceRealizer {
         return _unlit(res.properties);
       case 'physicallyBased':
         return _pbr(res.properties);
+      case 'fmat':
+        // Resolved by preload(); reaching here is the synchronous path.
+        debugPrint('fscene: fmat material needs the async loader; using unlit');
+        return _unlit(res.properties);
       default:
         debugPrint(
           'fscene: material type "${res.type}" not realized; using unlit',
@@ -175,14 +271,13 @@ class ResourceRealizer {
     }
     final payloadId = res.payload;
     if (payloadId == null) {
-      // External image assets need an async load path; only embedded payloads
-      // realize here.
-      // TODO(fscene): async-load external image-asset textures
-      // (TextureResource.asset).
-      throw FsceneFormatException(
-        'Texture $id references an external asset; only embedded image '
-        'payloads are realized',
+      // An external image asset, resolved by preload(). Reaching here means
+      // the synchronous path was used; fall back to a placeholder.
+      debugPrint(
+        'fscene: external-asset texture $id needs the async loader (loadScene '
+        '/ loadFscenebAsset); using a placeholder',
       );
+      return _placeholderTexture();
     }
     final payload = document.payload(payloadId);
     final bytes = payload?.bytes;
@@ -203,12 +298,13 @@ class ResourceRealizer {
       );
     }
     if (payload.format != 'rgba8') {
-      // Encoded images (png/jpg) would need an async decode step.
-      // TODO(fscene): decode encoded image payloads via instantiateImageCodec.
-      throw FsceneFormatException(
-        'Image payload format "${payload.format}" is not supported; expected '
-        'rgba8',
+      // Encoded (PNG/JPEG) payloads are decoded by preload(); the sync path
+      // can't decode them.
+      debugPrint(
+        'fscene: encoded image payload $payloadId needs the async loader; '
+        'using a placeholder',
       );
+      return _placeholderTexture();
     }
     final texture = gpu.gpuContext.createTexture(
       gpu.StorageMode.hostVisible,

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/src/fscene/id.dart';
 import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
 import 'package:flutter_scene/src/fscene/property_value.dart';
 import 'package:flutter_scene/src/fscene/realize/property_read.dart';
+import 'package:flutter_scene/src/fscene/realize/resource_origin.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
@@ -36,13 +37,17 @@ class ResourceRealizer {
   final Map<LocalId, gpu.Texture> _textures = {};
 
   /// The live geometry for resource [id], realized and memoized on first use.
-  Geometry geometry(LocalId id) => _geometries[id] ??= _buildGeometry(id);
+  /// The result is stamped with its origin so the serializer can recover it.
+  Geometry geometry(LocalId id) =>
+      _geometries[id] ??= tagResourceOrigin(_buildGeometry(id), document, id);
 
   /// The live material for resource [id], realized and memoized on first use.
-  Material material(LocalId id) => _materials[id] ??= _buildMaterial(id);
+  Material material(LocalId id) =>
+      _materials[id] ??= tagResourceOrigin(_buildMaterial(id), document, id);
 
   /// The live texture for resource [id], realized and memoized on first use.
-  gpu.Texture texture(LocalId id) => _textures[id] ??= _buildTexture(id);
+  gpu.Texture texture(LocalId id) =>
+      _textures[id] ??= tagResourceOrigin(_buildTexture(id), document, id);
 
   Geometry _buildGeometry(LocalId id) {
     final res = document.resource(id);

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -230,8 +230,15 @@ class ResourceRealizer {
     if (base != null) m.baseColorFactor = base;
     final baseColorTexture = _textureRef(p, 'baseColorTexture');
     if (baseColorTexture != null) m.baseColorTexture = baseColorTexture;
+    m.doubleSided = readBool(p, 'doubleSided', m.doubleSided);
     return m;
   }
+
+  AlphaMode _alphaMode(String name) => switch (name) {
+    'mask' => AlphaMode.mask,
+    'blend' => AlphaMode.blend,
+    _ => AlphaMode.opaque,
+  };
 
   PhysicallyBasedMaterial _pbr(Map<String, PropertyValue> p) {
     final m = PhysicallyBasedMaterial();
@@ -258,6 +265,10 @@ class ResourceRealizer {
     if (occlusionTexture != null) m.occlusionTexture = occlusionTexture;
     final emissiveTexture = _textureRef(p, 'emissiveTexture');
     if (emissiveTexture != null) m.emissiveTexture = emissiveTexture;
+    m.normalScale = readDouble(p, 'normalScale', m.normalScale);
+    m.doubleSided = readBool(p, 'doubleSided', m.doubleSided);
+    m.alphaMode = _alphaMode(readString(p, 'alphaMode', 'opaque'));
+    m.alphaCutoff = readDouble(p, 'alphaCutoff', m.alphaCutoff);
     return m;
   }
 }

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/fscene/id.dart';
 import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
@@ -8,6 +9,8 @@ import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/geometry/primitives.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/importer/constants.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/material/physically_based_material.dart';
 import 'package:flutter_scene/src/material/unlit_material.dart';
@@ -16,12 +19,11 @@ import 'package:flutter_scene/src/material/unlit_material.dart';
 /// [Material] objects, memoizing each so a resource shared by many nodes is
 /// realized once.
 ///
-/// Procedural geometry and parameter-only materials are realized here.
-/// Payload-backed geometry, image textures, and `fmat` materials are the
-/// renderer-facing seams the loader fills as those payloads become
-/// available.
-// TODO(fscene): realize payload-backed geometry, image textures (async asset
-// or embedded payload), and fmat materials.
+/// Procedural and payload-backed geometry, and parameter-only materials, are
+/// realized here. Image textures and `fmat` materials are the renderer-facing
+/// seams still to fill.
+// TODO(fscene): realize image textures (async asset or embedded payload) and
+// fmat materials.
 class ResourceRealizer {
   /// Creates a realizer over [document].
   ResourceRealizer(this.document);
@@ -45,9 +47,77 @@ class ResourceRealizer {
     }
     final procedural = res.procedural;
     if (procedural != null) return _buildProcedural(procedural);
-    throw UnimplementedError(
-      'Payload-backed geometry needs the binary package format',
+    return _buildPayloadGeometry(res);
+  }
+
+  /// Builds a live geometry from a resource's payload chunks, mirroring the
+  /// `.model` import path: the interleaved vertex bytes and optional index
+  /// bytes are uploaded straight into a GPU buffer.
+  Geometry _buildPayloadGeometry(GeometryResource res) {
+    final vertexId = res.vertices;
+    if (vertexId == null) {
+      throw FsceneFormatException(
+        'Geometry ${res.id} has neither a procedural descriptor nor a vertex '
+        'payload',
+      );
+    }
+    final vertexBytes = _payloadBytes(vertexId, 'vertex');
+    final vertexPayload = document.payload(vertexId)!;
+    final skinned = vertexPayload.layout == 'skinned';
+    final perVertexBytes = skinned
+        ? kSkinnedPerVertexSize
+        : kUnskinnedPerVertexSize;
+    final vertexCount = vertexBytes.lengthInBytes ~/ perVertexBytes;
+    final geometry = skinned ? SkinnedGeometry() : UnskinnedGeometry();
+
+    ByteData? indexBytes;
+    var indexType = gpu.IndexType.int16;
+    final indexId = res.indices;
+    if (indexId != null) {
+      indexBytes = ByteData.sublistView(_payloadBytes(indexId, 'index'));
+      indexType = document.payload(indexId)!.format == 'uint32'
+          ? gpu.IndexType.int32
+          : gpu.IndexType.int16;
+    }
+
+    // Set baked bounds before upload so the position scan is skipped; without
+    // bounds, uploadVertexData scans unskinned positions (and leaves skinned
+    // geometry unbounded, matching the importer).
+    final bounds = res.bounds;
+    if (bounds != null) {
+      final aabb = Aabb3.minMax(bounds.min.clone(), bounds.max.clone());
+      geometry.setLocalBounds(aabb, _circumscribedSphere(aabb));
+    }
+
+    geometry.uploadVertexData(
+      ByteData.sublistView(vertexBytes),
+      vertexCount,
+      indexBytes,
+      indexType: indexType,
     );
+    return geometry;
+  }
+
+  Uint8List _payloadBytes(LocalId id, String role) {
+    final payload = document.payload(id);
+    if (payload == null) {
+      throw FsceneFormatException(
+        'Geometry references missing $role payload $id',
+      );
+    }
+    final bytes = payload.bytes;
+    if (bytes == null) {
+      throw FsceneFormatException(
+        'The $role payload $id has no bytes; load the document from a '
+        '.fsceneb container so its chunks are attached',
+      );
+    }
+    return bytes;
+  }
+
+  static Sphere _circumscribedSphere(Aabb3 aabb) {
+    final center = (aabb.min + aabb.max)..scale(0.5);
+    return Sphere.centerRadius(center, (aabb.max - aabb.min).length * 0.5);
   }
 
   Geometry _buildProcedural(ProceduralGeometry p) => switch (p) {

--- a/packages/flutter_scene/lib/src/fscene/realize/skin_animation.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/skin_animation.dart
@@ -1,0 +1,144 @@
+/// Realizes a document's skins and animations onto a live node graph.
+///
+/// Skins bind live joint [Node]s and their inverse-bind matrices (from a
+/// payload chunk) and attach to the skinned node via [Node.skin]; animations
+/// become engine [engine.Animation]s parsed onto the root, ready for
+/// [Node.createAnimationClip]. This layer is GPU-free; the joints texture is
+/// built later by the renderer from the bound skin.
+library;
+
+import 'dart:typed_data';
+
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/animation.dart' as engine;
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/node.dart';
+import 'package:flutter_scene/src/skin.dart';
+
+/// Builds the document's skins and animations and wires them onto the live
+/// graph: skins onto their nodes, animations onto [root].
+void realizeSkinsAndAnimations(
+  SceneDocument document,
+  Node root,
+  Map<LocalId, Node> nodes,
+) {
+  final skins = <LocalId, Skin>{
+    for (final spec in document.skins.values)
+      spec.id: _buildSkin(document, spec, nodes),
+  };
+  for (final nodeSpec in document.nodes.values) {
+    final skinId = nodeSpec.skin;
+    if (skinId == null) continue;
+    final node = nodes[nodeSpec.id];
+    final skin = skins[skinId];
+    if (node != null && skin != null) node.skin = skin;
+  }
+
+  for (final spec in document.animations.values) {
+    final animation = _buildAnimation(document, spec, nodes);
+    if (animation != null) root.addParsedAnimation(animation);
+  }
+}
+
+Skin _buildSkin(
+  SceneDocument document,
+  SkinSpec spec,
+  Map<LocalId, Node> nodes,
+) {
+  final skin = Skin();
+  for (final jointId in spec.joints) {
+    final node = nodes[jointId];
+    if (node != null) node.isJoint = true;
+    // A null joint renders as identity, matching Node.clone's skin handling.
+    skin.joints.add(node);
+  }
+  final matrices = _matrices(document.payload(spec.inverseBindMatrices));
+  for (var i = 0; i < spec.joints.length; i++) {
+    skin.inverseBindMatrices.add(
+      i < matrices.length ? matrices[i] : Matrix4.identity(),
+    );
+  }
+  return skin;
+}
+
+engine.Animation? _buildAnimation(
+  SceneDocument document,
+  AnimationSpec spec,
+  Map<LocalId, Node> nodes,
+) {
+  final channels = <engine.AnimationChannel>[];
+  for (final channel in spec.channels) {
+    final times = _floats(document.payload(channel.timeline)).toList();
+    final values = _floats(document.payload(channel.keyframes));
+    final name = nodes[channel.target]?.name ?? channel.targetName ?? '';
+
+    final engine.AnimationProperty property;
+    final engine.PropertyResolver resolver;
+    switch (channel.property) {
+      case AnimationProperty.translation:
+        property = engine.AnimationProperty.translation;
+        resolver = engine.PropertyResolver.makeTranslationTimeline(
+          times,
+          _vec3List(values),
+        );
+      case AnimationProperty.rotation:
+        property = engine.AnimationProperty.rotation;
+        resolver = engine.PropertyResolver.makeRotationTimeline(
+          times,
+          _quaternionList(values),
+        );
+      case AnimationProperty.scale:
+        property = engine.AnimationProperty.scale;
+        resolver = engine.PropertyResolver.makeScaleTimeline(
+          times,
+          _vec3List(values),
+        );
+    }
+    channels.add(
+      engine.AnimationChannel(
+        bindTarget: engine.BindKey(nodeName: name, property: property),
+        resolver: resolver,
+      ),
+    );
+  }
+  if (channels.isEmpty) return null;
+  return engine.Animation(name: spec.name, channels: channels);
+}
+
+List<Matrix4> _matrices(PayloadSpec? payload) {
+  final floats = _floats(payload);
+  final count = floats.length ~/ 16;
+  return [
+    for (var i = 0; i < count; i++)
+      Matrix4.fromFloat32List(
+        Float32List.fromList(floats.sublist(i * 16, i * 16 + 16)),
+      ),
+  ];
+}
+
+// Reads a payload's bytes as native-endian float32s, matching how the emitter
+// (and the engine's vertex buffers) store them.
+Float32List _floats(PayloadSpec? payload) {
+  final bytes = payload?.bytes;
+  if (bytes == null) return Float32List(0);
+  if (bytes.offsetInBytes % 4 == 0) {
+    return bytes.buffer.asFloat32List(
+      bytes.offsetInBytes,
+      bytes.lengthInBytes ~/ 4,
+    );
+  }
+  final aligned = Uint8List.fromList(bytes);
+  return aligned.buffer.asFloat32List(0, aligned.lengthInBytes ~/ 4);
+}
+
+List<Vector3> _vec3List(Float32List v) => [
+  for (var i = 0; i + 3 <= v.length; i += 3) Vector3(v[i], v[i + 1], v[i + 2]),
+];
+
+List<Quaternion> _quaternionList(Float32List v) => [
+  for (var i = 0; i + 4 <= v.length; i += 4)
+    Quaternion(v[i], v[i + 1], v[i + 2], v[i + 3]),
+];

--- a/packages/flutter_scene/lib/src/fscene/reload/diff.dart
+++ b/packages/flutter_scene/lib/src/fscene/reload/diff.dart
@@ -1,0 +1,161 @@
+/// A structural diff between two `.fscene` documents, keyed by node id.
+///
+/// Scene-structure hot reload re-parses (and re-composes) the document after
+/// its file changes, diffs it against the previous document by stable node id,
+/// and patches the live graph: nodes whose id is unchanged keep their identity
+/// (and their live animation clips), so only what actually changed is touched.
+/// This layer is pure and GPU-free; applying the diff to a live graph lives in
+/// the patch layer.
+library;
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/json/canonical.dart';
+import 'package:flutter_scene/src/fscene/json/property_json.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+
+/// What changed about a node present in both documents.
+class NodeChange {
+  /// Records the changed aspects of node [id].
+  NodeChange(
+    this.id, {
+    this.transform = false,
+    this.name = false,
+    this.layers = false,
+    this.reparented = false,
+    this.components = false,
+    this.skin = false,
+  });
+
+  /// The node's id (the same in both documents).
+  final LocalId id;
+
+  /// The local transform changed.
+  final bool transform;
+
+  /// The name changed.
+  final bool name;
+
+  /// The render-layer mask changed.
+  final bool layers;
+
+  /// The node's parent changed (it moved in the hierarchy).
+  final bool reparented;
+
+  /// The component set or a component's properties changed.
+  final bool components;
+
+  /// The bound skin changed.
+  final bool skin;
+}
+
+/// The set of changes between two documents.
+class SceneDiff {
+  /// Creates a diff from its parts.
+  SceneDiff({
+    required this.added,
+    required this.removed,
+    required this.changed,
+  });
+
+  /// Node ids present in the new document but not the old (to realize and
+  /// attach).
+  final List<LocalId> added;
+
+  /// Node ids present in the old document but not the new (to detach).
+  final List<LocalId> removed;
+
+  /// Nodes present in both whose content changed.
+  final List<NodeChange> changed;
+
+  /// Whether nothing changed.
+  bool get isEmpty => added.isEmpty && removed.isEmpty && changed.isEmpty;
+}
+
+/// Computes the node-id-keyed diff turning [oldDocument] into [newDocument].
+///
+/// Both documents must be fully composed (no prefab instances); ids are assumed
+/// stable across the two (the same node keeps its id when its file is edited).
+SceneDiff diffScene(SceneDocument oldDocument, SceneDocument newDocument) {
+  final oldIds = oldDocument.nodes.keys.toSet();
+  final newIds = newDocument.nodes.keys.toSet();
+
+  final added = [
+    for (final id in newDocument.nodes.keys)
+      if (!oldIds.contains(id)) id,
+  ];
+  final removed = [
+    for (final id in oldDocument.nodes.keys)
+      if (!newIds.contains(id)) id,
+  ];
+
+  final oldParents = _parents(oldDocument);
+  final newParents = _parents(newDocument);
+
+  final changed = <NodeChange>[];
+  for (final id in newDocument.nodes.keys) {
+    if (!oldIds.contains(id)) continue;
+    final oldNode = oldDocument.nodes[id]!;
+    final newNode = newDocument.nodes[id]!;
+
+    final change = NodeChange(
+      id,
+      transform: !_transformsEqual(oldNode.transform, newNode.transform),
+      name: oldNode.name != newNode.name,
+      layers: oldNode.layers != newNode.layers,
+      reparented: oldParents[id] != newParents[id],
+      components: !_componentsEqual(oldNode.components, newNode.components),
+      skin: oldNode.skin != newNode.skin,
+    );
+    if (change.transform ||
+        change.name ||
+        change.layers ||
+        change.reparented ||
+        change.components ||
+        change.skin) {
+      changed.add(change);
+    }
+  }
+
+  return SceneDiff(added: added, removed: removed, changed: changed);
+}
+
+Map<LocalId, LocalId?> _parents(SceneDocument doc) {
+  final parents = <LocalId, LocalId?>{
+    for (final id in doc.nodes.keys) id: null,
+  };
+  for (final node in doc.nodes.values) {
+    for (final child in node.children) {
+      parents[child] = node.id;
+    }
+  }
+  return parents;
+}
+
+bool _transformsEqual(TransformSpec a, TransformSpec b) {
+  final sa = a.toMatrix4().storage;
+  final sb = b.toMatrix4().storage;
+  for (var i = 0; i < 16; i++) {
+    if (sa[i] != sb[i]) return false;
+  }
+  return true;
+}
+
+// Compares component lists by their canonical encoded form, so any
+// PropertyValue change (factor, reference, nested list/map) is detected without
+// a bespoke value-equality walk.
+bool _componentsEqual(List<ComponentSpec> a, List<ComponentSpec> b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (_encodeComponent(a[i]) != _encodeComponent(b[i])) return false;
+  }
+  return true;
+}
+
+String _encodeComponent(ComponentSpec component) => canonicalJson({
+  'type': component.type,
+  'properties': {
+    for (final e in component.properties.entries)
+      e.key: encodePropertyValue(e.value, (id) => id.toToken()),
+  },
+});

--- a/packages/flutter_scene/lib/src/fscene/reload/reload.dart
+++ b/packages/flutter_scene/lib/src/fscene/reload/reload.dart
@@ -1,0 +1,140 @@
+/// Scene-structure hot reload: patches a live [Node] graph in place to match a
+/// re-parsed document, using the node-id-keyed [diffScene].
+///
+/// A node whose id is unchanged keeps its identity (and any live animation
+/// clips, custom state, or app-held reference); only added, removed, reparented,
+/// and changed nodes are touched. New and changed components realize against
+/// the new document, so this is async (it preloads any external textures /
+/// `fmat` materials the new content references) and GPU-bound.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show AssetBundle;
+
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/realize/node_identity.dart';
+import 'package:flutter_scene/src/fscene/realize/realize.dart';
+import 'package:flutter_scene/src/fscene/realize/resource_realizer.dart';
+import 'package:flutter_scene/src/fscene/reload/diff.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/node.dart';
+
+/// Patches the live graph rooted at [liveRoot] (as returned by `realizeScene`,
+/// or `loadScene`) from [oldDocument] to [newDocument] in place.
+///
+/// [liveRoot] must currently match [oldDocument]; both documents must be fully
+/// composed. Nodes whose id is unchanged keep their identity. Returns the diff
+/// that was applied (empty when nothing changed).
+///
+// TODO(fscene): re-bind changed skins and re-attach changed animations; today
+// a skin/animation change is not patched.
+Future<SceneDiff> reloadScene(
+  Node liveRoot,
+  SceneDocument oldDocument,
+  SceneDocument newDocument, {
+  FsceneComponentRegistry? registry,
+  AssetBundle? bundle,
+}) async {
+  final diff = diffScene(oldDocument, newDocument);
+  if (diff.isEmpty) return diff;
+
+  final reg = registry ?? defaultComponentRegistry();
+  final resources = ResourceRealizer(newDocument, bundle: bundle);
+  await resources.preload();
+  final context = RealizeContext(newDocument, resources: resources);
+
+  // Index the live graph by document id.
+  final live = <LocalId, Node>{};
+  void collect(Node node) {
+    final id = nodeFsceneId(node);
+    if (id != null) live[id] = node;
+    for (final child in node.children) {
+      collect(child);
+    }
+  }
+
+  collect(liveRoot);
+
+  final newParents = _parents(newDocument);
+  Node parentFor(LocalId id) => live[newParents[id]] ?? liveRoot;
+
+  // 1. Detach removed nodes.
+  for (final id in diff.removed) {
+    live.remove(id)?.detach();
+  }
+
+  // 2. Create the added nodes (bare), then wire their children and components,
+  // then attach those still without a parent under their document parent.
+  for (final id in diff.added) {
+    final spec = newDocument.nodes[id]!;
+    live[id] = tagNodeId(
+      Node(name: spec.name, localTransform: spec.transform.toMatrix4())
+        ..layers = spec.layers,
+      id,
+    );
+  }
+  for (final id in diff.added) {
+    final spec = newDocument.nodes[id]!;
+    final node = live[id]!;
+    for (final childId in spec.children) {
+      final child = live[childId];
+      if (child != null && child.parent == null) node.add(child);
+    }
+    _setComponents(node, spec.components, reg, context);
+  }
+  for (final id in diff.added) {
+    final node = live[id]!;
+    if (node.parent == null) parentFor(id).add(node);
+  }
+
+  // 3. Update surviving nodes.
+  for (final change in diff.changed) {
+    final node = live[change.id]!;
+    final spec = newDocument.nodes[change.id]!;
+    if (change.transform) node.localTransform = spec.transform.toMatrix4();
+    if (change.name) node.name = spec.name;
+    if (change.layers) node.layers = spec.layers;
+    if (change.reparented) {
+      node.detach();
+      parentFor(change.id).add(node);
+    }
+    if (change.components) {
+      _setComponents(node, spec.components, reg, context);
+    }
+    if (change.skin) {
+      debugPrint(
+        'fscene: skin change on node ${change.id} is not hot-reloaded',
+      );
+    }
+  }
+
+  return diff;
+}
+
+void _setComponents(
+  Node node,
+  List<ComponentSpec> specs,
+  FsceneComponentRegistry registry,
+  RealizeContext context,
+) {
+  for (final component in node.getComponents<Component>().toList()) {
+    node.removeComponent(component);
+  }
+  for (final spec in specs) {
+    final component = registry.realize(spec, context);
+    if (component != null) node.addComponent(component);
+  }
+}
+
+Map<LocalId, LocalId?> _parents(SceneDocument doc) {
+  final parents = <LocalId, LocalId?>{};
+  for (final node in doc.nodes.values) {
+    for (final child in node.children) {
+      parents[child] = node.id;
+    }
+  }
+  return parents;
+}

--- a/packages/flutter_scene/lib/src/fscene/scene_document.dart
+++ b/packages/flutter_scene/lib/src/fscene/scene_document.dart
@@ -1,0 +1,156 @@
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+
+/// The in-memory `.fscene` document: a GPU-free, encoding-independent
+/// description of a scene that the encoders serialize and the realizer turns
+/// into a live `Node` graph.
+///
+/// A document owns one global [documentId] and id-keyed pools of [nodes],
+/// [resources], [skins], [animations], and [payloads], plus the scene-wide
+/// [stage] settings. Ids are minted from [allocator]; references between
+/// entities are by [LocalId]. This type holds the data only; encoding (JSON
+/// and packed binary), composition (prefab overrides), and realization live
+/// in separate layers.
+class SceneDocument {
+  /// Creates an empty document. A new [documentId] and [allocator] (with a
+  /// fresh session salt) are generated unless supplied.
+  SceneDocument({
+    DocumentId? documentId,
+    IdAllocator? allocator,
+    StageMetadata? stage,
+  }) : documentId = documentId ?? DocumentId.generate(),
+       allocator = allocator ?? IdAllocator(),
+       stage = stage ?? StageMetadata();
+
+  /// The coarse format version this document targets.
+  int formatVersion = 1;
+
+  /// The document's global id, minted once at creation.
+  final DocumentId documentId;
+
+  /// Features this document uses. Informational unless also in
+  /// [featuresRequired].
+  final Set<String> featuresUsed = {};
+
+  /// Features a loader must support to load this document; missing one means
+  /// it must refuse rather than load partially.
+  final Set<String> featuresRequired = {};
+
+  /// A human-readable producer string (for example the importer version).
+  String? generator;
+
+  /// Scene-wide, non-spatial render settings.
+  StageMetadata stage;
+
+  /// Mints ids for this editing session. Continuing a loaded document uses a
+  /// new allocator with a fresh session salt.
+  final IdAllocator allocator;
+
+  /// Shared resources (geometry, materials, textures), keyed by id.
+  final Map<LocalId, ResourceSpec> resources = {};
+
+  /// Scene-graph nodes, keyed by id.
+  final Map<LocalId, NodeSpec> nodes = {};
+
+  /// The document's root node ids, in order.
+  final List<LocalId> roots = [];
+
+  /// Skins, keyed by id.
+  final Map<LocalId, SkinSpec> skins = {};
+
+  /// Animations, keyed by id.
+  final Map<LocalId, AnimationSpec> animations = {};
+
+  /// The binary chunk manifest, keyed by id.
+  final Map<LocalId, PayloadSpec> payloads = {};
+
+  /// Mints a fresh, document-unique [LocalId] from [allocator].
+  LocalId newId() => allocator.mint();
+
+  /// Registers [node] in the document, optionally as a [root], and returns
+  /// it.
+  NodeSpec addNode(NodeSpec node, {bool root = false}) {
+    nodes[node.id] = node;
+    if (root) roots.add(node.id);
+    return node;
+  }
+
+  /// Creates a node with a fresh id, registers it (optionally as a [root]),
+  /// and returns it.
+  NodeSpec createNode({
+    String name = '',
+    TransformSpec? transform,
+    List<ComponentSpec>? components,
+    int layers = 1,
+    bool root = false,
+  }) {
+    return addNode(
+      NodeSpec(
+        id: newId(),
+        name: name,
+        transform: transform,
+        components: components,
+        layers: layers,
+      ),
+      root: root,
+    );
+  }
+
+  /// Registers a pre-built [resource] and returns it (preserving its type).
+  T addResource<T extends ResourceSpec>(T resource) {
+    resources[resource.id] = resource;
+    return resource;
+  }
+
+  /// Registers a pre-built [skin] and returns it.
+  SkinSpec addSkin(SkinSpec skin) {
+    skins[skin.id] = skin;
+    return skin;
+  }
+
+  /// Registers a pre-built [animation] and returns it.
+  AnimationSpec addAnimation(AnimationSpec animation) {
+    animations[animation.id] = animation;
+    return animation;
+  }
+
+  /// Registers a pre-built [payload] and returns it.
+  PayloadSpec addPayload(PayloadSpec payload) {
+    payloads[payload.id] = payload;
+    return payload;
+  }
+
+  /// The node with [id], or null.
+  NodeSpec? node(LocalId id) => nodes[id];
+
+  /// The resource with [id], or null.
+  ResourceSpec? resource(LocalId id) => resources[id];
+
+  /// The skin with [id], or null.
+  SkinSpec? skin(LocalId id) => skins[id];
+
+  /// The animation with [id], or null.
+  AnimationSpec? animation(LocalId id) => animations[id];
+
+  /// The payload with [id], or null.
+  PayloadSpec? payload(LocalId id) => payloads[id];
+
+  /// The root nodes, resolved from [roots] (skipping any dangling id).
+  Iterable<NodeSpec> get rootNodes =>
+      roots.map((id) => nodes[id]).whereType<NodeSpec>();
+
+  /// The distinct session salts present across every id in the document.
+  ///
+  /// A new editing session for this document should allocate with these
+  /// excluded so freshly minted ids cannot collide with existing ones.
+  Set<int> usedSessions() {
+    final sessions = <int>{};
+    void add(LocalId id) => sessions.add(id.session);
+    nodes.keys.forEach(add);
+    resources.keys.forEach(add);
+    skins.keys.forEach(add);
+    animations.keys.forEach(add);
+    payloads.keys.forEach(add);
+    return sessions;
+  }
+}

--- a/packages/flutter_scene/lib/src/fscene/specs.dart
+++ b/packages/flutter_scene/lib/src/fscene/specs.dart
@@ -203,14 +203,81 @@ sealed class ResourceSpec {
   final LocalId id;
 }
 
-/// Mesh geometry: vertex/index data held in a binary [payload] chunk, plus
-/// optional local [bounds].
-class GeometryResource extends ResourceSpec {
-  /// Creates a geometry resource backed by the [payload] chunk.
-  GeometryResource(super.id, {required this.payload, this.bounds});
+/// A procedural geometry the runtime builds from parameters (rather than from
+/// baked vertex buffers). Compact and editable; no payload needed.
+sealed class ProceduralGeometry {
+  const ProceduralGeometry();
+}
 
-  /// The binary chunk holding this geometry's vertex/index buffers.
-  final LocalId payload;
+/// A box of the given [extents], optionally with per-corner debug colors.
+class CuboidGeometrySpec extends ProceduralGeometry {
+  /// Creates a cuboid spec.
+  CuboidGeometrySpec({required this.extents, this.debugColors = false});
+
+  /// The box dimensions.
+  final Vector3 extents;
+
+  /// Whether each corner carries a distinct debug color.
+  final bool debugColors;
+}
+
+/// A flat plane in the XZ plane.
+class PlaneGeometrySpec extends ProceduralGeometry {
+  /// Creates a plane spec.
+  PlaneGeometrySpec({
+    this.width = 1.0,
+    this.depth = 1.0,
+    this.segmentsX = 1,
+    this.segmentsZ = 1,
+  });
+
+  /// Size along X.
+  final double width;
+
+  /// Size along Z.
+  final double depth;
+
+  /// Grid subdivisions along X.
+  final int segmentsX;
+
+  /// Grid subdivisions along Z.
+  final int segmentsZ;
+}
+
+/// A UV sphere.
+class SphereGeometrySpec extends ProceduralGeometry {
+  /// Creates a sphere spec.
+  SphereGeometrySpec({this.radius = 0.5, this.segments = 32, this.rings = 16});
+
+  /// The sphere radius.
+  final double radius;
+
+  /// Divisions around the equator.
+  final int segments;
+
+  /// Divisions from pole to pole.
+  final int rings;
+}
+
+/// Mesh geometry, sourced either from a binary [payload] chunk (imported
+/// content) or a [procedural] descriptor (a runtime primitive). Exactly one
+/// source is set. Carries optional local [bounds].
+class GeometryResource extends ResourceSpec {
+  /// Creates a geometry resource from a [payload] chunk or a [procedural]
+  /// descriptor.
+  GeometryResource(super.id, {this.payload, this.procedural, this.bounds})
+    : assert(
+        (payload == null) != (procedural == null),
+        'A geometry has exactly one source: a payload or a procedural '
+        'descriptor',
+      );
+
+  /// The binary chunk holding this geometry's vertex/index buffers, or null
+  /// when [procedural] is set.
+  final LocalId? payload;
+
+  /// The procedural descriptor, or null when [payload] is set.
+  final ProceduralGeometry? procedural;
 
   /// The geometry's local-space bounds, when known.
   final BoundsSpec? bounds;

--- a/packages/flutter_scene/lib/src/fscene/specs.dart
+++ b/packages/flutter_scene/lib/src/fscene/specs.dart
@@ -1,0 +1,492 @@
+import 'dart:typed_data';
+
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+
+/// A node's local transform, stored either as a 4x4 [matrix] or as a
+/// decomposed translation/rotation/scale ([TrsTransform]). The importer
+/// emits TRS for clean diffs; the runtime composes a [Matrix4].
+sealed class TransformSpec {
+  const TransformSpec();
+
+  /// The transform as a 4x4 matrix.
+  Matrix4 toMatrix4();
+}
+
+/// A transform stored as an explicit 4x4 matrix.
+class MatrixTransform extends TransformSpec {
+  MatrixTransform(this.matrix);
+
+  /// The 4x4 local transform.
+  final Matrix4 matrix;
+
+  @override
+  Matrix4 toMatrix4() => matrix.clone();
+}
+
+/// A transform stored as decomposed translation, rotation, and scale.
+class TrsTransform extends TransformSpec {
+  TrsTransform({Vector3? translation, Quaternion? rotation, Vector3? scale})
+    : translation = translation ?? Vector3.zero(),
+      rotation = rotation ?? Quaternion.identity(),
+      scale = scale ?? Vector3(1, 1, 1);
+
+  /// The translation component.
+  final Vector3 translation;
+
+  /// The rotation component.
+  final Quaternion rotation;
+
+  /// The scale component.
+  final Vector3 scale;
+
+  @override
+  Matrix4 toMatrix4() => Matrix4.compose(translation, rotation, scale);
+}
+
+/// A serialized component: a stable [type] name plus a typed property bag.
+///
+/// The [type] is resolved through the component codec registry at
+/// realization; the [properties] hold the component's typed fields.
+class ComponentSpec {
+  /// Creates a component of the given [type] with optional [properties].
+  ComponentSpec(this.type, {Map<String, PropertyValue>? properties})
+    : properties = properties ?? {};
+
+  /// The registered component type name (for example `mesh`,
+  /// `directionalLight`, `camera`).
+  final String type;
+
+  /// The component's typed fields, keyed by field name.
+  final Map<String, PropertyValue> properties;
+}
+
+/// Whether a prefab instance's content loads eagerly with the scene or is
+/// streamed in on demand.
+enum LoadPolicy {
+  /// Loaded with the containing scene.
+  eager,
+
+  /// A lightweight placeholder until explicitly loaded (level streaming).
+  lazy,
+}
+
+/// One per-instance override of a prefab: set the property at [path] on the
+/// node [target] (in the prefab's local id space) to [value].
+class PropertyOverride {
+  /// Creates an override of [path] on [target] to [value].
+  PropertyOverride({
+    required this.target,
+    required this.path,
+    required this.value,
+  });
+
+  /// The node in the referenced prefab whose property is overridden.
+  final LocalId target;
+
+  /// A dotted property path, for example `components.mesh.material` or
+  /// `transform.trs.t`.
+  final String path;
+
+  /// The overriding value (absolute, not a relative delta).
+  final PropertyValue value;
+}
+
+/// The data that makes a [NodeSpec] a prefab instance: a reference to another
+/// `.fscene` plus the per-instance delta (overrides and added/removed
+/// content). The prefab composer applies these against the referenced
+/// document; a plain node leaves [NodeSpec.instance] null.
+class PrefabInstanceSpec {
+  /// Creates a prefab instance of [source] with an optional delta.
+  PrefabInstanceSpec({
+    required this.source,
+    this.load = LoadPolicy.eager,
+    List<PropertyOverride>? overrides,
+    List<NodeSpec>? addedNodes,
+    List<LocalId>? removedNodes,
+    List<ComponentSpec>? addedComponents,
+    List<String>? removedComponentTypes,
+  }) : overrides = overrides ?? [],
+       addedNodes = addedNodes ?? [],
+       removedNodes = removedNodes ?? [],
+       addedComponents = addedComponents ?? [],
+       removedComponentTypes = removedComponentTypes ?? [];
+
+  /// The referenced prefab `.fscene`.
+  final AssetRef source;
+
+  /// Whether the instance's content loads eagerly or streams in.
+  final LoadPolicy load;
+
+  /// Per-property overrides applied on top of the prefab.
+  final List<PropertyOverride> overrides;
+
+  /// Nodes added to this instance that the prefab does not have.
+  final List<NodeSpec> addedNodes;
+
+  /// Prefab nodes (by their local id in the prefab) suppressed on this
+  /// instance.
+  final List<LocalId> removedNodes;
+
+  /// Components added to the instance's root that the prefab does not have.
+  final List<ComponentSpec> addedComponents;
+
+  /// Prefab component types suppressed on this instance's root.
+  final List<String> removedComponentTypes;
+}
+
+/// A node in the document's scene graph.
+///
+/// Identity is the stable [id]; [name] is a non-identifying label kept for
+/// animation binding and name lookup. Hierarchy is by [children] id list.
+/// A node is either a plain node or, when [instance] is non-null, a prefab
+/// instance.
+class NodeSpec {
+  /// Creates a node with the given stable [id].
+  NodeSpec({
+    required this.id,
+    this.name = '',
+    TransformSpec? transform,
+    List<LocalId>? children,
+    List<ComponentSpec>? components,
+    this.layers = 1,
+    this.skin,
+    this.instance,
+  }) : transform = transform ?? TrsTransform(),
+       children = children ?? [],
+       components = components ?? [];
+
+  /// This node's stable, document-scoped id.
+  final LocalId id;
+
+  /// A non-identifying label (used for animation binding and name lookup).
+  String name;
+
+  /// The node's local transform.
+  TransformSpec transform;
+
+  /// Child node ids, in order.
+  final List<LocalId> children;
+
+  /// The components attached to this node.
+  final List<ComponentSpec> components;
+
+  /// The render-layer bitmask (defaults to layer 0).
+  int layers;
+
+  /// The skin bound to this node, or null.
+  LocalId? skin;
+
+  /// Non-null when this node is a prefab instance.
+  PrefabInstanceSpec? instance;
+}
+
+/// An axis-aligned bounding box in a resource's local space.
+class BoundsSpec {
+  /// Creates bounds spanning [min] to [max].
+  BoundsSpec({required this.min, required this.max});
+
+  /// The minimum corner.
+  final Vector3 min;
+
+  /// The maximum corner.
+  final Vector3 max;
+}
+
+/// A shared, id-keyed resource referenced by nodes (and other resources).
+sealed class ResourceSpec {
+  ResourceSpec(this.id);
+
+  /// This resource's stable, document-scoped id.
+  final LocalId id;
+}
+
+/// Mesh geometry: vertex/index data held in a binary [payload] chunk, plus
+/// optional local [bounds].
+class GeometryResource extends ResourceSpec {
+  /// Creates a geometry resource backed by the [payload] chunk.
+  GeometryResource(super.id, {required this.payload, this.bounds});
+
+  /// The binary chunk holding this geometry's vertex/index buffers.
+  final LocalId payload;
+
+  /// The geometry's local-space bounds, when known.
+  final BoundsSpec? bounds;
+}
+
+/// A texture sourced either from an embedded [payload] chunk or an external
+/// image [asset].
+class TextureResource extends ResourceSpec {
+  /// Creates a texture from an embedded [payload] or an external [asset].
+  TextureResource(super.id, {this.payload, this.asset})
+    : assert(
+        (payload == null) != (asset == null),
+        'A texture has exactly one source: a payload or an asset',
+      );
+
+  /// The embedded image chunk, or null when [asset] is set.
+  final LocalId? payload;
+
+  /// The external image asset, or null when [payload] is set.
+  final AssetRef? asset;
+}
+
+/// A material: a [type] (for example `physicallyBased`, `unlit`, `fmat`)
+/// plus typed [properties]. An `fmat` material references its `.fmat` source
+/// via [asset].
+class MaterialResource extends ResourceSpec {
+  /// Creates a material of the given [type].
+  MaterialResource(
+    super.id, {
+    required this.type,
+    Map<String, PropertyValue>? properties,
+    this.asset,
+  }) : properties = properties ?? {};
+
+  /// The material kind (`physicallyBased`, `unlit`, `fmat`, ...).
+  final String type;
+
+  /// Typed material parameters (factors, texture refs, alpha mode, ...).
+  final Map<String, PropertyValue> properties;
+
+  /// For `fmat` materials, the `.fmat` source asset; otherwise null.
+  final AssetRef? asset;
+}
+
+/// A skin: the joint nodes it drives, its inverse-bind matrices (a binary
+/// chunk), and the optional skeleton root.
+class SkinSpec {
+  /// Creates a skin with the given stable [id].
+  SkinSpec(
+    this.id, {
+    List<LocalId>? joints,
+    required this.inverseBindMatrices,
+    this.skeleton,
+  }) : joints = joints ?? [];
+
+  /// This skin's stable id.
+  final LocalId id;
+
+  /// The joint node ids, in joint order.
+  final List<LocalId> joints;
+
+  /// The binary chunk holding the inverse-bind matrices.
+  final LocalId inverseBindMatrices;
+
+  /// The skeleton root joint node, when known.
+  final LocalId? skeleton;
+}
+
+/// The transform channel an animation drives on its target node.
+enum AnimationProperty {
+  /// Drives the target's translation.
+  translation,
+
+  /// Drives the target's rotation.
+  rotation,
+
+  /// Drives the target's scale.
+  scale,
+}
+
+/// One animation channel: a keyframe timeline driving one [property] of one
+/// target node.
+///
+/// Binds to its target by stable id ([target]); [targetName] is retained as
+/// a clone-friendly fallback and for readable merges.
+class AnimationChannelSpec {
+  /// Creates a channel driving [property] of [target].
+  AnimationChannelSpec({
+    required this.target,
+    this.targetName,
+    required this.property,
+    required this.timeline,
+    required this.keyframes,
+  });
+
+  /// The node this channel animates (primary, id-based binding).
+  final LocalId target;
+
+  /// The target node's name (fallback binding, for clones and merges).
+  final String? targetName;
+
+  /// Which transform channel this drives.
+  final AnimationProperty property;
+
+  /// The binary chunk of keyframe times (seconds).
+  final LocalId timeline;
+
+  /// The binary chunk of keyframe values.
+  final LocalId keyframes;
+}
+
+/// A named animation: a set of channels driving target nodes.
+class AnimationSpec {
+  /// Creates an animation with the given stable [id].
+  AnimationSpec(this.id, {this.name = '', List<AnimationChannelSpec>? channels})
+    : channels = channels ?? [];
+
+  /// This animation's stable id.
+  final LocalId id;
+
+  /// The animation's name.
+  String name;
+
+  /// The channels this animation drives.
+  final List<AnimationChannelSpec> channels;
+}
+
+/// How a binary payload chunk's bytes are interpreted.
+enum PayloadEncoding {
+  /// An interleaved vertex buffer (see [PayloadSpec.layout]).
+  vertexBuffer,
+
+  /// An index buffer.
+  indexBuffer,
+
+  /// An encoded or raw image (see [PayloadSpec.format]).
+  image,
+
+  /// A packed array of 4x4 matrices.
+  matrices,
+
+  /// A packed array of 32-bit floats.
+  floats,
+
+  /// Opaque bytes.
+  bytes,
+}
+
+/// A binary chunk in the document's payload manifest: a descriptor plus, when
+/// the document's payloads are loaded, the chunk [bytes].
+///
+/// The descriptor is what the text form carries; the bytes live in the
+/// package and are attached when the document's payloads are loaded.
+class PayloadSpec {
+  /// Creates a payload descriptor with the given stable [id].
+  PayloadSpec(
+    this.id, {
+    required this.encoding,
+    this.layout,
+    this.format,
+    this.width,
+    this.height,
+    this.length,
+    this.bytes,
+  });
+
+  /// This payload's stable id.
+  final LocalId id;
+
+  /// How the bytes are interpreted.
+  final PayloadEncoding encoding;
+
+  /// For [PayloadEncoding.vertexBuffer], the vertex layout (`unskinned` /
+  /// `skinned`); otherwise null.
+  final String? layout;
+
+  /// For [PayloadEncoding.image], the pixel format (`rgba8`, ...); otherwise
+  /// null.
+  final String? format;
+
+  /// For image payloads, the pixel width.
+  final int? width;
+
+  /// For image payloads, the pixel height.
+  final int? height;
+
+  /// The chunk's byte length, when known.
+  final int? length;
+
+  /// The chunk bytes, when the document's payloads are loaded; otherwise
+  /// null (a manifest-only document).
+  Uint8List? bytes;
+}
+
+/// The up axis convention a document was authored in.
+enum UpAxis {
+  /// X is up.
+  x,
+
+  /// Y is up (the glTF convention).
+  y,
+
+  /// Z is up.
+  z,
+}
+
+/// The handedness a document was authored in. Drives the scene-root mirror
+/// the importers apply, kept as metadata rather than a literal node
+/// transform.
+enum Handedness {
+  /// Left-handed.
+  left,
+
+  /// Right-handed (the glTF convention).
+  right,
+}
+
+/// The image-based-lighting environment for a scene.
+sealed class EnvironmentSpec {
+  const EnvironmentSpec();
+}
+
+/// The built-in procedural studio environment.
+class StudioEnvironment extends EnvironmentSpec {
+  /// The studio environment.
+  const StudioEnvironment();
+}
+
+/// An environment built from an external image [asset].
+class AssetEnvironment extends EnvironmentSpec {
+  /// An environment sourced from [asset].
+  const AssetEnvironment(this.asset);
+
+  /// The environment image asset.
+  final AssetRef asset;
+}
+
+/// An empty (black) environment.
+class EmptyEnvironment extends EnvironmentSpec {
+  /// The empty environment.
+  const EmptyEnvironment();
+}
+
+/// Scene-wide, non-spatial render settings (lights and cameras are per-node
+/// components, not stage data).
+class StageMetadata {
+  /// Creates stage metadata with the documented defaults.
+  StageMetadata({
+    this.upAxis = UpAxis.y,
+    this.handedness = Handedness.right,
+    this.unitsPerMeter = 1.0,
+    this.environment = const StudioEnvironment(),
+    this.environmentIntensity = 1.0,
+    this.exposure = 1.0,
+    this.toneMapping = 'pbrNeutral',
+  });
+
+  /// The authored up axis.
+  UpAxis upAxis;
+
+  /// The authored handedness.
+  Handedness handedness;
+
+  /// World units per meter.
+  double unitsPerMeter;
+
+  /// The image-based-lighting environment.
+  EnvironmentSpec environment;
+
+  /// Scalar multiplier on the environment's contribution.
+  double environmentIntensity;
+
+  /// Linear exposure multiplier applied before tone mapping.
+  double exposure;
+
+  /// The tone-mapping operator name (mapped to the runtime enum at
+  /// realization).
+  String toneMapping;
+}

--- a/packages/flutter_scene/lib/src/fscene/specs.dart
+++ b/packages/flutter_scene/lib/src/fscene/specs.dart
@@ -484,14 +484,18 @@ enum UpAxis {
   z,
 }
 
-/// The handedness a document was authored in. Drives the scene-root mirror
-/// the importers apply, kept as metadata rather than a literal node
-/// transform.
+/// The chirality of the coordinate system a document's positions and geometry
+/// are expressed in. Drives the scene-root mirror the realizer applies, kept
+/// as metadata rather than a literal node transform.
 enum Handedness {
-  /// Left-handed.
+  /// The engine's native, left-handed space (`+Z` into the screen). Content
+  /// authored in code or an editor against the runtime is already in this
+  /// space, so the realizer applies no mirror. This is the default.
   left,
 
-  /// Right-handed (the glTF convention).
+  /// Right-handed (the glTF convention, `+Z` out of the screen). The importer
+  /// declares this; the realizer mirrors `scale(1, 1, -1)` to convert it to
+  /// the engine's space.
   right,
 }
 
@@ -527,7 +531,7 @@ class StageMetadata {
   /// Creates stage metadata with the documented defaults.
   StageMetadata({
     this.upAxis = UpAxis.y,
-    this.handedness = Handedness.right,
+    this.handedness = Handedness.left,
     this.unitsPerMeter = 1.0,
     this.environment = const StudioEnvironment(),
     this.environmentIntensity = 1.0,

--- a/packages/flutter_scene/lib/src/fscene/specs.dart
+++ b/packages/flutter_scene/lib/src/fscene/specs.dart
@@ -263,20 +263,32 @@ class SphereGeometrySpec extends ProceduralGeometry {
 /// content) or a [procedural] descriptor (a runtime primitive). Exactly one
 /// source is set. Carries optional local [bounds].
 class GeometryResource extends ResourceSpec {
-  /// Creates a geometry resource from a [payload] chunk or a [procedural]
-  /// descriptor.
-  GeometryResource(super.id, {this.payload, this.procedural, this.bounds})
-    : assert(
-        (payload == null) != (procedural == null),
-        'A geometry has exactly one source: a payload or a procedural '
-        'descriptor',
-      );
+  /// Creates a geometry resource from payload chunks (a [vertices] buffer and
+  /// optional [indices] buffer) or a [procedural] descriptor.
+  GeometryResource(
+    super.id, {
+    this.vertices,
+    this.indices,
+    this.procedural,
+    this.bounds,
+  }) : assert(
+         (vertices == null) != (procedural == null),
+         'A geometry has exactly one source: a vertex payload or a procedural '
+         'descriptor',
+       );
 
-  /// The binary chunk holding this geometry's vertex/index buffers, or null
-  /// when [procedural] is set.
-  final LocalId? payload;
+  /// The binary chunk holding this geometry's interleaved vertex buffer, or
+  /// null when [procedural] is set. The vertex `layout` (`unskinned` /
+  /// `skinned`) lives on the referenced payload.
+  final LocalId? vertices;
 
-  /// The procedural descriptor, or null when [payload] is set.
+  /// The binary chunk holding this geometry's index buffer, or null for a
+  /// non-indexed payload geometry (always null when [procedural] is set). The
+  /// element width (`uint16` / `uint32`) lives on the referenced payload's
+  /// `format`.
+  final LocalId? indices;
+
+  /// The procedural descriptor, or null when [vertices] is set.
   final ProceduralGeometry? procedural;
 
   /// The geometry's local-space bounds, when known.

--- a/packages/flutter_scene/lib/src/fscene/stream/stream.dart
+++ b/packages/flutter_scene/lib/src/fscene/stream/stream.dart
@@ -1,0 +1,82 @@
+/// Level streaming: loading and unloading lazy prefab subtrees on demand.
+///
+/// A prefab instance authored with `LoadPolicy.lazy` survives composition and
+/// realizes as a lightweight placeholder ([lazyInstanceOf] is set, the node has
+/// no content). [loadSubtree] instantiates the prefab under the placeholder
+/// when needed; [unloadSubtree] detaches it again. A spatial auto-streamer
+/// (load/unload by camera distance) can be built on top of these.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show AssetBundle;
+
+import 'package:flutter_scene/src/fscene/compose/compose.dart';
+import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/realize/lazy_subtree.dart';
+import 'package:flutter_scene/src/fscene/realize/realize.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/node.dart';
+
+/// Whether [node] is a lazy prefab placeholder.
+bool isLazySubtree(Node node) => lazyInstanceOf(node) != null;
+
+/// Whether [node] is a lazy placeholder whose content is currently loaded.
+bool isSubtreeLoaded(Node node) =>
+    lazyInstanceOf(node) != null && node.children.isNotEmpty;
+
+/// Instantiates a lazy placeholder [node]'s prefab content under it.
+///
+/// [load] resolves the referenced prefab document (the same loader `loadScene`
+/// uses). No-op if [node] is not a lazy placeholder or is already loaded.
+Future<void> loadSubtree(
+  Node node, {
+  required AsyncPrefabLoader load,
+  FsceneComponentRegistry? registry,
+  AssetBundle? bundle,
+}) async {
+  final spec = lazyInstanceOf(node);
+  if (spec == null) {
+    debugPrint('fscene: loadSubtree on a node that is not a lazy placeholder');
+    return;
+  }
+  if (node.children.isNotEmpty) return; // already loaded
+
+  // Expand the instance in isolation, in engine space (no handedness mirror)
+  // and at identity: the placeholder already carries the placement, and the
+  // realized content inherits the placeholder's frame from its ancestors.
+  final host = SceneDocument(stage: StageMetadata(handedness: Handedness.left));
+  host.addNode(NodeSpec(id: host.newId(), instance: _eager(spec)), root: true);
+  final composed = await composeSceneAsync(host, load: load);
+  final realized = await realizeSceneAsync(
+    composed,
+    registry: registry,
+    bundle: bundle,
+  );
+  for (final child in List<Node>.of(realized.children)) {
+    realized.remove(child);
+    node.add(child);
+  }
+}
+
+/// Detaches a loaded lazy subtree [node]'s content; it can be loaded again with
+/// [loadSubtree]. No-op if [node] is not a lazy placeholder.
+void unloadSubtree(Node node) {
+  if (lazyInstanceOf(node) == null) {
+    debugPrint(
+      'fscene: unloadSubtree on a node that is not a lazy placeholder',
+    );
+    return;
+  }
+  node.removeAll();
+}
+
+// The same instance, but eager, so composeScene expands it.
+PrefabInstanceSpec _eager(PrefabInstanceSpec spec) => PrefabInstanceSpec(
+  source: spec.source,
+  overrides: spec.overrides,
+  addedNodes: spec.addedNodes,
+  removedNodes: spec.removedNodes,
+  addedComponents: spec.addedComponents,
+  removedComponentTypes: spec.removedComponentTypes,
+);

--- a/packages/flutter_scene/lib/src/hot_reload/hot_reload_coordinator.dart
+++ b/packages/flutter_scene/lib/src/hot_reload/hot_reload_coordinator.dart
@@ -43,12 +43,14 @@ class HotReloadCoordinator {
 
   final List<_MaterialRegistration> _materials = <_MaterialRegistration>[];
   final List<_ModelRegistration> _models = <_ModelRegistration>[];
+  final List<_SceneRegistration> _scenes = <_SceneRegistration>[];
 
-  /// Content hash of each sidecar / shader bundle / model asset last seen, to
-  /// skip unchanged assets.
+  /// Content hash of each sidecar / shader bundle / model / scene asset last
+  /// seen, to skip unchanged assets.
   final Map<String, int> _sidecarHashes = <String, int>{};
   final Map<String, int> _shaderBundleHashes = <String, int>{};
   final Map<String, int> _modelHashes = <String, int>{};
+  final Map<String, int> _sceneHashes = <String, int>{};
 
   bool _refreshing = false;
 
@@ -87,6 +89,23 @@ class HotReloadCoordinator {
     );
   }
 
+  /// Registers a scene [root] loaded from the `.fsceneb` asset [assetKey]. On
+  /// hot reload, when that asset's content changes, [onReload] is invoked to
+  /// re-read the document and patch the live graph in place (see `loadScene`).
+  /// The closure owns the re-read / re-compose / diff / patch; the coordinator
+  /// only detects the content change and drops the registration once [root] is
+  /// collected. No-op outside debug.
+  void registerScene(
+    Node root, {
+    required String assetKey,
+    required Future<void> Function() onReload,
+  }) {
+    if (!kDebugMode) return;
+    _scenes.add(
+      _SceneRegistration(WeakReference<Node>(root), assetKey, onReload),
+    );
+  }
+
   /// Called by every mounted `SceneView` on hot reload. Refreshes changed
   /// assets once per reload (callers while a refresh is already in flight are
   /// ignored). No-op outside debug.
@@ -100,11 +119,44 @@ class HotReloadCoordinator {
   Future<void> _refresh() async {
     _materials.removeWhere((r) => r.material.target == null);
     _models.removeWhere((r) => r.node.target == null);
-    if (_materials.isEmpty && _models.isEmpty) return;
+    _scenes.removeWhere((r) => r.root.target == null);
+    if (_materials.isEmpty && _models.isEmpty && _scenes.isEmpty) return;
 
     await _reinitializeChangedShaderBundles();
     await _refreshChangedSidecars();
     await _refreshChangedModels();
+    await _refreshChangedScenes();
+  }
+
+  /// Re-reads any changed `.fsceneb` scene asset and patches the live graph in
+  /// place via each registration's reload closure.
+  Future<void> _refreshChangedScenes() async {
+    if (_scenes.isEmpty) return;
+    final keys = <String>{for (final r in _scenes) r.assetKey};
+    for (final key in keys) {
+      rootBundle.evict(key);
+      List<int> bytes;
+      try {
+        final data = await rootBundle.load(key);
+        bytes = data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
+      } catch (_) {
+        continue; // not available this reload; try again next time
+      }
+      final hash = _fnv1aBytes(bytes);
+      if (_sceneHashes[key] == hash) continue; // unchanged
+      _sceneHashes[key] = hash;
+
+      for (final r in _scenes) {
+        if (r.assetKey != key) continue;
+        if (r.root.target == null) continue;
+        try {
+          await r.onReload();
+        } catch (e) {
+          debugPrint('flutter_scene: scene reload failed for "$key": $e');
+        }
+      }
+      debugPrint('flutter_scene: hot-reloaded scene "$key"');
+    }
   }
 
   /// Reloads the GLSL of any changed `.shaderbundle` in place. Done before the
@@ -269,4 +321,12 @@ class _ModelRegistration {
   final WeakReference<Node> node;
   final String assetKey;
   final ModelReloadCallback? onReload;
+}
+
+class _SceneRegistration {
+  _SceneRegistration(this.root, this.assetKey, this.onReload);
+
+  final WeakReference<Node> root;
+  final String assetKey;
+  final Future<void> Function() onReload;
 }

--- a/packages/flutter_scene/lib/src/importer/build_hooks.dart
+++ b/packages/flutter_scene/lib/src/importer/build_hooks.dart
@@ -35,6 +35,12 @@ const String _dataAssetsUnavailableMessage =
 String modelDataAssetName(String relativeModelPath) =>
     'flutter_scene/model/$relativeModelPath';
 
+/// Returns the DataAsset name for a generated `.fsceneb` output, where
+/// [relativeScenePath] is the source path relative to the package root with its
+/// extension swapped to `.fsceneb` (for example `assets/level.fsceneb`).
+String sceneDataAssetName(String relativeScenePath) =>
+    'flutter_scene/scene/$relativeScenePath';
+
 /// Returns the Flutter asset-bundle key for a model DataAsset.
 String modelFlutterAssetKey({required String package, required String name}) =>
     'packages/$package/$name';
@@ -171,6 +177,80 @@ void buildModels({
           package: buildInput.packageName,
           name: modelDataAssetName(relativeModelPath),
           file: outputModelUri,
+        ),
+      );
+    }
+  }
+}
+
+/// Converts glTF (`.glb`) source assets to flutter_scene's `.fsceneb` package
+/// format, the `.fscene` counterpart of [buildModels].
+///
+/// Call this from a consuming app's `hook/build.dart` alongside (or instead of)
+/// [buildModels]; load the result by source path with `loadScene`. Behaves like
+/// [buildModels]: when [inputFilePaths] is omitted, every `.glb` under
+/// [discoveryRoot] is discovered; each generated `.fsceneb` is written under
+/// [outputDirectory] and, in a DataAssets mode, registered as a DataAsset (key
+/// `packages/<package>/flutter_scene/scene/<name>.fsceneb`); the source `.glb`
+/// is declared as a build dependency.
+void buildScenes({
+  required BuildInput buildInput,
+  required BuildOutputBuilder buildOutput,
+  List<String>? inputFilePaths,
+  String outputDirectory = 'build/scenes/',
+  String discoveryRoot = 'assets/',
+  ModelAssetMode assetMode = ModelAssetMode.legacyOnly,
+}) {
+  final dataAssetsAvailable = buildInput.config.buildDataAssets;
+  if (assetMode == ModelAssetMode.dataAssetsRequired && !dataAssetsAvailable) {
+    throw UnsupportedError(_dataAssetsUnavailableMessage);
+  }
+  final emitDataAssets =
+      assetMode != ModelAssetMode.legacyOnly && dataAssetsAvailable;
+
+  final packageRoot = buildInput.packageRoot;
+  final inputs =
+      inputFilePaths ??
+      discoverGlbModels(packageRoot, discoveryRoot: discoveryRoot);
+  if (inputs.isEmpty) {
+    return;
+  }
+
+  final scenesRoot = packageRoot.resolve(outputDirectory);
+
+  for (final inputFilePath in inputs) {
+    if (!inputFilePath.endsWith('.glb')) {
+      throw Exception(
+        'Input file must be a .glb file. Given file path: $inputFilePath',
+      );
+    }
+    if (inputFilePath.startsWith('../') || inputFilePath.contains('/../')) {
+      throw Exception(
+        'Scene source must be inside the package: $inputFilePath. Place it '
+        'under the package (for example in assets/), using a symlink if needed.',
+      );
+    }
+
+    final relativeScenePath =
+        '${inputFilePath.substring(0, inputFilePath.length - '.glb'.length)}'
+        '.fsceneb';
+    final outputSceneUri = scenesRoot.resolve(relativeScenePath);
+    Directory.fromUri(outputSceneUri.resolve('.')).createSync(recursive: true);
+
+    importGltfToFsceneb(
+      inputFilePath,
+      outputSceneUri.toFilePath(),
+      workingDirectory: packageRoot.toFilePath(),
+    );
+
+    buildOutput.dependencies.add(packageRoot.resolve(inputFilePath));
+
+    if (emitDataAssets) {
+      buildOutput.assets.data.add(
+        DataAsset(
+          package: buildInput.packageName,
+          name: sceneDataAssetName(relativeScenePath),
+          file: outputSceneUri,
         ),
       );
     }

--- a/packages/flutter_scene/lib/src/importer/build_hooks_unsupported.dart
+++ b/packages/flutter_scene/lib/src/importer/build_hooks_unsupported.dart
@@ -20,3 +20,16 @@ Never buildModels({
 }) => throw UnsupportedError(
   'buildModels runs at build time on native platforms only.',
 );
+
+/// Throws on web/wasm; see the library doc above. The `.fscene` counterpart of
+/// [buildModels].
+Never buildScenes({
+  required Object buildInput,
+  required Object buildOutput,
+  List<String>? inputFilePaths,
+  String outputDirectory = 'build/scenes/',
+  String discoveryRoot = 'assets/',
+  ModelAssetMode assetMode = ModelAssetMode.legacyOnly,
+}) => throw UnsupportedError(
+  'buildScenes runs at build time on native platforms only.',
+);

--- a/packages/flutter_scene/lib/src/importer/in_memory_import.dart
+++ b/packages/flutter_scene/lib/src/importer/in_memory_import.dart
@@ -1,7 +1,9 @@
 import 'dart:typed_data';
 
+import '../fscene/scene_document.dart';
 import 'gltf.dart';
 import 'src/fb_emitter/model_emitter.dart';
+import 'src/fscene_emitter/fscene_emitter.dart';
 
 /// Converts a single-file glTF binary (`.glb`) to flutter_scene's `.model`
 /// flatbuffer bytes, entirely in memory.
@@ -17,4 +19,28 @@ Uint8List importGlbToModelBytes(Uint8List glbBytes) {
   final container = parseGlb(glbBytes);
   final doc = parseGltfJson(container.json);
   return emitModel(doc, container.binaryChunk);
+}
+
+/// Converts a single-file glTF binary (`.glb`) to an `.fscene` [SceneDocument]
+/// entirely in memory.
+///
+/// The document declares right-handed coordinates; realize it with
+/// `realizeScene` (or write it with `writeFscene` / `writeFsceneb`). Uses no
+/// `dart:io`, so it runs at runtime on any platform.
+SceneDocument importGlbToSceneDocument(Uint8List glbBytes) {
+  final container = parseGlb(glbBytes);
+  final doc = parseGltfJson(container.json);
+  return buildSceneDocument(doc, container.binaryChunk);
+}
+
+/// Converts a single-file glTF binary (`.glb`) to `.fsceneb` binary container
+/// bytes entirely in memory.
+///
+/// Geometry is packed with the same code the `.model` path uses, so a
+/// primitive's vertex/index payload bytes match the `.model` output. Uses no
+/// `dart:io`, so it runs at runtime on any platform.
+Uint8List importGlbToFscenebBytes(Uint8List glbBytes) {
+  final container = parseGlb(glbBytes);
+  final doc = parseGltfJson(container.json);
+  return emitFsceneb(doc, container.binaryChunk);
 }

--- a/packages/flutter_scene/lib/src/importer/offline_import.dart
+++ b/packages/flutter_scene/lib/src/importer/offline_import.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'gltf.dart';
 import 'src/fb_emitter/model_emitter.dart';
+import 'src/fscene_emitter/fscene_emitter.dart';
 
 /// Converts a single glTF binary at [inputGltfFilePath] to a Flutter
 /// Scene `.model` file at [outputModelFilePath].
@@ -41,6 +42,37 @@ void importGltf(
   final doc = parseGltfJson(container.json);
   final outputBytes = emitModel(doc, container.binaryChunk);
   final outputFile = File(outputModelFilePath);
+  outputFile.parent.createSync(recursive: true);
+  outputFile.writeAsBytesSync(outputBytes);
+}
+
+/// Converts a single glTF binary at [inputGltfFilePath] to a flutter_scene
+/// `.fsceneb` package at [outputFscenebFilePath].
+///
+/// The `.fscene` counterpart of [importGltf]. Both paths can be relative; they
+/// are resolved against [workingDirectory] (defaulting to the caller's current
+/// directory). Pure Dart, no native binary; geometry is packed exactly as the
+/// `.model` path packs it.
+void importGltfToFsceneb(
+  String inputGltfFilePath,
+  String outputFscenebFilePath, {
+  String? workingDirectory,
+}) {
+  final workingDirectoryUri = Uri.directory(
+    workingDirectory ?? Directory.current.path,
+  );
+  inputGltfFilePath = workingDirectoryUri
+      .resolveUri(Uri.file(inputGltfFilePath))
+      .toFilePath();
+  outputFscenebFilePath = workingDirectoryUri
+      .resolveUri(Uri.file(outputFscenebFilePath))
+      .toFilePath();
+
+  final inputBytes = File(inputGltfFilePath).readAsBytesSync();
+  final container = parseGlb(inputBytes);
+  final doc = parseGltfJson(container.json);
+  final outputBytes = emitFsceneb(doc, container.binaryChunk);
+  final outputFile = File(outputFscenebFilePath);
   outputFile.parent.createSync(recursive: true);
   outputFile.writeAsBytesSync(outputBytes);
 }

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -4,9 +4,10 @@ import '../fscene/binary/fsceneb.dart';
 import '../fscene/compose/compose.dart';
 import '../fscene/realize/component_codec.dart';
 import '../fscene/realize/realize.dart';
+import '../fscene/reload/reload.dart';
 import '../fscene/scene_document.dart';
+import '../hot_reload/hot_reload_coordinator.dart';
 import '../node.dart';
-import 'model_cache.dart';
 
 const String _sceneAssetMarker = 'flutter_scene/scene/';
 const String _sceneAssetSuffix = '.fsceneb';
@@ -58,11 +59,6 @@ final class SceneRegistry {
   SceneRegistry._(this._entries);
 
   final List<SceneEntry> _entries;
-
-  // A node-template cache (the same one [ModelRegistry] uses for `.model`):
-  // the first load of a key realizes the scene and caches the template; every
-  // load returns a fresh [Node.clone] sharing the GPU resources.
-  static final ModelImportCache _cache = ModelImportCache();
 
   /// Loads the registry by scanning the asset manifest for `.fsceneb`
   /// DataAssets.
@@ -122,16 +118,16 @@ final class SceneRegistry {
     String? package,
     AssetBundle? bundle,
     FsceneComponentRegistry? registry,
-  }) {
+  }) async {
     final key = resolveKey(sourcePath, package: package);
     final assetBundle = bundle ?? rootBundle;
-    // TODO(fscene): register for content hot reload (re-import on source
-    // change) once scene hot reload lands, mirroring loadModel.
-    return _cache.load(key, () async {
+
+    // Re-reads the host document and expands any prefab instances, resolving
+    // each referenced prefab by source path against this same registry. Run on
+    // load and again on each hot reload.
+    Future<SceneDocument> readComposed() async {
       final document = await _readDocument(key, assetBundle);
-      // Expand any prefab instances, resolving each referenced prefab by its
-      // source path against this same registry.
-      final composed = document.nodes.values.any((n) => n.instance != null)
+      return document.nodes.values.any((n) => n.instance != null)
           ? await composeSceneAsync(
               document,
               load: (ref) => _readDocument(
@@ -140,15 +136,38 @@ final class SceneRegistry {
               ),
             )
           : document;
-      return realizeSceneAsync(
-        composed,
-        registry: registry,
-        bundle: assetBundle,
-      );
-    });
+    }
+
+    var current = await readComposed();
+    final root = await realizeSceneAsync(
+      current,
+      registry: registry,
+      bundle: assetBundle,
+    );
+
+    // Patch the live graph in place when the scene's `.fsceneb` changes (debug
+    // only; a no-op registration in release).
+    HotReloadCoordinator.instance.registerScene(
+      root,
+      assetKey: key,
+      onReload: () async {
+        final next = await readComposed();
+        await reloadScene(
+          root,
+          current,
+          next,
+          registry: registry,
+          bundle: assetBundle,
+        );
+        current = next;
+      },
+    );
+    return root;
   }
 
   Future<SceneDocument> _readDocument(String key, AssetBundle bundle) async {
+    // Evict so a hot reload re-reads the changed asset.
+    bundle.evict(key);
     final data = await bundle.load(key);
     return readFsceneb(
       data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -126,9 +126,10 @@ final class SceneRegistry {
     // change) once scene hot reload lands, mirroring loadModel.
     return _cache.load(key, () async {
       final data = await assetBundle.load(key);
-      return loadFscenebBytes(
+      return loadFscenebBytesAsync(
         data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
         registry: registry,
+        bundle: assetBundle,
       );
     });
   }

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/services.dart';
 
+import '../fscene/binary/fsceneb.dart';
+import '../fscene/compose/compose.dart';
 import '../fscene/realize/component_codec.dart';
-import '../fscene/realize/loader.dart';
+import '../fscene/realize/realize.dart';
+import '../fscene/scene_document.dart';
 import '../node.dart';
 import 'model_cache.dart';
 
@@ -125,13 +128,31 @@ final class SceneRegistry {
     // TODO(fscene): register for content hot reload (re-import on source
     // change) once scene hot reload lands, mirroring loadModel.
     return _cache.load(key, () async {
-      final data = await assetBundle.load(key);
-      return loadFscenebBytesAsync(
-        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+      final document = await _readDocument(key, assetBundle);
+      // Expand any prefab instances, resolving each referenced prefab by its
+      // source path against this same registry.
+      final composed = document.nodes.values.any((n) => n.instance != null)
+          ? await composeSceneAsync(
+              document,
+              load: (ref) => _readDocument(
+                resolveKey(ref.key, package: package),
+                assetBundle,
+              ),
+            )
+          : document;
+      return realizeSceneAsync(
+        composed,
         registry: registry,
         bundle: assetBundle,
       );
     });
+  }
+
+  Future<SceneDocument> _readDocument(String key, AssetBundle bundle) async {
+    final data = await bundle.load(key);
+    return readFsceneb(
+      data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+    );
   }
 
   static Future<List<String>> _loadAssetManifestKeys(AssetBundle bundle) async {

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/services.dart';
+
+import '../fscene/realize/component_codec.dart';
+import '../fscene/realize/loader.dart';
+import '../node.dart';
+import 'model_cache.dart';
+
+const String _sceneAssetMarker = 'flutter_scene/scene/';
+const String _sceneAssetSuffix = '.fsceneb';
+
+/// Resolves and loads `.fsceneb` scene packages registered through DataAssets
+/// by the [buildScenes] build hook.
+///
+/// Scenes are keyed by their source path relative to the owning package's root
+/// (for example `assets/levels/forest.glb`), so two scenes that share a file
+/// name in different directories do not collide. This is the `.fscene`
+/// counterpart of `ModelEntry`.
+final class SceneEntry {
+  SceneEntry({
+    required this.assetKey,
+    required this.package,
+    required this.sceneId,
+  });
+
+  /// The full Flutter asset-bundle key, e.g.
+  /// `packages/<package>/flutter_scene/scene/assets/forest.fsceneb`.
+  final String assetKey;
+
+  /// The owning package.
+  final String package;
+
+  /// The source path relative to [package]'s root, without extension.
+  final String sceneId;
+
+  static SceneEntry? tryParse(String assetKey) {
+    if (!SceneRegistry.isSceneAssetKey(assetKey)) return null;
+    final rest = assetKey.substring('packages/'.length);
+    final slash = rest.indexOf('/');
+    if (slash < 0) return null;
+    final package = rest.substring(0, slash);
+    final afterPackage = rest.substring(slash + 1);
+    if (!afterPackage.startsWith(_sceneAssetMarker)) return null;
+    final relativeScenePath = afterPackage.substring(_sceneAssetMarker.length);
+    final sceneId = relativeScenePath.substring(
+      0,
+      relativeScenePath.length - _sceneAssetSuffix.length,
+    );
+    return SceneEntry(assetKey: assetKey, package: package, sceneId: sceneId);
+  }
+}
+
+/// Resolves DataAssets-backed `.fsceneb` files by source path, the `.fscene`
+/// counterpart of `ModelRegistry`.
+final class SceneRegistry {
+  SceneRegistry._(this._entries);
+
+  final List<SceneEntry> _entries;
+
+  // A node-template cache (the same one [ModelRegistry] uses for `.model`):
+  // the first load of a key realizes the scene and caches the template; every
+  // load returns a fresh [Node.clone] sharing the GPU resources.
+  static final ModelImportCache _cache = ModelImportCache();
+
+  /// Loads the registry by scanning the asset manifest for `.fsceneb`
+  /// DataAssets.
+  static Future<SceneRegistry> load({
+    AssetBundle? bundle,
+    Iterable<String>? assetKeys,
+  }) async {
+    final assetBundle = bundle ?? rootBundle;
+    final keys = assetKeys ?? await _loadAssetManifestKeys(assetBundle);
+    final entries =
+        keys.map(SceneEntry.tryParse).whereType<SceneEntry>().toList()
+          ..sort((a, b) => a.assetKey.compareTo(b.assetKey));
+    return SceneRegistry._(entries);
+  }
+
+  /// Returns true when [assetKey] is a generated `.fsceneb` DataAsset.
+  static bool isSceneAssetKey(String assetKey) =>
+      assetKey.startsWith('packages/') &&
+      assetKey.contains('/$_sceneAssetMarker') &&
+      assetKey.endsWith(_sceneAssetSuffix);
+
+  /// Resolves [sourcePath] (relative to the owning package's root, with or
+  /// without the `.glb`/`.fsceneb` extension) to exactly one scene asset key.
+  String resolveKey(String sourcePath, {String? package}) {
+    final id = _sceneId(sourcePath);
+    final matches = _entries
+        .where(
+          (entry) =>
+              entry.sceneId == id &&
+              (package == null || entry.package == package),
+        )
+        .toList();
+    if (matches.isEmpty) {
+      throw StateError(
+        'No DataAssets-backed .fsceneb for source "$sourcePath" was found. '
+        'Make sure the build hook calls buildScenes in a DataAssets mode, that '
+        'Dart data assets are enabled (flutter config '
+        '--enable-dart-data-assets), and that the app has been rebuilt.',
+      );
+    }
+    if (matches.length > 1) {
+      final choices = matches.map((match) => match.package).join(', ');
+      throw StateError(
+        'Multiple DataAssets-backed .fsceneb files for source "$sourcePath" '
+        'were found in packages: $choices. Pass package to disambiguate.',
+      );
+    }
+    return matches.single.assetKey;
+  }
+
+  /// Loads the scene whose source is [sourcePath] as a [Node].
+  ///
+  /// Pass a custom [registry] to realize app-defined component types; it only
+  /// applies on the first (cache-filling) load of a given scene.
+  Future<Node> loadScene(
+    String sourcePath, {
+    String? package,
+    AssetBundle? bundle,
+    FsceneComponentRegistry? registry,
+  }) {
+    final key = resolveKey(sourcePath, package: package);
+    final assetBundle = bundle ?? rootBundle;
+    // TODO(fscene): register for content hot reload (re-import on source
+    // change) once scene hot reload lands, mirroring loadModel.
+    return _cache.load(key, () async {
+      final data = await assetBundle.load(key);
+      return loadFscenebBytes(
+        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+        registry: registry,
+      );
+    });
+  }
+
+  static Future<List<String>> _loadAssetManifestKeys(AssetBundle bundle) async {
+    final manifest = await AssetManifest.loadFromAssetBundle(bundle);
+    return manifest.listAssets();
+  }
+}
+
+String _sceneId(String sourcePath) {
+  if (sourcePath.endsWith('.glb')) {
+    return sourcePath.substring(0, sourcePath.length - '.glb'.length);
+  }
+  if (sourcePath.endsWith(_sceneAssetSuffix)) {
+    return sourcePath.substring(
+      0,
+      sourcePath.length - _sceneAssetSuffix.length,
+    );
+  }
+  return sourcePath;
+}
+
+/// Loads a DataAssets-backed `.fsceneb` scene by its source path relative to
+/// the owning package's root (for example `assets/levels/forest.glb`).
+///
+/// The `.fscene` counterpart of `loadModel`. Pass [package] to disambiguate
+/// when the same source path is provided by more than one package, and a custom
+/// [registry] to realize app-defined component types.
+Future<Node> loadScene(
+  String sourcePath, {
+  String? package,
+  AssetBundle? bundle,
+  FsceneComponentRegistry? registry,
+}) async {
+  final sceneRegistry = await SceneRegistry.load(bundle: bundle);
+  return sceneRegistry.loadScene(
+    sourcePath,
+    package: package,
+    bundle: bundle,
+    registry: registry,
+  );
+}

--- a/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
+++ b/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
@@ -12,8 +12,8 @@
 /// isolate. Ids are derived deterministically from the binary chunk, so
 /// re-importing the same asset yields an identical document.
 ///
-// TODO(fscene): emit skins and animations (inverse-bind-matrix and keyframe
-// payloads); bake node-level / skinned pose-union bounds for subtree culling.
+// TODO(fscene): bake node-level / skinned pose-union bounds for subtree
+// culling (the realizer treats absent bounds as always-visible meanwhile).
 library;
 
 import 'dart:math' show Random;
@@ -27,6 +27,7 @@ import '../../../fscene/binary/fsceneb.dart';
 import '../../../fscene/property_value.dart';
 import '../../../fscene/scene_document.dart';
 import '../../../fscene/specs.dart';
+import '../gltf/accessor.dart';
 import '../gltf/primitive_packer.dart';
 import '../gltf/types.dart';
 
@@ -90,6 +91,13 @@ SceneDocument buildSceneDocument(GltfDocument doc, Uint8List bufferData) {
     meshPairs[meshIndex] = pairs;
   }
 
+  // Skins (joints reference nodes by id; inverse-bind matrices ride in a
+  // payload chunk).
+  final skinIds = [
+    for (final skin in doc.skins)
+      _buildSkin(document, skin, doc, bufferData, nodeIds),
+  ];
+
   // Nodes.
   for (var i = 0; i < doc.nodes.length; i++) {
     final node = doc.nodes[i];
@@ -108,7 +116,9 @@ SceneDocument buildSceneDocument(GltfDocument doc, Uint8List bufferData) {
             if (c >= 0 && c < nodeIds.length) nodeIds[c],
         ],
         components: components,
-        // TODO(fscene): bind node.skin once skins are emitted (P4b).
+        skin: (node.skin != null && node.skin! < skinIds.length)
+            ? skinIds[node.skin!]
+            : null,
       ),
     );
   }
@@ -121,7 +131,162 @@ SceneDocument buildSceneDocument(GltfDocument doc, Uint8List bufferData) {
     }
   }
 
+  // Animations (one keyframe timeline/value payload per channel).
+  for (final animation in doc.animations) {
+    _buildAnimation(document, animation, doc, bufferData, nodeIds);
+  }
+
   return document;
+}
+
+LocalId _buildSkin(
+  SceneDocument document,
+  GltfSkin skin,
+  GltfDocument doc,
+  Uint8List bufferData,
+  List<LocalId> nodeIds,
+) {
+  final Float32List matrices;
+  if (skin.inverseBindMatrices != null) {
+    final accessor = doc.accessors[skin.inverseBindMatrices!];
+    matrices = readAccessorAsFloat32(
+      accessor,
+      doc.bufferViews[accessor.bufferView!],
+      bufferData,
+    );
+  } else {
+    // Spec default: identity per joint, column-major.
+    matrices = Float32List(skin.joints.length * 16);
+    for (var i = 0; i < skin.joints.length; i++) {
+      matrices[i * 16 + 0] = 1.0;
+      matrices[i * 16 + 5] = 1.0;
+      matrices[i * 16 + 10] = 1.0;
+      matrices[i * 16 + 15] = 1.0;
+    }
+  }
+  final payload = _floatPayload(document, matrices, PayloadEncoding.matrices);
+  return document
+      .addSkin(
+        SkinSpec(
+          document.newId(),
+          joints: [
+            for (final j in skin.joints)
+              if (j >= 0 && j < nodeIds.length) nodeIds[j],
+          ],
+          inverseBindMatrices: payload,
+          skeleton: (skin.skeleton != null && skin.skeleton! < nodeIds.length)
+              ? nodeIds[skin.skeleton!]
+              : null,
+        ),
+      )
+      .id;
+}
+
+void _buildAnimation(
+  SceneDocument document,
+  GltfAnimation animation,
+  GltfDocument doc,
+  Uint8List bufferData,
+  List<LocalId> nodeIds,
+) {
+  final channels = <AnimationChannelSpec>[];
+  for (final channel in animation.channels) {
+    final target = channel.targetNode;
+    if (target == null || target < 0 || target >= nodeIds.length) continue;
+    if (channel.sampler < 0 || channel.sampler >= animation.samplers.length) {
+      continue;
+    }
+    final property = switch (channel.targetPath) {
+      'translation' => AnimationProperty.translation,
+      'rotation' => AnimationProperty.rotation,
+      'scale' => AnimationProperty.scale,
+      _ => null, // 'weights' (morph targets) and unknowns
+    };
+    if (property == null) continue;
+
+    final sampler = animation.samplers[channel.sampler];
+    final inputAccessor = doc.accessors[sampler.input];
+    final outputAccessor = doc.accessors[sampler.output];
+    final times = readAccessorAsFloat32(
+      inputAccessor,
+      doc.bufferViews[inputAccessor.bufferView!],
+      bufferData,
+    );
+    final values = readAccessorAsFloat32(
+      outputAccessor,
+      doc.bufferViews[outputAccessor.bufferView!],
+      bufferData,
+    );
+    final componentCount = property == AnimationProperty.rotation ? 4 : 3;
+    final keyframes = _stripCubicTangents(
+      values,
+      componentCount,
+      sampler.interpolation == 'CUBICSPLINE',
+    );
+
+    channels.add(
+      AnimationChannelSpec(
+        target: nodeIds[target],
+        targetName: resolveGltfNodeName(doc.nodes[target].name, target),
+        property: property,
+        timeline: _floatPayload(
+          document,
+          Float32List.fromList(times),
+          PayloadEncoding.floats,
+        ),
+        keyframes: _floatPayload(document, keyframes, PayloadEncoding.floats),
+      ),
+    );
+  }
+  if (channels.isEmpty) return;
+  document.addAnimation(
+    AnimationSpec(
+      document.newId(),
+      name: animation.name ?? '',
+      channels: channels,
+    ),
+  );
+}
+
+// Reduces a CUBICSPLINE sampler's [in-tangent, value, out-tangent] groups to
+// just the keyframe values, so the stored timeline is plain LINEAR keyframes
+// (the runtime treats both paths' values the same way). Non-cubic data is
+// copied through.
+Float32List _stripCubicTangents(
+  Float32List values,
+  int componentCount,
+  bool isCubic,
+) {
+  if (!isCubic) return Float32List.fromList(values);
+  final stride = componentCount * 3;
+  final out = <double>[];
+  for (var i = 0; i + stride <= values.length; i += stride) {
+    for (var c = 0; c < componentCount; c++) {
+      out.add(values[i + componentCount + c]);
+    }
+  }
+  return Float32List.fromList(out);
+}
+
+LocalId _floatPayload(
+  SceneDocument document,
+  Float32List floats,
+  PayloadEncoding encoding,
+) {
+  final bytes = floats.buffer.asUint8List(
+    floats.offsetInBytes,
+    floats.lengthInBytes,
+  );
+  return document
+      .addPayload(
+        PayloadSpec(
+          document.newId(),
+          encoding: encoding,
+          length: bytes.length,
+          bytes: bytes,
+        ),
+      )
+      .id;
 }
 
 ComponentSpec _meshComponent(List<(LocalId, LocalId)> pairs) {

--- a/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
+++ b/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
@@ -1,0 +1,374 @@
+/// Build-time emitter: parsed glTF -> an `.fscene` document and its `.fsceneb`
+/// binary package.
+///
+/// This is the `.fscene` counterpart of the `.model` emitter. It builds a
+/// [SceneDocument] from the same parsed glTF the `.model` path consumes, then
+/// packages it as a `.fsceneb` container. Geometry is packed with the shared
+/// [packGltfPrimitive], so a primitive's vertex/index payload bytes are
+/// identical to the bytes the `.model` emitter stores (validated by
+/// byte-comparison tests).
+///
+/// Pure Dart (no `dart:ui` / Flutter GPU), so it runs in the build-hook
+/// isolate. Ids are derived deterministically from the binary chunk, so
+/// re-importing the same asset yields an identical document.
+///
+// TODO(fscene): emit skins and animations (inverse-bind-matrix and keyframe
+// payloads); bake node-level / skinned pose-union bounds for subtree culling.
+library;
+
+import 'dart:math' show Random;
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+import 'package:vector_math/vector_math.dart';
+
+import '../../../fscene/id.dart';
+import '../../../fscene/binary/fsceneb.dart';
+import '../../../fscene/property_value.dart';
+import '../../../fscene/scene_document.dart';
+import '../../../fscene/specs.dart';
+import '../gltf/primitive_packer.dart';
+import '../gltf/types.dart';
+
+/// Converts a parsed glTF document (plus its binary buffer) into `.fsceneb`
+/// container bytes.
+Uint8List emitFsceneb(GltfDocument doc, Uint8List bufferData) =>
+    writeFsceneb(buildSceneDocument(doc, bufferData));
+
+/// Builds an `.fscene` [SceneDocument] from a parsed glTF document.
+///
+/// The document is declared right-handed ([Handedness.right]); the realizer
+/// applies the glTF-to-engine mirror, so no per-node winding flip is baked in.
+SceneDocument buildSceneDocument(GltfDocument doc, Uint8List bufferData) {
+  final seed = _seedFrom(bufferData);
+  final document = SceneDocument(
+    documentId: DocumentId.generate(Random(seed)),
+    allocator: IdAllocator(session: seed),
+  );
+  document.stage
+    ..upAxis = UpAxis.y
+    ..handedness = Handedness.right;
+  document.generator = 'flutter_scene glTF importer';
+
+  // Pre-mint a stable id per glTF node so child/joint/animation-target
+  // references resolve regardless of the build order below.
+  final nodeIds = [for (var i = 0; i < doc.nodes.length; i++) document.newId()];
+
+  // Textures, then materials (which reference textures), then mesh geometry
+  // (which references materials).
+  final textureIds = [
+    for (final texture in doc.textures)
+      _buildTexture(document, texture, doc, bufferData),
+  ];
+  final materialIds = [
+    for (final material in doc.materials)
+      _buildMaterial(document, material, textureIds),
+  ];
+
+  LocalId? defaultMaterialId;
+  LocalId materialFor(int? index) {
+    if (index != null && index >= 0 && index < materialIds.length) {
+      return materialIds[index];
+    }
+    return defaultMaterialId ??= document
+        .addResource(
+          MaterialResource(document.newId(), type: 'physicallyBased'),
+        )
+        .id;
+  }
+
+  // Geometry resources per mesh primitive, shared across the nodes that
+  // reference the same mesh.
+  final meshPairs = <int, List<(LocalId, LocalId)>>{};
+  for (var meshIndex = 0; meshIndex < doc.meshes.length; meshIndex++) {
+    final pairs = <(LocalId, LocalId)>[];
+    for (final primitive in doc.meshes[meshIndex].primitives) {
+      if (primitive.mode != 4) continue; // triangles only
+      final geometryId = _buildGeometry(document, primitive, doc, bufferData);
+      pairs.add((geometryId, materialFor(primitive.material)));
+    }
+    meshPairs[meshIndex] = pairs;
+  }
+
+  // Nodes.
+  for (var i = 0; i < doc.nodes.length; i++) {
+    final node = doc.nodes[i];
+    final components = <ComponentSpec>[];
+    if (node.mesh != null && node.mesh! < doc.meshes.length) {
+      final pairs = meshPairs[node.mesh!] ?? const [];
+      if (pairs.isNotEmpty) components.add(_meshComponent(pairs));
+    }
+    document.addNode(
+      NodeSpec(
+        id: nodeIds[i],
+        name: resolveGltfNodeName(node.name, i),
+        transform: _transform(node),
+        children: [
+          for (final c in node.children)
+            if (c >= 0 && c < nodeIds.length) nodeIds[c],
+        ],
+        components: components,
+        // TODO(fscene): bind node.skin once skins are emitted (P4b).
+      ),
+    );
+  }
+
+  // Roots from the default scene.
+  final sceneIndex = doc.scene ?? (doc.scenes.isNotEmpty ? 0 : -1);
+  if (sceneIndex >= 0 && sceneIndex < doc.scenes.length) {
+    for (final root in doc.scenes[sceneIndex].nodes) {
+      if (root >= 0 && root < nodeIds.length) document.roots.add(nodeIds[root]);
+    }
+  }
+
+  return document;
+}
+
+ComponentSpec _meshComponent(List<(LocalId, LocalId)> pairs) {
+  if (pairs.length == 1) {
+    return ComponentSpec(
+      'mesh',
+      properties: {
+        'geometry': ResourceRefValue(pairs.first.$1),
+        'material': ResourceRefValue(pairs.first.$2),
+      },
+    );
+  }
+  return ComponentSpec(
+    'mesh',
+    properties: {
+      'primitives': ListValue([
+        for (final (geometryId, materialId) in pairs)
+          MapValue({
+            'geometry': ResourceRefValue(geometryId),
+            'material': ResourceRefValue(materialId),
+          }),
+      ]),
+    },
+  );
+}
+
+TransformSpec _transform(GltfNode node) {
+  if (node.matrix != null) return MatrixTransform(node.matrix!.clone());
+  return TrsTransform(
+    translation: (node.translation ?? Vector3.zero()).clone(),
+    rotation: (node.rotation ?? Quaternion.identity()).clone(),
+    scale: (node.scale ?? Vector3(1, 1, 1)).clone(),
+  );
+}
+
+LocalId _buildGeometry(
+  SceneDocument document,
+  GltfMeshPrimitive primitive,
+  GltfDocument doc,
+  Uint8List bufferData,
+) {
+  final packed = packGltfPrimitive(
+    primitive: primitive,
+    accessors: doc.accessors,
+    bufferViews: doc.bufferViews,
+    bufferData: bufferData,
+  );
+  final vertices = document.addPayload(
+    PayloadSpec(
+      document.newId(),
+      encoding: PayloadEncoding.vertexBuffer,
+      layout: packed.isSkinned ? 'skinned' : 'unskinned',
+      length: packed.vertexBytes.length,
+      bytes: packed.vertexBytes,
+    ),
+  );
+  final indices = document.addPayload(
+    PayloadSpec(
+      document.newId(),
+      encoding: PayloadEncoding.indexBuffer,
+      format: packed.indices32Bit ? 'uint32' : 'uint16',
+      length: packed.indexBytes.length,
+      bytes: packed.indexBytes,
+    ),
+  );
+  return document
+      .addResource(
+        GeometryResource(
+          document.newId(),
+          vertices: vertices.id,
+          indices: indices.id,
+          bounds: _bounds(primitive, doc),
+        ),
+      )
+      .id;
+}
+
+BoundsSpec? _bounds(GltfMeshPrimitive primitive, GltfDocument doc) {
+  final index = primitive.attributes['POSITION'];
+  if (index == null) return null;
+  final accessor = doc.accessors[index];
+  final min = accessor.min;
+  final max = accessor.max;
+  if (min != null && min.length >= 3 && max != null && max.length >= 3) {
+    return BoundsSpec(
+      min: Vector3(min[0], min[1], min[2]),
+      max: Vector3(max[0], max[1], max[2]),
+    );
+  }
+  // No spec-provided bounds; the realizer scans positions on upload.
+  return null;
+}
+
+LocalId _buildMaterial(
+  SceneDocument document,
+  GltfMaterial material,
+  List<LocalId?> textureIds,
+) {
+  final pbr = material.pbrMetallicRoughness;
+  final base = pbr?.baseColorFactor;
+  final properties = <String, PropertyValue>{
+    'baseColor': ColorValue(
+      _at(base, 0, 1.0),
+      _at(base, 1, 1.0),
+      _at(base, 2, 1.0),
+      _at(base, 3, 1.0),
+    ),
+    'doubleSided': BoolValue(material.doubleSided),
+    'alphaMode': StringValue(material.alphaMode.toLowerCase()),
+    'alphaCutoff': DoubleValue(material.alphaCutoff),
+  };
+  _addTexture(
+    properties,
+    'baseColorTexture',
+    pbr?.baseColorTexture,
+    textureIds,
+  );
+
+  if (material.unlit) {
+    return document
+        .addResource(
+          MaterialResource(
+            document.newId(),
+            type: 'unlit',
+            properties: properties,
+          ),
+        )
+        .id;
+  }
+
+  properties['metallic'] = DoubleValue(pbr?.metallicFactor ?? 0.0);
+  properties['roughness'] = DoubleValue(pbr?.roughnessFactor ?? 0.5);
+  properties['emissive'] = ColorValue(
+    _at(material.emissiveFactor, 0, 0.0),
+    _at(material.emissiveFactor, 1, 0.0),
+    _at(material.emissiveFactor, 2, 0.0),
+    1.0,
+  );
+  properties['occlusionStrength'] = DoubleValue(
+    material.occlusionTexture?.strength ?? 1.0,
+  );
+  if (material.normalTexture?.scale != null) {
+    properties['normalScale'] = DoubleValue(material.normalTexture!.scale!);
+  }
+  _addTexture(
+    properties,
+    'metallicRoughnessTexture',
+    pbr?.metallicRoughnessTexture,
+    textureIds,
+  );
+  _addTexture(properties, 'normalTexture', material.normalTexture, textureIds);
+  _addTexture(
+    properties,
+    'occlusionTexture',
+    material.occlusionTexture,
+    textureIds,
+  );
+  _addTexture(
+    properties,
+    'emissiveTexture',
+    material.emissiveTexture,
+    textureIds,
+  );
+
+  return document
+      .addResource(
+        MaterialResource(
+          document.newId(),
+          type: 'physicallyBased',
+          properties: properties,
+        ),
+      )
+      .id;
+}
+
+void _addTexture(
+  Map<String, PropertyValue> properties,
+  String key,
+  GltfTextureInfo? info,
+  List<LocalId?> textureIds,
+) {
+  if (info == null) return;
+  if (info.index < 0 || info.index >= textureIds.length) return;
+  final id = textureIds[info.index];
+  if (id != null) properties[key] = ResourceRefValue(id);
+}
+
+LocalId? _buildTexture(
+  SceneDocument document,
+  GltfTexture texture,
+  GltfDocument doc,
+  Uint8List bufferData,
+) {
+  if (texture.source == null || texture.source! >= doc.images.length) {
+    return null;
+  }
+  final image = doc.images[texture.source!];
+  if (image.bufferView != null) {
+    final view = doc.bufferViews[image.bufferView!];
+    final encoded = Uint8List.sublistView(
+      bufferData,
+      view.byteOffset,
+      view.byteOffset + view.byteLength,
+    );
+    final decoded = img.decodeImage(encoded);
+    if (decoded != null) {
+      final rgba = decoded.convert(numChannels: 4, format: img.Format.uint8);
+      final bytes = rgba.getBytes(order: img.ChannelOrder.rgba);
+      final payload = document.addPayload(
+        PayloadSpec(
+          document.newId(),
+          encoding: PayloadEncoding.image,
+          format: 'rgba8',
+          width: rgba.width,
+          height: rgba.height,
+          length: bytes.length,
+          bytes: bytes,
+        ),
+      );
+      return document
+          .addResource(TextureResource(document.newId(), payload: payload.id))
+          .id;
+    }
+  }
+  if (image.uri != null) {
+    // An external image; the realizer loads it as an asset.
+    // TODO(fscene): the realizer needs an async external-image-asset path.
+    return document
+        .addResource(
+          TextureResource(document.newId(), asset: AssetRef(image.uri!)),
+        )
+        .id;
+  }
+  return null;
+}
+
+double _at(List<double>? values, int index, double fallback) =>
+    (values != null && values.length > index) ? values[index] : fallback;
+
+// A 32-bit FNV-1a hash of [data], used to seed deterministic, content-derived
+// document and session ids so re-importing the same asset is reproducible.
+// Build-time only (native), so 64-bit int math is fine.
+int _seedFrom(Uint8List data) {
+  var hash = 0x811c9dc5;
+  for (final byte in data) {
+    hash = (hash ^ byte) & 0xffffffff;
+    hash = (hash * 0x01000193) & 0xffffffff;
+  }
+  return hash == 0 ? 1 : hash;
+}

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -198,7 +198,14 @@ abstract class Material {
     gpu.HostBuffer transientsBuffer,
     Lighting lighting,
   ) {
-    pass.setCullMode(doubleSided ? gpu.CullMode.none : gpu.CullMode.backFace);
+    // Double-sided is honored only for opaque materials. A translucent
+    // material is always back-face culled: drawing both sides would blend the
+    // overlapping front and back surfaces in triangle-index order rather than
+    // depth order (the translucent pass has no per-fragment sorting), which
+    // seams thick double-sided glass. Single-sided draws just the outer
+    // surface, matching the legacy `.model` path.
+    final cullBackFace = !doubleSided || !isOpaque();
+    pass.setCullMode(cullBackFace ? gpu.CullMode.backFace : gpu.CullMode.none);
     pass.setWindingOrder(gpu.WindingOrder.counterClockwise);
   }
 

--- a/packages/flutter_scene/test/fscene/compose_test.dart
+++ b/packages/flutter_scene/test/fscene/compose_test.dart
@@ -203,4 +203,56 @@ void main() {
     final composed = composeScene(host, resolve: _resolveTo(cyclic));
     expect(composed.nodes.values.where((n) => n.instance != null), isEmpty);
   });
+
+  test('composeSceneAsync loads referenced prefabs transitively, once '
+      'each', () async {
+    final inner = SceneDocument()..createNode(name: 'gear', root: true);
+    final outer = SceneDocument();
+    final machine = outer.createNode(name: 'machine', root: true);
+    final innerInstance = outer.createNode(name: 'innerInstance');
+    innerInstance.instance = PrefabInstanceSpec(
+      source: const AssetRef('inner'),
+    );
+    machine.children.add(innerInstance.id);
+
+    final host = SceneDocument();
+    host.createNode(name: 'top', root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('outer'),
+    );
+
+    final docs = {'inner': inner, 'outer': outer};
+    final loads = <String>[];
+    final composed = await composeSceneAsync(
+      host,
+      load: (ref) async {
+        loads.add(ref.key);
+        return docs[ref.key]!;
+      },
+    );
+
+    expect(composed.nodes.values.where((n) => n.instance != null), isEmpty);
+    expect(composed.rootNodes.single.name, 'top');
+    expect(loads, unorderedEquals(['outer', 'inner']));
+  });
+
+  test('composeSceneAsync loads a shared prefab source only once', () async {
+    final prefab = SceneDocument()..createNode(name: 'p', root: true);
+    final host = SceneDocument();
+    host.createNode(name: 'a', root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('p'),
+    );
+    host.createNode(name: 'b', root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('p'),
+    );
+
+    var loads = 0;
+    await composeSceneAsync(
+      host,
+      load: (_) async {
+        loads++;
+        return prefab;
+      },
+    );
+    expect(loads, 1);
+  });
 }

--- a/packages/flutter_scene/test/fscene/compose_test.dart
+++ b/packages/flutter_scene/test/fscene/compose_test.dart
@@ -1,0 +1,206 @@
+// Covers the prefab composer: expanding instance nodes against referenced
+// prefab documents, id remapping, override/add/remove deltas, nested prefabs,
+// and cycle handling. All GPU-free (document-to-document).
+
+import 'package:flutter_scene/src/fscene/compose/compose.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+// A single-root prefab: 'body' (mesh referencing a material) with a 'wheel'
+// child.
+SceneDocument _prefab() {
+  final doc = SceneDocument();
+  final material = doc.addResource(
+    MaterialResource(doc.newId(), type: 'physicallyBased'),
+  );
+  final body = doc.createNode(
+    name: 'body',
+    root: true,
+    components: [
+      ComponentSpec(
+        'mesh',
+        properties: {'material': ResourceRefValue(material.id)},
+      ),
+    ],
+  );
+  final wheel = doc.createNode(name: 'wheel');
+  body.children.add(wheel.id);
+  return doc;
+}
+
+PrefabResolver _resolveTo(SceneDocument prefab) =>
+    (_) => prefab;
+
+void main() {
+  test('returns a document without instances unchanged', () {
+    final doc = SceneDocument();
+    doc.createNode(name: 'plain', root: true);
+    expect(
+      composeScene(doc, resolve: (_) => throw StateError('no resolve')),
+      same(doc),
+    );
+  });
+
+  test('instantiates a single-root prefab, merging the root into the '
+      'instance', () {
+    final host = SceneDocument();
+    host.createNode(name: 'enemy0', root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('enemy.fscene'),
+    );
+
+    final composed = composeScene(host, resolve: _resolveTo(_prefab()));
+    final node = composed.rootNodes.single;
+
+    expect(node.name, 'enemy0');
+    expect(node.instance, isNull);
+    expect(node.components.map((c) => c.type), contains('mesh'));
+    expect(node.children, hasLength(1));
+    expect(composed.node(node.children.single)!.name, 'wheel');
+    // The prefab's material was copied into the composed document.
+    expect(
+      composed.resources.values.whereType<MaterialResource>(),
+      hasLength(1),
+    );
+    // The merged mesh references that copied material.
+    final mesh = node.components.firstWhere((c) => c.type == 'mesh');
+    final materialId = (mesh.properties['material'] as ResourceRefValue).id;
+    expect(composed.resource(materialId), isA<MaterialResource>());
+  });
+
+  test('two instances of one prefab get distinct node ids', () {
+    final host = SceneDocument();
+    host.createNode(name: 'a', root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('p'),
+    );
+    host.createNode(name: 'b', root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('p'),
+    );
+
+    final composed = composeScene(host, resolve: _resolveTo(_prefab()));
+    final wheels = composed.nodes.values
+        .where((n) => n.name == 'wheel')
+        .toList();
+    expect(wheels, hasLength(2));
+    expect(wheels[0].id, isNot(wheels[1].id));
+  });
+
+  test('applies transform, name, and component overrides', () {
+    final prefab = _prefab();
+    final bodyId = prefab.rootNodes.single.id;
+    final wheelId = prefab.rootNodes.single.children.single;
+
+    final host = SceneDocument();
+    final newMaterial = host.addResource(
+      MaterialResource(host.newId(), type: 'unlit'),
+    );
+    host.createNode(name: 'enemy', root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('p'),
+      overrides: [
+        PropertyOverride(
+          target: bodyId,
+          path: 'components.mesh.material',
+          value: ResourceRefValue(newMaterial.id),
+        ),
+        PropertyOverride(
+          target: wheelId,
+          path: 'transform.trs.t',
+          value: Vec3Value(Vector3(5, 0, 0)),
+        ),
+        PropertyOverride(
+          target: wheelId,
+          path: 'name',
+          value: const StringValue('renamed'),
+        ),
+      ],
+    );
+
+    final composed = composeScene(host, resolve: _resolveTo(prefab));
+    final node = composed.rootNodes.single;
+    final mesh = node.components.firstWhere((c) => c.type == 'mesh');
+    expect(
+      (mesh.properties['material'] as ResourceRefValue).id,
+      newMaterial.id,
+    );
+
+    final wheel = composed.node(node.children.single)!;
+    expect(wheel.name, 'renamed');
+    expect((wheel.transform as TrsTransform).translation, Vector3(5, 0, 0));
+  });
+
+  test('removes a prefab node', () {
+    final prefab = _prefab();
+    final wheelId = prefab.rootNodes.single.children.single;
+    final host = SceneDocument();
+    host.createNode(root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('p'),
+      removedNodes: [wheelId],
+    );
+
+    final composed = composeScene(host, resolve: _resolveTo(prefab));
+    expect(composed.nodes.values.where((n) => n.name == 'wheel'), isEmpty);
+    expect(composed.rootNodes.single.children, isEmpty);
+  });
+
+  test('adds nodes and components, and removes component types', () {
+    final host = SceneDocument();
+    final extra = NodeSpec(id: host.newId(), name: 'extra');
+    host.createNode(root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('p'),
+      addedNodes: [extra],
+      addedComponents: [ComponentSpec('camera')],
+      removedComponentTypes: ['mesh'],
+    );
+
+    final composed = composeScene(host, resolve: _resolveTo(_prefab()));
+    final node = composed.rootNodes.single;
+    expect(node.components.map((c) => c.type), contains('camera'));
+    expect(node.components.map((c) => c.type), isNot(contains('mesh')));
+    expect(node.children.map((c) => composed.node(c)!.name), contains('extra'));
+  });
+
+  test('composes nested prefabs', () {
+    final inner = SceneDocument();
+    inner.createNode(name: 'gear', root: true);
+
+    final outer = SceneDocument();
+    final machine = outer.createNode(name: 'machine', root: true);
+    final innerInstance = outer.createNode(name: 'innerInstance');
+    innerInstance.instance = PrefabInstanceSpec(
+      source: const AssetRef('inner'),
+    );
+    machine.children.add(innerInstance.id);
+
+    final host = SceneDocument();
+    host.createNode(name: 'top', root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('outer'),
+    );
+
+    final composed = composeScene(
+      host,
+      resolve: (ref) => ref.key == 'inner' ? inner : outer,
+    );
+    final top = composed.rootNodes.single;
+    expect(top.name, 'top');
+    expect(composed.node(top.children.single)!.name, 'innerInstance');
+    expect(composed.nodes.values.where((n) => n.instance != null), isEmpty);
+  });
+
+  test('breaks a cyclic prefab reference without recursing forever', () {
+    final cyclic = SceneDocument();
+    final root = cyclic.createNode(name: 'root', root: true);
+    final self = cyclic.createNode(name: 'self');
+    self.instance = PrefabInstanceSpec(source: const AssetRef('cyclic'));
+    root.children.add(self.id);
+
+    final host = SceneDocument();
+    host.createNode(root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('cyclic'),
+    );
+
+    final composed = composeScene(host, resolve: _resolveTo(cyclic));
+    expect(composed.nodes.values.where((n) => n.instance != null), isEmpty);
+  });
+}

--- a/packages/flutter_scene/test/fscene/diff_test.dart
+++ b/packages/flutter_scene/test/fscene/diff_test.dart
@@ -1,0 +1,97 @@
+// Covers the scene-structure diff: the node-id-keyed comparison of two
+// documents that scene hot reload patches from. GPU-free.
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/reload/diff.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+const _a = LocalId(1, 1);
+const _b = LocalId(1, 2);
+const _c = LocalId(1, 3);
+const _mat1 = LocalId(9, 1);
+const _mat2 = LocalId(9, 2);
+
+ComponentSpec _mesh(LocalId material) =>
+    ComponentSpec('mesh', properties: {'material': ResourceRefValue(material)});
+
+// Base scene: a (root) -> b, where b has a mesh referencing mat1.
+SceneDocument _base() {
+  final doc = SceneDocument();
+  doc.addResource(MaterialResource(_mat1, type: 'physicallyBased'));
+  doc.addNode(NodeSpec(id: _a, name: 'a', children: [_b]), root: true);
+  doc.addNode(NodeSpec(id: _b, name: 'b', components: [_mesh(_mat1)]));
+  return doc;
+}
+
+NodeChange _change(SceneDiff diff, LocalId id) =>
+    diff.changed.firstWhere((c) => c.id == id);
+
+void main() {
+  test('identical documents diff to nothing', () {
+    expect(diffScene(_base(), _base()).isEmpty, isTrue);
+  });
+
+  test('detects an added node', () {
+    final next = _base();
+    next.node(_a)!.children.add(_c);
+    next.addNode(NodeSpec(id: _c, name: 'c'));
+
+    final diff = diffScene(_base(), next);
+    expect(diff.added, [_c]);
+    expect(diff.removed, isEmpty);
+  });
+
+  test('detects a removed node', () {
+    final next = _base();
+    next.nodes.remove(_b);
+    next.node(_a)!.children.remove(_b);
+
+    final diff = diffScene(_base(), next);
+    expect(diff.removed, [_b]);
+    expect(diff.added, isEmpty);
+  });
+
+  test('detects a transform change', () {
+    final next = _base();
+    next.node(_a)!.transform = TrsTransform(translation: Vector3(1, 2, 3));
+
+    final diff = diffScene(_base(), next);
+    expect(_change(diff, _a).transform, isTrue);
+    expect(_change(diff, _a).components, isFalse);
+  });
+
+  test('detects name and layer changes', () {
+    final next = _base();
+    next.node(_b)!
+      ..name = 'renamed'
+      ..layers = 4;
+
+    final change = _change(diffScene(_base(), next), _b);
+    expect(change.name, isTrue);
+    expect(change.layers, isTrue);
+  });
+
+  test('detects a component property change', () {
+    final next = _base();
+    next.node(_b)!.components
+      ..clear()
+      ..add(_mesh(_mat2));
+
+    final change = _change(diffScene(_base(), next), _b);
+    expect(change.components, isTrue);
+    expect(change.transform, isFalse);
+  });
+
+  test('detects a reparent', () {
+    final next = _base();
+    next.node(_a)!.children.remove(_b);
+    next.roots.add(_b);
+
+    final change = _change(diffScene(_base(), next), _b);
+    expect(change.reparented, isTrue);
+  });
+}

--- a/packages/flutter_scene/test/fscene/document_model_test.dart
+++ b/packages/flutter_scene/test/fscene/document_model_test.dart
@@ -179,7 +179,7 @@ void main() {
         PayloadSpec(doc.newId(), encoding: PayloadEncoding.vertexBuffer),
       );
       final GeometryResource geo = doc.addResource(
-        GeometryResource(doc.newId(), payload: payload.id),
+        GeometryResource(doc.newId(), vertices: payload.id),
       );
       expect(doc.resource(geo.id), same(geo));
       expect(doc.payload(payload.id), same(payload));
@@ -193,7 +193,7 @@ void main() {
       );
       doc.createNode();
       doc.addResource(
-        GeometryResource(const LocalId(22, 5), payload: const LocalId(22, 6)),
+        GeometryResource(const LocalId(22, 5), vertices: const LocalId(22, 6)),
       );
       expect(doc.usedSessions(), containsAll(<int>{11, 22}));
     });

--- a/packages/flutter_scene/test/fscene/document_model_test.dart
+++ b/packages/flutter_scene/test/fscene/document_model_test.dart
@@ -1,0 +1,209 @@
+// Covers the pure-Dart .fscene document model: identity (ids + allocator),
+// the spec types, and the SceneDocument container. No GPU is required.
+
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  group('base32', () {
+    test('encodes most-significant-bit first, unpadded', () {
+      expect(encodeBase32(Uint8List.fromList([0x00])), '00');
+      expect(encodeBase32(Uint8List.fromList([0xFF])), 'ZW');
+      expect(encodeBase32(Uint8List(8)), '0000000000000');
+    });
+  });
+
+  group('DocumentId', () {
+    test('is 16 bytes with a 26-character token', () {
+      final id = DocumentId.generate(Random(1));
+      expect(id.bytes, hasLength(16));
+      expect(id.toToken().length, 26);
+    });
+
+    test('is deterministic for a seeded random and stamps UUIDv4 bits', () {
+      final a = DocumentId.generate(Random(7));
+      final b = DocumentId.generate(Random(7));
+      expect(a, b);
+      expect(a.toToken(), b.toToken());
+      // Version 4 in the high nibble of byte 6, variant 1 in byte 8.
+      expect(a.bytes[6] & 0xF0, 0x40);
+      expect(a.bytes[8] & 0xC0, 0x80);
+    });
+
+    test('distinct draws differ', () {
+      final a = DocumentId.generate(Random(1));
+      final b = DocumentId.generate(Random(2));
+      expect(a, isNot(b));
+    });
+  });
+
+  group('LocalId', () {
+    test('equality and hashing are by (session, index)', () {
+      expect(const LocalId(3, 9), const LocalId(3, 9));
+      expect(const LocalId(3, 9).hashCode, const LocalId(3, 9).hashCode);
+      expect(const LocalId(3, 9), isNot(const LocalId(3, 8)));
+      expect(const LocalId(3, 9), isNot(const LocalId(4, 9)));
+      final deduped = <LocalId>{}
+        ..add(const LocalId(1, 1))
+        ..add(const LocalId(1, 1));
+      expect(deduped, hasLength(1));
+    });
+
+    test('token is 13 base32 characters of the 8 id bytes', () {
+      expect(const LocalId(0, 0).toToken(), '0000000000000');
+      expect(const LocalId(1, 2).toToken().length, 13);
+    });
+  });
+
+  group('IdAllocator', () {
+    test('mints monotonic, never-reused ids in one session', () {
+      final alloc = IdAllocator(session: 42);
+      expect(alloc.session, 42);
+      expect(alloc.mint(), const LocalId(42, 0));
+      expect(alloc.mint(), const LocalId(42, 1));
+      expect(alloc.mint(), const LocalId(42, 2));
+    });
+
+    test('different sessions mint disjoint id sets (merge-safe)', () {
+      final a = IdAllocator(session: 1);
+      final b = IdAllocator(session: 2);
+      final idsA = {for (var i = 0; i < 100; i++) a.mint()};
+      final idsB = {for (var i = 0; i < 100; i++) b.mint()};
+      expect(idsA, hasLength(100));
+      expect(idsA.intersection(idsB), isEmpty);
+    });
+
+    test('excludedSessions forces a fresh salt', () {
+      // Find the salt the seed would draw first.
+      final probe = IdAllocator(random: Random(5));
+      final firstSalt = probe.session;
+      // The same seed, but with that salt excluded, must redraw.
+      final avoided = IdAllocator(
+        random: Random(5),
+        excludedSessions: {firstSalt},
+      );
+      expect(avoided.session, isNot(firstSalt));
+    });
+  });
+
+  group('TransformSpec', () {
+    test('an identity TRS composes to the identity matrix', () {
+      expect(TrsTransform().toMatrix4(), Matrix4.identity());
+    });
+
+    test('a translation-only TRS composes to a translation matrix', () {
+      final m = TrsTransform(translation: Vector3(1, 2, 3)).toMatrix4();
+      expect(m.getTranslation(), Vector3(1, 2, 3));
+    });
+
+    test('MatrixTransform returns a copy, not the stored matrix', () {
+      final stored = Matrix4.identity();
+      final spec = MatrixTransform(stored);
+      final out = spec.toMatrix4();
+      out.setEntry(0, 3, 9.0);
+      expect(stored.entry(0, 3), 0.0, reason: 'toMatrix4 must not alias');
+    });
+  });
+
+  group('specs', () {
+    test('a plain node has no prefab instance and empty lists', () {
+      final node = NodeSpec(id: const LocalId(1, 0));
+      expect(node.instance, isNull);
+      expect(node.children, isEmpty);
+      expect(node.components, isEmpty);
+      expect(node.layers, 1);
+    });
+
+    test('a prefab instance carries its source and empty deltas', () {
+      final instance = PrefabInstanceSpec(
+        source: const AssetRef('enemy.fscene'),
+      );
+      expect(instance.source.key, 'enemy.fscene');
+      expect(instance.load, LoadPolicy.eager);
+      expect(instance.overrides, isEmpty);
+      expect(instance.removedNodes, isEmpty);
+    });
+
+    test('a texture has exactly one source', () {
+      expect(
+        () => TextureResource(const LocalId(1, 0)),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => TextureResource(
+          const LocalId(1, 0),
+          payload: const LocalId(2, 0),
+          asset: const AssetRef('x.png'),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        TextureResource(
+          const LocalId(1, 0),
+          payload: const LocalId(2, 0),
+        ).asset,
+        isNull,
+      );
+    });
+  });
+
+  group('SceneDocument', () {
+    test('mints document-unique ids', () {
+      final doc = SceneDocument();
+      final ids = {for (var i = 0; i < 1000; i++) doc.newId()};
+      expect(ids, hasLength(1000));
+    });
+
+    test('createNode registers the node and tracks roots', () {
+      final doc = SceneDocument();
+      final root = doc.createNode(name: 'root', root: true);
+      final child = doc.createNode(name: 'child');
+      root.children.add(child.id);
+
+      expect(doc.node(root.id), same(root));
+      expect(doc.node(child.id), same(child));
+      expect(doc.roots, [root.id]);
+      expect(doc.rootNodes, [root]);
+    });
+
+    test('addResource preserves the concrete type and is looked up by id', () {
+      final doc = SceneDocument();
+      final payload = doc.addPayload(
+        PayloadSpec(doc.newId(), encoding: PayloadEncoding.vertexBuffer),
+      );
+      final GeometryResource geo = doc.addResource(
+        GeometryResource(doc.newId(), payload: payload.id),
+      );
+      expect(doc.resource(geo.id), same(geo));
+      expect(doc.payload(payload.id), same(payload));
+    });
+
+    test('usedSessions collects every id pool session salt', () {
+      final docId = DocumentId.generate(Random(3));
+      final doc = SceneDocument(
+        documentId: docId,
+        allocator: IdAllocator(session: 11),
+      );
+      doc.createNode();
+      doc.addResource(
+        GeometryResource(const LocalId(22, 5), payload: const LocalId(22, 6)),
+      );
+      expect(doc.usedSessions(), containsAll(<int>{11, 22}));
+    });
+
+    test('a fresh document has a studio environment and v1 format', () {
+      final doc = SceneDocument();
+      expect(doc.formatVersion, 1);
+      expect(doc.stage.environment, isA<StudioEnvironment>());
+      expect(doc.stage.upAxis, UpAxis.y);
+      expect(doc.stage.toneMapping, 'pbrNeutral');
+    });
+  });
+}

--- a/packages/flutter_scene/test/fscene/fsceneb_test.dart
+++ b/packages/flutter_scene/test/fscene/fsceneb_test.dart
@@ -1,0 +1,103 @@
+// Covers the .fsceneb binary container: round-tripping a document plus its
+// embedded payload chunks, deterministic output, chunk alignment, and the
+// malformed-input guards. All GPU-free (no realization).
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Uint8List _ramp(int length) =>
+    Uint8List.fromList(List.generate(length, (i) => i & 0xFF));
+
+// A document with a couple of nodes and payload chunks of deliberately
+// awkward (non-8-multiple) lengths to exercise chunk padding.
+SceneDocument _sample() {
+  final doc = SceneDocument();
+  doc.generator = 'fsceneb_test';
+  doc.createNode(name: 'world', root: true);
+  doc.addPayload(
+    PayloadSpec(
+      doc.newId(),
+      encoding: PayloadEncoding.vertexBuffer,
+      layout: 'unskinned',
+      bytes: _ramp(48),
+    ),
+  );
+  doc.addPayload(
+    PayloadSpec(
+      doc.newId(),
+      encoding: PayloadEncoding.indexBuffer,
+      bytes: _ramp(5), // not a multiple of the alignment
+    ),
+  );
+  doc.addPayload(
+    PayloadSpec(doc.newId(), encoding: PayloadEncoding.bytes, bytes: _ramp(13)),
+  );
+  return doc;
+}
+
+void main() {
+  group('writeFsceneb / readFsceneb', () {
+    test('round-trips the document and every payload byte', () {
+      final doc = _sample();
+      final restored = readFsceneb(writeFsceneb(doc));
+
+      expect(restored.documentId, doc.documentId);
+      expect(restored.generator, 'fsceneb_test');
+      expect(restored.rootNodes.single.name, 'world');
+
+      expect(restored.payloads.length, doc.payloads.length);
+      for (final entry in doc.payloads.entries) {
+        final restoredPayload = restored.payload(entry.key);
+        expect(restoredPayload, isNotNull);
+        expect(restoredPayload!.encoding, entry.value.encoding);
+        expect(restoredPayload.layout, entry.value.layout);
+        expect(restoredPayload.bytes, equals(entry.value.bytes));
+      }
+    });
+
+    test('a document with no payloads round-trips', () {
+      final doc = SceneDocument();
+      doc.createNode(name: 'solo', root: true);
+      final restored = readFsceneb(writeFsceneb(doc));
+      expect(restored.payloads, isEmpty);
+      expect(restored.rootNodes.single.name, 'solo');
+    });
+
+    test('output is deterministic for a given document', () {
+      final doc = _sample();
+      expect(writeFsceneb(doc), equals(writeFsceneb(doc)));
+    });
+
+    test('header is well-formed and the container is 8-byte aligned', () {
+      final bytes = writeFsceneb(_sample());
+      expect(String.fromCharCodes(bytes.sublist(0, 4)), 'FSCB');
+      final view = ByteData.sublistView(bytes);
+      expect(view.getUint32(4, Endian.little), kFscenebVersion);
+      expect(view.getUint32(8, Endian.little), bytes.length);
+      expect(bytes.length % 8, 0);
+    });
+  });
+
+  group('malformed input', () {
+    test('a bad magic is rejected', () {
+      final bytes = writeFsceneb(_sample());
+      bytes[0] = 0;
+      expect(() => readFsceneb(bytes), throwsA(isA<FscenebFormatException>()));
+    });
+
+    test('a truncated header is rejected', () {
+      expect(
+        () => readFsceneb(Uint8List(4)),
+        throwsA(isA<FscenebFormatException>()),
+      );
+    });
+
+    test('writing a payload with no bytes is rejected', () {
+      final doc = SceneDocument();
+      doc.addPayload(PayloadSpec(doc.newId(), encoding: PayloadEncoding.bytes));
+      expect(() => writeFsceneb(doc), throwsA(isA<FscenebFormatException>()));
+    });
+  });
+}

--- a/packages/flutter_scene/test/fscene/importer_test.dart
+++ b/packages/flutter_scene/test/fscene/importer_test.dart
@@ -87,6 +87,33 @@ void main() {
       });
     }
 
+    test('emits skins and animations for a skinned, animated model', () {
+      final path = _resolve('examples/assets_src/dash.glb');
+      if (!File(path).existsSync()) {
+        // ignore: avoid_print
+        print('Test data missing ($path) - skipping.');
+        return;
+      }
+      final document = importGlbToSceneDocument(File(path).readAsBytesSync());
+      expect(document.skins, isNotEmpty);
+      expect(document.animations, isNotEmpty);
+
+      // Every skin references an inverse-bind-matrices payload with bytes.
+      for (final skin in document.skins.values) {
+        expect(skin.joints, isNotEmpty);
+        final payload = document.payload(skin.inverseBindMatrices);
+        expect(payload?.encoding, PayloadEncoding.matrices);
+        expect(payload?.bytes, isNotNull);
+      }
+      // Every channel references timeline + keyframe payloads with bytes.
+      final channels = document.animations.values.expand((a) => a.channels);
+      expect(channels, isNotEmpty);
+      for (final channel in channels) {
+        expect(document.payload(channel.timeline)?.bytes, isNotNull);
+        expect(document.payload(channel.keyframes)?.bytes, isNotNull);
+      }
+    });
+
     test('declares right-handed glTF coordinates and a generator', () {
       final path = _resolve('examples/assets_src/fcar.glb');
       if (!File(path).existsSync()) {

--- a/packages/flutter_scene/test/fscene/importer_test.dart
+++ b/packages/flutter_scene/test/fscene/importer_test.dart
@@ -1,0 +1,128 @@
+// Covers the glTF -> .fscene importer. The load-bearing check is byte parity:
+// a primitive's packed vertex/index payload must equal packGltfPrimitive's
+// output, which is exactly what the .model emitter stores. This is the
+// project's proven import-verification method (compare bytes against the
+// known-good packer rather than eyeballing renders).
+//
+// Runs only when the source GLB corpus is present (CI without it skips).
+
+import 'dart:io';
+
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/importer/gltf.dart';
+import 'package:flutter_scene/src/importer/in_memory_import.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Every committed corpus GLB; each is checked when present.
+const _corpus = [
+  'fcar.glb',
+  'dash.glb',
+  'two_triangles.glb',
+  'flutter_logo_baked.glb',
+];
+
+void main() {
+  group('buildSceneDocument', () {
+    for (final name in _corpus) {
+      test('packs $name geometry byte-for-byte like the shared packer', () {
+        final path = _resolve('examples/assets_src/$name');
+        final file = File(path);
+        if (!file.existsSync()) {
+          // ignore: avoid_print
+          print('Test data missing ($path) - skipping.');
+          return;
+        }
+        final bytes = file.readAsBytesSync();
+        final container = parseGlb(bytes);
+        final doc = parseGltfJson(container.json);
+        final document = importGlbToSceneDocument(bytes);
+
+        // Expected packed primitives, in the same mesh/primitive walk order
+        // the emitter uses.
+        final expected = <PackedPrimitive>[];
+        for (final mesh in doc.meshes) {
+          for (final primitive in mesh.primitives) {
+            if (primitive.mode != 4) continue;
+            expected.add(
+              packGltfPrimitive(
+                primitive: primitive,
+                accessors: doc.accessors,
+                bufferViews: doc.bufferViews,
+                bufferData: container.binaryChunk,
+              ),
+            );
+          }
+        }
+
+        final geometries = document.resources.values
+            .whereType<GeometryResource>()
+            .toList();
+        expect(geometries, hasLength(expected.length));
+        expect(expected, isNotEmpty);
+
+        for (var i = 0; i < expected.length; i++) {
+          final packed = expected[i];
+          final geometry = geometries[i];
+          final vertexPayload = document.payload(geometry.vertices!)!;
+          final indexPayload = document.payload(geometry.indices!)!;
+          expect(
+            vertexPayload.bytes,
+            equals(packed.vertexBytes),
+            reason: '$name geometry $i vertex bytes',
+          );
+          expect(
+            indexPayload.bytes,
+            equals(packed.indexBytes),
+            reason: '$name geometry $i index bytes',
+          );
+          expect(
+            vertexPayload.layout,
+            packed.isSkinned ? 'skinned' : 'unskinned',
+          );
+          expect(
+            indexPayload.format,
+            packed.indices32Bit ? 'uint32' : 'uint16',
+          );
+        }
+      });
+    }
+
+    test('declares right-handed glTF coordinates and a generator', () {
+      final path = _resolve('examples/assets_src/fcar.glb');
+      if (!File(path).existsSync()) {
+        // ignore: avoid_print
+        print('Test data missing ($path) - skipping.');
+        return;
+      }
+      final document = importGlbToSceneDocument(File(path).readAsBytesSync());
+      expect(document.stage.handedness, Handedness.right);
+      expect(document.stage.upAxis, UpAxis.y);
+      expect(document.generator, isNotNull);
+      expect(document.roots, isNotEmpty);
+    });
+
+    test('is deterministic: re-importing yields identical container bytes', () {
+      final path = _resolve('examples/assets_src/fcar.glb');
+      if (!File(path).existsSync()) {
+        // ignore: avoid_print
+        print('Test data missing ($path) - skipping.');
+        return;
+      }
+      final bytes = File(path).readAsBytesSync();
+      expect(
+        importGlbToFscenebBytes(bytes),
+        equals(importGlbToFscenebBytes(bytes)),
+      );
+    });
+  });
+}
+
+String _resolve(String relative) {
+  for (final prefix in ['', '../../']) {
+    final candidate = '$prefix$relative';
+    if (File(candidate).existsSync() || Directory(candidate).existsSync()) {
+      return candidate;
+    }
+  }
+  return relative;
+}

--- a/packages/flutter_scene/test/fscene/json_test.dart
+++ b/packages/flutter_scene/test/fscene/json_test.dart
@@ -226,4 +226,43 @@ void main() {
       );
     });
   });
+
+  group('procedural geometry', () {
+    test('cuboid/plane/sphere resources round-trip through JSON', () {
+      final doc = SceneDocument(
+        documentId: DocumentId.generate(Random(1)),
+        allocator: IdAllocator(session: 2),
+      );
+      doc.createNode(name: 'root', root: true);
+      final cuboid = doc.addResource(
+        GeometryResource(
+          doc.newId(),
+          procedural: CuboidGeometrySpec(
+            extents: Vector3(2, 1, 0.5),
+            debugColors: true,
+          ),
+        ),
+      );
+      doc.addResource(
+        GeometryResource(
+          doc.newId(),
+          procedural: PlaneGeometrySpec(width: 4, depth: 4, segmentsZ: 3),
+        ),
+      );
+      doc.addResource(
+        GeometryResource(
+          doc.newId(),
+          procedural: SphereGeometrySpec(radius: 0.7, segments: 12, rings: 6),
+        ),
+      );
+
+      final back = readFscene(writeFscene(doc));
+      expect(back.resources, hasLength(3));
+      final shape =
+          (back.resource(cuboid.id) as GeometryResource).procedural
+              as CuboidGeometrySpec;
+      expect(shape.extents, Vector3(2, 1, 0.5));
+      expect(shape.debugColors, isTrue);
+    });
+  });
 }

--- a/packages/flutter_scene/test/fscene/json_test.dart
+++ b/packages/flutter_scene/test/fscene/json_test.dart
@@ -287,5 +287,45 @@ void main() {
       expect(shape.extents, Vector3(2, 1, 0.5));
       expect(shape.debugColors, isTrue);
     });
+
+    test('fmat materials and external/encoded textures round-trip', () {
+      final doc = SceneDocument();
+      final assetTexture = doc.addResource(
+        TextureResource(doc.newId(), asset: const AssetRef('assets/x.png')),
+      );
+      final pngPayload = doc.addPayload(
+        PayloadSpec(
+          doc.newId(),
+          encoding: PayloadEncoding.image,
+          format: 'png',
+          length: 4,
+        ),
+      );
+      final encodedTexture = doc.addResource(
+        TextureResource(doc.newId(), payload: pngPayload.id),
+      );
+      final fmat = doc.addResource(
+        MaterialResource(
+          doc.newId(),
+          type: 'fmat',
+          asset: const AssetRef('materials/toon.fmat'),
+          properties: {'baseColorTexture': ResourceRefValue(assetTexture.id)},
+        ),
+      );
+
+      final back = readFscene(writeFscene(doc));
+      expect(
+        (back.resource(assetTexture.id) as TextureResource).asset?.key,
+        'assets/x.png',
+      );
+      expect(
+        (back.resource(encodedTexture.id) as TextureResource).payload,
+        pngPayload.id,
+      );
+      expect(back.payload(pngPayload.id)?.format, 'png');
+      final material = back.resource(fmat.id) as MaterialResource;
+      expect(material.type, 'fmat');
+      expect(material.asset?.key, 'materials/toon.fmat');
+    });
   });
 }

--- a/packages/flutter_scene/test/fscene/json_test.dart
+++ b/packages/flutter_scene/test/fscene/json_test.dart
@@ -35,10 +35,19 @@ SceneDocument _sampleDocument() {
       length: 480,
     ),
   );
+  final indexPayload = doc.addPayload(
+    PayloadSpec(
+      doc.newId(),
+      encoding: PayloadEncoding.indexBuffer,
+      format: 'uint16',
+      length: 36,
+    ),
+  );
   final geo = doc.addResource(
     GeometryResource(
       doc.newId(),
-      payload: payload.id,
+      vertices: payload.id,
+      indices: indexPayload.id,
       bounds: BoundsSpec(min: Vector3(-1, -1, -1), max: Vector3(1, 1, 1)),
     ),
   );

--- a/packages/flutter_scene/test/fscene/json_test.dart
+++ b/packages/flutter_scene/test/fscene/json_test.dart
@@ -1,0 +1,229 @@
+// Covers the .fscene JSON encoding: canonical write, tolerant (JSONC) read,
+// round-trip fidelity, the version/migration framework, and feature gating.
+
+import 'dart:math';
+
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/json/canonical.dart';
+import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
+import 'package:flutter_scene/src/fscene/json/jsonc.dart';
+import 'package:flutter_scene/src/fscene/json/property_json.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+// Builds a small but representative document deterministically.
+SceneDocument _sampleDocument() {
+  final doc = SceneDocument(
+    documentId: DocumentId.generate(Random(99)),
+    allocator: IdAllocator(session: 7),
+  );
+  doc.generator = 'test';
+  doc.featuresRequired.add('skinning');
+  doc.stage
+    ..exposure = 2.5
+    ..toneMapping = 'pbrNeutral'
+    ..environment = const AssetEnvironment(AssetRef('assets/env.png'));
+
+  final payload = doc.addPayload(
+    PayloadSpec(
+      doc.newId(),
+      encoding: PayloadEncoding.vertexBuffer,
+      layout: 'unskinned',
+      length: 480,
+    ),
+  );
+  final geo = doc.addResource(
+    GeometryResource(
+      doc.newId(),
+      payload: payload.id,
+      bounds: BoundsSpec(min: Vector3(-1, -1, -1), max: Vector3(1, 1, 1)),
+    ),
+  );
+  final mat = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'physicallyBased',
+      properties: {
+        'baseColor': const ColorValue(1, 0.5, 0.25, 1),
+        'metallic': const DoubleValue(0.0),
+      },
+    ),
+  );
+
+  final root = doc.createNode(name: 'root', root: true);
+  root.transform = TrsTransform(translation: Vector3(0, 1, 0));
+  final car = doc.createNode(
+    name: 'Car',
+    components: [
+      ComponentSpec(
+        'mesh',
+        properties: {
+          'geometry': ResourceRefValue(geo.id),
+          'material': ResourceRefValue(mat.id),
+        },
+      ),
+    ],
+    layers: 3,
+  );
+  root.children.add(car.id);
+  return doc;
+}
+
+// Compares two documents structurally enough to catch round-trip loss.
+void _expectSameStructure(SceneDocument a, SceneDocument b) {
+  expect(b.documentId, a.documentId);
+  expect(b.formatVersion, a.formatVersion);
+  expect(b.generator, a.generator);
+  expect(b.featuresRequired, a.featuresRequired);
+  expect(b.stage.exposure, a.stage.exposure);
+  expect(b.stage.environment, isA<AssetEnvironment>());
+  expect(b.nodes.keys.toSet(), a.nodes.keys.toSet());
+  expect(b.roots, a.roots);
+  expect(b.resources.keys.toSet(), a.resources.keys.toSet());
+  expect(b.payloads.keys.toSet(), a.payloads.keys.toSet());
+
+  for (final id in a.nodes.keys) {
+    final an = a.nodes[id]!;
+    final bn = b.nodes[id]!;
+    expect(bn.name, an.name);
+    expect(bn.layers, an.layers);
+    expect(bn.children, an.children);
+    expect(bn.components.length, an.components.length);
+    expect(bn.transform.toMatrix4(), an.transform.toMatrix4());
+  }
+}
+
+void main() {
+  group('canonicalJson', () {
+    test('inlines number arrays and rejects non-finite numbers', () {
+      final out = canonicalJson({
+        'v': [1.0, 2.0, 3.0],
+        'n': 5,
+      });
+      expect(out, contains('[1.0, 2.0, 3.0]'));
+      expect(out.endsWith('\n'), isTrue);
+      expect(
+        () => canonicalJson(double.nan),
+        throwsA(isA<FsceneEncodeException>()),
+      );
+      expect(
+        () => canonicalJson(double.infinity),
+        throwsA(isA<FsceneEncodeException>()),
+      );
+    });
+
+    test('normalizes negative zero', () {
+      expect(canonicalJson(-0.0).trim(), '0.0');
+    });
+  });
+
+  group('stripJsonc', () {
+    test('removes comments and trailing commas, keeping string contents', () {
+      const src = '''
+{
+  // a line comment
+  "a": 1, /* block */
+  "b": "http://x/y, // not a comment",
+  "c": [1, 2,],
+}
+''';
+      final stripped = stripJsonc(src);
+      expect(stripped, isNot(contains('line comment')));
+      expect(stripped, isNot(contains('block')));
+      expect(stripped, contains('http://x/y, // not a comment'));
+      expect(stripped.replaceAll(RegExp(r'\s'), ''), isNot(contains(',}')));
+      expect(stripped.replaceAll(RegExp(r'\s'), ''), isNot(contains(',]')));
+    });
+  });
+
+  group('property values', () {
+    test('every variant round-trips through JSON', () {
+      String token(LocalId id) => 'r:${id.toToken()}';
+      final values = <PropertyValue>[
+        const BoolValue(true),
+        const IntValue(-7),
+        const DoubleValue(1.5),
+        const StringValue('hi'),
+        Vec3Value(Vector3(1, 2, 3)),
+        QuaternionValue(Quaternion(0, 0, 0, 1)),
+        Matrix4Value(Matrix4.identity()),
+        const ColorValue(1, 0, 0, 1),
+        const ResourceRefValue(LocalId(5, 9)),
+        const NodeRefValue(LocalId(5, 10)),
+        ListValue([const IntValue(1), const StringValue('x')]),
+        MapValue({'k': const BoolValue(false)}),
+      ];
+      for (final v in values) {
+        final decoded = decodePropertyValue(encodePropertyValue(v, token));
+        expect(decoded.runtimeType, v.runtimeType);
+      }
+      // Spot-check a reference's id survives the prefix round-trip.
+      final ref = decodePropertyValue(
+        encodePropertyValue(const ResourceRefValue(LocalId(5, 9)), token),
+      );
+      expect((ref as ResourceRefValue).id, const LocalId(5, 9));
+    });
+  });
+
+  group('document round-trip', () {
+    test('write then read reproduces the document', () {
+      final doc = _sampleDocument();
+      final text = writeFscene(doc);
+      final back = readFscene(text);
+      _expectSameStructure(doc, back);
+    });
+
+    test('canonical write is stable across two passes', () {
+      final doc = _sampleDocument();
+      final first = writeFscene(doc);
+      final second = writeFscene(readFscene(first));
+      expect(second, first);
+    });
+
+    test('reads through a JSONC superset', () {
+      final text = writeFscene(_sampleDocument());
+      final loose =
+          '// header comment\n${text.replaceFirst('{', '{\n  /* note */')}';
+      expect(() => readFscene(loose), returnsNormally);
+    });
+
+    test('ignores unknown fields', () {
+      final text = writeFscene(_sampleDocument());
+      final withExtra = text.replaceFirst('{', '{\n  "futureField": 123,');
+      expect(() => readFscene(withExtra), returnsNormally);
+    });
+  });
+
+  group('versioning', () {
+    test('refuses a newer-than-supported version', () {
+      final text = writeFscene(
+        _sampleDocument(),
+      ).replaceFirst('"fscene": 1', '"fscene": 999');
+      expect(() => readFscene(text), throwsA(isA<FsceneVersionException>()));
+    });
+
+    test('runs the migration chain to the current version', () {
+      // A version-0 document plus a single v0 -> v1 migration step.
+      final v1Text = writeFscene(_sampleDocument());
+      final v0Text = v1Text.replaceFirst('"fscene": 1', '"fscene": 0');
+      // Without a migration, version 0 cannot load.
+      expect(() => readFscene(v0Text), throwsA(isA<FsceneVersionException>()));
+      // With one, it migrates and loads.
+      final migrated = readFscene(v0Text, migrations: [(json) => json]);
+      expect(migrated.formatVersion, currentFsceneVersion);
+    });
+
+    test('refuses an unsupported required feature', () {
+      final doc = _sampleDocument();
+      doc.featuresRequired.add('timeTravel');
+      final text = writeFscene(doc);
+      expect(
+        () => readFscene(text),
+        throwsA(isA<FsceneUnsupportedFeatureException>()),
+      );
+    });
+  });
+}

--- a/packages/flutter_scene/test/fscene/json_test.dart
+++ b/packages/flutter_scene/test/fscene/json_test.dart
@@ -51,6 +51,19 @@ SceneDocument _sampleDocument() {
       bounds: BoundsSpec(min: Vector3(-1, -1, -1), max: Vector3(1, 1, 1)),
     ),
   );
+  final imagePayload = doc.addPayload(
+    PayloadSpec(
+      doc.newId(),
+      encoding: PayloadEncoding.image,
+      format: 'rgba8',
+      width: 2,
+      height: 2,
+      length: 16,
+    ),
+  );
+  final albedo = doc.addResource(
+    TextureResource(doc.newId(), payload: imagePayload.id),
+  );
   final mat = doc.addResource(
     MaterialResource(
       doc.newId(),
@@ -58,6 +71,7 @@ SceneDocument _sampleDocument() {
       properties: {
         'baseColor': const ColorValue(1, 0.5, 0.25, 1),
         'metallic': const DoubleValue(0.0),
+        'baseColorTexture': ResourceRefValue(albedo.id),
       },
     ),
   );

--- a/packages/flutter_scene/test/fscene/realize_test.dart
+++ b/packages/flutter_scene/test/fscene/realize_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/fscene/property_value.dart';
 import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/realize/property_read.dart';
 import 'package:flutter_scene/src/fscene/realize/realize.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';

--- a/packages/flutter_scene/test/fscene/realize_test.dart
+++ b/packages/flutter_scene/test/fscene/realize_test.dart
@@ -1,0 +1,169 @@
+// Covers .fscene realization: building a live Node graph from a document and
+// serializing one back. These exercise the GPU-free parts (node graph,
+// transforms, layers, light/camera components, handedness, and the component
+// codec registry); mesh/resource realization is a separate, GPU-bound step.
+
+import 'package:flutter_scene/src/components/camera_component.dart';
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/components/directional_light_component.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/realize/realize.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// A tagged component plus its codec, for the registry-extensibility test.
+class _TagComponent extends Component {
+  _TagComponent(this.tag);
+  final String tag;
+}
+
+class _TagCodec extends ComponentCodec {
+  @override
+  String get type => 'tag';
+
+  @override
+  Component realize(ComponentSpec spec, RealizeContext context) =>
+      _TagComponent(readString(spec.properties, 'tag', ''));
+
+  @override
+  ComponentSpec? serialize(Component component, SerializeContext context) =>
+      component is _TagComponent
+      ? ComponentSpec('tag', properties: {'tag': StringValue(component.tag)})
+      : null;
+}
+
+// Builds: world (root) -> { sun (directionalLight), eye (camera), pivot }.
+SceneDocument _sampleScene({Handedness handedness = Handedness.right}) {
+  final doc = SceneDocument();
+  doc.stage.handedness = handedness;
+
+  final world = doc.createNode(name: 'world', root: true);
+  final sun = doc.createNode(
+    name: 'sun',
+    components: [
+      ComponentSpec(
+        'directionalLight',
+        properties: {
+          'intensity': const DoubleValue(5.0),
+          'castsShadow': const BoolValue(true),
+        },
+      ),
+    ],
+  );
+  final eye = doc.createNode(
+    name: 'eye',
+    components: [
+      ComponentSpec(
+        'camera',
+        properties: {'fovRadiansY': const DoubleValue(1.2)},
+      ),
+    ],
+  );
+  final pivot = doc.createNode(name: 'pivot', layers: 4);
+  world.children.addAll([sun.id, eye.id, pivot.id]);
+  return doc;
+}
+
+void main() {
+  group('realizeScene', () {
+    test('builds the node graph with components and layers', () {
+      final root = realizeScene(_sampleScene());
+      expect(root.name, 'root');
+      expect(root.excludeFromWindingParity, isTrue);
+      expect(root.children, hasLength(1));
+
+      final world = root.children.single;
+      expect(world.name, 'world');
+      expect(world.children, hasLength(3));
+
+      final sun = world.getChildByName('sun')!;
+      final light = sun.getComponent<DirectionalLightComponent>();
+      expect(light, isNotNull);
+      expect(light!.light.intensity, 5.0);
+      expect(light.light.castsShadow, isTrue);
+
+      final eye = world.getChildByName('eye')!;
+      expect(eye.getComponent<CameraComponent>(), isNotNull);
+
+      final pivot = world.getChildByName('pivot')!;
+      expect(pivot.layers, 4);
+      expect(pivot.getComponents<Component>(), isEmpty);
+    });
+
+    test('a right-handed stage flips the synthesized root', () {
+      expect(
+        realizeScene(
+          _sampleScene(handedness: Handedness.right),
+        ).localTransform.determinant(),
+        lessThan(0),
+      );
+      expect(
+        realizeScene(
+          _sampleScene(handedness: Handedness.left),
+        ).localTransform.determinant(),
+        greaterThan(0),
+      );
+    });
+
+    test('skips a component with no registered codec', () {
+      final doc = SceneDocument();
+      doc.createNode(
+        name: 'mystery',
+        root: true,
+        components: [ComponentSpec('notRegistered')],
+      );
+      final root = realizeScene(doc);
+      expect(root.children.single.getComponents<Component>(), isEmpty);
+    });
+  });
+
+  group('serializeScene', () {
+    test('round-trips structure and components through a live graph', () {
+      final doc = _sampleScene();
+      final back = serializeScene(realizeScene(doc));
+
+      expect(back.stage.handedness, doc.stage.handedness);
+      expect(back.rootNodes, hasLength(1));
+
+      final world = back.rootNodes.single;
+      final childNames = world.children
+          .map((id) => back.node(id)!.name)
+          .toSet();
+      expect(childNames, {'sun', 'eye', 'pivot'});
+
+      final sunSpec = world.children
+          .map((id) => back.node(id)!)
+          .firstWhere((n) => n.name == 'sun');
+      final lightSpec = sunSpec.components.single;
+      expect(lightSpec.type, 'directionalLight');
+      expect((lightSpec.properties['intensity'] as DoubleValue).value, 5.0);
+    });
+  });
+
+  group('component registry', () {
+    test('a custom codec realizes and serializes a custom component', () {
+      final registry = defaultComponentRegistry()..register(_TagCodec());
+
+      final doc = SceneDocument();
+      doc.createNode(
+        name: 'tagged',
+        root: true,
+        components: [
+          ComponentSpec('tag', properties: {'tag': const StringValue('hello')}),
+        ],
+      );
+
+      final root = realizeScene(doc, registry: registry);
+      final tag = root.children.single.getComponent<_TagComponent>();
+      expect(tag, isNotNull);
+      expect(tag!.tag, 'hello');
+
+      final back = serializeScene(root, registry: registry);
+      final spec = back.rootNodes.single.components.single;
+      expect(spec.type, 'tag');
+      expect((spec.properties['tag'] as StringValue).value, 'hello');
+    });
+  });
+}

--- a/packages/flutter_scene/test/fscene/reload_test.dart
+++ b/packages/flutter_scene/test/fscene/reload_test.dart
@@ -1,0 +1,92 @@
+// Covers the scene-structure hot-reload patch: applying a diff to a live node
+// graph in place. Uses component-less nodes and a directional light (both
+// realize without the GPU), so the structural patching is exercised GPU-free.
+
+import 'package:flutter_scene/src/components/directional_light_component.dart';
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/realize/realize.dart';
+import 'package:flutter_scene/src/fscene/reload/reload.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  test(
+    'patches added, removed, reparented, and transform-changed nodes',
+    () async {
+      const r = LocalId(1, 1);
+      const a = LocalId(1, 2);
+      const b = LocalId(1, 3);
+      const c = LocalId(1, 4);
+      const d = LocalId(1, 5);
+
+      final oldDoc = SceneDocument();
+      oldDoc.addNode(NodeSpec(id: r, name: 'r', children: [a, b]), root: true);
+      oldDoc.addNode(NodeSpec(id: a, name: 'a'));
+      oldDoc.addNode(NodeSpec(id: b, name: 'b', children: [c]));
+      oldDoc.addNode(NodeSpec(id: c, name: 'c'));
+
+      final liveRoot = realizeScene(oldDoc);
+      final liveR = liveRoot.children.single;
+      final liveC = liveR.getChildByName('c')!; // under b
+
+      // Remove a; add d under r; move c from b to r; move b up.
+      final newDoc = SceneDocument();
+      newDoc.addNode(
+        NodeSpec(id: r, name: 'r', children: [b, d, c]),
+        root: true,
+      );
+      newDoc.addNode(
+        NodeSpec(
+          id: b,
+          name: 'b',
+          transform: TrsTransform(translation: Vector3(0, 5, 0)),
+        ),
+      );
+      newDoc.addNode(NodeSpec(id: c, name: 'c'));
+      newDoc.addNode(NodeSpec(id: d, name: 'd'));
+
+      await reloadScene(liveRoot, oldDoc, newDoc);
+
+      expect(liveRoot.getChildByName('a'), isNull); // removed
+      expect(liveR.children.map((n) => n.name).toSet(), {'b', 'd', 'c'});
+
+      final liveB = liveR.children.firstWhere((n) => n.name == 'b');
+      expect(liveB.children, isEmpty); // c moved out
+      expect(liveB.localTransform.getTranslation(), Vector3(0, 5, 0));
+
+      // c kept its identity, now parented under r.
+      expect(liveR.children.firstWhere((n) => n.name == 'c'), same(liveC));
+      expect(liveC.parent, same(liveR));
+    },
+  );
+
+  test('rebuilds a changed component, keeping node identity', () async {
+    const sunId = LocalId(2, 1);
+    ComponentSpec light(double intensity) => ComponentSpec(
+      'directionalLight',
+      properties: {'intensity': DoubleValue(intensity)},
+    );
+
+    final oldDoc = SceneDocument();
+    oldDoc.addNode(
+      NodeSpec(id: sunId, name: 'sun', components: [light(3.0)]),
+      root: true,
+    );
+    final liveRoot = realizeScene(oldDoc);
+    final sun = liveRoot.children.single;
+    expect(sun.getComponent<DirectionalLightComponent>()!.light.intensity, 3.0);
+
+    final newDoc = SceneDocument();
+    newDoc.addNode(
+      NodeSpec(id: sunId, name: 'sun', components: [light(7.0)]),
+      root: true,
+    );
+    await reloadScene(liveRoot, oldDoc, newDoc);
+
+    expect(liveRoot.children.single, same(sun)); // identity preserved
+    expect(sun.getComponent<DirectionalLightComponent>()!.light.intensity, 7.0);
+  });
+}

--- a/packages/flutter_scene/test/fscene/resource_copy_test.dart
+++ b/packages/flutter_scene/test/fscene/resource_copy_test.dart
@@ -1,0 +1,125 @@
+// Covers copyResourceInto: moving a resource and the payload chunks it
+// references from one document into another with ids preserved. This is the
+// GPU-free half of mesh serialization (the realizer stamps live objects with
+// their origin, and the serializer copies those origins here).
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/realize/resource_copy.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  group('copyResourceInto', () {
+    test('copies a payload-backed geometry with its chunks and ids', () {
+      final source = SceneDocument();
+      final vertices = source.addPayload(
+        PayloadSpec(
+          source.newId(),
+          encoding: PayloadEncoding.vertexBuffer,
+          layout: 'unskinned',
+          bytes: Uint8List.fromList([1, 2, 3, 4]),
+        ),
+      );
+      final indices = source.addPayload(
+        PayloadSpec(
+          source.newId(),
+          encoding: PayloadEncoding.indexBuffer,
+          format: 'uint16',
+          bytes: Uint8List.fromList([9, 8]),
+        ),
+      );
+      final geometry = source.addResource(
+        GeometryResource(
+          source.newId(),
+          vertices: vertices.id,
+          indices: indices.id,
+        ),
+      );
+
+      final dest = SceneDocument();
+      final copiedId = copyResourceInto(dest, source, geometry.id);
+
+      expect(copiedId, geometry.id);
+      final copied = dest.resource(geometry.id) as GeometryResource;
+      expect(copied.vertices, vertices.id);
+      expect(copied.indices, indices.id);
+      expect(dest.payload(vertices.id)!.bytes, equals(vertices.bytes));
+      expect(dest.payload(indices.id)!.format, 'uint16');
+      expect(dest.payload(indices.id)!.bytes, equals(indices.bytes));
+    });
+
+    test('copies a procedural geometry without any payloads', () {
+      final source = SceneDocument();
+      final geometry = source.addResource(
+        GeometryResource(
+          source.newId(),
+          procedural: CuboidGeometrySpec(extents: Vector3(1, 1, 1)),
+        ),
+      );
+
+      final dest = SceneDocument();
+      copyResourceInto(dest, source, geometry.id);
+
+      final copied = dest.resource(geometry.id) as GeometryResource;
+      expect(copied.procedural, isA<CuboidGeometrySpec>());
+      expect(dest.payloads, isEmpty);
+    });
+
+    test('copies a material together with its texture and image chunk', () {
+      final source = SceneDocument();
+      final image = source.addPayload(
+        PayloadSpec(
+          source.newId(),
+          encoding: PayloadEncoding.image,
+          format: 'rgba8',
+          width: 1,
+          height: 1,
+          bytes: Uint8List.fromList([255, 255, 255, 255]),
+        ),
+      );
+      final texture = source.addResource(
+        TextureResource(source.newId(), payload: image.id),
+      );
+      final material = source.addResource(
+        MaterialResource(
+          source.newId(),
+          type: 'physicallyBased',
+          properties: {'baseColorTexture': ResourceRefValue(texture.id)},
+        ),
+      );
+
+      final dest = SceneDocument();
+      copyResourceInto(dest, source, material.id);
+
+      expect(dest.resource(material.id), isA<MaterialResource>());
+      expect(dest.resource(texture.id), isA<TextureResource>());
+      expect(dest.payload(image.id)!.bytes, equals(image.bytes));
+    });
+
+    test('is idempotent for a resource shared by several meshes', () {
+      final source = SceneDocument();
+      final vertices = source.addPayload(
+        PayloadSpec(
+          source.newId(),
+          encoding: PayloadEncoding.vertexBuffer,
+          layout: 'unskinned',
+          bytes: Uint8List.fromList([1, 2, 3, 4]),
+        ),
+      );
+      final geometry = source.addResource(
+        GeometryResource(source.newId(), vertices: vertices.id),
+      );
+
+      final dest = SceneDocument();
+      copyResourceInto(dest, source, geometry.id);
+      copyResourceInto(dest, source, geometry.id);
+
+      expect(dest.resources, hasLength(1));
+      expect(dest.payloads, hasLength(1));
+    });
+  });
+}

--- a/packages/flutter_scene/test/fscene/scene_data_assets_test.dart
+++ b/packages/flutter_scene/test/fscene/scene_data_assets_test.dart
@@ -1,0 +1,98 @@
+// Covers the buildScenes build hook: discovering .glb sources, importing them
+// to .fsceneb packages, and registering them as DataAssets. Mirrors the
+// buildModels coverage. Runs only when the source GLB corpus is present.
+
+import 'dart:io';
+
+import 'package:data_assets/data_assets.dart';
+import 'package:flutter_scene/src/importer/build_hooks.dart';
+import 'package:flutter_scene/src/fscene/binary/fsceneb.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks/hooks.dart';
+
+void main() {
+  test('sceneDataAssetName computes a stable DataAsset name', () {
+    expect(
+      sceneDataAssetName('assets/levels/forest.fsceneb'),
+      'flutter_scene/scene/assets/levels/forest.fsceneb',
+    );
+  });
+
+  test('imports a .glb, writes a .fsceneb, and emits a DataAsset', () {
+    final glbSource = _resolve('examples/assets_src/two_triangles.glb');
+    if (!File(glbSource).existsSync()) {
+      // ignore: avoid_print
+      print('Test data missing ($glbSource) - skipping.');
+      return;
+    }
+
+    final temp = Directory.systemTemp.createTempSync('scene_build');
+    try {
+      final glbUri = temp.uri.resolve('assets/two_triangles.glb');
+      File.fromUri(glbUri)
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(File(glbSource).readAsBytesSync());
+
+      final input = _buildInput(packageRoot: temp.uri, buildDataAssets: true);
+      final outputBuilder = BuildOutputBuilder();
+
+      // No inputFilePaths: exercises auto-discovery of assets/**/*.glb.
+      buildScenes(
+        buildInput: input,
+        buildOutput: outputBuilder,
+        assetMode: ModelAssetMode.dataAssetsIfAvailable,
+      );
+
+      final scenePath = temp.uri.resolve(
+        'build/scenes/assets/two_triangles.fsceneb',
+      );
+      expect(File.fromUri(scenePath).existsSync(), isTrue);
+
+      // The written package is a valid container that round-trips.
+      final document = readFsceneb(File.fromUri(scenePath).readAsBytesSync());
+      expect(document.nodes, isNotEmpty);
+      expect(document.payloads, isNotEmpty);
+
+      final output = outputBuilder.build();
+      final data = output.assets.data;
+      expect(data, hasLength(1));
+      expect(data.single.package, 'example_app');
+      expect(
+        data.single.name,
+        'flutter_scene/scene/assets/two_triangles.fsceneb',
+      );
+      expect(output.dependencies, contains(glbUri));
+    } finally {
+      temp.deleteSync(recursive: true);
+    }
+  });
+}
+
+BuildInput _buildInput({
+  required Uri packageRoot,
+  required bool buildDataAssets,
+}) {
+  final builder = BuildInputBuilder()
+    ..setupShared(
+      packageRoot: packageRoot,
+      packageName: 'example_app',
+      outputDirectoryShared: packageRoot.resolve('.dart_tool/hook/'),
+      outputFile: packageRoot.resolve('.dart_tool/hook/output.json'),
+    )
+    ..setupBuildInput();
+  builder.config.setupBuild(linkingEnabled: false);
+  if (buildDataAssets) {
+    DataAssetsExtension().setupBuildInput(builder);
+  }
+  return builder.build();
+}
+
+String _resolve(String relative) {
+  for (final prefix in ['', '../../']) {
+    final candidate = '$prefix$relative';
+    if (File(candidate).existsSync() || Directory(candidate).existsSync()) {
+      return candidate;
+    }
+  }
+  return relative;
+}

--- a/packages/flutter_scene/test/fscene/scene_registry_test.dart
+++ b/packages/flutter_scene/test/fscene/scene_registry_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_scene/src/importer/scene_registry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SceneRegistry', () {
+    test('isSceneAssetKey matches only .fsceneb DataAsset keys', () {
+      expect(
+        SceneRegistry.isSceneAssetKey(
+          'packages/app/flutter_scene/scene/assets/forest.fsceneb',
+        ),
+        isTrue,
+      );
+      expect(SceneRegistry.isSceneAssetKey('assets/forest.fsceneb'), isFalse);
+      expect(
+        SceneRegistry.isSceneAssetKey(
+          'packages/app/flutter_scene/model/x.model',
+        ),
+        isFalse,
+      );
+    });
+
+    test('resolves a scene by source path, ignoring extension', () async {
+      final registry = await SceneRegistry.load(
+        assetKeys: const [
+          'packages/app/flutter_scene/scene/assets/levels/forest.fsceneb',
+          'assets/other.txt',
+        ],
+      );
+
+      const key =
+          'packages/app/flutter_scene/scene/assets/levels/forest.fsceneb';
+      expect(registry.resolveKey('assets/levels/forest.glb'), key);
+      expect(registry.resolveKey('assets/levels/forest.fsceneb'), key);
+      expect(registry.resolveKey('assets/levels/forest'), key);
+    });
+
+    test('same file name in different directories does not collide', () async {
+      final registry = await SceneRegistry.load(
+        assetKeys: const [
+          'packages/app/flutter_scene/scene/assets/a/forest.fsceneb',
+          'packages/app/flutter_scene/scene/assets/b/forest.fsceneb',
+        ],
+      );
+      expect(
+        registry.resolveKey('assets/a/forest.glb'),
+        'packages/app/flutter_scene/scene/assets/a/forest.fsceneb',
+      );
+      expect(
+        registry.resolveKey('assets/b/forest.glb'),
+        'packages/app/flutter_scene/scene/assets/b/forest.fsceneb',
+      );
+    });
+
+    test('throws when a source path is not found', () async {
+      final registry = await SceneRegistry.load(assetKeys: const []);
+      expect(
+        () => registry.resolveKey('assets/missing.glb'),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test(
+      'requires package disambiguation for duplicate source paths',
+      () async {
+        final registry = await SceneRegistry.load(
+          assetKeys: const [
+            'packages/a/flutter_scene/scene/assets/forest.fsceneb',
+            'packages/b/flutter_scene/scene/assets/forest.fsceneb',
+          ],
+        );
+        expect(
+          () => registry.resolveKey('assets/forest.glb'),
+          throwsA(
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              contains('Pass package to disambiguate'),
+            ),
+          ),
+        );
+        expect(
+          registry.resolveKey('assets/forest.glb', package: 'b'),
+          'packages/b/flutter_scene/scene/assets/forest.fsceneb',
+        );
+      },
+    );
+  });
+}

--- a/packages/flutter_scene/test/fscene/skin_animation_test.dart
+++ b/packages/flutter_scene/test/fscene/skin_animation_test.dart
@@ -1,0 +1,96 @@
+// Covers realizing skins and animations onto a live graph. GPU-free: the
+// nodes carry no meshes, so no geometry/material is built, but skins bind to
+// their joint nodes and animations parse onto the root.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/fscene/realize/realize.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Uint8List _floatBytes(List<double> values) =>
+    Float32List.fromList(values).buffer.asUint8List();
+
+const _identity = [
+  1.0, 0.0, 0.0, 0.0, //
+  0.0, 1.0, 0.0, 0.0, //
+  0.0, 0.0, 1.0, 0.0, //
+  0.0, 0.0, 0.0, 1.0, //
+];
+
+void main() {
+  test('realizes a skin and binds its joint nodes', () {
+    final doc = SceneDocument();
+    final jointA = doc.createNode(name: 'jointA');
+    final jointB = doc.createNode(name: 'jointB');
+    final ibm = doc.addPayload(
+      PayloadSpec(
+        doc.newId(),
+        encoding: PayloadEncoding.matrices,
+        bytes: _floatBytes([..._identity, ..._identity]),
+      ),
+    );
+    final skin = doc.addSkin(
+      SkinSpec(
+        doc.newId(),
+        joints: [jointA.id, jointB.id],
+        inverseBindMatrices: ibm.id,
+      ),
+    );
+    final mesh = doc.createNode(name: 'skinnedMesh', root: true);
+    mesh.skin = skin.id;
+    mesh.children.addAll([jointA.id, jointB.id]);
+
+    final root = realizeScene(doc);
+    final skinnedNode = root.getChildByName('skinnedMesh')!;
+
+    expect(skinnedNode.skin, isNotNull);
+    expect(skinnedNode.skin!.joints, hasLength(2));
+    expect(skinnedNode.skin!.joints.map((j) => j?.name), ['jointA', 'jointB']);
+    expect(skinnedNode.skin!.inverseBindMatrices, hasLength(2));
+    expect(root.getChildByName('jointA')!.isJoint, isTrue);
+  });
+
+  test('realizes an animation onto the root', () {
+    final doc = SceneDocument();
+    final bone = doc.createNode(name: 'Bone', root: true);
+    final timeline = doc.addPayload(
+      PayloadSpec(
+        doc.newId(),
+        encoding: PayloadEncoding.floats,
+        bytes: _floatBytes([0.0, 1.0]),
+      ),
+    );
+    final keyframes = doc.addPayload(
+      PayloadSpec(
+        doc.newId(),
+        encoding: PayloadEncoding.floats,
+        // Two vec3 translation keyframes.
+        bytes: _floatBytes([0, 0, 0, 1, 2, 3]),
+      ),
+    );
+    doc.addAnimation(
+      AnimationSpec(
+        doc.newId(),
+        name: 'Wiggle',
+        channels: [
+          AnimationChannelSpec(
+            target: bone.id,
+            targetName: 'Bone',
+            property: AnimationProperty.translation,
+            timeline: timeline.id,
+            keyframes: keyframes.id,
+          ),
+        ],
+      ),
+    );
+
+    final root = realizeScene(doc);
+    expect(root.parsedAnimations, hasLength(1));
+    final animation = root.findAnimationByName('Wiggle');
+    expect(animation, isNotNull);
+    // A clip can be instantiated and bound without error.
+    expect(root.createAnimationClip(animation!), isNotNull);
+  });
+}

--- a/packages/flutter_scene/test/fscene/stream_test.dart
+++ b/packages/flutter_scene/test/fscene/stream_test.dart
@@ -1,0 +1,82 @@
+// Covers lazy-subtree streaming: a LoadPolicy.lazy instance survives
+// composition, realizes as a placeholder, and loads/unloads on demand. Uses
+// component-less nodes so realization is GPU-free.
+
+import 'package:flutter_scene/src/fscene/compose/compose.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/realize/realize.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/fscene/stream/stream.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// A single-root prefab: 'content' with a 'leaf' child (no components).
+SceneDocument _prefab() {
+  final doc = SceneDocument();
+  final content = doc.createNode(name: 'content', root: true);
+  final leaf = doc.createNode(name: 'leaf');
+  content.children.add(leaf.id);
+  return doc;
+}
+
+void main() {
+  test('composeScene leaves a lazy instance unexpanded', () {
+    final host = SceneDocument();
+    host.createNode(name: 'placeholder', root: true).instance =
+        PrefabInstanceSpec(source: const AssetRef('p'), load: LoadPolicy.lazy);
+
+    // The lazy instance is the only one, so nothing is resolved or expanded.
+    final composed = composeScene(
+      host,
+      resolve: (_) => throw StateError('a lazy instance must not resolve'),
+    );
+    expect(composed.node(host.rootNodes.single.id)!.instance, isNotNull);
+  });
+
+  test(
+    'a lazy instance realizes as a placeholder, then loads and unloads',
+    () async {
+      final host = SceneDocument();
+      final placeholder = host.createNode(name: 'placeholder', root: true);
+      placeholder.instance = PrefabInstanceSpec(
+        source: const AssetRef('p'),
+        load: LoadPolicy.lazy,
+      );
+
+      final live = realizeScene(host).getChildByName('placeholder')!;
+      expect(isLazySubtree(live), isTrue);
+      expect(isSubtreeLoaded(live), isFalse);
+      expect(live.children, isEmpty);
+
+      await loadSubtree(live, load: (_) async => _prefab());
+      expect(isSubtreeLoaded(live), isTrue);
+      expect(live.getChildByName('leaf'), isNotNull);
+
+      unloadSubtree(live);
+      expect(live.children, isEmpty);
+      expect(isLazySubtree(live), isTrue); // still a placeholder, reloadable
+    },
+  );
+
+  test('eager instances still expand alongside a lazy one', () {
+    final prefab = SceneDocument();
+    prefab.createNode(name: 'eagerContent', root: true);
+
+    final host = SceneDocument();
+    host.createNode(name: 'eager', root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('p'),
+    );
+    host.createNode(name: 'lazy', root: true).instance = PrefabInstanceSpec(
+      source: const AssetRef('p'),
+      load: LoadPolicy.lazy,
+    );
+
+    final composed = composeScene(host, resolve: (_) => prefab);
+    // The eager instance expanded (its instance cleared); the lazy one did not
+    // (its instance survives for the streaming layer).
+    final lazy = composed.nodes.values.firstWhere((n) => n.name == 'lazy');
+    final eager = composed.nodes.values.firstWhere((n) => n.name == 'eager');
+    expect(lazy.instance, isNotNull);
+    expect(eager.instance, isNull);
+  });
+}


### PR DESCRIPTION
Adds the `.fscene` / `.fsceneb` serialized scene format: a GPU-free document model with two interchangeable encodings (canonical JSON text and a `.glb`-style binary container), realization to and from a live `Node` graph, a glTF importer that emits the format, `loadScene` (the analog of `loadModel`) via a `buildScenes` build hook, a prefab composer, scene-structure hot reload, and lazy-subtree streaming.

All new code is internal under `lib/src/fscene/` behind the curated `package:flutter_scene/fscene.dart` surface and is additive, with one exception: `Material.bind` now back-face-culls translucent materials even when double-sided (double-sided transparent geometry has no per-fragment sort, which seamed thick glass). Double-sided is still honored for opaque, and this also fixes the `.model` / runtime glTF path.

- Document model + canonical JSON + `.fsceneb` binary container (one shared JSON codec)
- Realize/serialize (mesh, light, camera, skin, animation); async realize preloads external/encoded textures and `fmat` materials
- glTF importer emits `.fscene` / `.fsceneb`; geometry packs byte-for-byte like `.model` (byte-comparison tests across the corpus)
- `loadScene(sourcePath)` plus the `buildScenes` build hook
- Prefab composer (overrides / add / remove, nested, id-remapped per instance)
- Scene-structure hot reload (id-keyed diff/patch, wired into the hot-reload coordinator)
- Lazy-subtree streaming (`loadSubtree` / `unloadSubtree`)

~90 fscene tests; geometry/texture realize is verified via the example app (new fscene examples for round-trip, import, animation, prefabs, streaming). `.model` stays loadable; `TODO(model)` to retire it once `.fsceneb` is the default importer output.
