### PR TITLE
Add optional texture compression for imported models

### DIFF
--- a/examples/flutter_app/hook/build.dart
+++ b/examples/flutter_app/hook/build.dart
@@ -25,6 +25,10 @@ void main(List<String> args) {
       buildOutput: output,
       inputFilePaths: corpus,
       assetMode: ModelAssetMode.dataAssetsIfAvailable,
+      // Store imported textures as compressed KTX2 block payloads so the
+      // import -> compress -> render path is exercised in the app (dash's
+      // textures shrink the most).
+      compressTextures: true,
     );
     await buildShaderBundleJson(
       buildInput: config,

--- a/examples/flutter_app/lib/example_fscene.dart
+++ b/examples/flutter_app/lib/example_fscene.dart
@@ -385,13 +385,7 @@ TextureResource _ktx2Texture(SceneDocument doc) {
       pixels[i + 3] = 255;
     }
   }
-  final ktx2 = encodeImageToKtx2Bytes(
-    pixels,
-    size,
-    size,
-    generateMips: true,
-    supercompress: true,
-  );
+  final ktx2 = encodeImageToKtx2Bytes(pixels, size, size, supercompress: true);
   final payload = doc.addPayload(
     PayloadSpec(
       doc.newId(),

--- a/examples/flutter_app/lib/example_fscene.dart
+++ b/examples/flutter_app/lib/example_fscene.dart
@@ -8,6 +8,8 @@ import 'package:flutter_scene/scene.dart';
 // ignore: implementation_imports
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 // ignore: implementation_imports
+import 'package:flutter_scene/src/texture/ktx2_image.dart';
+// ignore: implementation_imports
 import 'package:flutter_scene/src/geometry/primitives.dart'
     show buildCuboidArrays;
 import 'package:vector_math/vector_math.dart' as vm;
@@ -20,9 +22,9 @@ import 'example_settings.dart';
 /// graph again. The twice-realized scene is what renders, so anything that
 /// fails to survive serialization would visibly drop out. It exercises
 /// procedural geometry, a payload-backed mesh, parameter materials, a
-/// directional light, and the asynchronously-loaded resources: an embedded
-/// `rgba8` texture, an external image-asset texture, an encoded (PNG) image
-/// payload, and an `fmat` custom material.
+/// directional light, an embedded `rgba8` texture, a compressed KTX2 block
+/// texture, and the asynchronously-loaded resources: an external image-asset
+/// texture, an encoded (PNG) image payload, and an `fmat` custom material.
 class ExampleFscene extends StatefulWidget {
   const ExampleFscene({super.key});
 
@@ -220,6 +222,30 @@ SceneDocument _buildDocument(Uint8List pngBytes) {
     ],
   );
 
+  // A cube textured from a compressed KTX2 block payload (gradient image),
+  // exercising the compressed-texture load path.
+  final ktx2Material = doc.addResource(
+    MaterialResource(
+      doc.newId(),
+      type: 'unlit',
+      properties: {'baseColorTexture': ResourceRefValue(_ktx2Texture(doc).id)},
+    ),
+  );
+  doc.createNode(
+    name: 'ktx2Cube',
+    root: true,
+    transform: TrsTransform(translation: vm.Vector3(0, 0.5, -3.6)),
+    components: [
+      ComponentSpec(
+        'mesh',
+        properties: {
+          'geometry': ResourceRefValue(cubeGeometry.id),
+          'material': ResourceRefValue(ktx2Material.id),
+        },
+      ),
+    ],
+  );
+
   // A row of asynchronously-loaded resources above the ring.
   // 1. An external image-asset texture (referenced by path, not embedded).
   final assetTexture = doc.addResource(
@@ -338,6 +364,42 @@ TextureResource _checkerTexture(SceneDocument doc) {
       width: size,
       height: size,
       bytes: pixels,
+    ),
+  );
+  return doc.addResource(TextureResource(doc.newId(), payload: payload.id));
+}
+
+/// A gradient image stored as a compressed KTX2 block payload (mipped and
+/// supercompressed), the shape a compressed imported texture takes. The
+/// realizer decodes it (or transcodes it to a GPU block format where
+/// supported) at load.
+TextureResource _ktx2Texture(SceneDocument doc) {
+  const size = 64;
+  final pixels = Uint8List(size * size * 4);
+  for (var y = 0; y < size; y++) {
+    for (var x = 0; x < size; x++) {
+      final i = (y * size + x) * 4;
+      pixels[i] = x * 255 ~/ (size - 1);
+      pixels[i + 1] = y * 255 ~/ (size - 1);
+      pixels[i + 2] = 200 - (x * 160 ~/ (size - 1));
+      pixels[i + 3] = 255;
+    }
+  }
+  final ktx2 = encodeImageToKtx2Bytes(
+    pixels,
+    size,
+    size,
+    generateMips: true,
+    supercompress: true,
+  );
+  final payload = doc.addPayload(
+    PayloadSpec(
+      doc.newId(),
+      encoding: PayloadEncoding.image,
+      format: 'ktx2',
+      width: size,
+      height: size,
+      bytes: ktx2,
     ),
   );
   return doc.addResource(TextureResource(doc.newId(), payload: payload.id));

--- a/examples/flutter_app/lib/example_fscene_animated.dart
+++ b/examples/flutter_app/lib/example_fscene_animated.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:flutter/foundation.dart' show compute;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_scene/fscene.dart';
@@ -34,10 +35,12 @@ class _ExampleFsceneAnimatedState extends State<ExampleFsceneAnimated> {
 
   Future<void> _load() async {
     final glb = await rootBundle.load('assets_src/dash.glb');
-    final container = importGlbToFscenebBytes(
-      glb.buffer.asUint8List(glb.offsetInBytes, glb.lengthInBytes),
-    );
-    final dash = loadFscenebBytes(container)..name = 'Dash';
+    final bytes = glb.buffer.asUint8List(glb.offsetInBytes, glb.lengthInBytes);
+    // The glTF import (image decode + geometry packing) is heavy CPU work, so
+    // run it on a background isolate to keep the UI responsive while loading.
+    final container = await compute(importGlbToFscenebBytes, bytes);
+    if (!mounted) return;
+    final dash = (await loadFscenebBytesAsync(container))..name = 'Dash';
     if (!mounted) return;
 
     // Play a clearly-moving clip, looping (falls back to the first animation).

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -18,6 +18,7 @@ import 'package:flutter_scene/src/importer/constants.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/material/physically_based_material.dart';
 import 'package:flutter_scene/src/material/unlit_material.dart';
+import 'package:flutter_scene/src/texture/compressed_texture.dart';
 
 /// Turns a document's resources into live, GPU-backed [Geometry] and
 /// [Material] objects, memoizing each so a resource shared by many nodes is
@@ -80,7 +81,11 @@ class ResourceRealizer {
   bool _needsAsyncTexture(TextureResource res) {
     if (res.asset != null) return true;
     final payload = res.payload;
-    return payload != null && document.payload(payload)?.format != 'rgba8';
+    if (payload == null) return false;
+    final format = document.payload(payload)?.format;
+    // rgba8 and our KTX2 block payloads realize synchronously; only encoded
+    // (PNG/JPEG) image payloads need the async image decoder.
+    return format != 'rgba8' && format != 'ktx2';
   }
 
   Future<void> _preloadTexture(TextureResource res) async {
@@ -289,6 +294,10 @@ class ResourceRealizer {
     }
     if (payload.encoding != PayloadEncoding.image) {
       throw FsceneFormatException('Payload $payloadId is not an image');
+    }
+    if (payload.format == 'ktx2') {
+      // Our KTX2 block payload: decode (or transcode) and upload synchronously.
+      return gpuTextureFromKtx2(bytes);
     }
     final width = payload.width;
     final height = payload.height;

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -82,20 +82,16 @@ class ResourceRealizer {
     if (res.asset != null) return true;
     final payload = res.payload;
     if (payload == null) return false;
-    final format = document.payload(payload)?.format;
-    // rgba8 and our KTX2 block payloads realize synchronously; only encoded
-    // (PNG/JPEG) image payloads need the async image decoder.
-    return format != 'rgba8' && format != 'ktx2';
+    // Only raw rgba8 payloads realize synchronously (a plain upload). Encoded
+    // (PNG/JPEG) images decode asynchronously, and KTX2 block payloads
+    // transcode on a background isolate, so both go through preload.
+    return document.payload(payload)?.format != 'rgba8';
   }
 
   Future<void> _preloadTexture(TextureResource res) async {
     try {
-      final asset = res.asset;
-      final image = asset != null
-          ? await imageFromAsset(asset.key, bundle: bundle)
-          : await imageFromBytes(_payloadBytes(res.payload!, 'image'));
       _textures[res.id] = tagResourceOrigin(
-        await gpuTextureFromImage(image),
+        await _loadTextureAsync(res),
         document,
         res.id,
       );
@@ -103,6 +99,22 @@ class ResourceRealizer {
       debugPrint('fscene: failed to load texture ${res.id}: $e; placeholder');
       _textures[res.id] = _placeholderTexture();
     }
+  }
+
+  Future<gpu.Texture> _loadTextureAsync(TextureResource res) async {
+    final asset = res.asset;
+    if (asset != null) {
+      return gpuTextureFromImage(
+        await imageFromAsset(asset.key, bundle: bundle),
+      );
+    }
+    final bytes = _payloadBytes(res.payload!, 'image');
+    // KTX2 block payloads transcode off the main isolate; other encoded images
+    // decode via dart:ui.
+    if (document.payload(res.payload!)?.format == 'ktx2') {
+      return gpuTextureFromKtx2Async(bytes);
+    }
+    return gpuTextureFromImage(await imageFromBytes(bytes));
   }
 
   Future<void> _preloadFmat(MaterialResource res) async {
@@ -296,8 +308,13 @@ class ResourceRealizer {
       throw FsceneFormatException('Payload $payloadId is not an image');
     }
     if (payload.format == 'ktx2') {
-      // Our KTX2 block payload: decode (or transcode) and upload synchronously.
-      return gpuTextureFromKtx2(bytes);
+      // KTX2 block payloads transcode off the main isolate via preload(); the
+      // sync path can't await that.
+      debugPrint(
+        'fscene: ktx2 texture payload $payloadId needs the async loader; '
+        'using a placeholder',
+      );
+      return _placeholderTexture();
     }
     final width = payload.width;
     final height = payload.height;

--- a/packages/flutter_scene/lib/src/gpu/stub/formats.dart
+++ b/packages/flutter_scene/lib/src/gpu/stub/formats.dart
@@ -24,7 +24,51 @@ enum PixelFormat {
   s8UInt,
   d24UnormS8Uint,
   d32FloatS8UInt,
+  // Block-compressed (sample-only) formats. Support varies by family; check
+  // GpuContext.supportsTextureCompression before allocating.
+  bc1RGBAUNormInt,
+  bc1RGBAUNormIntSRGB,
+  bc3RGBAUNormInt,
+  bc3RGBAUNormIntSRGB,
+  bc5RGUNormInt,
+  bc7RGBAUNormInt,
+  bc7RGBAUNormIntSRGB,
+  etc2RGB8UNormInt,
+  etc2RGB8UNormIntSRGB,
+  etc2RGBA8UNormInt,
+  etc2RGBA8UNormIntSRGB,
+  astc4x4LDR,
+  astc4x4LDRSRGB,
+  astc8x8LDR,
+  astc8x8LDRSRGB;
+
+  /// Whether this is a block-compressed (sample-only) format.
+  bool get isCompressed {
+    switch (this) {
+      case PixelFormat.bc1RGBAUNormInt:
+      case PixelFormat.bc1RGBAUNormIntSRGB:
+      case PixelFormat.bc3RGBAUNormInt:
+      case PixelFormat.bc3RGBAUNormIntSRGB:
+      case PixelFormat.bc5RGUNormInt:
+      case PixelFormat.bc7RGBAUNormInt:
+      case PixelFormat.bc7RGBAUNormIntSRGB:
+      case PixelFormat.etc2RGB8UNormInt:
+      case PixelFormat.etc2RGB8UNormIntSRGB:
+      case PixelFormat.etc2RGBA8UNormInt:
+      case PixelFormat.etc2RGBA8UNormIntSRGB:
+      case PixelFormat.astc4x4LDR:
+      case PixelFormat.astc4x4LDRSRGB:
+      case PixelFormat.astc8x8LDR:
+      case PixelFormat.astc8x8LDRSRGB:
+        return true;
+      default:
+        return false;
+    }
+  }
 }
+
+/// Hardware families for block-compressed texture support.
+enum TextureCompressionFamily { bc, etc2, astc }
 
 enum TextureCoordinateSystem { uploadFromHost, renderToTexture }
 

--- a/packages/flutter_scene/lib/src/gpu/stub/shim_stubs.dart
+++ b/packages/flutter_scene/lib/src/gpu/stub/shim_stubs.dart
@@ -38,6 +38,7 @@ base class GpuContext {
     bool enableShaderWriteUsage = false,
     int mipLevelCount = 1,
   }) => _stub();
+  bool supportsTextureCompression(TextureCompressionFamily family) => _stub();
   CommandBuffer createCommandBuffer() => _stub();
   RenderPipeline createRenderPipeline(
     Shader vertexShader,

--- a/packages/flutter_scene/lib/src/gpu/web/formats.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/formats.dart
@@ -23,7 +23,51 @@ enum PixelFormat {
   s8UInt,
   d24UnormS8Uint,
   d32FloatS8UInt,
+  // Block-compressed (sample-only) formats. Support varies by family; check
+  // GpuContext.supportsTextureCompression before allocating.
+  bc1RGBAUNormInt,
+  bc1RGBAUNormIntSRGB,
+  bc3RGBAUNormInt,
+  bc3RGBAUNormIntSRGB,
+  bc5RGUNormInt,
+  bc7RGBAUNormInt,
+  bc7RGBAUNormIntSRGB,
+  etc2RGB8UNormInt,
+  etc2RGB8UNormIntSRGB,
+  etc2RGBA8UNormInt,
+  etc2RGBA8UNormIntSRGB,
+  astc4x4LDR,
+  astc4x4LDRSRGB,
+  astc8x8LDR,
+  astc8x8LDRSRGB;
+
+  /// Whether this is a block-compressed (sample-only) format.
+  bool get isCompressed {
+    switch (this) {
+      case PixelFormat.bc1RGBAUNormInt:
+      case PixelFormat.bc1RGBAUNormIntSRGB:
+      case PixelFormat.bc3RGBAUNormInt:
+      case PixelFormat.bc3RGBAUNormIntSRGB:
+      case PixelFormat.bc5RGUNormInt:
+      case PixelFormat.bc7RGBAUNormInt:
+      case PixelFormat.bc7RGBAUNormIntSRGB:
+      case PixelFormat.etc2RGB8UNormInt:
+      case PixelFormat.etc2RGB8UNormIntSRGB:
+      case PixelFormat.etc2RGBA8UNormInt:
+      case PixelFormat.etc2RGBA8UNormIntSRGB:
+      case PixelFormat.astc4x4LDR:
+      case PixelFormat.astc4x4LDRSRGB:
+      case PixelFormat.astc8x8LDR:
+      case PixelFormat.astc8x8LDRSRGB:
+        return true;
+      default:
+        return false;
+    }
+  }
 }
+
+/// Hardware families for block-compressed texture support.
+enum TextureCompressionFamily { bc, etc2, astc }
 
 enum TextureCoordinateSystem { uploadFromHost, renderToTexture }
 

--- a/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
@@ -54,11 +54,21 @@ base class GpuContext {
 
   bool get doesSupportOffscreenMSAA => true;
 
-  /// The WebGL2 backend does not yet upload block-compressed textures, so no
-  /// family is reported and callers fall back to an uncompressed upload.
-  // TODO(texture-compression): probe WEBGL_compressed_texture_s3tc / _etc /
-  // _astc and upload via compressedTexImage2D, then report support truthfully.
-  bool supportsTextureCompression(TextureCompressionFamily family) => false;
+  final Map<TextureCompressionFamily, bool> _compressionSupport = {};
+
+  /// Reports block-compression support by probing (and enabling) the matching
+  /// WebGL2 compressed-texture extension. Enabling it here makes the compressed
+  /// internal formats valid for the `createTexture` / `overwrite` upload path.
+  bool supportsTextureCompression(TextureCompressionFamily family) {
+    return _compressionSupport.putIfAbsent(family, () {
+      final name = switch (family) {
+        TextureCompressionFamily.bc => 'WEBGL_compressed_texture_s3tc',
+        TextureCompressionFamily.etc2 => 'WEBGL_compressed_texture_etc',
+        TextureCompressionFamily.astc => 'WEBGL_compressed_texture_astc',
+      };
+      return _gl.getExtension(name) != null;
+    });
+  }
 
   DeviceBuffer createDeviceBuffer(StorageMode storageMode, int sizeInBytes) {
     if (storageMode == StorageMode.deviceTransient) {

--- a/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
@@ -54,6 +54,12 @@ base class GpuContext {
 
   bool get doesSupportOffscreenMSAA => true;
 
+  /// The WebGL2 backend does not yet upload block-compressed textures, so no
+  /// family is reported and callers fall back to an uncompressed upload.
+  // TODO(texture-compression): probe WEBGL_compressed_texture_s3tc / _etc /
+  // _astc and upload via compressedTexImage2D, then report support truthfully.
+  bool supportsTextureCompression(TextureCompressionFamily family) => false;
+
   DeviceBuffer createDeviceBuffer(StorageMode storageMode, int sizeInBytes) {
     if (storageMode == StorageMode.deviceTransient) {
       throw Exception(

--- a/packages/flutter_scene/lib/src/gpu/web/texture.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/texture.dart
@@ -56,7 +56,23 @@ const Map<PixelFormat, _GlFormat> _formatTable = <PixelFormat, _GlFormat>{
     web.WebGL2RenderingContext.UNSIGNED_INT_24_8,
     4,
   ),
+  // Block-compressed formats. The internal format is an extension constant
+  // (the matching extension must be enabled, see supportsTextureCompression);
+  // format/type/bytesPerTexel are unused (size comes from _compressedBlockBytes).
+  PixelFormat.bc1RGBAUNormInt: _GlFormat(0x83F1, 0, 0, 0), // S3TC DXT1
+  PixelFormat.etc2RGB8UNormInt: _GlFormat(0x9274, 0, 0, 0), // ETC2 RGB8
+  PixelFormat.astc4x4LDR: _GlFormat(0x93B0, 0, 0, 0), // ASTC 4x4
 };
+
+/// Bytes per 4x4 block for the compressed formats the upload path supports.
+const Map<PixelFormat, int> _compressedBlockBytes = <PixelFormat, int>{
+  PixelFormat.bc1RGBAUNormInt: 8,
+  PixelFormat.etc2RGB8UNormInt: 8,
+  PixelFormat.astc4x4LDR: 16,
+};
+
+bool _isCompressedFormat(PixelFormat format) =>
+    _compressedBlockBytes.containsKey(format);
 
 bool _isDepthOrStencilFormat(PixelFormat format) {
   switch (format) {
@@ -204,6 +220,12 @@ base class Texture {
   int getMipLevelSizeInBytes(int mipLevel) {
     final mipWidth = (width >> mipLevel).clamp(1, width).toInt();
     final mipHeight = (height >> mipLevel).clamp(1, height).toInt();
+    final blockBytes = _compressedBlockBytes[format];
+    if (blockBytes != null) {
+      final blocksX = (mipWidth + 3) ~/ 4;
+      final blocksY = (mipHeight + 3) ~/ 4;
+      return blocksX * blocksY * blockBytes;
+    }
     return bytesPerTexel * mipWidth * mipHeight;
   }
 
@@ -232,6 +254,22 @@ base class Texture {
     final mipWidth = (width >> mipLevel).clamp(1, width).toInt();
     final mipHeight = (height >> mipLevel).clamp(1, height).toInt();
     gl.bindTexture(web.WebGL2RenderingContext.TEXTURE_2D, _texture);
+    if (_isCompressedFormat(format)) {
+      final blocks = sourceBytes.buffer
+          .asUint8List(sourceBytes.offsetInBytes, sourceBytes.lengthInBytes)
+          .toJS;
+      gl.compressedTexSubImage2D(
+        web.WebGL2RenderingContext.TEXTURE_2D,
+        mipLevel,
+        0,
+        0,
+        mipWidth,
+        mipHeight,
+        _glFormat.internalFormat,
+        blocks,
+      );
+      return;
+    }
     // texSubImage2D requires the JS typed-array view to match the GL pixel
     // type: FLOAT wants a Float32Array, HALF_FLOAT a Uint16Array, and the
     // integer formats a Uint8Array. (A Uint8Array for a FLOAT texture throws

--- a/packages/flutter_scene/lib/src/importer/build_hooks.dart
+++ b/packages/flutter_scene/lib/src/importer/build_hooks.dart
@@ -200,6 +200,7 @@ void buildScenes({
   String outputDirectory = 'build/scenes/',
   String discoveryRoot = 'assets/',
   ModelAssetMode assetMode = ModelAssetMode.legacyOnly,
+  bool compressTextures = false,
 }) {
   final dataAssetsAvailable = buildInput.config.buildDataAssets;
   if (assetMode == ModelAssetMode.dataAssetsRequired && !dataAssetsAvailable) {
@@ -241,6 +242,7 @@ void buildScenes({
       inputFilePath,
       outputSceneUri.toFilePath(),
       workingDirectory: packageRoot.toFilePath(),
+      compressTextures: compressTextures,
     );
 
     buildOutput.dependencies.add(packageRoot.resolve(inputFilePath));

--- a/packages/flutter_scene/lib/src/importer/build_hooks_unsupported.dart
+++ b/packages/flutter_scene/lib/src/importer/build_hooks_unsupported.dart
@@ -30,6 +30,7 @@ Never buildScenes({
   String outputDirectory = 'build/scenes/',
   String discoveryRoot = 'assets/',
   ModelAssetMode assetMode = ModelAssetMode.legacyOnly,
+  bool compressTextures = false,
 }) => throw UnsupportedError(
   'buildScenes runs at build time on native platforms only.',
 );

--- a/packages/flutter_scene/lib/src/importer/in_memory_import.dart
+++ b/packages/flutter_scene/lib/src/importer/in_memory_import.dart
@@ -27,10 +27,17 @@ Uint8List importGlbToModelBytes(Uint8List glbBytes) {
 /// The document declares right-handed coordinates; realize it with
 /// `realizeScene` (or write it with `writeFscene` / `writeFsceneb`). Uses no
 /// `dart:io`, so it runs at runtime on any platform.
-SceneDocument importGlbToSceneDocument(Uint8List glbBytes) {
+SceneDocument importGlbToSceneDocument(
+  Uint8List glbBytes, {
+  bool compressTextures = false,
+}) {
   final container = parseGlb(glbBytes);
   final doc = parseGltfJson(container.json);
-  return buildSceneDocument(doc, container.binaryChunk);
+  return buildSceneDocument(
+    doc,
+    container.binaryChunk,
+    compressTextures: compressTextures,
+  );
 }
 
 /// Converts a single-file glTF binary (`.glb`) to `.fsceneb` binary container
@@ -39,8 +46,15 @@ SceneDocument importGlbToSceneDocument(Uint8List glbBytes) {
 /// Geometry is packed with the same code the `.model` path uses, so a
 /// primitive's vertex/index payload bytes match the `.model` output. Uses no
 /// `dart:io`, so it runs at runtime on any platform.
-Uint8List importGlbToFscenebBytes(Uint8List glbBytes) {
+Uint8List importGlbToFscenebBytes(
+  Uint8List glbBytes, {
+  bool compressTextures = false,
+}) {
   final container = parseGlb(glbBytes);
   final doc = parseGltfJson(container.json);
-  return emitFsceneb(doc, container.binaryChunk);
+  return emitFsceneb(
+    doc,
+    container.binaryChunk,
+    compressTextures: compressTextures,
+  );
 }

--- a/packages/flutter_scene/lib/src/importer/offline_import.dart
+++ b/packages/flutter_scene/lib/src/importer/offline_import.dart
@@ -57,6 +57,7 @@ void importGltfToFsceneb(
   String inputGltfFilePath,
   String outputFscenebFilePath, {
   String? workingDirectory,
+  bool compressTextures = false,
 }) {
   final workingDirectoryUri = Uri.directory(
     workingDirectory ?? Directory.current.path,
@@ -71,7 +72,11 @@ void importGltfToFsceneb(
   final inputBytes = File(inputGltfFilePath).readAsBytesSync();
   final container = parseGlb(inputBytes);
   final doc = parseGltfJson(container.json);
-  final outputBytes = emitFsceneb(doc, container.binaryChunk);
+  final outputBytes = emitFsceneb(
+    doc,
+    container.binaryChunk,
+    compressTextures: compressTextures,
+  );
   final outputFile = File(outputFscenebFilePath);
   outputFile.parent.createSync(recursive: true);
   outputFile.writeAsBytesSync(outputBytes);

--- a/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
+++ b/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
@@ -27,20 +27,34 @@ import '../../../fscene/binary/fsceneb.dart';
 import '../../../fscene/property_value.dart';
 import '../../../fscene/scene_document.dart';
 import '../../../fscene/specs.dart';
+import '../../../texture/ktx2_image.dart';
 import '../gltf/accessor.dart';
 import '../gltf/primitive_packer.dart';
 import '../gltf/types.dart';
 
 /// Converts a parsed glTF document (plus its binary buffer) into `.fsceneb`
 /// container bytes.
-Uint8List emitFsceneb(GltfDocument doc, Uint8List bufferData) =>
-    writeFsceneb(buildSceneDocument(doc, bufferData));
+Uint8List emitFsceneb(
+  GltfDocument doc,
+  Uint8List bufferData, {
+  bool compressTextures = false,
+}) => writeFsceneb(
+  buildSceneDocument(doc, bufferData, compressTextures: compressTextures),
+);
 
 /// Builds an `.fscene` [SceneDocument] from a parsed glTF document.
 ///
 /// The document is declared right-handed ([Handedness.right]); the realizer
 /// applies the glTF-to-engine mirror, so no per-node winding flip is baked in.
-SceneDocument buildSceneDocument(GltfDocument doc, Uint8List bufferData) {
+///
+/// When [compressTextures] is set, images are stored as mipped, supercompressed
+/// KTX2 block payloads (`format: 'ktx2'`) instead of raw `rgba8`, shrinking the
+/// container; the realizer transcodes or decodes them at load.
+SceneDocument buildSceneDocument(
+  GltfDocument doc,
+  Uint8List bufferData, {
+  bool compressTextures = false,
+}) {
   final seed = _seedFrom(bufferData);
   final document = SceneDocument(
     documentId: DocumentId.generate(Random(seed)),
@@ -59,7 +73,13 @@ SceneDocument buildSceneDocument(GltfDocument doc, Uint8List bufferData) {
   // (which references materials).
   final textureIds = [
     for (final texture in doc.textures)
-      _buildTexture(document, texture, doc, bufferData),
+      _buildTexture(
+        document,
+        texture,
+        doc,
+        bufferData,
+        compressTextures: compressTextures,
+      ),
   ];
   final materialIds = [
     for (final material in doc.materials)
@@ -478,8 +498,9 @@ LocalId? _buildTexture(
   SceneDocument document,
   GltfTexture texture,
   GltfDocument doc,
-  Uint8List bufferData,
-) {
+  Uint8List bufferData, {
+  bool compressTextures = false,
+}) {
   if (texture.source == null || texture.source! >= doc.images.length) {
     return null;
   }
@@ -494,12 +515,24 @@ LocalId? _buildTexture(
     final decoded = img.decodeImage(encoded);
     if (decoded != null) {
       final rgba = decoded.convert(numChannels: 4, format: img.Format.uint8);
-      final bytes = rgba.getBytes(order: img.ChannelOrder.rgba);
+      final raw = rgba.getBytes(order: img.ChannelOrder.rgba);
+      // TODO(texture-compression): pick quality/sRGB per material role (base
+      // color is sRGB; normal/metallic-roughness/occlusion are linear) once the
+      // texture's slot is known here.
+      final bytes = compressTextures
+          ? encodeImageToKtx2Bytes(
+              raw,
+              rgba.width,
+              rgba.height,
+              generateMips: true,
+              supercompress: true,
+            )
+          : raw;
       final payload = document.addPayload(
         PayloadSpec(
           document.newId(),
           encoding: PayloadEncoding.image,
-          format: 'rgba8',
+          format: compressTextures ? 'ktx2' : 'rgba8',
           width: rgba.width,
           height: rgba.height,
           length: bytes.length,

--- a/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
+++ b/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
@@ -519,12 +519,14 @@ LocalId? _buildTexture(
       // TODO(texture-compression): pick quality/sRGB per material role (base
       // color is sRGB; normal/metallic-roughness/occlusion are linear) once the
       // texture's slot is known here.
+      // TODO(texture-compression): set generateMips once the GPU upload uploads
+      // the full chain (see compressed_texture.dart); today the upload uses the
+      // base level only, so storing mips would just bloat the container.
       final bytes = compressTextures
           ? encodeImageToKtx2Bytes(
               raw,
               rgba.width,
               rgba.height,
-              generateMips: true,
               supercompress: true,
             )
           : raw;

--- a/packages/flutter_scene/lib/src/texture/block/transcode_astc.dart
+++ b/packages/flutter_scene/lib/src/texture/block/transcode_astc.dart
@@ -1,0 +1,158 @@
+// Transcodes our 4x4 block format to ASTC 4x4 LDR (the Apple / modern-mobile
+// family), plus a CPU decoder for testing.
+//
+// We emit ONE fixed ASTC configuration so the encoder stays tractable:
+//   - 4x4 block footprint, 4x4 weight grid (16 weights, one per texel)
+//   - single plane, single partition
+//   - color endpoint mode 8 (LDR RGB direct), 6 endpoint integers
+//   - 8-bit (QUANT_256) endpoints, 3-bit (range 7) weights, both pure-bit ISE
+//
+// Block layout (128 bits, byte 0 = bits 0..7):
+//   bits [10:0]   block mode 0x53 (4x4 grid, range 7, single plane)
+//   bits [12:11]  partition count - 1 = 0
+//   bits [16:13]  CEM = 8
+//   bits [64:17]  endpoints v0..v5, 8 bits each, LSB-first
+//   bits [79:65]  unused
+//   bits [127:80] weights, 16 x 3 bits, written reversed from bit 127 down
+//
+// The exact A/B size-field bit positions, the weight bit-reversal, and the
+// endpoint ordering are reconstructed from the ASTC spec and reference
+// decoders; GPU acceptance of these bytes is confirmed by on-device rendering.
+// TODO(texture-compression): widen beyond this single config (other ranges,
+// dual plane, RGBA via CEM 12 for alpha) once the base config is GPU-confirmed.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/block/universal_block.dart';
+
+/// Bytes per ASTC 4x4 block.
+const int kAstcBlockBytes = 16;
+
+const int _astcBlockMode = 0x53; // 4x4 grid, weight range 7, single plane
+const int _astcCem = 8; // LDR RGB direct
+const int _weightLevels = 8; // range 7 -> 0..7
+const int _weightBits = 3;
+const int _numWeights = 16;
+const int _weightDataBits = _numWeights * _weightBits; // 48 (weights at 127:80)
+const int _endpointStartBit = 17;
+
+/// Transcodes packed universal blocks to packed ASTC 4x4 LDR blocks.
+/// [blockCount] is the number of 4x4 blocks.
+Uint8List transcodeUniversalToAstc4x4(Uint8List blocks, int blockCount) {
+  final out = Uint8List(blockCount * kAstcBlockBytes);
+  for (var b = 0; b < blockCount; b++) {
+    _transcodeBlock(blocks, b * kBlockBytes, out, b * kAstcBlockBytes);
+  }
+  return out;
+}
+
+void _setBit(Uint8List blk, int base, int bit, int value) {
+  if (value != 0) blk[base + (bit >> 3)] |= 1 << (bit & 7);
+}
+
+void _setBits(Uint8List blk, int base, int start, int count, int value) {
+  for (var j = 0; j < count; j++) {
+    _setBit(blk, base, start + j, (value >> j) & 1);
+  }
+}
+
+int _round(double v) => (v + 0.5).floor();
+
+void _transcodeBlock(Uint8List src, int si, Uint8List out, int oi) {
+  final e0 = [src[si], src[si + 1], src[si + 2]];
+  final e1 = [src[si + 4], src[si + 5], src[si + 6]];
+
+  // Order endpoints so the higher-luma one is the odd (v1,v3,v5) endpoint; with
+  // sum(odd) >= sum(even) the decoder takes the direct path (no blue contract).
+  final sum0 = e0[0] + e0[1] + e0[2];
+  final sum1 = e1[0] + e1[1] + e1[2];
+  final low = sum1 >= sum0 ? e0 : e1;
+  final high = sum1 >= sum0 ? e1 : e0;
+  final flip = sum1 < sum0;
+
+  // Config.
+  _setBits(out, oi, 0, 11, _astcBlockMode);
+  _setBits(out, oi, 11, 2, 0); // 1 partition
+  _setBits(out, oi, 13, 4, _astcCem);
+
+  // Endpoints v0..v5 = (low.r, high.r, low.g, high.g, low.b, high.b), 8 bits.
+  final v = [low[0], high[0], low[1], high[1], low[2], high[2]];
+  var pos = _endpointStartBit;
+  for (final value in v) {
+    _setBits(out, oi, pos, 8, value);
+    pos += 8;
+  }
+
+  // Weights: build the ISE bitstream (LSB-first per weight, weights in raster
+  // order), then place it reversed into the top of the block.
+  final ws = Uint8List(_weightDataBits);
+  for (var i = 0; i < _numWeights; i++) {
+    final byte = src[si + 8 + (i >> 1)];
+    final w16 = i.isEven ? byte & 0x0F : (byte >> 4) & 0x0F;
+    final t = (flip ? (15 - w16) : w16) / 15.0;
+    final w = _round(t * (_weightLevels - 1)).clamp(0, _weightLevels - 1);
+    for (var b = 0; b < _weightBits; b++) {
+      ws[i * _weightBits + b] = (w >> b) & 1;
+    }
+  }
+  for (var k = 0; k < _weightDataBits; k++) {
+    _setBit(out, oi, 127 - k, ws[k]);
+  }
+}
+
+int _getBit(Uint8List blk, int base, int bit) =>
+    (blk[base + (bit >> 3)] >> (bit & 7)) & 1;
+
+int _getBits(Uint8List blk, int base, int start, int count) {
+  var value = 0;
+  for (var j = 0; j < count; j++) {
+    value |= _getBit(blk, base, start + j) << j;
+  }
+  return value;
+}
+
+/// Decodes packed ASTC 4x4 blocks (our fixed config only) to rgba8, for tests.
+Uint8List decodeAstc4x4ToRgba8(Uint8List astc, int width, int height) {
+  final blocksX = (width + kBlockDim - 1) ~/ kBlockDim;
+  final blocksY = (height + kBlockDim - 1) ~/ kBlockDim;
+  final out = Uint8List(width * height * 4);
+  for (var by = 0; by < blocksY; by++) {
+    for (var bx = 0; bx < blocksX; bx++) {
+      final base = (by * blocksX + bx) * kAstcBlockBytes;
+
+      // Endpoints.
+      final v = List<int>.filled(6, 0);
+      var pos = _endpointStartBit;
+      for (var k = 0; k < 6; k++) {
+        v[k] = _getBits(astc, base, pos, 8);
+        pos += 8;
+      }
+      final low = [v[0], v[2], v[4]];
+      final high = [v[1], v[3], v[5]];
+
+      // Weights (reverse the placement).
+      final ws = Uint8List(_weightDataBits);
+      for (var k = 0; k < _weightDataBits; k++) {
+        ws[k] = _getBit(astc, base, 127 - k);
+      }
+
+      for (var i = 0; i < _numWeights; i++) {
+        var w = 0;
+        for (var b = 0; b < _weightBits; b++) {
+          w |= ws[i * _weightBits + b] << b;
+        }
+        final y = i ~/ 4;
+        final x = i % 4;
+        final dy = by * 4 + y;
+        final dx = bx * 4 + x;
+        if (dy >= height || dx >= width) continue;
+        final dst = (dy * width + dx) * 4;
+        for (var c = 0; c < 3; c++) {
+          out[dst + c] = low[c] + (high[c] - low[c]) * w ~/ (_weightLevels - 1);
+        }
+        out[dst + 3] = 255;
+      }
+    }
+  }
+  return out;
+}

--- a/packages/flutter_scene/lib/src/texture/block/transcode_bc1.dart
+++ b/packages/flutter_scene/lib/src/texture/block/transcode_bc1.dart
@@ -1,0 +1,145 @@
+// Transcodes our 4x4 block format to BC1 (DXT1), the desktop BC-family block
+// format, plus a CPU decoder used for testing.
+//
+// BC1 is 8 bytes per 4x4 block: two RGB565 endpoints then sixteen 2-bit
+// indices. When color0 > color1 (as unsigned 16-bit) the block is opaque
+// 4-color; otherwise it is 3-color-plus-transparent. We always emit the
+// 4-color form so output stays opaque (BC1 carries no real alpha; textures
+// with alpha need BC3/BC7).
+// TODO(texture-compression): add BC3/BC7 (alpha), and ASTC/ETC2 for the mobile
+// and Apple families, which is where the VRAM win lands on those devices.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/block/universal_block.dart';
+
+/// Bytes per BC1 block.
+const int kBc1BlockBytes = 8;
+
+/// Transcodes packed universal blocks to packed BC1 blocks. [blockCount] is the
+/// number of 4x4 blocks in [blocks].
+Uint8List transcodeUniversalToBc1(Uint8List blocks, int blockCount) {
+  final out = Uint8List(blockCount * kBc1BlockBytes);
+  for (var b = 0; b < blockCount; b++) {
+    _transcodeBlock(blocks, b * kBlockBytes, out, b * kBc1BlockBytes);
+  }
+  return out;
+}
+
+void _transcodeBlock(Uint8List src, int si, Uint8List out, int oi) {
+  // Endpoints, as RGB565.
+  var c0 = _pack565(src[si], src[si + 1], src[si + 2]);
+  var c1 = _pack565(src[si + 4], src[si + 5], src[si + 6]);
+  // 4-color (opaque) mode requires color0 > color1. If swapped, flip the
+  // weight direction below.
+  final swapped = c0 < c1;
+  if (swapped) {
+    final t = c0;
+    c0 = c1;
+    c1 = t;
+  }
+  out[oi] = c0 & 0xFF;
+  out[oi + 1] = (c0 >> 8) & 0xFF;
+  out[oi + 2] = c1 & 0xFF;
+  out[oi + 3] = (c1 >> 8) & 0xFF;
+
+  // Map each texel's 4-bit weight along the endpoint line to a 2-bit BC1 index.
+  // BC1 reconstruction points sit at t = 0 (index 0), 1/3 (index 2), 2/3
+  // (index 3), 1 (index 1), measured from color0 to color1.
+  var bits = 0;
+  for (var i = 0; i < 16; i++) {
+    final byte = src[si + 8 + (i >> 1)];
+    final w = i.isEven ? byte & 0x0F : (byte >> 4) & 0x0F;
+    var t = w / 15.0; // 0 at endpoint 0, 1 at endpoint 1
+    if (swapped) t = 1.0 - t;
+    final int index;
+    if (t < 1 / 6) {
+      index = 0;
+    } else if (t < 3 / 6) {
+      index = 2;
+    } else if (t < 5 / 6) {
+      index = 3;
+    } else {
+      index = 1;
+    }
+    bits |= index << (i * 2);
+  }
+  out[oi + 4] = bits & 0xFF;
+  out[oi + 5] = (bits >> 8) & 0xFF;
+  out[oi + 6] = (bits >> 16) & 0xFF;
+  out[oi + 7] = (bits >> 24) & 0xFF;
+}
+
+int _pack565(int r, int g, int b) =>
+    ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
+
+({int r, int g, int b}) _unpack565(int c) {
+  final r5 = (c >> 11) & 0x1F;
+  final g6 = (c >> 5) & 0x3F;
+  final b5 = c & 0x1F;
+  // Expand to 8 bits with bit replication, matching standard BC1 decoders.
+  return (
+    r: (r5 << 3) | (r5 >> 2),
+    g: (g6 << 2) | (g6 >> 4),
+    b: (b5 << 3) | (b5 >> 2),
+  );
+}
+
+/// Decodes packed BC1 blocks to rgba8, dropping the replicated edge texels of
+/// partial blocks. For tests and the no-GPU reference path.
+Uint8List decodeBc1ToRgba8(Uint8List bc1, int width, int height) {
+  final blocksX = (width + kBlockDim - 1) ~/ kBlockDim;
+  final blocksY = (height + kBlockDim - 1) ~/ kBlockDim;
+  final out = Uint8List(width * height * 4);
+  for (var by = 0; by < blocksY; by++) {
+    for (var bx = 0; bx < blocksX; bx++) {
+      final bi = (by * blocksX + bx) * kBc1BlockBytes;
+      final c0 = bc1[bi] | (bc1[bi + 1] << 8);
+      final c1 = bc1[bi + 2] | (bc1[bi + 3] << 8);
+      final e0 = _unpack565(c0);
+      final e1 = _unpack565(c1);
+      final palette = <List<int>>[
+        [e0.r, e0.g, e0.b, 255],
+        [e1.r, e1.g, e1.b, 255],
+        if (c0 > c1) ...[
+          [
+            (2 * e0.r + e1.r) ~/ 3,
+            (2 * e0.g + e1.g) ~/ 3,
+            (2 * e0.b + e1.b) ~/ 3,
+            255,
+          ],
+          [
+            (e0.r + 2 * e1.r) ~/ 3,
+            (e0.g + 2 * e1.g) ~/ 3,
+            (e0.b + 2 * e1.b) ~/ 3,
+            255,
+          ],
+        ] else ...[
+          [(e0.r + e1.r) ~/ 2, (e0.g + e1.g) ~/ 2, (e0.b + e1.b) ~/ 2, 255],
+          [0, 0, 0, 0],
+        ],
+      ];
+      final bits =
+          bc1[bi + 4] |
+          (bc1[bi + 5] << 8) |
+          (bc1[bi + 6] << 16) |
+          (bc1[bi + 7] << 24);
+      for (var ty = 0; ty < kBlockDim; ty++) {
+        final dy = by * kBlockDim + ty;
+        if (dy >= height) break;
+        for (var tx = 0; tx < kBlockDim; tx++) {
+          final dx = bx * kBlockDim + tx;
+          if (dx >= width) continue;
+          final i = ty * kBlockDim + tx;
+          final color = palette[(bits >> (i * 2)) & 0x3];
+          final dst = (dy * width + dx) * 4;
+          out[dst] = color[0];
+          out[dst + 1] = color[1];
+          out[dst + 2] = color[2];
+          out[dst + 3] = color[3];
+        }
+      }
+    }
+  }
+  return out;
+}

--- a/packages/flutter_scene/lib/src/texture/block/transcode_etc2.dart
+++ b/packages/flutter_scene/lib/src/texture/block/transcode_etc2.dart
@@ -1,0 +1,369 @@
+// Transcodes our 4x4 block format to ETC2 RGB8 (the GLES3 / WebGL2 / mobile
+// family), plus a CPU decoder for testing.
+//
+// We emit ETC1-subset blocks (individual and differential modes), which every
+// ETC2 RGB8 sampler decodes. Transcoding goes through rgba: each universal
+// block is decoded to 16 texels, then ETC1-encoded. ETC2 RGB8 is 8 bytes per
+// 4x4 block (opaque); textures with alpha need a separate path.
+// TODO(texture-compression): add the ETC2 T/H/planar modes for higher quality,
+// and ETC2 RGBA8 (with the EAC alpha block) for textures with alpha.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/block/universal_block.dart';
+
+/// Bytes per ETC2 RGB8 block.
+const int kEtc2Rgb8BlockBytes = 8;
+
+// Intensity modifier sets, indexed [tableCodeword][pixelIndex], where the
+// pixel index is (msb << 1) | lsb. Ordered {small+, large+, small-, large-}.
+const List<List<int>> _modifier = [
+  [2, 8, -2, -8],
+  [5, 17, -5, -17],
+  [9, 29, -9, -29],
+  [13, 42, -13, -42],
+  [18, 60, -18, -60],
+  [24, 80, -24, -80],
+  [33, 106, -33, -106],
+  [47, 183, -47, -183],
+];
+
+/// Transcodes packed universal blocks to packed ETC2 RGB8 blocks. [blockCount]
+/// is the number of 4x4 blocks.
+Uint8List transcodeUniversalToEtc2Rgb(Uint8List blocks, int blockCount) {
+  final out = Uint8List(blockCount * kEtc2Rgb8BlockBytes);
+  final rgb = Int32List(16 * 3);
+  for (var b = 0; b < blockCount; b++) {
+    _decodeUniversalToRgb(blocks, b * kBlockBytes, rgb);
+    _encodeEtc1Block(rgb, out, b * kEtc2Rgb8BlockBytes);
+  }
+  return out;
+}
+
+int _clampByte(int v) => v < 0
+    ? 0
+    : v > 255
+    ? 255
+    : v;
+
+/// Decodes one universal block to 16 RGB texels (alpha dropped), texel
+/// i = row*4 + col.
+void _decodeUniversalToRgb(Uint8List blocks, int offset, Int32List rgb) {
+  final e0 = [blocks[offset], blocks[offset + 1], blocks[offset + 2]];
+  final e1 = [blocks[offset + 4], blocks[offset + 5], blocks[offset + 6]];
+  for (var i = 0; i < 16; i++) {
+    final byte = blocks[offset + 8 + (i >> 1)];
+    final w = i.isEven ? byte & 0x0F : (byte >> 4) & 0x0F;
+    for (var c = 0; c < 3; c++) {
+      rgb[i * 3 + c] = (e0[c] * (15 - w) + e1[c] * w + 7) ~/ 15;
+    }
+  }
+}
+
+// Pixel layout within an ETC1 block: texel index p = x * 4 + y (x is the
+// column 0..3, y the row 0..3). Our texel index i = y * 4 + x, so map between
+// them when reading/writing pixels.
+int _etcPixelIndex(int x, int y) => x * 4 + y;
+
+/// Encodes 16 RGB texels (texel i = y*4 + x) to one ETC1 block at [out]/[oi].
+void _encodeEtc1Block(Int32List rgb, Uint8List out, int oi) {
+  var bestErr = -1;
+  var bestHigh = 0, bestLow = 0;
+
+  for (var flip = 0; flip < 2; flip++) {
+    // The two subblocks' texel coordinates.
+    final subA = <int>[]; // our texel indices (y*4 + x)
+    final subB = <int>[];
+    for (var y = 0; y < 4; y++) {
+      for (var x = 0; x < 4; x++) {
+        final inA = flip == 0 ? x < 2 : y < 2;
+        (inA ? subA : subB).add(y * 4 + x);
+      }
+    }
+
+    // Average color per subblock.
+    final avgA = _avg(rgb, subA);
+    final avgB = _avg(rgb, subB);
+
+    // Individual mode: each base is RGB444.
+    final q444a = _quant444(avgA);
+    final q444b = _quant444(avgB);
+    final baseAi = _expand444(q444a);
+    final baseBi = _expand444(q444b);
+    final fitAi = _fitSubblock(rgb, subA, baseAi);
+    final fitBi = _fitSubblock(rgb, subB, baseBi);
+    final errI = fitAi.error + fitBi.error;
+
+    // Differential mode: base1 RGB555, base2 = base1 + 3-bit signed delta.
+    final q1 = _quant555(avgA);
+    final q2 = _quant555(avgB);
+    var feasible = true;
+    final delta = List<int>.filled(3, 0);
+    for (var c = 0; c < 3; c++) {
+      delta[c] = q2[c] - q1[c];
+      if (delta[c] < -4 || delta[c] > 3) feasible = false;
+    }
+    var useDiff = false;
+    late _Fit fitAd, fitBd;
+    if (feasible) {
+      final baseAd = _expand555(q1);
+      final baseBd = _expand555([
+        q1[0] + delta[0],
+        q1[1] + delta[1],
+        q1[2] + delta[2],
+      ]);
+      fitAd = _fitSubblock(rgb, subA, baseAd);
+      fitBd = _fitSubblock(rgb, subB, baseBd);
+      final errD = fitAd.error + fitBd.error;
+      useDiff = errD <= errI;
+    }
+
+    final int err;
+    final int high;
+    if (useDiff) {
+      err = fitAd.error + fitBd.error;
+      high = _packHighDiff(q1, delta, fitAd.table, fitBd.table, flip);
+    } else {
+      err = errI;
+      high = _packHighIndividual(q444a, q444b, fitAi.table, fitBi.table, flip);
+    }
+    final low = _packPixels(
+      flip,
+      subA,
+      useDiff ? fitAd.indices : fitAi.indices,
+      subB,
+      useDiff ? fitBd.indices : fitBi.indices,
+    );
+
+    if (bestErr < 0 || err < bestErr) {
+      bestErr = err;
+      bestHigh = high;
+      bestLow = low;
+    }
+  }
+
+  out[oi] = (bestHigh >> 24) & 0xFF;
+  out[oi + 1] = (bestHigh >> 16) & 0xFF;
+  out[oi + 2] = (bestHigh >> 8) & 0xFF;
+  out[oi + 3] = bestHigh & 0xFF;
+  out[oi + 4] = (bestLow >> 24) & 0xFF;
+  out[oi + 5] = (bestLow >> 16) & 0xFF;
+  out[oi + 6] = (bestLow >> 8) & 0xFF;
+  out[oi + 7] = bestLow & 0xFF;
+}
+
+class _Fit {
+  _Fit(this.table, this.indices, this.error);
+  final int table;
+  final List<int> indices; // per pixel of the subblock, 0..3
+  final int error;
+}
+
+List<int> _avg(Int32List rgb, List<int> texels) {
+  var r = 0, g = 0, b = 0;
+  for (final i in texels) {
+    r += rgb[i * 3];
+    g += rgb[i * 3 + 1];
+    b += rgb[i * 3 + 2];
+  }
+  final n = texels.length;
+  return [(r + n ~/ 2) ~/ n, (g + n ~/ 2) ~/ n, (b + n ~/ 2) ~/ n];
+}
+
+/// Picks the table codeword and per-pixel indices minimizing error for a fixed
+/// [base] color.
+_Fit _fitSubblock(Int32List rgb, List<int> texels, List<int> base) {
+  var bestTable = 0;
+  var bestErr = -1;
+  late List<int> bestIndices;
+  for (var t = 0; t < 8; t++) {
+    final indices = List<int>.filled(texels.length, 0);
+    var total = 0;
+    for (var p = 0; p < texels.length; p++) {
+      final i = texels[p];
+      var pErr = -1;
+      var pIdx = 0;
+      for (var idx = 0; idx < 4; idx++) {
+        final m = _modifier[t][idx];
+        var e = 0;
+        for (var c = 0; c < 3; c++) {
+          final d = _clampByte(base[c] + m) - rgb[i * 3 + c];
+          e += d * d;
+        }
+        if (pErr < 0 || e < pErr) {
+          pErr = e;
+          pIdx = idx;
+        }
+      }
+      indices[p] = pIdx;
+      total += pErr;
+    }
+    if (bestErr < 0 || total < bestErr) {
+      bestErr = total;
+      bestTable = t;
+      bestIndices = indices;
+    }
+  }
+  return _Fit(bestTable, bestIndices, bestErr);
+}
+
+List<int> _quant444(List<int> c) => [c[0] >> 4, c[1] >> 4, c[2] >> 4];
+List<int> _quant555(List<int> c) => [c[0] >> 3, c[1] >> 3, c[2] >> 3];
+List<int> _expand444(List<int> q) {
+  final out = List<int>.filled(3, 0);
+  for (var i = 0; i < 3; i++) {
+    final v = q[i] & 0xF;
+    out[i] = (v << 4) | v;
+  }
+  return out;
+}
+
+int _packPixels(
+  int flip,
+  List<int> subA,
+  List<int> idxA,
+  List<int> subB,
+  List<int> idxB,
+) {
+  var low = 0;
+  void place(int texel, int idx) {
+    final x = texel % 4;
+    final y = texel ~/ 4;
+    final p = _etcPixelIndex(x, y); // 0..15
+    final msb = (idx >> 1) & 1;
+    final lsb = idx & 1;
+    low |= msb << (16 + p);
+    low |= lsb << p;
+  }
+
+  for (var k = 0; k < subA.length; k++) {
+    place(subA[k], idxA[k]);
+  }
+  for (var k = 0; k < subB.length; k++) {
+    place(subB[k], idxB[k]);
+  }
+  return low & 0xFFFFFFFF;
+}
+
+int _packHighIndividual(
+  List<int> q444a,
+  List<int> q444b,
+  int table1,
+  int table2,
+  int flip,
+) {
+  var high = 0;
+  high |= q444a[0] << 28;
+  high |= q444b[0] << 24;
+  high |= q444a[1] << 20;
+  high |= q444b[1] << 16;
+  high |= q444a[2] << 12;
+  high |= q444b[2] << 8;
+  high |= table1 << 5;
+  high |= table2 << 2;
+  high |= 0 << 1; // diffbit = 0
+  high |= flip;
+  return high & 0xFFFFFFFF;
+}
+
+int _packHighDiff(
+  List<int> base555,
+  List<int> delta,
+  int table1,
+  int table2,
+  int flip,
+) {
+  var high = 0;
+  high |= base555[0] << 27;
+  high |= (delta[0] & 0x7) << 24;
+  high |= base555[1] << 19;
+  high |= (delta[1] & 0x7) << 16;
+  high |= base555[2] << 11;
+  high |= (delta[2] & 0x7) << 8;
+  high |= table1 << 5;
+  high |= table2 << 2;
+  high |= 1 << 1; // diffbit = 1
+  high |= flip;
+  return high & 0xFFFFFFFF;
+}
+
+/// Decodes packed ETC2 RGB8 (ETC1-subset) blocks to rgba8, for tests.
+Uint8List decodeEtc2RgbToRgba8(Uint8List etc2, int width, int height) {
+  final blocksX = (width + kBlockDim - 1) ~/ kBlockDim;
+  final blocksY = (height + kBlockDim - 1) ~/ kBlockDim;
+  final out = Uint8List(width * height * 4);
+  for (var by = 0; by < blocksY; by++) {
+    for (var bx = 0; bx < blocksX; bx++) {
+      final bi = (by * blocksX + bx) * kEtc2Rgb8BlockBytes;
+      final high =
+          (etc2[bi] << 24) |
+          (etc2[bi + 1] << 16) |
+          (etc2[bi + 2] << 8) |
+          etc2[bi + 3];
+      final low =
+          (etc2[bi + 4] << 24) |
+          (etc2[bi + 5] << 16) |
+          (etc2[bi + 6] << 8) |
+          etc2[bi + 7];
+      final diff = (high >> 1) & 1;
+      final flip = high & 1;
+      final table1 = (high >> 5) & 0x7;
+      final table2 = (high >> 2) & 0x7;
+
+      final List<int> baseA, baseB;
+      if (diff == 1) {
+        final r = (high >> 27) & 0x1F;
+        final g = (high >> 19) & 0x1F;
+        final b = (high >> 11) & 0x1F;
+        final dr = _signed3((high >> 24) & 0x7);
+        final dg = _signed3((high >> 16) & 0x7);
+        final db = _signed3((high >> 8) & 0x7);
+        baseA = _expand555([r, g, b]);
+        baseB = _expand555([r + dr, g + dg, b + db]);
+      } else {
+        baseA = _expand444([
+          (high >> 28) & 0xF,
+          (high >> 20) & 0xF,
+          (high >> 12) & 0xF,
+        ]);
+        baseB = _expand444([
+          (high >> 24) & 0xF,
+          (high >> 16) & 0xF,
+          (high >> 8) & 0xF,
+        ]);
+      }
+
+      for (var y = 0; y < 4; y++) {
+        final dy = by * 4 + y;
+        if (dy >= height) continue;
+        for (var x = 0; x < 4; x++) {
+          final dx = bx * 4 + x;
+          if (dx >= width) continue;
+          final p = _etcPixelIndex(x, y);
+          final msb = (low >> (16 + p)) & 1;
+          final lsb = (low >> p) & 1;
+          final idx = (msb << 1) | lsb;
+          final inA = flip == 0 ? x < 2 : y < 2;
+          final base = inA ? baseA : baseB;
+          final m = _modifier[inA ? table1 : table2][idx];
+          final dst = (dy * width + dx) * 4;
+          out[dst] = _clampByte(base[0] + m);
+          out[dst + 1] = _clampByte(base[1] + m);
+          out[dst + 2] = _clampByte(base[2] + m);
+          out[dst + 3] = 255;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+int _signed3(int v) => v >= 4 ? v - 8 : v;
+List<int> _expand555(List<int> c) {
+  final out = List<int>.filled(3, 0);
+  for (var i = 0; i < 3; i++) {
+    final v = c[i] & 0x1F;
+    out[i] = (v << 3) | (v >> 2);
+  }
+  return out;
+}

--- a/packages/flutter_scene/lib/src/texture/block/universal_block.dart
+++ b/packages/flutter_scene/lib/src/texture/block/universal_block.dart
@@ -1,0 +1,291 @@
+// A pure-Dart 4x4 LDR block codec, the transcode-friendly intermediate that
+// rides inside KTX2 and is decoded (or transcoded to a GPU block format) at
+// load time.
+//
+// This is flutter_scene's own block format, not Basis UASTC. It keeps UASTC's
+// architecture (one 16-byte 4x4 block that transcodes to the device's family
+// at load) but a layout we both encode and decode, so every layer is
+// round-trip testable without external reference vectors. The format is
+// deliberately simple: two RGBA8 endpoints and a 4-bit weight per texel along
+// the endpoint line.
+//
+// Block layout (128 bits, little-endian byte order):
+//   bytes 0..3   endpoint 0 = R, G, B, A
+//   bytes 4..7   endpoint 1 = R, G, B, A
+//   bytes 8..15  sixteen 4-bit weights, texel 0 in the low nibble of byte 8
+//
+// A texel is reconstructed as lerp(endpoint0, endpoint1, weight / 15) per
+// channel. Color and alpha share one weight; uncorrelated alpha loses
+// precision.
+// TODO(texture-compression): add a second (alpha) endpoint line for textures
+// whose alpha is uncorrelated with color, the way BC7/UASTC partition modes do.
+
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+/// Edge length of a block in texels.
+const int kBlockDim = 4;
+
+/// Bytes per encoded block (1 byte per texel, a 4x compression of rgba8).
+const int kBlockBytes = 16;
+
+const int _texelsPerBlock = kBlockDim * kBlockDim;
+const int _weightLevels = 16; // 4-bit weights
+
+/// Encodes [width] x [height] rgba8 pixels to packed 4x4 blocks. Dimensions
+/// need not be multiples of four; edge texels are replicated to fill the last
+/// partial blocks.
+Uint8List encodeUniversalBlocks(Uint8List rgba, int width, int height) {
+  if (rgba.length < width * height * 4) {
+    throw ArgumentError('rgba is too small for ${width}x$height');
+  }
+  final blocksX = (width + kBlockDim - 1) ~/ kBlockDim;
+  final blocksY = (height + kBlockDim - 1) ~/ kBlockDim;
+  final out = Uint8List(blocksX * blocksY * kBlockBytes);
+
+  final texel = Int32List(_texelsPerBlock * 4);
+  for (var by = 0; by < blocksY; by++) {
+    for (var bx = 0; bx < blocksX; bx++) {
+      // Gather the block, clamping coordinates into the image for partial
+      // blocks at the right/bottom edges.
+      for (var ty = 0; ty < kBlockDim; ty++) {
+        final sy = _clamp(by * kBlockDim + ty, height - 1);
+        for (var tx = 0; tx < kBlockDim; tx++) {
+          final sx = _clamp(bx * kBlockDim + tx, width - 1);
+          final src = (sy * width + sx) * 4;
+          final dst = (ty * kBlockDim + tx) * 4;
+          texel[dst] = rgba[src];
+          texel[dst + 1] = rgba[src + 1];
+          texel[dst + 2] = rgba[src + 2];
+          texel[dst + 3] = rgba[src + 3];
+        }
+      }
+      _encodeBlock(texel, out, (by * blocksX + bx) * kBlockBytes);
+    }
+  }
+  return out;
+}
+
+/// Decodes packed 4x4 blocks back to [width] x [height] rgba8 pixels, dropping
+/// the replicated edge texels of partial blocks.
+Uint8List decodeUniversalBlocksToRgba8(
+  Uint8List blocks,
+  int width,
+  int height,
+) {
+  final blocksX = (width + kBlockDim - 1) ~/ kBlockDim;
+  final blocksY = (height + kBlockDim - 1) ~/ kBlockDim;
+  if (blocks.length < blocksX * blocksY * kBlockBytes) {
+    throw ArgumentError('blocks is too small for ${width}x$height');
+  }
+  final out = Uint8List(width * height * 4);
+  final texel = Int32List(_texelsPerBlock * 4);
+  for (var by = 0; by < blocksY; by++) {
+    for (var bx = 0; bx < blocksX; bx++) {
+      _decodeBlock(blocks, (by * blocksX + bx) * kBlockBytes, texel);
+      for (var ty = 0; ty < kBlockDim; ty++) {
+        final dy = by * kBlockDim + ty;
+        if (dy >= height) break;
+        for (var tx = 0; tx < kBlockDim; tx++) {
+          final dx = bx * kBlockDim + tx;
+          if (dx >= width) continue;
+          final src = (ty * kBlockDim + tx) * 4;
+          final dst = (dy * width + dx) * 4;
+          out[dst] = texel[src];
+          out[dst + 1] = texel[src + 1];
+          out[dst + 2] = texel[src + 2];
+          out[dst + 3] = texel[src + 3];
+        }
+      }
+    }
+  }
+  return out;
+}
+
+int _clamp(int value, int max) => value < 0
+    ? 0
+    : value > max
+    ? max
+    : value;
+
+int _round8(double v) => v < 0
+    ? 0
+    : v > 255
+    ? 255
+    : (v + 0.5).floor();
+
+/// Fits two endpoints along the block's principal color axis, then picks the
+/// nearest weight for each texel and refines the endpoints once by least
+/// squares.
+void _encodeBlock(Int32List texel, Uint8List out, int offset) {
+  // Mean of the 16 texels.
+  final mean = Float64List(4);
+  for (var i = 0; i < _texelsPerBlock; i++) {
+    for (var c = 0; c < 4; c++) {
+      mean[c] += texel[i * 4 + c];
+    }
+  }
+  for (var c = 0; c < 4; c++) {
+    mean[c] /= _texelsPerBlock;
+  }
+
+  // Principal axis by power iteration on the covariance (without forming the
+  // full 4x4 matrix): v <- sum_i (d_i . v) d_i.
+  var vx = 1.0, vy = 1.0, vz = 1.0, vw = 0.0;
+  for (var iter = 0; iter < 8; iter++) {
+    var ax = 0.0, ay = 0.0, az = 0.0, aw = 0.0;
+    for (var i = 0; i < _texelsPerBlock; i++) {
+      final dx = texel[i * 4] - mean[0];
+      final dy = texel[i * 4 + 1] - mean[1];
+      final dz = texel[i * 4 + 2] - mean[2];
+      final dw = texel[i * 4 + 3] - mean[3];
+      final dot = dx * vx + dy * vy + dz * vz + dw * vw;
+      ax += dot * dx;
+      ay += dot * dy;
+      az += dot * dz;
+      aw += dot * dw;
+    }
+    final len = math.sqrt(ax * ax + ay * ay + az * az + aw * aw);
+    if (len < 1e-9) break; // solid block; axis is irrelevant
+    vx = ax / len;
+    vy = ay / len;
+    vz = az / len;
+    vw = aw / len;
+  }
+
+  // Project onto the axis; endpoints are the extreme projections.
+  var minT = double.infinity, maxT = double.negativeInfinity;
+  for (var i = 0; i < _texelsPerBlock; i++) {
+    final t =
+        (texel[i * 4] - mean[0]) * vx +
+        (texel[i * 4 + 1] - mean[1]) * vy +
+        (texel[i * 4 + 2] - mean[2]) * vz +
+        (texel[i * 4 + 3] - mean[3]) * vw;
+    if (t < minT) minT = t;
+    if (t > maxT) maxT = t;
+  }
+
+  final e0 = Float64List(4), e1 = Float64List(4);
+  for (var c = 0; c < 4; c++) {
+    final axis = [vx, vy, vz, vw][c];
+    e0[c] = mean[c] + minT * axis;
+    e1[c] = mean[c] + maxT * axis;
+  }
+
+  // One least-squares refinement: solve the endpoints that minimize error for
+  // the weights chosen against the current endpoints.
+  final weights = Int32List(_texelsPerBlock);
+  _chooseWeights(texel, e0, e1, weights);
+  _refineEndpoints(texel, weights, e0, e1);
+  _chooseWeights(texel, e0, e1, weights);
+
+  out[offset] = _round8(e0[0]);
+  out[offset + 1] = _round8(e0[1]);
+  out[offset + 2] = _round8(e0[2]);
+  out[offset + 3] = _round8(e0[3]);
+  out[offset + 4] = _round8(e1[0]);
+  out[offset + 5] = _round8(e1[1]);
+  out[offset + 6] = _round8(e1[2]);
+  out[offset + 7] = _round8(e1[3]);
+  // Re-pick weights against the quantized endpoints actually stored, so the
+  // decoder and encoder agree.
+  final q0 = Float64List(4), q1 = Float64List(4);
+  for (var c = 0; c < 4; c++) {
+    q0[c] = out[offset + c].toDouble();
+    q1[c] = out[offset + 4 + c].toDouble();
+  }
+  _chooseWeights(texel, q0, q1, weights);
+  for (var i = 0; i < _texelsPerBlock; i++) {
+    final byte = offset + 8 + (i >> 1);
+    if (i.isEven) {
+      out[byte] = weights[i];
+    } else {
+      out[byte] |= weights[i] << 4;
+    }
+  }
+}
+
+void _decodeBlock(Uint8List blocks, int offset, Int32List texel) {
+  final e0 = [
+    blocks[offset],
+    blocks[offset + 1],
+    blocks[offset + 2],
+    blocks[offset + 3],
+  ];
+  final e1 = [
+    blocks[offset + 4],
+    blocks[offset + 5],
+    blocks[offset + 6],
+    blocks[offset + 7],
+  ];
+  for (var i = 0; i < _texelsPerBlock; i++) {
+    final byte = blocks[offset + 8 + (i >> 1)];
+    final w = i.isEven ? byte & 0x0F : (byte >> 4) & 0x0F;
+    for (var c = 0; c < 4; c++) {
+      // Rounded fixed-point lerp: e0 + (e1 - e0) * w / 15.
+      final value = e0[c] * (_weightLevels - 1 - w) + e1[c] * w;
+      texel[i * 4 + c] =
+          (value + (_weightLevels - 1) ~/ 2) ~/ (_weightLevels - 1);
+    }
+  }
+}
+
+/// Picks, per texel, the weight whose reconstruction is closest to the source.
+void _chooseWeights(
+  Int32List texel,
+  Float64List e0,
+  Float64List e1,
+  Int32List weights,
+) {
+  for (var i = 0; i < _texelsPerBlock; i++) {
+    var bestW = 0;
+    var bestErr = double.infinity;
+    for (var w = 0; w < _weightLevels; w++) {
+      final f = w / (_weightLevels - 1);
+      var err = 0.0;
+      for (var c = 0; c < 4; c++) {
+        final recon = e0[c] + (e1[c] - e0[c]) * f;
+        final d = recon - texel[i * 4 + c];
+        err += d * d;
+      }
+      if (err < bestErr) {
+        bestErr = err;
+        bestW = w;
+      }
+    }
+    weights[i] = bestW;
+  }
+}
+
+/// Least-squares endpoint fit for fixed weights: minimizes sum over texels of
+/// |e0 + (e1 - e0) f_i - color_i|^2 for each channel independently.
+void _refineEndpoints(
+  Int32List texel,
+  Int32List weights,
+  Float64List e0,
+  Float64List e1,
+) {
+  var sff = 0.0, sgg = 0.0, sfg = 0.0;
+  for (var i = 0; i < _texelsPerBlock; i++) {
+    final f = weights[i] / (_weightLevels - 1);
+    final g = 1.0 - f;
+    sff += f * f;
+    sgg += g * g;
+    sfg += f * g;
+  }
+  final det = sgg * sff - sfg * sfg;
+  if (det.abs() < 1e-9) return; // all weights equal; keep current endpoints
+  for (var c = 0; c < 4; c++) {
+    var bf = 0.0, bg = 0.0;
+    for (var i = 0; i < _texelsPerBlock; i++) {
+      final f = weights[i] / (_weightLevels - 1);
+      final g = 1.0 - f;
+      final value = texel[i * 4 + c].toDouble();
+      bf += f * value;
+      bg += g * value;
+    }
+    // Solve [sgg sfg; sfg sff] [e0; e1] = [bg; bf].
+    e0[c] = (sff * bg - sfg * bf) / det;
+    e1[c] = (sgg * bf - sfg * bg) / det;
+  }
+}

--- a/packages/flutter_scene/lib/src/texture/compressed_texture.dart
+++ b/packages/flutter_scene/lib/src/texture/compressed_texture.dart
@@ -34,55 +34,47 @@ gpu.Texture gpuTextureFromKtx2Texture(Ktx2Texture texture) {
   return _uploadRgba8(texture);
 }
 
-/// Transcodes each level to BC1 and uploads a compressed, mipped texture.
+// TODO(texture-compression): upload the full mip chain once Flutter GPU can
+// mark/generate sampleable mipmaps. Today there is no generateMipmaps API and
+// Impeller does not treat per-level overwrite as a generated mipmap (it warns
+// "mip count > 1, but the mipmap has not been generated" and samples wrong), so
+// the base level is uploaded alone. The KTX2 still carries the precomputed
+// chain for when the engine supports it.
+
+/// Transcodes the base level to BC1 and uploads a compressed texture.
 gpu.Texture _uploadBc1(Ktx2Texture texture) {
-  final levelCount = texture.levels.length;
-  final base = mipSize(
+  final size = mipSize(
     texture.pixelWidth,
     texture.pixelHeight < 1 ? 1 : texture.pixelHeight,
     0,
   );
+  final blocksX = (size.width + 3) ~/ 4;
+  final blocksY = (size.height + 3) ~/ 4;
+  final bc1 = transcodeUniversalToBc1(
+    ktx2LevelBlocks(texture, 0),
+    blocksX * blocksY,
+  );
   final result = gpu.gpuContext.createTexture(
     gpu.StorageMode.hostVisible,
-    base.width,
-    base.height,
+    size.width,
+    size.height,
     format: gpu.PixelFormat.bc1RGBAUNormInt,
     enableRenderTargetUsage: false,
     enableShaderWriteUsage: false,
-    mipLevelCount: levelCount,
   );
-  for (var level = 0; level < levelCount; level++) {
-    final size = mipSize(
-      texture.pixelWidth,
-      texture.pixelHeight < 1 ? 1 : texture.pixelHeight,
-      level,
-    );
-    final blocksX = (size.width + 3) ~/ 4;
-    final blocksY = (size.height + 3) ~/ 4;
-    final bc1 = transcodeUniversalToBc1(
-      ktx2LevelBlocks(texture, level),
-      blocksX * blocksY,
-    );
-    result.overwrite(ByteData.sublistView(bc1), mipLevel: level);
-  }
+  result.overwrite(ByteData.sublistView(bc1));
   return result;
 }
 
-/// Decodes every level to rgba8 and uploads an uncompressed, mipped texture.
+/// Decodes the base level to rgba8 and uploads an uncompressed texture.
 gpu.Texture _uploadRgba8(Ktx2Texture texture) {
   final base = decodeKtx2Level(texture, level: 0);
-  final levelCount = texture.levels.length;
   final result = gpu.gpuContext.createTexture(
     gpu.StorageMode.hostVisible,
     base.width,
     base.height,
-    mipLevelCount: levelCount,
   );
-  result.overwrite(ByteData.sublistView(base.rgba), mipLevel: 0);
-  for (var level = 1; level < levelCount; level++) {
-    final mip = decodeKtx2Level(texture, level: level);
-    result.overwrite(ByteData.sublistView(mip.rgba), mipLevel: level);
-  }
+  result.overwrite(ByteData.sublistView(base.rgba));
   return result;
 }
 

--- a/packages/flutter_scene/lib/src/texture/compressed_texture.dart
+++ b/packages/flutter_scene/lib/src/texture/compressed_texture.dart
@@ -6,9 +6,10 @@
 // VRAM). Otherwise the payload is decoded to rgba8 and uploaded uncompressed,
 // which is always correct and the only path on web today.
 
-import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/texture/block/transcode_bc1.dart';
 import 'package:flutter_scene/src/texture/ktx2/ktx2.dart';
 import 'package:flutter_scene/src/texture/ktx2_image.dart';
 
@@ -20,12 +21,51 @@ gpu.Texture gpuTextureFromKtx2(Uint8List bytes) =>
 
 /// As [gpuTextureFromKtx2], for an already-parsed [texture].
 gpu.Texture gpuTextureFromKtx2Texture(Ktx2Texture texture) {
-  // TODO(texture-compression): when a transcoder for a supported family exists,
-  // pick the best of supportsTextureCompression(astc|bc|etc2), transcode each
-  // level's block payload to it, createTexture(format: <compressed>,
-  // enableRenderTargetUsage: false, enableShaderWriteUsage: false), and
-  // overwrite each mip. Until then every device takes the rgba8 path below.
+  _logFamiliesOnce();
+  // Prefer a compressed upload when both the device and a transcoder support
+  // the family. Only BC1 is implemented today.
+  // TODO(texture-compression): add ASTC and ETC2 transcoders (the Apple and
+  // mobile families) and prefer ASTC > BC > ETC2 per the plan.
+  if (gpu.gpuContext.supportsTextureCompression(
+    gpu.TextureCompressionFamily.bc,
+  )) {
+    return _uploadBc1(texture);
+  }
   return _uploadRgba8(texture);
+}
+
+/// Transcodes each level to BC1 and uploads a compressed, mipped texture.
+gpu.Texture _uploadBc1(Ktx2Texture texture) {
+  final levelCount = texture.levels.length;
+  final base = mipSize(
+    texture.pixelWidth,
+    texture.pixelHeight < 1 ? 1 : texture.pixelHeight,
+    0,
+  );
+  final result = gpu.gpuContext.createTexture(
+    gpu.StorageMode.hostVisible,
+    base.width,
+    base.height,
+    format: gpu.PixelFormat.bc1RGBAUNormInt,
+    enableRenderTargetUsage: false,
+    enableShaderWriteUsage: false,
+    mipLevelCount: levelCount,
+  );
+  for (var level = 0; level < levelCount; level++) {
+    final size = mipSize(
+      texture.pixelWidth,
+      texture.pixelHeight < 1 ? 1 : texture.pixelHeight,
+      level,
+    );
+    final blocksX = (size.width + 3) ~/ 4;
+    final blocksY = (size.height + 3) ~/ 4;
+    final bc1 = transcodeUniversalToBc1(
+      ktx2LevelBlocks(texture, level),
+      blocksX * blocksY,
+    );
+    result.overwrite(ByteData.sublistView(bc1), mipLevel: level);
+  }
+  return result;
 }
 
 /// Decodes every level to rgba8 and uploads an uncompressed, mipped texture.
@@ -44,4 +84,22 @@ gpu.Texture _uploadRgba8(Ktx2Texture texture) {
     result.overwrite(ByteData.sublistView(mip.rgba), mipLevel: level);
   }
   return result;
+}
+
+bool _logged = false;
+
+/// Logs the device's block-compression family support once. This doubles as the
+/// device probe: running an app that loads a KTX2 texture reports which
+/// families are available and therefore which upload path is taken.
+void _logFamiliesOnce() {
+  if (_logged) return;
+  _logged = true;
+  final context = gpu.gpuContext;
+  debugPrint(
+    'flutter_scene texture compression support: '
+    'bc=${context.supportsTextureCompression(gpu.TextureCompressionFamily.bc)} '
+    'etc2=${context.supportsTextureCompression(gpu.TextureCompressionFamily.etc2)} '
+    'astc=${context.supportsTextureCompression(gpu.TextureCompressionFamily.astc)} '
+    '(bc -> BC1 upload; otherwise rgba8 fallback)',
+  );
 }

--- a/packages/flutter_scene/lib/src/texture/compressed_texture.dart
+++ b/packages/flutter_scene/lib/src/texture/compressed_texture.dart
@@ -1,0 +1,47 @@
+// Uploads a flutter_scene KTX2 texture to the GPU. This is the one layer that
+// touches Flutter GPU.
+//
+// The device may support a block-compressed family directly, in which case the
+// block payload is transcoded to that format and uploaded compressed (less
+// VRAM). Otherwise the payload is decoded to rgba8 and uploaded uncompressed,
+// which is always correct and the only path on web today.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/texture/ktx2/ktx2.dart';
+import 'package:flutter_scene/src/texture/ktx2_image.dart';
+
+/// Reads a flutter_scene KTX2 file from [bytes] and uploads it as a GPU
+/// texture, choosing a compressed upload when the device supports one and
+/// falling back to an uncompressed rgba8 upload otherwise.
+gpu.Texture gpuTextureFromKtx2(Uint8List bytes) =>
+    gpuTextureFromKtx2Texture(readKtx2(bytes));
+
+/// As [gpuTextureFromKtx2], for an already-parsed [texture].
+gpu.Texture gpuTextureFromKtx2Texture(Ktx2Texture texture) {
+  // TODO(texture-compression): when a transcoder for a supported family exists,
+  // pick the best of supportsTextureCompression(astc|bc|etc2), transcode each
+  // level's block payload to it, createTexture(format: <compressed>,
+  // enableRenderTargetUsage: false, enableShaderWriteUsage: false), and
+  // overwrite each mip. Until then every device takes the rgba8 path below.
+  return _uploadRgba8(texture);
+}
+
+/// Decodes every level to rgba8 and uploads an uncompressed, mipped texture.
+gpu.Texture _uploadRgba8(Ktx2Texture texture) {
+  final base = decodeKtx2Level(texture, level: 0);
+  final levelCount = texture.levels.length;
+  final result = gpu.gpuContext.createTexture(
+    gpu.StorageMode.hostVisible,
+    base.width,
+    base.height,
+    mipLevelCount: levelCount,
+  );
+  result.overwrite(ByteData.sublistView(base.rgba), mipLevel: 0);
+  for (var level = 1; level < levelCount; level++) {
+    final mip = decodeKtx2Level(texture, level: level);
+    result.overwrite(ByteData.sublistView(mip.rgba), mipLevel: level);
+  }
+  return result;
+}

--- a/packages/flutter_scene/lib/src/texture/compressed_texture.dart
+++ b/packages/flutter_scene/lib/src/texture/compressed_texture.dart
@@ -10,8 +10,18 @@ import 'package:flutter/foundation.dart';
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/texture/block/transcode_bc1.dart';
+import 'package:flutter_scene/src/texture/block/transcode_etc2.dart';
 import 'package:flutter_scene/src/texture/ktx2/ktx2.dart';
 import 'package:flutter_scene/src/texture/ktx2_image.dart';
+
+/// The order in which compressed families are preferred when the device
+/// supports more than one. BC (desktop) outranks ETC2 (mobile/GLES3/web) on
+/// quality; ASTC is not transcoded yet.
+// TODO(texture-compression): add ASTC at the front once a transcoder exists.
+const List<gpu.TextureCompressionFamily> compressionFamilyPreference = [
+  gpu.TextureCompressionFamily.bc,
+  gpu.TextureCompressionFamily.etc2,
+];
 
 /// Reads a flutter_scene KTX2 file from [bytes] and uploads it as a GPU
 /// texture, choosing a compressed upload when the device supports one and
@@ -22,14 +32,15 @@ gpu.Texture gpuTextureFromKtx2(Uint8List bytes) =>
 /// As [gpuTextureFromKtx2], for an already-parsed [texture].
 gpu.Texture gpuTextureFromKtx2Texture(Ktx2Texture texture) {
   _logFamiliesOnce();
-  // Prefer a compressed upload when both the device and a transcoder support
-  // the family. Only BC1 is implemented today.
-  // TODO(texture-compression): add ASTC and ETC2 transcoders (the Apple and
-  // mobile families) and prefer ASTC > BC > ETC2 per the plan.
-  if (gpu.gpuContext.supportsTextureCompression(
-    gpu.TextureCompressionFamily.bc,
-  )) {
-    return _uploadBc1(texture);
+  // Transcode to the first supported family in the preference order for which
+  // we have a transcoder; otherwise decode to rgba8 and upload uncompressed.
+  for (final family in compressionFamilyPreference) {
+    if (!gpu.gpuContext.supportsTextureCompression(family)) continue;
+    if (family == gpu.TextureCompressionFamily.bc) return _uploadBc1(texture);
+    if (family == gpu.TextureCompressionFamily.etc2) {
+      return _uploadEtc2(texture);
+    }
+    // ASTC: no transcoder yet; fall through to the next family or rgba8.
   }
   return _uploadRgba8(texture);
 }
@@ -63,6 +74,31 @@ gpu.Texture _uploadBc1(Ktx2Texture texture) {
     enableShaderWriteUsage: false,
   );
   result.overwrite(ByteData.sublistView(bc1));
+  return result;
+}
+
+/// Transcodes the base level to ETC2 RGB8 and uploads a compressed texture.
+gpu.Texture _uploadEtc2(Ktx2Texture texture) {
+  final size = mipSize(
+    texture.pixelWidth,
+    texture.pixelHeight < 1 ? 1 : texture.pixelHeight,
+    0,
+  );
+  final blocksX = (size.width + 3) ~/ 4;
+  final blocksY = (size.height + 3) ~/ 4;
+  final etc2 = transcodeUniversalToEtc2Rgb(
+    ktx2LevelBlocks(texture, 0),
+    blocksX * blocksY,
+  );
+  final result = gpu.gpuContext.createTexture(
+    gpu.StorageMode.hostVisible,
+    size.width,
+    size.height,
+    format: gpu.PixelFormat.etc2RGB8UNormInt,
+    enableRenderTargetUsage: false,
+    enableShaderWriteUsage: false,
+  );
+  result.overwrite(ByteData.sublistView(etc2));
   return result;
 }
 

--- a/packages/flutter_scene/lib/src/texture/compressed_texture.dart
+++ b/packages/flutter_scene/lib/src/texture/compressed_texture.dart
@@ -9,16 +9,18 @@
 import 'package:flutter/foundation.dart';
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/texture/block/transcode_astc.dart';
 import 'package:flutter_scene/src/texture/block/transcode_bc1.dart';
 import 'package:flutter_scene/src/texture/block/transcode_etc2.dart';
 import 'package:flutter_scene/src/texture/ktx2/ktx2.dart';
 import 'package:flutter_scene/src/texture/ktx2_image.dart';
 
 /// The order in which compressed families are preferred when the device
-/// supports more than one. BC (desktop) outranks ETC2 (mobile/GLES3/web) on
-/// quality; ASTC is not transcoded yet.
-// TODO(texture-compression): add ASTC at the front once a transcoder exists.
-const List<gpu.TextureCompressionFamily> compressionFamilyPreference = [
+/// supports more than one: ASTC (highest quality) > BC (desktop) > ETC2
+/// (mobile/GLES3/web). Reorder for testing a specific family on a device that
+/// supports several.
+List<gpu.TextureCompressionFamily> compressionFamilyPreference = [
+  gpu.TextureCompressionFamily.astc,
   gpu.TextureCompressionFamily.bc,
   gpu.TextureCompressionFamily.etc2,
 ];
@@ -36,11 +38,13 @@ gpu.Texture gpuTextureFromKtx2Texture(Ktx2Texture texture) {
   // we have a transcoder; otherwise decode to rgba8 and upload uncompressed.
   for (final family in compressionFamilyPreference) {
     if (!gpu.gpuContext.supportsTextureCompression(family)) continue;
+    if (family == gpu.TextureCompressionFamily.astc) {
+      return _uploadAstc(texture);
+    }
     if (family == gpu.TextureCompressionFamily.bc) return _uploadBc1(texture);
     if (family == gpu.TextureCompressionFamily.etc2) {
       return _uploadEtc2(texture);
     }
-    // ASTC: no transcoder yet; fall through to the next family or rgba8.
   }
   return _uploadRgba8(texture);
 }
@@ -99,6 +103,31 @@ gpu.Texture _uploadEtc2(Ktx2Texture texture) {
     enableShaderWriteUsage: false,
   );
   result.overwrite(ByteData.sublistView(etc2));
+  return result;
+}
+
+/// Transcodes the base level to ASTC 4x4 LDR and uploads a compressed texture.
+gpu.Texture _uploadAstc(Ktx2Texture texture) {
+  final size = mipSize(
+    texture.pixelWidth,
+    texture.pixelHeight < 1 ? 1 : texture.pixelHeight,
+    0,
+  );
+  final blocksX = (size.width + 3) ~/ 4;
+  final blocksY = (size.height + 3) ~/ 4;
+  final astc = transcodeUniversalToAstc4x4(
+    ktx2LevelBlocks(texture, 0),
+    blocksX * blocksY,
+  );
+  final result = gpu.gpuContext.createTexture(
+    gpu.StorageMode.hostVisible,
+    size.width,
+    size.height,
+    format: gpu.PixelFormat.astc4x4LDR,
+    enableRenderTargetUsage: false,
+    enableShaderWriteUsage: false,
+  );
+  result.overwrite(ByteData.sublistView(astc));
   return result;
 }
 

--- a/packages/flutter_scene/lib/src/texture/compressed_texture.dart
+++ b/packages/flutter_scene/lib/src/texture/compressed_texture.dart
@@ -1,10 +1,10 @@
-// Uploads a flutter_scene KTX2 texture to the GPU. This is the one layer that
-// touches Flutter GPU.
+// Uploads a flutter_scene KTX2 texture to the GPU. The CPU-heavy transcode runs
+// off the main isolate; only the GPU calls stay on the main thread.
 //
 // The device may support a block-compressed family directly, in which case the
 // block payload is transcoded to that format and uploaded compressed (less
 // VRAM). Otherwise the payload is decoded to rgba8 and uploaded uncompressed,
-// which is always correct and the only path on web today.
+// which is always correct and the only path on web without the extensions.
 
 import 'package:flutter/foundation.dart';
 
@@ -25,122 +25,113 @@ List<gpu.TextureCompressionFamily> compressionFamilyPreference = [
   gpu.TextureCompressionFamily.etc2,
 ];
 
-/// Reads a flutter_scene KTX2 file from [bytes] and uploads it as a GPU
-/// texture, choosing a compressed upload when the device supports one and
-/// falling back to an uncompressed rgba8 upload otherwise.
+// Transcode target, chosen on the main thread (from the device probe) and
+// passed to the transcode isolate so it knows which format to produce.
+const int _modeRgba8 = 0;
+const int _modeBc1 = 1;
+const int _modeEtc2 = 2;
+const int _modeAstc = 3;
+
+/// The transcoded bytes ready for GPU upload. Plain data so it can cross an
+/// isolate boundary (no GPU types).
+typedef _Prepared = ({Uint8List bytes, int mode, int width, int height});
+
+/// Reads a flutter_scene KTX2 file from [bytes], transcodes it on a background
+/// isolate, and uploads the result. Use this from async load paths so large
+/// textures do not block the UI.
+Future<gpu.Texture> gpuTextureFromKtx2Async(Uint8List bytes) async {
+  _logFamiliesOnce();
+  final mode = _selectMode();
+  final prepared = await compute(_prepareFromBytes, (ktx2: bytes, mode: mode));
+  return _upload(prepared);
+}
+
+/// Synchronous variant: transcodes on the calling (usually main) thread. Heavy
+/// for large textures; prefer [gpuTextureFromKtx2Async]. Kept for the sync
+/// realize path.
 gpu.Texture gpuTextureFromKtx2(Uint8List bytes) =>
     gpuTextureFromKtx2Texture(readKtx2(bytes));
 
 /// As [gpuTextureFromKtx2], for an already-parsed [texture].
 gpu.Texture gpuTextureFromKtx2Texture(Ktx2Texture texture) {
   _logFamiliesOnce();
-  // Transcode to the first supported family in the preference order for which
-  // we have a transcoder; otherwise decode to rgba8 and upload uncompressed.
+  return _upload(_prepare(texture, _selectMode()));
+}
+
+/// Picks the transcode target for the current device.
+int _selectMode() {
   for (final family in compressionFamilyPreference) {
     if (!gpu.gpuContext.supportsTextureCompression(family)) continue;
-    if (family == gpu.TextureCompressionFamily.astc) {
-      return _uploadAstc(texture);
-    }
-    if (family == gpu.TextureCompressionFamily.bc) return _uploadBc1(texture);
-    if (family == gpu.TextureCompressionFamily.etc2) {
-      return _uploadEtc2(texture);
+    switch (family) {
+      case gpu.TextureCompressionFamily.astc:
+        return _modeAstc;
+      case gpu.TextureCompressionFamily.bc:
+        return _modeBc1;
+      case gpu.TextureCompressionFamily.etc2:
+        return _modeEtc2;
     }
   }
-  return _uploadRgba8(texture);
+  return _modeRgba8;
 }
 
-// TODO(texture-compression): upload the full mip chain once Flutter GPU can
-// mark/generate sampleable mipmaps. Today there is no generateMipmaps API and
-// Impeller does not treat per-level overwrite as a generated mipmap (it warns
-// "mip count > 1, but the mipmap has not been generated" and samples wrong), so
-// the base level is uploaded alone. The KTX2 still carries the precomputed
-// chain for when the engine supports it.
+/// Isolate entry point: parse and transcode. Pure Dart, no GPU.
+_Prepared _prepareFromBytes(({Uint8List ktx2, int mode}) input) =>
+    _prepare(readKtx2(input.ktx2), input.mode);
 
-/// Transcodes the base level to BC1 and uploads a compressed texture.
-gpu.Texture _uploadBc1(Ktx2Texture texture) {
+/// Transcodes the base level of [texture] to [mode]. Pure Dart, no GPU.
+_Prepared _prepare(Ktx2Texture texture, int mode) {
   final size = mipSize(
     texture.pixelWidth,
     texture.pixelHeight < 1 ? 1 : texture.pixelHeight,
     0,
   );
-  final blocksX = (size.width + 3) ~/ 4;
-  final blocksY = (size.height + 3) ~/ 4;
-  final bc1 = transcodeUniversalToBc1(
-    ktx2LevelBlocks(texture, 0),
-    blocksX * blocksY,
-  );
-  final result = gpu.gpuContext.createTexture(
+  if (mode == _modeRgba8) {
+    final base = decodeKtx2Level(texture, level: 0);
+    return (
+      bytes: base.rgba,
+      mode: _modeRgba8,
+      width: base.width,
+      height: base.height,
+    );
+  }
+  final blocks = ktx2LevelBlocks(texture, 0);
+  final blockCount = ((size.width + 3) ~/ 4) * ((size.height + 3) ~/ 4);
+  final bytes = switch (mode) {
+    _modeBc1 => transcodeUniversalToBc1(blocks, blockCount),
+    _modeEtc2 => transcodeUniversalToEtc2Rgb(blocks, blockCount),
+    _ => transcodeUniversalToAstc4x4(blocks, blockCount),
+  };
+  return (bytes: bytes, mode: mode, width: size.width, height: size.height);
+}
+
+/// Uploads prepared bytes to a GPU texture. Must run on the main thread.
+gpu.Texture _upload(_Prepared p) {
+  if (p.mode == _modeRgba8) {
+    final texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      p.width,
+      p.height,
+    );
+    texture.overwrite(ByteData.sublistView(p.bytes));
+    return texture;
+  }
+  // TODO(texture-compression): upload the full mip chain once Flutter GPU can
+  // mark/generate sampleable mipmaps; today the base level is uploaded alone.
+  final format = switch (p.mode) {
+    _modeBc1 => gpu.PixelFormat.bc1RGBAUNormInt,
+    _modeEtc2 => gpu.PixelFormat.etc2RGB8UNormInt,
+    _ => gpu.PixelFormat.astc4x4LDR,
+  };
+  final texture = gpu.gpuContext.createTexture(
     gpu.StorageMode.hostVisible,
-    size.width,
-    size.height,
-    format: gpu.PixelFormat.bc1RGBAUNormInt,
+    p.width,
+    p.height,
+    format: format,
     enableRenderTargetUsage: false,
     enableShaderWriteUsage: false,
   );
-  result.overwrite(ByteData.sublistView(bc1));
-  return result;
-}
-
-/// Transcodes the base level to ETC2 RGB8 and uploads a compressed texture.
-gpu.Texture _uploadEtc2(Ktx2Texture texture) {
-  final size = mipSize(
-    texture.pixelWidth,
-    texture.pixelHeight < 1 ? 1 : texture.pixelHeight,
-    0,
-  );
-  final blocksX = (size.width + 3) ~/ 4;
-  final blocksY = (size.height + 3) ~/ 4;
-  final etc2 = transcodeUniversalToEtc2Rgb(
-    ktx2LevelBlocks(texture, 0),
-    blocksX * blocksY,
-  );
-  final result = gpu.gpuContext.createTexture(
-    gpu.StorageMode.hostVisible,
-    size.width,
-    size.height,
-    format: gpu.PixelFormat.etc2RGB8UNormInt,
-    enableRenderTargetUsage: false,
-    enableShaderWriteUsage: false,
-  );
-  result.overwrite(ByteData.sublistView(etc2));
-  return result;
-}
-
-/// Transcodes the base level to ASTC 4x4 LDR and uploads a compressed texture.
-gpu.Texture _uploadAstc(Ktx2Texture texture) {
-  final size = mipSize(
-    texture.pixelWidth,
-    texture.pixelHeight < 1 ? 1 : texture.pixelHeight,
-    0,
-  );
-  final blocksX = (size.width + 3) ~/ 4;
-  final blocksY = (size.height + 3) ~/ 4;
-  final astc = transcodeUniversalToAstc4x4(
-    ktx2LevelBlocks(texture, 0),
-    blocksX * blocksY,
-  );
-  final result = gpu.gpuContext.createTexture(
-    gpu.StorageMode.hostVisible,
-    size.width,
-    size.height,
-    format: gpu.PixelFormat.astc4x4LDR,
-    enableRenderTargetUsage: false,
-    enableShaderWriteUsage: false,
-  );
-  result.overwrite(ByteData.sublistView(astc));
-  return result;
-}
-
-/// Decodes the base level to rgba8 and uploads an uncompressed texture.
-gpu.Texture _uploadRgba8(Ktx2Texture texture) {
-  final base = decodeKtx2Level(texture, level: 0);
-  final result = gpu.gpuContext.createTexture(
-    gpu.StorageMode.hostVisible,
-    base.width,
-    base.height,
-  );
-  result.overwrite(ByteData.sublistView(base.rgba));
-  return result;
+  texture.overwrite(ByteData.sublistView(p.bytes));
+  return texture;
 }
 
 bool _logged = false;
@@ -157,6 +148,6 @@ void _logFamiliesOnce() {
     'bc=${context.supportsTextureCompression(gpu.TextureCompressionFamily.bc)} '
     'etc2=${context.supportsTextureCompression(gpu.TextureCompressionFamily.etc2)} '
     'astc=${context.supportsTextureCompression(gpu.TextureCompressionFamily.astc)} '
-    '(bc -> BC1 upload; otherwise rgba8 fallback)',
+    '(transcode runs off the main isolate; rgba8 fallback otherwise)',
   );
 }

--- a/packages/flutter_scene/lib/src/texture/ktx2/ktx2.dart
+++ b/packages/flutter_scene/lib/src/texture/ktx2/ktx2.dart
@@ -1,0 +1,362 @@
+// A pure-Dart reader and writer for the KTX2 container (Khronos KTX 2.0).
+//
+// This is container plumbing only: it moves level payloads, the data format
+// descriptor, key/value data, and supercompression global data in and out of
+// the byte layout. It does not encode, decode, or transcode pixels; the codec
+// layers sit on top and treat a level's bytes as opaque.
+//
+// Offsets in KTX2 are 64-bit. dart2js has no 64-bit integers, so every 64-bit
+// field is read and written as two 32-bit words here. Files larger than 4 GiB
+// (a non-zero high word) are rejected rather than silently truncated.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Supercompression schemes defined by the KTX2 specification. A level's stored
+/// bytes are compressed with this scheme; [Ktx2Supercompression.none] stores
+/// them verbatim.
+enum Ktx2Supercompression {
+  none(0),
+  basisLz(1),
+  zstandard(2),
+  zlib(3);
+
+  const Ktx2Supercompression(this.value);
+
+  /// The on-disk integer for the `supercompressionScheme` header field.
+  final int value;
+
+  static Ktx2Supercompression fromValue(int value) {
+    for (final scheme in Ktx2Supercompression.values) {
+      if (scheme.value == value) return scheme;
+    }
+    throw Ktx2FormatException('Unknown supercompression scheme: $value');
+  }
+}
+
+/// One mip level's payload. [data] is the bytes as stored (supercompressed when
+/// the texture's scheme is not [Ktx2Supercompression.none]);
+/// [uncompressedByteLength] is the size after decompression, equal to
+/// `data.length` when the scheme is none.
+class Ktx2Level {
+  Ktx2Level({required this.data, int? uncompressedByteLength})
+    : uncompressedByteLength = uncompressedByteLength ?? data.length;
+
+  final Uint8List data;
+  final int uncompressedByteLength;
+}
+
+/// An in-memory KTX2 texture: the header fields plus the four byte sections
+/// (level payloads, data format descriptor, key/value data, supercompression
+/// global data). Levels are ordered with index 0 as the base (largest) level,
+/// matching the KTX2 level index order.
+class Ktx2Texture {
+  Ktx2Texture({
+    required this.vkFormat,
+    this.typeSize = 1,
+    required this.pixelWidth,
+    this.pixelHeight = 0,
+    this.pixelDepth = 0,
+    this.layerCount = 0,
+    this.faceCount = 1,
+    required this.levels,
+    this.supercompression = Ktx2Supercompression.none,
+    Uint8List? dataFormatDescriptor,
+    this.keyValues = const {},
+    Uint8List? supercompressionGlobalData,
+    this.levelAlignment = 16,
+  }) : assert(levels.isNotEmpty, 'A KTX2 texture needs at least one level'),
+       assert(faceCount == 1 || faceCount == 6, 'faceCount must be 1 or 6'),
+       assert(levelAlignment > 0, 'levelAlignment must be positive'),
+       dataFormatDescriptor =
+           dataFormatDescriptor ?? _nullDataFormatDescriptor(),
+       supercompressionGlobalData = supercompressionGlobalData ?? Uint8List(0);
+
+  /// Vulkan format enum (`VK_FORMAT_*`). UASTC and other Basis payloads use
+  /// `VK_FORMAT_UNDEFINED` (0) and rely on the data format descriptor.
+  final int vkFormat;
+
+  /// Size in bytes of the format's underlying type (1 for byte-typed and
+  /// block-compressed formats).
+  final int typeSize;
+
+  final int pixelWidth;
+
+  /// 0 for a 1D texture, otherwise the height.
+  final int pixelHeight;
+
+  /// 0 for a non-3D texture, otherwise the depth.
+  final int pixelDepth;
+
+  /// 0 for a non-array texture, otherwise the layer count.
+  final int layerCount;
+
+  /// 1 for a normal texture, 6 for a cube map.
+  final int faceCount;
+
+  /// Mip levels, index 0 = base (largest).
+  final List<Ktx2Level> levels;
+
+  final Ktx2Supercompression supercompression;
+
+  /// The data format descriptor block, stored opaquely. Defaults to a minimal
+  /// "null" descriptor (just a total-size word); a format-accurate descriptor
+  /// is the codec layer's responsibility.
+  // TODO(ktx2): build a real basic DFD (Khronos basic descriptor block) for the
+  // formats we emit (UASTC, rgba8, the BC/ETC2/ASTC families) once the codec
+  // lands, so the files validate against KTX-Software.
+  final Uint8List dataFormatDescriptor;
+
+  /// Key/value metadata. Keys are UTF-8; values are arbitrary bytes. Written in
+  /// codepoint-sorted key order per the specification.
+  final Map<String, Uint8List> keyValues;
+
+  /// Supercompression global data (used by BasisLZ); empty for none/zstd/zlib.
+  final Uint8List supercompressionGlobalData;
+
+  /// Required alignment for mip level data when not supercompressed
+  /// (`lcm(texelBlockSize, 4)`). 16 covers UASTC and the 4x4 block formats; a
+  /// caller emitting rgba8 (texel block size 4) can pass 4.
+  final int levelAlignment;
+}
+
+/// Thrown when bytes are not a valid KTX2 file or exceed what this reader
+/// supports (e.g. a 64-bit offset that does not fit in a web-safe integer).
+class Ktx2FormatException implements Exception {
+  Ktx2FormatException(this.message);
+  final String message;
+  @override
+  String toString() => 'Ktx2FormatException: $message';
+}
+
+/// The 12-byte KTX2 file identifier: `«KTX 20»\r\n\x1A\n`.
+const List<int> ktx2Identifier = <int>[
+  0xAB, 0x4B, 0x54, 0x58, 0x20, 0x32, 0x30, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A, //
+];
+
+const int _headerEnd = 80; // identifier(12) + header(36) + index(32)
+const int _levelIndexEntrySize = 24; // three 64-bit fields
+
+Uint8List _nullDataFormatDescriptor() {
+  // A descriptor consisting only of its own total-size field (4 bytes).
+  final dfd = Uint8List(4);
+  ByteData.sublistView(dfd).setUint32(0, 4, Endian.little);
+  return dfd;
+}
+
+int _align(int value, int alignment) =>
+    (value + alignment - 1) ~/ alignment * alignment;
+
+/// Reads a 64-bit little-endian field as two 32-bit words. Rejects values that
+/// do not fit in a web-safe integer (high word non-zero).
+int _readU64(ByteData data, int offset) {
+  final low = data.getUint32(offset, Endian.little);
+  final high = data.getUint32(offset + 4, Endian.little);
+  if (high != 0) {
+    throw Ktx2FormatException(
+      'Offset/length at byte $offset exceeds the 4 GiB supported range',
+    );
+  }
+  return low;
+}
+
+/// Writes a web-safe integer as a 64-bit little-endian field (high word zero).
+void _writeU64(ByteData data, int offset, int value) {
+  data.setUint32(offset, value, Endian.little);
+  data.setUint32(offset + 4, 0, Endian.little);
+}
+
+/// Parses [bytes] as a KTX2 file. Throws [Ktx2FormatException] on malformed
+/// input.
+Ktx2Texture readKtx2(Uint8List bytes) {
+  if (bytes.length < _headerEnd) {
+    throw Ktx2FormatException('Too short to be a KTX2 file');
+  }
+  for (var i = 0; i < ktx2Identifier.length; i++) {
+    if (bytes[i] != ktx2Identifier[i]) {
+      throw Ktx2FormatException('Bad KTX2 identifier');
+    }
+  }
+  final data = ByteData.sublistView(bytes);
+  final vkFormat = data.getUint32(12, Endian.little);
+  final typeSize = data.getUint32(16, Endian.little);
+  final pixelWidth = data.getUint32(20, Endian.little);
+  final pixelHeight = data.getUint32(24, Endian.little);
+  final pixelDepth = data.getUint32(28, Endian.little);
+  final layerCount = data.getUint32(32, Endian.little);
+  final faceCount = data.getUint32(36, Endian.little);
+  final levelCount = data.getUint32(40, Endian.little);
+  final supercompression = Ktx2Supercompression.fromValue(
+    data.getUint32(44, Endian.little),
+  );
+
+  final dfdByteOffset = data.getUint32(48, Endian.little);
+  final dfdByteLength = data.getUint32(52, Endian.little);
+  final kvdByteOffset = data.getUint32(56, Endian.little);
+  final kvdByteLength = data.getUint32(60, Endian.little);
+  final sgdByteOffset = _readU64(data, 64);
+  final sgdByteLength = _readU64(data, 72);
+
+  final storedLevelCount = levelCount == 0 ? 1 : levelCount;
+  final levelIndexEnd = _headerEnd + _levelIndexEntrySize * storedLevelCount;
+  if (bytes.length < levelIndexEnd) {
+    throw Ktx2FormatException('Truncated level index');
+  }
+  final levels = <Ktx2Level>[];
+  for (var i = 0; i < storedLevelCount; i++) {
+    final entry = _headerEnd + _levelIndexEntrySize * i;
+    final byteOffset = _readU64(data, entry);
+    final byteLength = _readU64(data, entry + 8);
+    final uncompressedByteLength = _readU64(data, entry + 16);
+    levels.add(
+      Ktx2Level(
+        data: _slice(bytes, byteOffset, byteLength),
+        uncompressedByteLength: uncompressedByteLength,
+      ),
+    );
+  }
+
+  final dfd = dfdByteLength == 0
+      ? _nullDataFormatDescriptor()
+      : _slice(bytes, dfdByteOffset, dfdByteLength);
+  final keyValues = kvdByteLength == 0
+      ? <String, Uint8List>{}
+      : _decodeKeyValues(_slice(bytes, kvdByteOffset, kvdByteLength));
+  final sgd = sgdByteLength == 0
+      ? Uint8List(0)
+      : _slice(bytes, sgdByteOffset, sgdByteLength);
+
+  return Ktx2Texture(
+    vkFormat: vkFormat,
+    typeSize: typeSize,
+    pixelWidth: pixelWidth,
+    pixelHeight: pixelHeight,
+    pixelDepth: pixelDepth,
+    layerCount: layerCount,
+    faceCount: faceCount,
+    levels: levels,
+    supercompression: supercompression,
+    dataFormatDescriptor: dfd,
+    keyValues: keyValues,
+    supercompressionGlobalData: sgd,
+  );
+}
+
+/// Serializes [texture] to KTX2 bytes.
+Uint8List writeKtx2(Ktx2Texture texture) {
+  final levels = texture.levels;
+  final dfd = texture.dataFormatDescriptor;
+  final kvd = _encodeKeyValues(texture.keyValues);
+  final sgd = texture.supercompressionGlobalData;
+  final levelAlignment = texture.supercompression == Ktx2Supercompression.none
+      ? texture.levelAlignment
+      : 1;
+
+  // Lay the file out, computing every offset before writing.
+  var cursor = _headerEnd + _levelIndexEntrySize * levels.length;
+
+  final dfdOffset = dfd.isEmpty ? 0 : _align(cursor, 4);
+  cursor = dfd.isEmpty ? cursor : dfdOffset + dfd.length;
+
+  final kvdOffset = kvd.isEmpty ? 0 : _align(cursor, 4);
+  cursor = kvd.isEmpty ? cursor : kvdOffset + kvd.length;
+
+  final sgdOffset = sgd.isEmpty ? 0 : _align(cursor, 8);
+  cursor = sgd.isEmpty ? cursor : sgdOffset + sgd.length;
+
+  // Level payloads are stored smallest-first; the level index keeps base-first
+  // order with explicit offsets.
+  final levelOffsets = List<int>.filled(levels.length, 0);
+  for (var i = levels.length - 1; i >= 0; i--) {
+    cursor = _align(cursor, levelAlignment);
+    levelOffsets[i] = cursor;
+    cursor += levels[i].data.length;
+  }
+
+  final out = Uint8List(cursor);
+  final data = ByteData.sublistView(out);
+  out.setRange(0, ktx2Identifier.length, ktx2Identifier);
+  data.setUint32(12, texture.vkFormat, Endian.little);
+  data.setUint32(16, texture.typeSize, Endian.little);
+  data.setUint32(20, texture.pixelWidth, Endian.little);
+  data.setUint32(24, texture.pixelHeight, Endian.little);
+  data.setUint32(28, texture.pixelDepth, Endian.little);
+  data.setUint32(32, texture.layerCount, Endian.little);
+  data.setUint32(36, texture.faceCount, Endian.little);
+  data.setUint32(40, levels.length, Endian.little);
+  data.setUint32(44, texture.supercompression.value, Endian.little);
+
+  data.setUint32(48, dfdOffset, Endian.little);
+  data.setUint32(52, dfd.length, Endian.little);
+  data.setUint32(56, kvdOffset, Endian.little);
+  data.setUint32(60, kvd.length, Endian.little);
+  _writeU64(data, 64, sgdOffset);
+  _writeU64(data, 72, sgd.length);
+
+  for (var i = 0; i < levels.length; i++) {
+    final entry = _headerEnd + _levelIndexEntrySize * i;
+    _writeU64(data, entry, levelOffsets[i]);
+    _writeU64(data, entry + 8, levels[i].data.length);
+    _writeU64(data, entry + 16, levels[i].uncompressedByteLength);
+  }
+
+  if (dfd.isNotEmpty) out.setRange(dfdOffset, dfdOffset + dfd.length, dfd);
+  if (kvd.isNotEmpty) out.setRange(kvdOffset, kvdOffset + kvd.length, kvd);
+  if (sgd.isNotEmpty) out.setRange(sgdOffset, sgdOffset + sgd.length, sgd);
+  for (var i = 0; i < levels.length; i++) {
+    final payload = levels[i].data;
+    out.setRange(levelOffsets[i], levelOffsets[i] + payload.length, payload);
+  }
+  return out;
+}
+
+Uint8List _slice(Uint8List bytes, int offset, int length) {
+  if (offset < 0 || length < 0 || offset + length > bytes.length) {
+    throw Ktx2FormatException(
+      'Section at offset $offset length $length is out of range',
+    );
+  }
+  return Uint8List.sublistView(bytes, offset, offset + length);
+}
+
+/// Encodes key/value data: per entry a 32-bit length, the UTF-8 key, a NUL, the
+/// value bytes, then zero padding to a 4-byte boundary. Keys are sorted by
+/// codepoint as the specification requires.
+Uint8List _encodeKeyValues(Map<String, Uint8List> keyValues) {
+  if (keyValues.isEmpty) return Uint8List(0);
+  final keys = keyValues.keys.toList()..sort();
+  final builder = BytesBuilder(copy: false);
+  for (final key in keys) {
+    final keyBytes = utf8.encode(key);
+    final value = keyValues[key]!;
+    final length = keyBytes.length + 1 + value.length;
+    final header = Uint8List(4);
+    ByteData.sublistView(header).setUint32(0, length, Endian.little);
+    builder.add(header);
+    builder.add(keyBytes);
+    builder.addByte(0);
+    builder.add(value);
+    final pad = _align(length, 4) - length;
+    if (pad > 0) builder.add(Uint8List(pad));
+  }
+  return builder.toBytes();
+}
+
+Map<String, Uint8List> _decodeKeyValues(Uint8List kvd) {
+  final result = <String, Uint8List>{};
+  final data = ByteData.sublistView(kvd);
+  var offset = 0;
+  while (offset + 4 <= kvd.length) {
+    final length = data.getUint32(offset, Endian.little);
+    offset += 4;
+    if (length == 0 || offset + length > kvd.length) break;
+    final entry = Uint8List.sublistView(kvd, offset, offset + length);
+    final nul = entry.indexOf(0);
+    if (nul >= 0) {
+      final key = utf8.decode(Uint8List.sublistView(entry, 0, nul));
+      result[key] = Uint8List.sublistView(entry, nul + 1);
+    }
+    offset = _align(offset + length, 4);
+  }
+  return result;
+}

--- a/packages/flutter_scene/lib/src/texture/ktx2_image.dart
+++ b/packages/flutter_scene/lib/src/texture/ktx2_image.dart
@@ -8,12 +8,28 @@ import 'dart:typed_data';
 
 import 'package:flutter_scene/src/texture/block/universal_block.dart';
 import 'package:flutter_scene/src/texture/ktx2/ktx2.dart';
+import 'package:flutter_scene/src/texture/supercompress/lz.dart';
 
 /// Key/value marker naming the block payload format inside our KTX2 files.
 const String kFsBlockFormatKey = 'fsBlockFormat';
 
 /// Current block payload identifier (the [universal_block] layout).
 const String kFsBlockFormatUniversal = 'universal/1';
+
+/// Key/value marker set when level payloads are LZ-supercompressed.
+const String kFsSupercompressKey = 'fsSupercompress';
+
+/// Identifier for the [lz] supercompression of the block payload.
+const String kFsSupercompressLz = 'lz/1';
+
+/// Bytes a level's block payload occupies once decompressed, derived from the
+/// image dimensions (one byte per texel, padded to whole 4x4 blocks).
+int _levelBlockBytes(int width, int height, int level) {
+  final size = mipSize(width, math.max(1, height), level);
+  final blocksX = (size.width + kBlockDim - 1) ~/ kBlockDim;
+  final blocksY = (size.height + kBlockDim - 1) ~/ kBlockDim;
+  return blocksX * blocksY * kBlockBytes;
+}
 
 /// Encodes [width] x [height] rgba8 pixels into a KTX2 texture holding our 4x4
 /// block payload. When [generateMips] is set, a full box-filtered mip chain is
@@ -23,13 +39,12 @@ Ktx2Texture encodeImageToKtx2(
   int width,
   int height, {
   bool generateMips = false,
+  bool supercompress = false,
 }) {
   if (rgba.length < width * height * 4) {
     throw ArgumentError('rgba is too small for ${width}x$height');
   }
-  final levels = <Ktx2Level>[
-    Ktx2Level(data: encodeUniversalBlocks(rgba, width, height)),
-  ];
+  final blockLevels = <Uint8List>[encodeUniversalBlocks(rgba, width, height)];
   if (generateMips) {
     var w = width, h = height;
     var src = rgba;
@@ -37,14 +52,21 @@ Ktx2Texture encodeImageToKtx2(
       final nw = math.max(1, w >> 1);
       final nh = math.max(1, h >> 1);
       src = _downsampleBox(src, w, h, nw, nh);
-      levels.add(Ktx2Level(data: encodeUniversalBlocks(src, nw, nh)));
+      blockLevels.add(encodeUniversalBlocks(src, nw, nh));
       w = nw;
       h = nh;
     }
   }
+  final levels = [
+    for (final blocks in blockLevels)
+      Ktx2Level(
+        data: supercompress ? lzCompress(blocks) : blocks,
+        uncompressedByteLength: blocks.length,
+      ),
+  ];
   return Ktx2Texture(
     vkFormat:
-        0, // VK_FORMAT_UNDEFINED; the block format is in the marker below.
+        0, // VK_FORMAT_UNDEFINED; the block format is in the marker above.
     pixelWidth: width,
     pixelHeight: height,
     levels: levels,
@@ -52,6 +74,10 @@ Ktx2Texture encodeImageToKtx2(
       kFsBlockFormatKey: Uint8List.fromList(
         utf8.encode(kFsBlockFormatUniversal),
       ),
+      if (supercompress)
+        kFsSupercompressKey: Uint8List.fromList(
+          utf8.encode(kFsSupercompressLz),
+        ),
     },
   );
 }
@@ -62,8 +88,15 @@ Uint8List encodeImageToKtx2Bytes(
   int width,
   int height, {
   bool generateMips = false,
+  bool supercompress = false,
 }) => writeKtx2(
-  encodeImageToKtx2(rgba, width, height, generateMips: generateMips),
+  encodeImageToKtx2(
+    rgba,
+    width,
+    height,
+    generateMips: generateMips,
+    supercompress: supercompress,
+  ),
 );
 
 /// The pixel dimensions of mip [level] of a [width] x [height] base image.
@@ -98,22 +131,22 @@ Uint8List encodeImageToKtx2Bytes(
   );
 }
 
-/// Returns a level's decompressed block bytes, undoing supercompression.
+/// Returns a level's block bytes, undoing our LZ supercompression when the
+/// marker is present. The container's own supercompressionScheme stays `none`;
+/// our LZ is a payload-level wrapper signaled by [kFsSupercompressKey].
 Uint8List _levelPayload(Ktx2Texture texture, int level) {
   final stored = texture.levels[level].data;
-  switch (texture.supercompression) {
-    case Ktx2Supercompression.none:
-      return stored;
-    // TODO(texture-compression): decode zstd/zlib/BasisLZ supercompression here
-    // once the supercompressor lands; until then only uncompressed payloads are
-    // read back.
-    case Ktx2Supercompression.zstandard:
-    case Ktx2Supercompression.zlib:
-    case Ktx2Supercompression.basisLz:
-      throw Ktx2FormatException(
-        'Supercompression ${texture.supercompression} is not decodable yet',
-      );
+  final marker = texture.keyValues[kFsSupercompressKey];
+  if (marker == null) return stored;
+  if (utf8.decode(marker) != kFsSupercompressLz) {
+    throw Ktx2FormatException(
+      'Unknown supercompression: ${utf8.decode(marker)}',
+    );
   }
+  return lzDecompress(
+    stored,
+    _levelBlockBytes(texture.pixelWidth, texture.pixelHeight, level),
+  );
 }
 
 /// Box-filters [src] (rgba8, [sw] x [sh]) down to [dw] x [dh].

--- a/packages/flutter_scene/lib/src/texture/ktx2_image.dart
+++ b/packages/flutter_scene/lib/src/texture/ktx2_image.dart
@@ -46,9 +46,10 @@ Ktx2Texture encodeImageToKtx2(
   }
   final blockLevels = <Uint8List>[encodeUniversalBlocks(rgba, width, height)];
   if (generateMips) {
+    final levelCount = engineMipLevelCount(width, height);
     var w = width, h = height;
     var src = rgba;
-    while (w > 1 || h > 1) {
+    for (var level = 1; level < levelCount; level++) {
       final nw = math.max(1, w >> 1);
       final nh = math.max(1, h >> 1);
       src = _downsampleBox(src, w, h, nw, nh);
@@ -102,6 +103,17 @@ Uint8List encodeImageToKtx2Bytes(
 /// The pixel dimensions of mip [level] of a [width] x [height] base image.
 ({int width, int height}) mipSize(int width, int height, int level) =>
     (width: math.max(1, width >> level), height: math.max(1, height >> level));
+
+/// The number of mip levels Flutter GPU expects for a [width] x [height]
+/// texture. The engine stops one level short of 1x1, so a generated mip chain
+/// matches what `createTexture(mipLevelCount:)` accepts (this mirrors the web
+/// shim's `fullMipCount`). Returns at least 1.
+int engineMipLevelCount(int width, int height) {
+  final smallest = width < height ? width : height;
+  if (smallest < 1) return 1;
+  final count = smallest.bitLength - 1;
+  return count > 0 ? count : 1;
+}
 
 /// Decodes one [level] of a flutter_scene KTX2 texture back to rgba8. Throws if
 /// the file is not in our block format.

--- a/packages/flutter_scene/lib/src/texture/ktx2_image.dart
+++ b/packages/flutter_scene/lib/src/texture/ktx2_image.dart
@@ -131,6 +131,11 @@ Uint8List encodeImageToKtx2Bytes(
   );
 }
 
+/// The decompressed 4x4 block payload for [level], ready to decode to rgba8 or
+/// transcode to a GPU block format. Undoes LZ supercompression when present.
+Uint8List ktx2LevelBlocks(Ktx2Texture texture, int level) =>
+    _levelPayload(texture, level);
+
 /// Returns a level's block bytes, undoing our LZ supercompression when the
 /// marker is present. The container's own supercompressionScheme stays `none`;
 /// our LZ is a payload-level wrapper signaled by [kFsSupercompressKey].

--- a/packages/flutter_scene/lib/src/texture/ktx2_image.dart
+++ b/packages/flutter_scene/lib/src/texture/ktx2_image.dart
@@ -1,0 +1,149 @@
+// Bridges rgba8 pixels and the flutter_scene KTX2 representation: encode rgba8
+// into a KTX2 texture carrying our 4x4 block payload, and decode a level back
+// to rgba8. Pure data, no GPU; the GPU upload lives in compressed_texture.dart.
+
+import 'dart:convert';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/block/universal_block.dart';
+import 'package:flutter_scene/src/texture/ktx2/ktx2.dart';
+
+/// Key/value marker naming the block payload format inside our KTX2 files.
+const String kFsBlockFormatKey = 'fsBlockFormat';
+
+/// Current block payload identifier (the [universal_block] layout).
+const String kFsBlockFormatUniversal = 'universal/1';
+
+/// Encodes [width] x [height] rgba8 pixels into a KTX2 texture holding our 4x4
+/// block payload. When [generateMips] is set, a full box-filtered mip chain is
+/// built and each level encoded.
+Ktx2Texture encodeImageToKtx2(
+  Uint8List rgba,
+  int width,
+  int height, {
+  bool generateMips = false,
+}) {
+  if (rgba.length < width * height * 4) {
+    throw ArgumentError('rgba is too small for ${width}x$height');
+  }
+  final levels = <Ktx2Level>[
+    Ktx2Level(data: encodeUniversalBlocks(rgba, width, height)),
+  ];
+  if (generateMips) {
+    var w = width, h = height;
+    var src = rgba;
+    while (w > 1 || h > 1) {
+      final nw = math.max(1, w >> 1);
+      final nh = math.max(1, h >> 1);
+      src = _downsampleBox(src, w, h, nw, nh);
+      levels.add(Ktx2Level(data: encodeUniversalBlocks(src, nw, nh)));
+      w = nw;
+      h = nh;
+    }
+  }
+  return Ktx2Texture(
+    vkFormat:
+        0, // VK_FORMAT_UNDEFINED; the block format is in the marker below.
+    pixelWidth: width,
+    pixelHeight: height,
+    levels: levels,
+    keyValues: {
+      kFsBlockFormatKey: Uint8List.fromList(
+        utf8.encode(kFsBlockFormatUniversal),
+      ),
+    },
+  );
+}
+
+/// Convenience: [encodeImageToKtx2] followed by [writeKtx2].
+Uint8List encodeImageToKtx2Bytes(
+  Uint8List rgba,
+  int width,
+  int height, {
+  bool generateMips = false,
+}) => writeKtx2(
+  encodeImageToKtx2(rgba, width, height, generateMips: generateMips),
+);
+
+/// The pixel dimensions of mip [level] of a [width] x [height] base image.
+({int width, int height}) mipSize(int width, int height, int level) =>
+    (width: math.max(1, width >> level), height: math.max(1, height >> level));
+
+/// Decodes one [level] of a flutter_scene KTX2 texture back to rgba8. Throws if
+/// the file is not in our block format.
+({Uint8List rgba, int width, int height}) decodeKtx2Level(
+  Ktx2Texture texture, {
+  int level = 0,
+}) {
+  final marker = texture.keyValues[kFsBlockFormatKey];
+  if (marker != null && utf8.decode(marker) != kFsBlockFormatUniversal) {
+    throw Ktx2FormatException(
+      'Unsupported block format: ${utf8.decode(marker)}',
+    );
+  }
+  if (level < 0 || level >= texture.levels.length) {
+    throw Ktx2FormatException('No level $level in texture');
+  }
+  final size = mipSize(
+    texture.pixelWidth,
+    math.max(1, texture.pixelHeight),
+    level,
+  );
+  final blocks = _levelPayload(texture, level);
+  return (
+    rgba: decodeUniversalBlocksToRgba8(blocks, size.width, size.height),
+    width: size.width,
+    height: size.height,
+  );
+}
+
+/// Returns a level's decompressed block bytes, undoing supercompression.
+Uint8List _levelPayload(Ktx2Texture texture, int level) {
+  final stored = texture.levels[level].data;
+  switch (texture.supercompression) {
+    case Ktx2Supercompression.none:
+      return stored;
+    // TODO(texture-compression): decode zstd/zlib/BasisLZ supercompression here
+    // once the supercompressor lands; until then only uncompressed payloads are
+    // read back.
+    case Ktx2Supercompression.zstandard:
+    case Ktx2Supercompression.zlib:
+    case Ktx2Supercompression.basisLz:
+      throw Ktx2FormatException(
+        'Supercompression ${texture.supercompression} is not decodable yet',
+      );
+  }
+}
+
+/// Box-filters [src] (rgba8, [sw] x [sh]) down to [dw] x [dh].
+// TODO(texture-compression): do gamma-correct downsampling for sRGB base color
+// (decode to linear, average, re-encode) instead of averaging in sRGB.
+Uint8List _downsampleBox(Uint8List src, int sw, int sh, int dw, int dh) {
+  final out = Uint8List(dw * dh * 4);
+  for (var y = 0; y < dh; y++) {
+    final y0 = y * sh ~/ dh;
+    final y1 = math.max(y0 + 1, (y + 1) * sh ~/ dh);
+    for (var x = 0; x < dw; x++) {
+      final x0 = x * sw ~/ dw;
+      final x1 = math.max(x0 + 1, (x + 1) * sw ~/ dw);
+      var r = 0, g = 0, b = 0, a = 0, n = 0;
+      for (var sy = y0; sy < y1; sy++) {
+        for (var sx = x0; sx < x1; sx++) {
+          final i = (sy * sw + sx) * 4;
+          r += src[i];
+          g += src[i + 1];
+          b += src[i + 2];
+          a += src[i + 3];
+          n++;
+        }
+      }
+      final o = (y * dw + x) * 4;
+      out[o] = r ~/ n;
+      out[o + 1] = g ~/ n;
+      out[o + 2] = b ~/ n;
+      out[o + 3] = a ~/ n;
+    }
+  }
+  return out;
+}

--- a/packages/flutter_scene/lib/src/texture/supercompress/lz.dart
+++ b/packages/flutter_scene/lib/src/texture/supercompress/lz.dart
@@ -1,0 +1,140 @@
+// A small pure-Dart LZ77 codec used to supercompress KTX2 block payloads.
+//
+// We compress and decompress our own files, so this is a private byte format
+// rather than zstd/zlib (which would need a native library or a much larger
+// pure-Dart decoder). The compressor is build-time only; the decompressor is
+// the hot path and runs on every backend including web, so it avoids 64-bit
+// math and any platform library.
+//
+// Stream format: a sequence of [literalLength][literal bytes] runs, each
+// optionally followed by a back-reference [matchLength - kMinMatch][distance].
+// All lengths and the distance are unsigned LEB128 varints. Decoding stops when
+// the output reaches its known uncompressed size, so no end marker is stored.
+
+import 'dart:typed_data';
+
+const int _minMatch = 4;
+const int _maxChain = 32; // candidates examined per position (ratio vs speed)
+const int _hashBits = 16;
+const int _hashSize = 1 << _hashBits;
+
+/// Compresses [input] with LZ77. Build-time only.
+Uint8List lzCompress(Uint8List input) {
+  final n = input.length;
+  final out = BytesBuilder(copy: false);
+  if (n == 0) return out.toBytes();
+
+  final head = Int32List(_hashSize)..fillRange(0, _hashSize, -1);
+  final prev = Int32List(n);
+
+  var i = 0;
+  var literalStart = 0;
+  while (i < n) {
+    var matchLen = 0;
+    var matchDist = 0;
+    if (i + _minMatch <= n) {
+      final h = _hash(input, i);
+      var candidate = head[h];
+      prev[i] = candidate;
+      head[h] = i;
+      var tries = 0;
+      while (candidate >= 0 && tries < _maxChain) {
+        final len = _matchLength(input, candidate, i, n);
+        if (len > matchLen) {
+          matchLen = len;
+          matchDist = i - candidate;
+          if (i + len >= n) break; // can't do better than reaching the end
+        }
+        candidate = prev[candidate];
+        tries++;
+      }
+    }
+
+    if (matchLen >= _minMatch) {
+      _emitLiterals(out, input, literalStart, i);
+      _writeVarint(out, matchLen - _minMatch);
+      _writeVarint(out, matchDist);
+      // Insert the covered positions so later matches can reference them.
+      final end = i + matchLen;
+      for (var k = i + 1; k < end; k++) {
+        if (k + _minMatch <= n) {
+          final h = _hash(input, k);
+          prev[k] = head[h];
+          head[h] = k;
+        }
+      }
+      i = end;
+      literalStart = i;
+    } else {
+      i++;
+    }
+  }
+  _emitLiterals(out, input, literalStart, n);
+  return out.toBytes();
+}
+
+/// Decompresses [compressed] to exactly [uncompressedSize] bytes.
+Uint8List lzDecompress(Uint8List compressed, int uncompressedSize) {
+  final out = Uint8List(uncompressedSize);
+  var produced = 0;
+  var p = 0;
+
+  int readVarint() {
+    var shift = 0;
+    var result = 0;
+    while (true) {
+      final b = compressed[p++];
+      result |= (b & 0x7F) << shift;
+      if (b < 0x80) return result;
+      shift += 7;
+    }
+  }
+
+  while (produced < uncompressedSize) {
+    final literalLength = readVarint();
+    for (var k = 0; k < literalLength; k++) {
+      out[produced++] = compressed[p++];
+    }
+    if (produced >= uncompressedSize) break;
+    final matchLength = readVarint() + _minMatch;
+    final distance = readVarint();
+    var src = produced - distance;
+    if (src < 0) {
+      throw const FormatException('LZ back-reference before start of output');
+    }
+    for (var k = 0; k < matchLength; k++) {
+      out[produced++] = out[src++];
+    }
+  }
+  return out;
+}
+
+void _emitLiterals(BytesBuilder out, Uint8List input, int start, int end) {
+  _writeVarint(out, end - start);
+  if (end > start) out.add(Uint8List.sublistView(input, start, end));
+}
+
+void _writeVarint(BytesBuilder out, int value) {
+  var v = value;
+  while (v >= 0x80) {
+    out.addByte((v & 0x7F) | 0x80);
+    v >>= 7;
+  }
+  out.addByte(v);
+}
+
+/// A web-safe polynomial hash of the four bytes at [i] (stays well under 2^53).
+int _hash(Uint8List input, int i) {
+  final h =
+      ((input[i] * 131 + input[i + 1]) * 131 + input[i + 2]) * 131 +
+      input[i + 3];
+  return (h ^ (h >> 13)) & (_hashSize - 1);
+}
+
+int _matchLength(Uint8List input, int a, int b, int n) {
+  var len = 0;
+  while (b + len < n && input[a + len] == input[b + len]) {
+    len++;
+  }
+  return len;
+}

--- a/packages/flutter_scene/test/fscene/importer_texture_compression_test.dart
+++ b/packages/flutter_scene/test/fscene/importer_texture_compression_test.dart
@@ -1,0 +1,85 @@
+// Covers the glTF importer's optional KTX2 texture compression. Runs only when
+// the source GLB corpus is present (CI without it skips). The GPU upload is
+// verified in the example app; here we check the importer emits KTX2 payloads,
+// that the container shrinks, and that the payload decodes back to the image.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/fscene/binary/fsceneb.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/importer/in_memory_import.dart';
+import 'package:flutter_scene/src/texture/ktx2/ktx2.dart';
+import 'package:flutter_scene/src/texture/ktx2_image.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+String _resolve(String relative) {
+  for (final prefix in ['', '../../']) {
+    final candidate = '$prefix$relative';
+    if (File(candidate).existsSync()) return candidate;
+  }
+  return relative;
+}
+
+void main() {
+  group('importer texture compression', () {
+    const name = 'flutter_logo_baked.glb'; // 1 texture
+
+    Uint8List? load() {
+      final file = File(_resolve('examples/assets_src/$name'));
+      if (!file.existsSync()) {
+        // ignore: avoid_print
+        print('Test data missing ($name) - skipping.');
+        return null;
+      }
+      return file.readAsBytesSync();
+    }
+
+    test('emits ktx2 texture payloads when asked, rgba8 otherwise', () {
+      final glb = load();
+      if (glb == null) return;
+
+      final plain = importGlbToSceneDocument(glb);
+      final compressed = importGlbToSceneDocument(glb, compressTextures: true);
+
+      final plainTexPayloads = _imagePayloads(plain);
+      final compressedTexPayloads = _imagePayloads(compressed);
+      expect(plainTexPayloads, isNotEmpty);
+      expect(compressedTexPayloads, hasLength(plainTexPayloads.length));
+      expect(plainTexPayloads.every((p) => p.format == 'rgba8'), isTrue);
+      expect(compressedTexPayloads.every((p) => p.format == 'ktx2'), isTrue);
+    });
+
+    test('shrinks the .fsceneb container', () {
+      final glb = load();
+      if (glb == null) return;
+
+      final plain = importGlbToFscenebBytes(glb);
+      final compressed = importGlbToFscenebBytes(glb, compressTextures: true);
+      expect(compressed.length, lessThan(plain.length));
+    });
+
+    test('ktx2 payloads decode back to the source image dimensions', () {
+      final glb = load();
+      if (glb == null) return;
+
+      // Re-read through the container codec to exercise the real load path.
+      final document = readFsceneb(
+        importGlbToFscenebBytes(glb, compressTextures: true),
+      );
+      final payloads = _imagePayloads(document);
+      for (final payload in payloads) {
+        final texture = readKtx2(payload.bytes!);
+        final decoded = decodeKtx2Level(texture);
+        expect(decoded.width, payload.width);
+        expect(decoded.height, payload.height);
+      }
+    });
+  });
+}
+
+List<PayloadSpec> _imagePayloads(SceneDocument document) => [
+  for (final payload in document.payloads.values)
+    if (payload.encoding == PayloadEncoding.image) payload,
+];

--- a/packages/flutter_scene/test/texture/ktx2_image_test.dart
+++ b/packages/flutter_scene/test/texture/ktx2_image_test.dart
@@ -1,0 +1,95 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/ktx2/ktx2.dart';
+import 'package:flutter_scene/src/texture/ktx2_image.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+double _psnr(Uint8List a, Uint8List b) {
+  var sum = 0.0;
+  for (var i = 0; i < a.length; i++) {
+    final d = a[i] - b[i];
+    sum += d * d;
+  }
+  final mse = sum / a.length;
+  return mse == 0 ? double.infinity : 10 * (math.log(65025 / mse) / math.ln10);
+}
+
+Uint8List _gradient(int w, int h) {
+  final out = Uint8List(w * h * 4);
+  for (var y = 0; y < h; y++) {
+    for (var x = 0; x < w; x++) {
+      final i = (y * w + x) * 4;
+      out[i] = x * 255 ~/ (w - 1);
+      out[i + 1] = y * 255 ~/ (h - 1);
+      out[i + 2] = 128;
+      out[i + 3] = 255;
+    }
+  }
+  return out;
+}
+
+void main() {
+  group('rgba8 <-> KTX2 image', () {
+    test('round-trips an image through KTX2 bytes', () {
+      const w = 64, h = 64;
+      final rgba = _gradient(w, h);
+      final bytes = encodeImageToKtx2Bytes(rgba, w, h);
+
+      final decoded = decodeKtx2Level(readKtx2(bytes));
+      expect(decoded.width, w);
+      expect(decoded.height, h);
+      expect(_psnr(rgba, decoded.rgba), greaterThan(36));
+    });
+
+    test('writes the block-format marker', () {
+      final texture = encodeImageToKtx2(_gradient(8, 8), 8, 8);
+      expect(texture.keyValues.containsKey(kFsBlockFormatKey), isTrue);
+      expect(
+        String.fromCharCodes(texture.keyValues[kFsBlockFormatKey]!),
+        kFsBlockFormatUniversal,
+      );
+    });
+
+    test('rejects an unknown block format', () {
+      final texture = Ktx2Texture(
+        vkFormat: 0,
+        pixelWidth: 4,
+        pixelHeight: 4,
+        levels: [Ktx2Level(data: Uint8List(16))],
+        keyValues: {kFsBlockFormatKey: Uint8List.fromList('other/9'.codeUnits)},
+      );
+      expect(
+        () => decodeKtx2Level(texture),
+        throwsA(isA<Ktx2FormatException>()),
+      );
+    });
+
+    test('builds a full mip chain', () {
+      const w = 16, h = 16;
+      final texture = encodeImageToKtx2(
+        _gradient(w, h),
+        w,
+        h,
+        generateMips: true,
+      );
+      // 16 -> 8 -> 4 -> 2 -> 1 is five levels.
+      expect(texture.levels, hasLength(5));
+
+      for (var level = 0; level < texture.levels.length; level++) {
+        final size = mipSize(w, h, level);
+        final decoded = decodeKtx2Level(texture, level: level);
+        expect(decoded.width, size.width);
+        expect(decoded.height, size.height);
+      }
+    });
+
+    test('reports a smaller payload than rgba8', () {
+      const w = 64, h = 64;
+      final bytes = encodeImageToKtx2Bytes(_gradient(w, h), w, h);
+      // Block payload is 1 byte/texel; the file (plus a small header) is well
+      // under the 4 bytes/texel of raw rgba8.
+      expect(bytes.length, lessThan(w * h * 4));
+    });
+  });
+}

--- a/packages/flutter_scene/test/texture/ktx2_image_test.dart
+++ b/packages/flutter_scene/test/texture/ktx2_image_test.dart
@@ -91,5 +91,38 @@ void main() {
       // under the 4 bytes/texel of raw rgba8.
       expect(bytes.length, lessThan(w * h * 4));
     });
+
+    test('round-trips a supercompressed image and shrinks it further', () {
+      const w = 64, h = 64;
+      final rgba = _gradient(w, h);
+      final plain = encodeImageToKtx2Bytes(rgba, w, h);
+      final packed = encodeImageToKtx2Bytes(rgba, w, h, supercompress: true);
+
+      // A smooth gradient compresses well, so the supercompressed file is
+      // smaller than the raw-block file.
+      expect(packed.length, lessThan(plain.length));
+
+      final decoded = decodeKtx2Level(readKtx2(packed));
+      expect(decoded.width, w);
+      expect(decoded.height, h);
+      expect(_psnr(rgba, decoded.rgba), greaterThan(36));
+    });
+
+    test('round-trips supercompressed mips', () {
+      const w = 32, h = 32;
+      final texture = encodeImageToKtx2(
+        _gradient(w, h),
+        w,
+        h,
+        generateMips: true,
+        supercompress: true,
+      );
+      for (var level = 0; level < texture.levels.length; level++) {
+        final size = mipSize(w, h, level);
+        final decoded = decodeKtx2Level(texture, level: level);
+        expect(decoded.width, size.width);
+        expect(decoded.height, size.height);
+      }
+    });
   });
 }

--- a/packages/flutter_scene/test/texture/ktx2_image_test.dart
+++ b/packages/flutter_scene/test/texture/ktx2_image_test.dart
@@ -65,7 +65,7 @@ void main() {
       );
     });
 
-    test('builds a full mip chain', () {
+    test('builds a mip chain matching the engine mip count', () {
       const w = 16, h = 16;
       final texture = encodeImageToKtx2(
         _gradient(w, h),
@@ -73,8 +73,9 @@ void main() {
         h,
         generateMips: true,
       );
-      // 16 -> 8 -> 4 -> 2 -> 1 is five levels.
-      expect(texture.levels, hasLength(5));
+      // The engine stops one short of 1x1: 16 -> 8 -> 4 -> 2 is four levels.
+      expect(texture.levels, hasLength(engineMipLevelCount(w, h)));
+      expect(texture.levels, hasLength(4));
 
       for (var level = 0; level < texture.levels.length; level++) {
         final size = mipSize(w, h, level);
@@ -82,6 +83,13 @@ void main() {
         expect(decoded.width, size.width);
         expect(decoded.height, size.height);
       }
+    });
+
+    test('engine mip count stops one level short of 1x1', () {
+      expect(engineMipLevelCount(64, 64), 6); // not 7
+      expect(engineMipLevelCount(2048, 2048), 11); // not 12
+      expect(engineMipLevelCount(1, 1), 1);
+      expect(engineMipLevelCount(64, 32), 5);
     });
 
     test('reports a smaller payload than rgba8', () {

--- a/packages/flutter_scene/test/texture/ktx2_test.dart
+++ b/packages/flutter_scene/test/texture/ktx2_test.dart
@@ -1,0 +1,169 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/ktx2/ktx2.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Uint8List _bytes(int length, {int seed = 0}) {
+  final out = Uint8List(length);
+  for (var i = 0; i < length; i++) {
+    out[i] = (i * 31 + seed * 7 + 1) & 0xFF;
+  }
+  return out;
+}
+
+int _u32(Uint8List bytes, int offset) =>
+    ByteData.sublistView(bytes).getUint32(offset, Endian.little);
+
+void main() {
+  group('KTX2 container', () {
+    test('writes the identifier and header for a single-level texture', () {
+      final texture = Ktx2Texture(
+        vkFormat: 37, // VK_FORMAT_R8G8B8A8_UNORM
+        pixelWidth: 4,
+        pixelHeight: 4,
+        levels: [Ktx2Level(data: _bytes(64))],
+        levelAlignment: 4,
+      );
+      final out = writeKtx2(texture);
+
+      expect(out.sublist(0, 12), ktx2Identifier);
+      expect(_u32(out, 12), 37); // vkFormat
+      expect(_u32(out, 16), 1); // typeSize
+      expect(_u32(out, 20), 4); // pixelWidth
+      expect(_u32(out, 24), 4); // pixelHeight
+      expect(_u32(out, 40), 1); // levelCount
+      expect(_u32(out, 44), 0); // supercompressionScheme = none
+    });
+
+    test('round-trips a single level', () {
+      final payload = _bytes(64, seed: 3);
+      final texture = Ktx2Texture(
+        vkFormat: 37,
+        pixelWidth: 4,
+        pixelHeight: 4,
+        levels: [Ktx2Level(data: payload)],
+        levelAlignment: 4,
+      );
+      final decoded = readKtx2(writeKtx2(texture));
+
+      expect(decoded.vkFormat, 37);
+      expect(decoded.pixelWidth, 4);
+      expect(decoded.pixelHeight, 4);
+      expect(decoded.levels, hasLength(1));
+      expect(decoded.levels.single.data, payload);
+      expect(decoded.levels.single.uncompressedByteLength, 64);
+      expect(decoded.supercompression, Ktx2Supercompression.none);
+    });
+
+    test('round-trips a mip chain, base level first', () {
+      final mips = [
+        Ktx2Level(data: _bytes(256, seed: 0)), // base
+        Ktx2Level(data: _bytes(64, seed: 1)),
+        Ktx2Level(data: _bytes(16, seed: 2)),
+      ];
+      final texture = Ktx2Texture(
+        vkFormat: 0,
+        pixelWidth: 8,
+        pixelHeight: 8,
+        levels: mips,
+      );
+      final decoded = readKtx2(writeKtx2(texture));
+
+      expect(decoded.levels, hasLength(3));
+      expect(decoded.levels[0].data, mips[0].data);
+      expect(decoded.levels[1].data, mips[1].data);
+      expect(decoded.levels[2].data, mips[2].data);
+    });
+
+    test('stores level data smallest-first with aligned offsets', () {
+      final mips = [
+        Ktx2Level(data: _bytes(100, seed: 0)), // base
+        Ktx2Level(data: _bytes(30, seed: 1)),
+      ];
+      final texture = Ktx2Texture(
+        vkFormat: 0,
+        pixelWidth: 8,
+        pixelHeight: 8,
+        levels: mips,
+        levelAlignment: 16,
+      );
+      final out = writeKtx2(texture);
+
+      // Level index entries are base-first (index 0 = base).
+      const levelIndexStart = 80;
+      final baseOffset = _u32(out, levelIndexStart);
+      final smallOffset = _u32(out, levelIndexStart + 24);
+
+      // Both offsets honor the 16-byte alignment, and the smaller level is
+      // stored at the lower offset.
+      expect(baseOffset % 16, 0);
+      expect(smallOffset % 16, 0);
+      expect(smallOffset, lessThan(baseOffset));
+      expect(_u32(out, levelIndexStart + 8), 100); // base byteLength
+      expect(_u32(out, levelIndexStart + 24 + 8), 30); // small byteLength
+    });
+
+    test('round-trips key/value data in sorted key order', () {
+      final texture = Ktx2Texture(
+        vkFormat: 37,
+        pixelWidth: 1,
+        pixelHeight: 1,
+        levels: [Ktx2Level(data: _bytes(4))],
+        levelAlignment: 4,
+        keyValues: {
+          'KTXorientation': Uint8List.fromList('rd'.codeUnits),
+          'KTXwriter': Uint8List.fromList('flutter_scene'.codeUnits),
+        },
+      );
+      final decoded = readKtx2(writeKtx2(texture));
+
+      expect(decoded.keyValues.keys, ['KTXorientation', 'KTXwriter']);
+      expect(String.fromCharCodes(decoded.keyValues['KTXorientation']!), 'rd');
+      expect(
+        String.fromCharCodes(decoded.keyValues['KTXwriter']!),
+        'flutter_scene',
+      );
+    });
+
+    test('passes supercompressed payloads through opaquely', () {
+      final stored = _bytes(40, seed: 9); // pretend-compressed bytes
+      final texture = Ktx2Texture(
+        vkFormat: 0,
+        pixelWidth: 8,
+        pixelHeight: 8,
+        levels: [Ktx2Level(data: stored, uncompressedByteLength: 256)],
+        supercompression: Ktx2Supercompression.zstandard,
+        supercompressionGlobalData: _bytes(8, seed: 5),
+      );
+      final out = writeKtx2(texture);
+      final decoded = readKtx2(out);
+
+      expect(_u32(out, 44), Ktx2Supercompression.zstandard.value);
+      expect(decoded.supercompression, Ktx2Supercompression.zstandard);
+      expect(decoded.levels.single.data, stored);
+      expect(decoded.levels.single.uncompressedByteLength, 256);
+      expect(decoded.supercompressionGlobalData, _bytes(8, seed: 5));
+    });
+
+    test('rejects a bad identifier', () {
+      final out = writeKtx2(
+        Ktx2Texture(
+          vkFormat: 37,
+          pixelWidth: 1,
+          pixelHeight: 1,
+          levels: [Ktx2Level(data: _bytes(4))],
+          levelAlignment: 4,
+        ),
+      );
+      out[1] = 0x00; // corrupt the identifier
+      expect(() => readKtx2(out), throwsA(isA<Ktx2FormatException>()));
+    });
+
+    test('rejects truncated input', () {
+      expect(
+        () => readKtx2(Uint8List(20)),
+        throwsA(isA<Ktx2FormatException>()),
+      );
+    });
+  });
+}

--- a/packages/flutter_scene/test/texture/lz_test.dart
+++ b/packages/flutter_scene/test/texture/lz_test.dart
@@ -1,0 +1,49 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/supercompress/lz.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Uint8List _roundTrip(Uint8List input) =>
+    lzDecompress(lzCompress(input), input.length);
+
+void main() {
+  group('LZ supercompression', () {
+    test('round-trips empty input', () {
+      expect(_roundTrip(Uint8List(0)), isEmpty);
+    });
+
+    test('round-trips incompressible random bytes', () {
+      final rng = math.Random(11);
+      final input = Uint8List.fromList(
+        List.generate(4096, (_) => rng.nextInt(256)),
+      );
+      expect(_roundTrip(input), input);
+    });
+
+    test('round-trips and shrinks highly repetitive bytes', () {
+      final input = Uint8List(8192);
+      for (var i = 0; i < input.length; i++) {
+        input[i] = (i ~/ 64) & 0xFF; // long runs
+      }
+      final compressed = lzCompress(input);
+      expect(lzDecompress(compressed, input.length), input);
+      expect(compressed.length, lessThan(input.length ~/ 4));
+    });
+
+    test('round-trips a repeated pattern with back-references', () {
+      final pattern = Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]);
+      final input = Uint8List(8 * 500);
+      for (var i = 0; i < input.length; i++) {
+        input[i] = pattern[i % pattern.length];
+      }
+      final compressed = lzCompress(input);
+      expect(lzDecompress(compressed, input.length), input);
+      expect(compressed.length, lessThan(input.length ~/ 10));
+    });
+
+    test('round-trips a single byte', () {
+      expect(_roundTrip(Uint8List.fromList([42])), [42]);
+    });
+  });
+}

--- a/packages/flutter_scene/test/texture/transcode_astc_test.dart
+++ b/packages/flutter_scene/test/texture/transcode_astc_test.dart
@@ -1,0 +1,86 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/block/transcode_astc.dart';
+import 'package:flutter_scene/src/texture/block/universal_block.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+double _psnrRgb(Uint8List a, Uint8List b) {
+  var sum = 0.0;
+  var count = 0;
+  for (var i = 0; i < a.length; i += 4) {
+    for (var c = 0; c < 3; c++) {
+      final d = a[i + c] - b[i + c];
+      sum += d * d;
+      count++;
+    }
+  }
+  final mse = sum / count;
+  return mse == 0 ? double.infinity : 10 * (math.log(65025 / mse) / math.ln10);
+}
+
+int _blockCount(int w, int h) => ((w + 3) ~/ 4) * ((h + 3) ~/ 4);
+
+Uint8List _viaAstc(Uint8List rgba, int w, int h) => decodeAstc4x4ToRgba8(
+  transcodeUniversalToAstc4x4(
+    encodeUniversalBlocks(rgba, w, h),
+    _blockCount(w, h),
+  ),
+  w,
+  h,
+);
+
+void main() {
+  group('ASTC 4x4 transcode', () {
+    test('produces 16 bytes per block', () {
+      final blocks = encodeUniversalBlocks(Uint8List(16 * 16 * 4), 16, 16);
+      final astc = transcodeUniversalToAstc4x4(blocks, _blockCount(16, 16));
+      expect(astc.length, _blockCount(16, 16) * 16);
+    });
+
+    test('writes the fixed block mode and CEM', () {
+      final astc = transcodeUniversalToAstc4x4(
+        encodeUniversalBlocks(Uint8List(4 * 4 * 4), 4, 4),
+        1,
+      );
+      // Block mode is bits [10:0] = 0x53.
+      final blockMode = astc[0] | ((astc[1] & 0x7) << 8);
+      expect(blockMode, 0x53);
+      // Partition bits [12:11] = 0, CEM bits [16:13] = 8.
+      final lowHalf = astc[1] | (astc[2] << 8);
+      final partition = (lowHalf >> 3) & 0x3; // bits 11-12
+      final cem = (lowHalf >> 5) & 0xF; // bits 13-16
+      expect(partition, 0);
+      expect(cem, 8);
+    });
+
+    test('keeps a solid color through transcode', () {
+      const w = 8, h = 8;
+      final rgba = Uint8List(w * h * 4);
+      for (var i = 0; i < w * h; i++) {
+        rgba[i * 4] = 200;
+        rgba[i * 4 + 1] = 120;
+        rgba[i * 4 + 2] = 60;
+        rgba[i * 4 + 3] = 255;
+      }
+      // 8-bit endpoints reproduce a solid color exactly.
+      expect(_psnrRgb(rgba, _viaAstc(rgba, w, h)), greaterThan(45));
+    });
+
+    test('approximates a color gradient', () {
+      const w = 64, h = 64;
+      final rgba = Uint8List(w * h * 4);
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
+          final i = (y * w + x) * 4;
+          rgba[i] = x * 255 ~/ (w - 1);
+          rgba[i + 1] = y * 255 ~/ (h - 1);
+          rgba[i + 2] = 128;
+          rgba[i + 3] = 255;
+        }
+      }
+      // 8-bit endpoints + 3-bit weights track the gradient well.
+      expect(_psnrRgb(rgba, _viaAstc(rgba, w, h)), greaterThan(30));
+    });
+  });
+}

--- a/packages/flutter_scene/test/texture/transcode_bc1_test.dart
+++ b/packages/flutter_scene/test/texture/transcode_bc1_test.dart
@@ -1,0 +1,93 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/block/transcode_bc1.dart';
+import 'package:flutter_scene/src/texture/block/universal_block.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+double _psnrRgb(Uint8List a, Uint8List b) {
+  // Compare RGB only; BC1 carries no alpha.
+  var sum = 0.0;
+  var count = 0;
+  for (var i = 0; i < a.length; i += 4) {
+    for (var c = 0; c < 3; c++) {
+      final d = a[i + c] - b[i + c];
+      sum += d * d;
+      count++;
+    }
+  }
+  final mse = sum / count;
+  return mse == 0 ? double.infinity : 10 * (math.log(65025 / mse) / math.ln10);
+}
+
+int _blockCount(int w, int h) => ((w + 3) ~/ 4) * ((h + 3) ~/ 4);
+
+void main() {
+  group('BC1 transcode', () {
+    test('produces 8 bytes per block', () {
+      final blocks = encodeUniversalBlocks(Uint8List(16 * 16 * 4), 16, 16);
+      final bc1 = transcodeUniversalToBc1(blocks, _blockCount(16, 16));
+      expect(bc1.length, _blockCount(16, 16) * 8);
+      // Half the size of our 16-byte blocks.
+      expect(bc1.length, blocks.length ~/ 2);
+    });
+
+    test('keeps a solid color through transcode', () {
+      const w = 8, h = 8;
+      final rgba = Uint8List(w * h * 4);
+      for (var i = 0; i < w * h; i++) {
+        rgba[i * 4] = 180;
+        rgba[i * 4 + 1] = 90;
+        rgba[i * 4 + 2] = 40;
+        rgba[i * 4 + 3] = 255;
+      }
+      final blocks = encodeUniversalBlocks(rgba, w, h);
+      final bc1 = transcodeUniversalToBc1(blocks, _blockCount(w, h));
+      final decoded = decodeBc1ToRgba8(bc1, w, h);
+      // Only the RGB565 endpoint quantization error remains.
+      expect(_psnrRgb(rgba, decoded), greaterThan(33));
+    });
+
+    test('approximates a gradient via the BC1 path', () {
+      const w = 64, h = 64;
+      final rgba = Uint8List(w * h * 4);
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
+          final i = (y * w + x) * 4;
+          rgba[i] = x * 255 ~/ (w - 1);
+          rgba[i + 1] = y * 255 ~/ (h - 1);
+          rgba[i + 2] = 128;
+          rgba[i + 3] = 255;
+        }
+      }
+      final blocks = encodeUniversalBlocks(rgba, w, h);
+      final bc1 = transcodeUniversalToBc1(blocks, _blockCount(w, h));
+      final viaBc1 = decodeBc1ToRgba8(bc1, w, h);
+
+      // BC1 has 2-bit weights and RGB565 endpoints, so it is lossier than the
+      // source but should still track the gradient.
+      expect(_psnrRgb(rgba, viaBc1), greaterThan(28));
+    });
+
+    test('stays close to the universal-block decode it transcodes from', () {
+      const w = 32, h = 32;
+      final rng = math.Random(5);
+      final rgba = Uint8List(w * h * 4);
+      for (var i = 0; i < rgba.length; i += 4) {
+        rgba[i] = rng.nextInt(256);
+        rgba[i + 1] = rng.nextInt(256);
+        rgba[i + 2] = rng.nextInt(256);
+        rgba[i + 3] = 255;
+      }
+      final blocks = encodeUniversalBlocks(rgba, w, h);
+      final viaBlocks = decodeUniversalBlocksToRgba8(blocks, w, h);
+      final viaBc1 = decodeBc1ToRgba8(
+        transcodeUniversalToBc1(blocks, _blockCount(w, h)),
+        w,
+        h,
+      );
+      // The transcode should not diverge wildly from the block decode.
+      expect(_psnrRgb(viaBlocks, viaBc1), greaterThan(24));
+    });
+  });
+}

--- a/packages/flutter_scene/test/texture/transcode_etc2_test.dart
+++ b/packages/flutter_scene/test/texture/transcode_etc2_test.dart
@@ -1,0 +1,90 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/block/transcode_etc2.dart';
+import 'package:flutter_scene/src/texture/block/universal_block.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+double _psnrRgb(Uint8List a, Uint8List b) {
+  var sum = 0.0;
+  var count = 0;
+  for (var i = 0; i < a.length; i += 4) {
+    for (var c = 0; c < 3; c++) {
+      final d = a[i + c] - b[i + c];
+      sum += d * d;
+      count++;
+    }
+  }
+  final mse = sum / count;
+  return mse == 0 ? double.infinity : 10 * (math.log(65025 / mse) / math.ln10);
+}
+
+int _blockCount(int w, int h) => ((w + 3) ~/ 4) * ((h + 3) ~/ 4);
+
+Uint8List _viaEtc2(Uint8List rgba, int w, int h) => decodeEtc2RgbToRgba8(
+  transcodeUniversalToEtc2Rgb(
+    encodeUniversalBlocks(rgba, w, h),
+    _blockCount(w, h),
+  ),
+  w,
+  h,
+);
+
+void main() {
+  group('ETC2 RGB transcode', () {
+    test('produces 8 bytes per block', () {
+      final blocks = encodeUniversalBlocks(Uint8List(16 * 16 * 4), 16, 16);
+      final etc2 = transcodeUniversalToEtc2Rgb(blocks, _blockCount(16, 16));
+      expect(etc2.length, _blockCount(16, 16) * 8);
+      expect(etc2.length, blocks.length ~/ 2);
+    });
+
+    test('keeps a solid color through transcode', () {
+      const w = 8, h = 8;
+      final rgba = Uint8List(w * h * 4);
+      for (var i = 0; i < w * h; i++) {
+        rgba[i * 4] = 70;
+        rgba[i * 4 + 1] = 160;
+        rgba[i * 4 + 2] = 210;
+        rgba[i * 4 + 3] = 255;
+      }
+      // A solid color needs only the base color; quantization is the only loss.
+      expect(_psnrRgb(rgba, _viaEtc2(rgba, w, h)), greaterThan(30));
+    });
+
+    test('tracks a luminance ramp (ETC2 strength)', () {
+      // ETC1/ETC2 modulate luminance per subblock, so a brightness ramp is its
+      // best case.
+      const w = 16, h = 16;
+      final rgba = Uint8List(w * h * 4);
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
+          final i = (y * w + x) * 4;
+          final v = x * 255 ~/ (w - 1);
+          rgba[i] = v;
+          rgba[i + 1] = v;
+          rgba[i + 2] = v;
+          rgba[i + 3] = 255;
+        }
+      }
+      expect(_psnrRgb(rgba, _viaEtc2(rgba, w, h)), greaterThan(30));
+    });
+
+    test('approximates a color gradient', () {
+      const w = 64, h = 64;
+      final rgba = Uint8List(w * h * 4);
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
+          final i = (y * w + x) * 4;
+          rgba[i] = x * 255 ~/ (w - 1);
+          rgba[i + 1] = y * 255 ~/ (h - 1);
+          rgba[i + 2] = 128;
+          rgba[i + 3] = 255;
+        }
+      }
+      // Color (not just luminance) variation within a block is ETC's weak spot,
+      // but it should still track the gradient.
+      expect(_psnrRgb(rgba, _viaEtc2(rgba, w, h)), greaterThan(26));
+    });
+  });
+}

--- a/packages/flutter_scene/test/texture/universal_block_test.dart
+++ b/packages/flutter_scene/test/texture/universal_block_test.dart
@@ -1,0 +1,107 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/block/universal_block.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+double _psnr(Uint8List a, Uint8List b) {
+  assert(a.length == b.length);
+  var sum = 0.0;
+  for (var i = 0; i < a.length; i++) {
+    final d = a[i] - b[i];
+    sum += d * d;
+  }
+  final mse = sum / a.length;
+  if (mse == 0) return double.infinity;
+  return 10 * (math.log(255 * 255 / mse) / math.ln10);
+}
+
+Uint8List _solid(int w, int h, int r, int g, int b, int a) {
+  final out = Uint8List(w * h * 4);
+  for (var i = 0; i < w * h; i++) {
+    out[i * 4] = r;
+    out[i * 4 + 1] = g;
+    out[i * 4 + 2] = b;
+    out[i * 4 + 3] = a;
+  }
+  return out;
+}
+
+Uint8List _roundTrip(Uint8List rgba, int w, int h) =>
+    decodeUniversalBlocksToRgba8(encodeUniversalBlocks(rgba, w, h), w, h);
+
+void main() {
+  group('universal block codec', () {
+    test('compresses to one byte per texel', () {
+      final blocks = encodeUniversalBlocks(_solid(8, 8, 10, 20, 30, 255), 8, 8);
+      // 8x8 = 4 blocks of 16 bytes = 64 bytes for 64 texels.
+      expect(blocks.length, 64);
+      expect(blocks.length, (8 * 8 * 4) ~/ 4);
+    });
+
+    test('reproduces a solid block exactly', () {
+      final rgba = _solid(4, 4, 200, 100, 50, 255);
+      expect(_roundTrip(rgba, 4, 4), rgba);
+    });
+
+    test('reproduces a solid translucent block exactly', () {
+      final rgba = _solid(4, 4, 12, 240, 7, 128);
+      expect(_roundTrip(rgba, 4, 4), rgba);
+    });
+
+    test('keeps a two-color split within tight error', () {
+      // A block split between two colors lies on one line, so the two-endpoint
+      // fit should be near-exact.
+      final rgba = Uint8List(4 * 4 * 4);
+      for (var i = 0; i < 16; i++) {
+        final c = i < 8 ? 30 : 220;
+        rgba[i * 4] = c;
+        rgba[i * 4 + 1] = c;
+        rgba[i * 4 + 2] = c;
+        rgba[i * 4 + 3] = 255;
+      }
+      expect(_psnr(rgba, _roundTrip(rgba, 4, 4)), greaterThan(45));
+    });
+
+    test('keeps a smooth gradient at high quality', () {
+      const w = 64, h = 64;
+      final rgba = Uint8List(w * h * 4);
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
+          final i = (y * w + x) * 4;
+          rgba[i] = (x * 255 ~/ (w - 1));
+          rgba[i + 1] = (y * 255 ~/ (h - 1));
+          rgba[i + 2] = ((x + y) * 255 ~/ (w + h - 2));
+          rgba[i + 3] = 255;
+        }
+      }
+      expect(_psnr(rgba, _roundTrip(rgba, w, h)), greaterThan(38));
+    });
+
+    test('stays reasonable on pseudo-random content', () {
+      const w = 32, h = 32;
+      final rng = math.Random(7);
+      final rgba = Uint8List(w * h * 4);
+      for (var i = 0; i < rgba.length; i++) {
+        rgba[i] = rng.nextInt(256);
+      }
+      // Pure noise has no color line, so a single-line fit is the worst case;
+      // quality is low but bounded (real textures are locally coherent and do
+      // far better, see the gradient test).
+      expect(_psnr(rgba, _roundTrip(rgba, w, h)), greaterThan(12));
+    });
+
+    test('handles dimensions that are not multiples of four', () {
+      const w = 13, h = 7;
+      final rng = math.Random(3);
+      final rgba = Uint8List(w * h * 4);
+      for (var i = 0; i < rgba.length; i++) {
+        rgba[i] = rng.nextInt(256);
+      }
+      final decoded = _roundTrip(rgba, w, h);
+      expect(decoded.length, w * h * 4);
+      // 4x2 blocks cover 13x7.
+      expect(encodeUniversalBlocks(rgba, w, h).length, 4 * 2 * 16);
+    });
+  });
+}


### PR DESCRIPTION
Adds optional texture compression to the importer and renderer, cutting GPU memory for imported models. It is opt in via a `compressTextures` flag on the importers and the `buildModels` build hook (default off); the example app turns it on.

How it works:
- A KTX2 container reader and writer, with a small LZ codec to supercompress the stored block payloads.
- Images are stored as a 4x4 LDR block format, then transcoded at load to a format the device supports (BC1, ETC2 RGB8, or ASTC 4x4), chosen by a family preference order, with an rgba8 fallback when none are available.
- Compressed upload works on every backend, including the WebGL2 shim.
- Transcoding runs off the main isolate so it does not stall the frame, and the animated example imports its model on a background isolate.

Textures upload at the base level with a mip count matching the engine. The example build hook compresses its imported textures, and a compressed KTX2 texture is added to the fscene example.

On device, BC1 is visually confirmed on Metal and ETC2/ASTC are structurally smoke tested. The block format is a self contained 4x4 LDR codec (not UASTC), chosen so it can be tested headless.
