### PR TITLE
Generate vertex normals matching the engine front-face winding

### DIFF
--- a/examples/flutter_app/lib/example_widget_texture.dart
+++ b/examples/flutter_app/lib/example_widget_texture.dart
@@ -1,4 +1,3 @@
-import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -230,27 +229,17 @@ Geometry _buildCrtScreen({
   final columns = segments + 1;
   final rows = (segments * 3) ~/ 4 + 1;
   final positions = Float32List(columns * rows * 3);
-  final normals = Float32List(columns * rows * 3);
   final texCoords = Float32List(columns * rows * 2);
   for (var r = 0; r < rows; r++) {
     final ny = r / (rows - 1) * 2 - 1; // -1 (bottom) .. 1 (top)
     for (var c = 0; c < columns; c++) {
       final nx = c / (columns - 1) * 2 - 1;
       final v = r * columns + c;
-      // A smooth dome: full bulge at the center, flat at the rim,
-      // z = bulge * (1 - nx^2)(1 - ny^2) over x = nx*w/2, y = ny*h/2.
+      // A smooth dome: full bulge at the center, flat at the rim.
       final dome = (1 - nx * nx) * (1 - ny * ny);
       positions[v * 3] = nx * width / 2;
       positions[v * 3 + 1] = ny * height / 2;
       positions[v * 3 + 2] = bulge * dome;
-      // Analytic surface normal: (-dz/dx, -dz/dy, 1) normalized. The
-      // chain rule brings in dnx/dx = 2/width (and likewise for y).
-      final dzdx = bulge * (-2 * nx) * (1 - ny * ny) * (2 / width);
-      final dzdy = bulge * (1 - nx * nx) * (-2 * ny) * (2 / height);
-      final inverseLength = 1 / math.sqrt(dzdx * dzdx + dzdy * dzdy + 1);
-      normals[v * 3] = -dzdx * inverseLength;
-      normals[v * 3 + 1] = -dzdy * inverseLength;
-      normals[v * 3 + 2] = inverseLength;
       // u = 0 at +x, matching the engine's hand-built front-face
       // convention (see the component quad).
       texCoords[v * 2] = (1 - nx) / 2;
@@ -269,9 +258,10 @@ Geometry _buildCrtScreen({
       indices.addAll([br, bl, tr, tr, bl, tl]);
     }
   }
+  // Normals are omitted; smooth area-weighted vertex normals are generated
+  // from the faces.
   return MeshGeometry.fromArrays(
     positions: positions,
-    normals: normals,
     texCoords: texCoords,
     indices: indices,
   );

--- a/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
+++ b/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
@@ -119,6 +119,12 @@ abstract final class InterleavedLayoutAdapter {
   /// larger faces contribute proportionally; the result is normalized
   /// per vertex. Vertices touched by no (or only degenerate) triangles
   /// receive a default normal of `(0, 0, 1)`.
+  ///
+  /// Normals point out of the face the engine renders as front. The
+  /// engine's front faces wind clockwise in model space (the hand-built
+  /// primitives' convention; rasterization is Y-down, which flips the
+  /// apparent winding to counter-clockwise), so the face normal is the
+  /// REVERSED right-hand cross product of the edges.
   static Float32List generateNormals({
     required Float32List positions,
     required int vertexCount,
@@ -139,11 +145,12 @@ abstract final class InterleavedLayoutAdapter {
           cz = positions[c * 3 + 2];
       final e1x = bx - ax, e1y = by - ay, e1z = bz - az;
       final e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
-      // Unnormalized cross product: its magnitude is twice the triangle
-      // area, which weights each face's contribution by its size.
-      final nx = e1y * e2z - e1z * e2y;
-      final ny = e1z * e2x - e1x * e2z;
-      final nz = e1x * e2y - e1y * e2x;
+      // Unnormalized cross product (reversed for the engine's clockwise
+      // front-face winding): its magnitude is twice the triangle area,
+      // which weights each face's contribution by its size.
+      final nx = e2y * e1z - e2z * e1y;
+      final ny = e2z * e1x - e2x * e1z;
+      final nz = e2x * e1y - e2y * e1x;
       for (final v in [a, b, c]) {
         normals[v * 3] += nx;
         normals[v * 3 + 1] += ny;

--- a/packages/flutter_scene/test/interleaved_layout_test.dart
+++ b/packages/flutter_scene/test/interleaved_layout_test.dart
@@ -3,6 +3,7 @@
 // selection, and area-weighted normal generation. Pure logic, so these
 // run without a Flutter GPU context.
 
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
@@ -88,9 +89,12 @@ void main() {
   });
 
   group('generateNormals', () {
-    test('generates +Z for a counter-clockwise triangle in the XY plane', () {
+    test('generates +Z for a front-face-wound triangle in the XY plane', () {
+      // Wound like the cuboid's +Z face (clockwise in model space, the
+      // engine's front-face convention), so the normal points at the
+      // viewer of that face.
       final normals = InterleavedLayoutAdapter.generateNormals(
-        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        positions: Float32List.fromList([1, -1, 0, -1, -1, 0, 1, 1, 0]),
         vertexCount: 3,
         indices: [0, 1, 2],
       );
@@ -103,10 +107,67 @@ void main() {
 
     test('handles a non-indexed triangle list', () {
       final normals = InterleavedLayoutAdapter.generateNormals(
-        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        positions: Float32List.fromList([1, -1, 0, -1, -1, 0, 1, 1, 0]),
         vertexCount: 3,
       );
       expect(normals[2], closeTo(1, 1e-6));
+    });
+
+    test('matches analytic normals on a curved front-face-wound grid', () {
+      // A dome z = b(1 - nx^2)(1 - ny^2) over [-1, 1]^2, wound per the
+      // engine front-face convention (the same construction as the
+      // widget-texture example's screen). The generated smooth normals
+      // must agree with the analytic surface normals, including SIGN
+      // (pointing out of the bulge, toward the front-face viewer).
+      const n = 8;
+      const bulge = 0.3;
+      final positions = Float32List((n + 1) * (n + 1) * 3);
+      for (var r = 0; r <= n; r++) {
+        final ny = r / n * 2 - 1;
+        for (var c = 0; c <= n; c++) {
+          final nx = c / n * 2 - 1;
+          final v = r * (n + 1) + c;
+          positions[v * 3] = nx;
+          positions[v * 3 + 1] = ny;
+          positions[v * 3 + 2] = bulge * (1 - nx * nx) * (1 - ny * ny);
+        }
+      }
+      final indices = <int>[];
+      for (var r = 0; r < n; r++) {
+        for (var c = 0; c < n; c++) {
+          final bl = r * (n + 1) + c;
+          final br = bl + 1;
+          final tl = bl + n + 1;
+          final tr = tl + 1;
+          indices.addAll([br, bl, tr, tr, bl, tl]);
+        }
+      }
+      final normals = InterleavedLayoutAdapter.generateNormals(
+        positions: positions,
+        vertexCount: (n + 1) * (n + 1),
+        indices: indices,
+      );
+      for (var r = 0; r <= n; r++) {
+        final ny = r / n * 2 - 1;
+        for (var c = 0; c <= n; c++) {
+          final nx = c / n * 2 - 1;
+          final v = r * (n + 1) + c;
+          final dzdx = bulge * -2 * nx * (1 - ny * ny);
+          final dzdy = bulge * (1 - nx * nx) * -2 * ny;
+          final inverseLength = 1 / sqrt(dzdx * dzdx + dzdy * dzdy + 1);
+          final dot =
+              normals[v * 3] * -dzdx * inverseLength +
+              normals[v * 3 + 1] * -dzdy * inverseLength +
+              normals[v * 3 + 2] * inverseLength;
+          expect(
+            dot,
+            greaterThan(0.98),
+            reason:
+                'vertex ($nx, $ny) generated normal disagrees with '
+                'the analytic surface normal',
+          );
+        }
+      }
     });
 
     test('falls back to (0, 0, 1) for a vertex touched by no triangle', () {

--- a/packages/flutter_scene/test/mesh_geometry_test.dart
+++ b/packages/flutter_scene/test/mesh_geometry_test.dart
@@ -75,10 +75,12 @@ void main() {
     });
 
     test('packVertices generates normals for an authored triangle', () {
+      // Wound per the engine front-face convention (clockwise in model
+      // space), so the generated face normal points at the front viewer.
       final builder = GeometryBuilder(deduplicate: false)
         ..addVertex(Vector3(0, 0, 0))
-        ..addVertex(Vector3(1, 0, 0))
         ..addVertex(Vector3(0, 1, 0))
+        ..addVertex(Vector3(1, 0, 0))
         ..addTriangle(0, 1, 2);
       final floats = Float32List.sublistView(builder.packVertices());
       // Vertex 0 normal (floats 3..5) is the generated face normal +Z.


### PR DESCRIPTION
Generated vertex normals pointed into correctly wound surfaces.

`generateNormals` (the fallback when `MeshGeometry.fromArrays` is given no normals) used the right-hand-rule cross product, which assumes counter-clockwise front faces. The engine's front faces wind clockwise in model space (the hand-built primitives' convention; rasterization is Y-down, which flips the apparent winding to counter-clockwise), so every generated normal pointed inward and environment lighting sampled the wrong hemisphere, reading as a mirror-metal look on lit surfaces.

- Reverses the cross product so generated normals point out of the face the engine renders as front, and documents the convention on `generateNormals`.
- Adds a regression test pinning generated normals against analytic surface normals on a curved, front-face-wound grid, sign included, plus rewinds two test fixtures that encoded the old assumption.
- The widget-texture example's CRT screen now omits normals and exercises the generated path (its hand-computed normals were a workaround attempt for the flat `MaterialInputs.normal` default fixed in #170, and they masked this bug).
