### PR TITLE
Curate the public API with explicit show lists

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 0.18.0
 
+* BREAKING: the package exports are now explicit show lists; implementation
+  details that previously leaked from wholesale exports (the scene encoder,
+  render-graph texture pooling, environment-prefilter internals, animation
+  channel/resolver plumbing, and the fscene built-in codec classes) are no
+  longer exported. If something you used disappeared, please file an issue,
+  re-exporting an accidentally hidden symbol is a quick patch release.
+
 * Added scene raycasting: `Scene.raycast` / `Scene.raycastAll` cast a ray
   through the rendered meshes (no colliders or physics setup) and return
   typed hits with the distance, world point, geometric normal, barycentric

--- a/packages/flutter_scene/dartdoc_options.yaml
+++ b/packages/flutter_scene/dartdoc_options.yaml
@@ -1,0 +1,12 @@
+dartdoc:
+  categoryOrder:
+    - "Scene graph"
+    - "Geometry"
+    - "Materials"
+    - "Lighting and environment"
+    - "Rendering"
+    - "Animation"
+    - "Physics"
+    - "Picking and input"
+    - "Widgets"
+    - "Assets and loading"

--- a/packages/flutter_scene/lib/fscene.dart
+++ b/packages/flutter_scene/lib/fscene.dart
@@ -23,17 +23,90 @@ export 'src/fscene/json/fscene_json.dart'
         FsceneFormatException,
         FsceneVersionException,
         FsceneUnsupportedFeatureException;
-export 'src/fscene/property_value.dart';
-export 'src/fscene/realize/builtin_codecs.dart';
+export 'src/fscene/property_value.dart'
+    show
+        AssetRef,
+        BoolValue,
+        ColorValue,
+        DoubleValue,
+        IntValue,
+        ListValue,
+        MapValue,
+        Matrix4Value,
+        NodeRefValue,
+        PropertyValue,
+        QuaternionValue,
+        ResourceRefValue,
+        StringValue,
+        Vec2Value,
+        Vec3Value,
+        Vec4Value;
+export 'src/fscene/realize/builtin_codecs.dart'
+    show registerBuiltinComponentCodecs;
 export 'src/fscene/reload/diff.dart' show diffScene, SceneDiff, NodeChange;
 export 'src/fscene/reload/reload.dart' show reloadScene;
-export 'src/fscene/realize/component_codec.dart';
-export 'src/fscene/realize/loader.dart';
-export 'src/fscene/realize/property_read.dart';
-export 'src/fscene/realize/realize.dart';
-export 'src/fscene/realize/resource_realizer.dart';
+export 'src/fscene/realize/component_codec.dart'
+    show
+        ComponentCodec,
+        FsceneComponentRegistry,
+        RealizeContext,
+        SerializeContext;
+export 'src/fscene/realize/loader.dart'
+    show
+        loadFsceneAsset,
+        loadFsceneString,
+        loadFscenebAsset,
+        loadFscenebBytes,
+        loadFscenebBytesAsync;
+export 'src/fscene/realize/property_read.dart'
+    show readBool, readColor, readDouble, readInt, readString, readVec3;
+export 'src/fscene/realize/realize.dart'
+    show
+        defaultComponentRegistry,
+        realizeScene,
+        realizeSceneAsync,
+        serializeScene;
+export 'src/fscene/realize/resource_realizer.dart' show ResourceRealizer;
 export 'src/fscene/realize/stage.dart' show realizeStage, serializeStage;
-export 'src/fscene/scene_document.dart';
-export 'src/fscene/specs.dart';
+export 'src/fscene/scene_document.dart' show SceneDocument;
+export 'src/fscene/specs.dart'
+    show
+        AnimationChannelSpec,
+        AnimationProperty,
+        AnimationSpec,
+        AssetEnvironment,
+        BoundsSpec,
+        ComponentSpec,
+        CuboidGeometrySpec,
+        EmptyEnvironment,
+        EnvironmentSkySpec,
+        EnvironmentSpec,
+        FmatSkySpec,
+        GeometryResource,
+        GradientSkySpec,
+        Handedness,
+        LoadPolicy,
+        MaterialResource,
+        MatrixTransform,
+        NodeSpec,
+        PayloadEncoding,
+        PayloadSpec,
+        PhysicalSkySpec,
+        PlaneGeometrySpec,
+        PrefabInstanceSpec,
+        ProceduralGeometry,
+        PropertyOverride,
+        ResourceSpec,
+        SkinSpec,
+        SkyEnvironmentSpec,
+        SkySourceSpec,
+        SkyboxSpec,
+        SphereGeometrySpec,
+        StageMetadata,
+        StudioEnvironment,
+        TextureResource,
+        TransformSpec,
+        TrsTransform,
+        UpAxis;
 export 'src/fscene/stream/stream.dart'
     show loadSubtree, unloadSubtree, isLazySubtree, isSubtreeLoaded;

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -20,9 +20,10 @@
 /// depends on the Flutter GPU API.
 library;
 
-export 'src/animation.dart';
+export 'src/animation.dart' show Animation, AnimationClip, AnimationPlayer;
 
-export 'src/geometry/geometry.dart';
+export 'src/geometry/geometry.dart'
+    show Geometry, SkinnedGeometry, UnskinnedGeometry;
 export 'src/geometry/mesh_geometry.dart'
     show GeometryBuilder, GeometryStorage, MeshGeometry;
 export 'src/geometry/primitives.dart'
@@ -32,62 +33,113 @@ export 'src/geometry/polyline_geometry.dart'
 export 'src/geometry/swept_geometry.dart'
     show ExtrudeGeometry, RibbonAlignment, RibbonGeometry, TubeGeometry;
 
-export 'src/material/environment.dart';
-export 'src/material/material.dart';
-export 'src/material/material_parameters.dart';
-export 'src/material/physically_based_material.dart';
-export 'src/material/preprocessed_material.dart';
-export 'src/material/preprocessed_sky.dart';
-export 'src/material/shader_material.dart';
-export 'src/material/unlit_material.dart';
+export 'src/material/environment.dart'
+    show EnvironmentMap, environmentAssetPathOf, kDiffuseShCoefficientCount;
+export 'src/material/material.dart' show Material;
+export 'src/material/material_parameters.dart' show MaterialParameters;
+export 'src/material/physically_based_material.dart'
+    show AlphaMode, PhysicallyBasedMaterial;
+export 'src/material/preprocessed_material.dart' show PreprocessedMaterial;
+export 'src/material/preprocessed_sky.dart' show PreprocessedSky;
+export 'src/material/shader_material.dart' show ShaderMaterial;
+export 'src/material/unlit_material.dart' show UnlitMaterial;
 export 'src/fmat/material_registry.dart'
     show FmatMaterialRegistry, loadFmatMaterial, loadFmatSky;
 export 'src/importer/scene_registry.dart'
     show SceneRegistry, SceneReloadCallback, loadScene, loadSceneSubtree;
 
-export 'src/ambient_occlusion.dart';
-export 'src/asset_helpers.dart';
-export 'src/camera.dart';
-export 'src/components/camera_component.dart';
-export 'src/components/component.dart';
-export 'src/components/directional_light_component.dart';
-export 'src/components/instanced_mesh_component.dart';
-export 'src/components/mesh_component.dart';
-export 'src/components/widget_component.dart';
-export 'src/instanced_mesh.dart';
-export 'src/light.dart';
-export 'src/render/render_layers.dart';
-export 'src/render_view.dart';
-export 'src/math_extensions.dart';
-export 'src/mesh.dart';
-export 'src/node.dart';
+export 'src/ambient_occlusion.dart'
+    show AmbientOcclusionSettings, SpecularAmbientOcclusionMode;
+export 'src/asset_helpers.dart'
+    show
+        gpuTextureFromAsset,
+        gpuTextureFromImage,
+        imageFromAsset,
+        imageFromBytes;
+export 'src/camera.dart'
+    show Camera, CameraProjection, PerspectiveCamera, PerspectiveProjection;
+export 'src/components/camera_component.dart' show CameraComponent;
+export 'src/components/component.dart' show Component;
+export 'src/components/directional_light_component.dart'
+    show DirectionalLightComponent;
+export 'src/components/instanced_mesh_component.dart'
+    show InstancedMeshComponent;
+export 'src/components/mesh_component.dart' show MeshComponent;
+export 'src/components/widget_component.dart' show WidgetComponent, WidgetInput;
+export 'src/instanced_mesh.dart' show InstancedMesh;
+export 'src/light.dart' show DirectionalLight, Lighting, ShadowCascade;
+export 'src/render/render_layers.dart'
+    show kRenderLayerAll, kRenderLayerDefault;
+export 'src/render_view.dart' show RenderView;
+export 'src/math_extensions.dart' show QuaternionSlerp, Vector3Lerp;
+export 'src/mesh.dart' show Mesh, MeshPrimitive;
+export 'src/node.dart' show Node;
 export 'src/physics/basic/basic_collider.dart' show BasicCollider;
 export 'src/physics/basic/basic_kinematic_body.dart' show BasicKinematicBody;
 export 'src/physics/basic/basic_world.dart' show BasicPhysicsWorld;
-export 'src/physics/collider.dart';
-export 'src/physics/events.dart';
-export 'src/physics/joint.dart';
-export 'src/physics/material.dart';
-export 'src/physics/physics_world.dart';
-export 'src/physics/queries.dart';
-export 'src/physics/rigid_body.dart';
-export 'src/physics/shape.dart';
-export 'src/post_process/post_effect.dart';
-export 'src/post_process/post_process.dart';
-export 'src/render/env_prefilter.dart';
+export 'src/physics/collider.dart' show Collider;
+export 'src/physics/events.dart'
+    show
+        CollisionBegan,
+        CollisionEnded,
+        CollisionEvent,
+        ContactPoint,
+        TriggerEntered,
+        TriggerExited;
+export 'src/physics/joint.dart'
+    show
+        FixedJoint,
+        GenericJoint,
+        Joint,
+        JointAxis,
+        JointAxisConfig,
+        JointAxisMotion,
+        JointMotor,
+        JointMotorModel,
+        PrismaticJoint,
+        RevoluteJoint,
+        SphericalJoint;
+export 'src/physics/material.dart' show CombineRule, PhysicsMaterial;
+export 'src/physics/physics_world.dart' show PhysicsWorld;
+export 'src/physics/queries.dart' show OverlapHit, RaycastHit, ShapeCastHit;
+export 'src/physics/rigid_body.dart' show BodyType, RigidBody;
+export 'src/physics/shape.dart'
+    show
+        BoxShape,
+        CapsuleShape,
+        CompoundChild,
+        CompoundShape,
+        ConvexHullShape,
+        CylinderShape,
+        HeightFieldShape,
+        Shape,
+        SphereShape,
+        TriMeshShape;
+export 'src/post_process/post_effect.dart' show PostEffect, PostInsertion;
+export 'src/post_process/post_process.dart'
+    show
+        BloomSettings,
+        ChromaticAberrationSettings,
+        ColorGradingSettings,
+        FilmGrainSettings,
+        PostProcessSettings,
+        VignetteSettings;
+export 'src/render/env_prefilter.dart' show prefilterEquirectRadiance;
 export 'src/runtime_importer/gltf_resources.dart' show GltfResourceResolver;
-export 'src/scene_encoder.dart' hide evictPipelinesForShaders, resolvePipeline;
-export 'src/scene_path.dart';
-export 'src/raycast.dart';
-export 'src/scene_pointer.dart';
-export 'src/scene.dart';
-export 'src/widget_texture.dart';
-export 'src/shaders.dart';
-export 'src/skin.dart';
-export 'src/sky_environment.dart';
-export 'src/sky_sources.dart';
-export 'src/skybox.dart';
-export 'src/surface.dart';
+export 'src/scene_path.dart'
+    show BezierPath, CatmullRomPath, PolylinePath, ScenePath, ScenePathFrame;
+export 'src/raycast.dart' show SceneRaycastHit, raycastNode, raycastNodeAll;
+export 'src/scene_pointer.dart' show ScenePointer;
+export 'src/scene.dart' show AntiAliasingMode, Scene, SceneGraph;
+export 'src/widget_texture.dart'
+    show WidgetTexture, WidgetTextureController, WidgetUpdatePolicy;
+export 'src/shaders.dart' show baseShaderLibrary, loadBaseShaderLibrary;
+export 'src/skin.dart' show Skin;
+export 'src/sky_environment.dart' show SkyEnvironment, SkyEnvironmentRefresh;
+export 'src/sky_sources.dart' show GradientSkySource, PhysicalSkySource;
+export 'src/skybox.dart'
+    show EnvironmentSkySource, ShaderSkySource, SkySource, Skybox;
+export 'src/surface.dart' show Surface;
 export 'src/widgets/scene_view.dart'
     show SceneCameraBuilder, SceneScope, SceneTickCallback, SceneView;
-export 'src/tone_mapping.dart';
+export 'src/tone_mapping.dart' show ToneMappingMode;

--- a/packages/flutter_scene/lib/src/ambient_occlusion.dart
+++ b/packages/flutter_scene/lib/src/ambient_occlusion.dart
@@ -16,6 +16,7 @@
 /// (the per-pixel normal is reconstructed from depth), so it fits a
 /// forward renderer with no normal buffer, and runs as full-screen
 /// fragment passes with no compute.
+/// {@category Rendering}
 class AmbientOcclusionSettings {
   /// Whether ambient occlusion runs. Off by default. When false the scene
   /// adds no ambient-occlusion passes and the lighting is unaffected.
@@ -56,6 +57,7 @@ class AmbientOcclusionSettings {
 /// occluding the specular lobe with the same factor over-darkens glossy
 /// reflections. These modes select how (or whether) the specular lobe is
 /// occluded.
+/// {@category Rendering}
 enum SpecularAmbientOcclusionMode {
   /// Indirect specular is not occluded by ambient occlusion. Cheapest and
   /// the default.

--- a/packages/flutter_scene/lib/src/animation/animation.dart
+++ b/packages/flutter_scene/lib/src/animation/animation.dart
@@ -61,6 +61,7 @@ class AnimationChannel {
 /// [PropertyResolver]. To play an animation, instantiate it as an
 /// [AnimationClip] bound to a target subtree with
 /// [Node.createAnimationClip].
+/// {@category Animation}
 class Animation {
   /// Display name of the animation, used by [Node.findAnimationByName].
   final String name;

--- a/packages/flutter_scene/lib/src/animation/animation_clip.dart
+++ b/packages/flutter_scene/lib/src/animation/animation_clip.dart
@@ -17,6 +17,7 @@ class _ChannelBinding {
 /// Multiple clips on the same node are blended by an internal
 /// [AnimationPlayer] that normalizes their weights when the sum exceeds
 /// `1`.
+/// {@category Animation}
 class AnimationClip {
   Animation _animation;
   final List<_ChannelBinding> _bindings = [];

--- a/packages/flutter_scene/lib/src/animation/animation_player.dart
+++ b/packages/flutter_scene/lib/src/animation/animation_player.dart
@@ -11,6 +11,7 @@ part of '../animation.dart';
 /// It advances every clip by the frame delta, blends their results into
 /// the bind pose, and writes the resulting transforms back to the bound
 /// nodes.
+/// {@category Animation}
 class AnimationPlayer {
   final Map<Node, AnimationTransforms> _targetTransforms = {};
   final Map<String, AnimationClip> _clips = {};

--- a/packages/flutter_scene/lib/src/asset_helpers.dart
+++ b/packages/flutter_scene/lib/src/asset_helpers.dart
@@ -12,6 +12,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 /// [EnvironmentMap].
 ///
 /// Throws if the image can't be read as RGBA.
+/// {@category Assets and loading}
 Future<gpu.Texture> gpuTextureFromImage(ui.Image image) async {
   final byteData = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
   if (byteData == null) {
@@ -33,6 +34,7 @@ Future<gpu.Texture> gpuTextureFromImage(ui.Image image) async {
 ///
 /// Uses `dart:ui`'s built-in image codecs (PNG, JPEG, etc.). Throws if
 /// the asset is not present in the bundle or cannot be decoded.
+/// {@category Assets and loading}
 Future<ui.Image> imageFromAsset(String assetPath, {AssetBundle? bundle}) async {
   // Load resource from the asset bundle. Throws exception if the asset couldn't
   // be found in the bundle.
@@ -48,6 +50,7 @@ Future<ui.Image> imageFromAsset(String assetPath, {AssetBundle? bundle}) async {
 ///
 /// Uses `dart:ui`'s built-in image codecs. Throws if the bytes can't be
 /// decoded as an image.
+/// {@category Assets and loading}
 Future<ui.Image> imageFromBytes(Uint8List bytes) async {
   final buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
   final codec = await ui.instantiateImageCodecFromBuffer(buffer);
@@ -61,6 +64,7 @@ Future<ui.Image> imageFromBytes(Uint8List bytes) async {
 /// The asset is decoded with [imageFromAsset] and then uploaded via
 /// [gpuTextureFromImage]. Throws if the asset is not present in the
 /// bundle or cannot be decoded.
+/// {@category Assets and loading}
 Future<gpu.Texture> gpuTextureFromAsset(String assetPath) async {
   return await gpuTextureFromImage(await imageFromAsset(assetPath));
 }

--- a/packages/flutter_scene/lib/src/camera.dart
+++ b/packages/flutter_scene/lib/src/camera.dart
@@ -11,6 +11,7 @@ import 'package:vector_math/vector_math.dart';
 /// [Camera]'s [Camera.getViewMatrix]) to form a full view-projection
 /// transform. [PerspectiveProjection] is the built-in option; applications
 /// can implement [CameraProjection] for orthographic or other projections.
+/// {@category Scene graph}
 abstract class CameraProjection {
   /// Returns the projection matrix for a render target of the given
   /// [aspectRatio] (width / height).
@@ -18,6 +19,7 @@ abstract class CameraProjection {
 }
 
 /// A standard pinhole perspective projection.
+/// {@category Scene graph}
 class PerspectiveProjection extends CameraProjection {
   /// Creates a [PerspectiveProjection] with a vertical field of view
   /// [fovRadiansY] and a [near]/[far] clip range.
@@ -51,6 +53,7 @@ class PerspectiveProjection extends CameraProjection {
 /// [PerspectiveCamera] is the built-in free camera, positioned by
 /// eye/target/up. Attach a [CameraComponent] to a [Node] to drive the view
 /// from that node's transform instead.
+/// {@category Scene graph}
 abstract class Camera {
   /// The world-space position of the camera (the eye point). Used by
   /// materials for view-dependent shading (e.g. specular reflections).
@@ -173,6 +176,7 @@ Matrix4 _matrix4Perspective(
 /// Default placement is at `(0, 0, -5)` looking at the origin with `+Y`
 /// up, suitable for inspecting a model that fits within a unit cube
 /// centered on the origin.
+/// {@category Scene graph}
 class PerspectiveCamera extends Camera {
   /// Creates a [PerspectiveCamera].
   ///

--- a/packages/flutter_scene/lib/src/components/camera_component.dart
+++ b/packages/flutter_scene/lib/src/components/camera_component.dart
@@ -14,6 +14,7 @@ import 'package:flutter_scene/src/components/component.dart';
 /// Use [toCamera] to capture a [Camera] for the node's current transform to
 /// pass to `Scene.render`. (The node should not be scaled; a camera node is
 /// expected to carry only rotation and translation.)
+/// {@category Scene graph}
 class CameraComponent extends Component {
   /// Creates a camera component with the given [projection] (a
   /// [PerspectiveProjection] by default).

--- a/packages/flutter_scene/lib/src/components/component.dart
+++ b/packages/flutter_scene/lib/src/components/component.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene/src/node.dart';
 ///
 /// Subclasses override the `onX` hooks and [update]; all other members
 /// are driven by the engine and should not be called directly.
+/// {@category Scene graph}
 abstract class Component {
   Node? _node;
 

--- a/packages/flutter_scene/lib/src/components/directional_light_component.dart
+++ b/packages/flutter_scene/lib/src/components/directional_light_component.dart
@@ -18,6 +18,7 @@ import 'package:flutter_scene/src/light.dart';
 /// The renderer currently shades a single directional light (the first one
 /// registered); additional directional lights are collected but not yet
 /// shaded.
+/// {@category Scene graph}
 // TODO(lighting): shade multiple directional lights once the material
 // shader supports more than one.
 class DirectionalLightComponent extends Component {

--- a/packages/flutter_scene/lib/src/components/instanced_mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/instanced_mesh_component.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene/src/render/render_scene.dart';
 /// registers a single [RenderItem] for the whole instanced mesh and
 /// refreshes it each frame. The render passes draw every instance from
 /// that one item.
+/// {@category Scene graph}
 class InstancedMeshComponent extends Component {
   /// Creates a component that draws [instancedMesh].
   InstancedMeshComponent(this.instancedMesh);

--- a/packages/flutter_scene/lib/src/components/mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/mesh_component.dart
@@ -12,6 +12,7 @@ import 'package:flutter_scene/src/render/render_scene.dart';
 ///
 /// A node's [Node.mesh] getter and setter are a convenience over the
 /// node's first `MeshComponent`.
+/// {@category Scene graph}
 class MeshComponent extends Component {
   /// Creates a component that draws [mesh].
   MeshComponent(this._mesh);

--- a/packages/flutter_scene/lib/src/components/widget_component.dart
+++ b/packages/flutter_scene/lib/src/components/widget_component.dart
@@ -12,6 +12,7 @@ import 'package:flutter_scene/src/widget_texture.dart';
 import 'dart:typed_data';
 
 /// How a [WidgetComponent] receives pointer input.
+/// {@category Widgets}
 enum WidgetInput {
   /// `SceneView` forwards platform pointer events automatically: presses
   /// and drags raycast into the scene, and when this component's surface is
@@ -45,6 +46,7 @@ enum WidgetInput {
 /// The texture object is stable across captures (overwritten in place) and
 /// replaced only when the capture size changes; [bind] re-fires exactly on
 /// replacement.
+/// {@category Widgets}
 // TODO(widget-component): WidgetInput.automatic via ScenePointer (phase 3).
 // TODO(fscene): serialize the component spec (size, policy, geometry) with a
 // named slot the app binds the widget tree to at runtime.

--- a/packages/flutter_scene/lib/src/fmat/material_registry.dart
+++ b/packages/flutter_scene/lib/src/fmat/material_registry.dart
@@ -65,6 +65,7 @@ final class FmatMaterialIndexEntry {
 /// Materials are keyed by their `.fmat` source path relative to the owning
 /// package's root, so two materials that share a name in different directories
 /// do not collide.
+/// {@category Materials}
 final class FmatMaterialRegistry {
   FmatMaterialRegistry._(this._bundle, this._indexes);
 
@@ -266,6 +267,7 @@ final Expando<String> _fmatSourcePaths = Expando('fmat source path');
 String? fmatSourcePathOf(Object materialOrSky) =>
     _fmatSourcePaths[materialOrSky];
 
+/// {@category Materials}
 Future<PreprocessedMaterial> loadFmatMaterial(
   String sourcePath, {
   String? package,
@@ -287,6 +289,7 @@ Future<PreprocessedMaterial> loadFmatMaterial(
 /// the result to `Scene.skybox` via a `Skybox`. Pass [package] and/or
 /// [bundleName] to disambiguate when the same source path is provided by more
 /// than one bundle.
+/// {@category Materials}
 Future<PreprocessedSky> loadFmatSky(
   String sourcePath, {
   String? package,

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -56,6 +56,7 @@ abstract class Geometry {
   ///
   /// Lets cache holders such as [Mesh] notice that an updatable
   /// geometry's bounds moved without an explicit invalidation call.
+  @internal
   int get localBoundsVersion => _localBoundsVersion;
 
   /// Local-space axis-aligned bounding box of this geometry's vertex

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -21,6 +21,7 @@ import 'package:flutter_scene/src/shaders.dart';
 /// supply mesh data. For procedurally generated meshes, `MeshGeometry`
 /// and `GeometryBuilder` assemble a [Geometry] from vertex attribute
 /// arrays without packing vertex bytes by hand.
+/// {@category Geometry}
 abstract class Geometry {
   gpu.BufferView? _vertices;
   int _vertexCount = 0;
@@ -296,6 +297,7 @@ abstract class Geometry {
 ///
 /// This is the default vertex format for static (non-animated) meshes
 /// imported from a scene package or glTF.
+/// {@category Geometry}
 class UnskinnedGeometry extends Geometry {
   /// Creates an [UnskinnedGeometry] preconfigured with the
   /// `UnskinnedVertex` shader from [baseShaderLibrary].
@@ -374,6 +376,7 @@ class UnskinnedGeometry extends Geometry {
 /// Used for meshes attached to a [Skin] for skeletal animation. The
 /// joints texture supplied by the skin must be assigned before each draw
 /// via [setJointsTexture].
+/// {@category Geometry}
 class SkinnedGeometry extends Geometry {
   gpu.Texture? _jointsTexture;
   int _jointsTextureWidth = 0;

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 
 /// How a [MeshGeometry] manages its GPU buffers over its lifetime.
+/// {@category Geometry}
 enum GeometryStorage {
   /// The vertex and index buffers are uploaded once at construction and
   /// never change. This is the right choice for imported or generated
@@ -43,6 +44,7 @@ enum GeometryStorage {
 /// attribute when the vertex count is unchanged; [rebuild] replaces
 /// everything and reallocates only when the data outgrows the spare
 /// capacity.
+/// {@category Geometry}
 class MeshGeometry extends UnskinnedGeometry {
   /// Builds a mesh from structure-of-arrays vertex attributes.
   ///
@@ -499,6 +501,7 @@ int nextBufferCapacity(int needed, {int minimum = 16}) {
 ///       ..addTriangle(0, 1, 2))
 ///     .build();
 /// ```
+/// {@category Geometry}
 class GeometryBuilder {
   /// Creates an empty builder.
   ///

--- a/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
@@ -8,6 +8,7 @@ import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
 
 /// How a [PolylineGeometry]'s width is measured.
+/// {@category Geometry}
 enum PolylineWidthMode {
   /// The width is a constant number of screen pixels at every distance,
   /// so a route line keeps the same on-screen thickness as the camera
@@ -20,6 +21,7 @@ enum PolylineWidthMode {
 }
 
 /// How a [PolylineGeometry] finishes its two end points.
+/// {@category Geometry}
 enum PolylineCap {
   /// The strip ends flat at the end point.
   butt,
@@ -30,6 +32,7 @@ enum PolylineCap {
 
 /// A repeating dash-and-gap pattern for a [PolylineGeometry], measured
 /// in scene units along the line's arc length.
+/// {@category Geometry}
 class DashPattern {
   /// Creates a dash pattern; both lengths must be positive.
   const DashPattern({
@@ -71,6 +74,7 @@ const int _diskSegments = 16;
 /// pinch on a very sharp turn. Rounded corner joins and a GPU
 /// vertex-shader expansion that avoids the per-frame rebuild are
 /// planned follow-ups.
+/// {@category Geometry}
 class PolylineGeometry extends MeshGeometry {
   /// Creates a polyline through [points] (at least two).
   ///

--- a/packages/flutter_scene/lib/src/geometry/primitives.dart
+++ b/packages/flutter_scene/lib/src/geometry/primitives.dart
@@ -24,6 +24,7 @@ typedef PrimitiveArrays = ({
 /// (visualized with an unlit material, as in the Cuboid example). It is off
 /// by default so a lit material renders the box in its own base color rather
 /// than tinted by the debug colors.
+/// {@category Geometry}
 class CuboidGeometry extends MeshGeometry {
   /// Builds a cuboid sized to [extents].
   ///
@@ -48,6 +49,7 @@ class CuboidGeometry extends MeshGeometry {
 /// linearly from height `0` at the `-Z` edge to height `Y` at the `+Z`
 /// edge, so the slope angle is `atan(Y / Z)`. Normals are flat per face.
 /// Useful as a ramp the character walks up.
+/// {@category Geometry}
 class WedgeGeometry extends MeshGeometry {
   /// Builds a wedge sized to [size] = `(width, height, run)`.
   factory WedgeGeometry(Vector3 size) =>
@@ -69,6 +71,7 @@ class WedgeGeometry extends MeshGeometry {
 /// [width] spans X and [depth] spans Z. [segmentsX] and [segmentsZ] set
 /// the number of grid cells along each axis; subdividing is useful when
 /// the surface will be deformed or lit by per-vertex data.
+/// {@category Geometry}
 class PlaneGeometry extends MeshGeometry {
   /// Builds a plane of the given size and subdivision.
   factory PlaneGeometry({
@@ -102,6 +105,7 @@ class PlaneGeometry extends MeshGeometry {
 /// [rings] the number of divisions from pole to pole. Vertex normals
 /// point radially outward and texture coordinates wrap longitude in `u`
 /// and latitude in `v`.
+/// {@category Geometry}
 class SphereGeometry extends MeshGeometry {
   /// Builds a sphere of the given [radius] and tessellation.
   factory SphereGeometry({

--- a/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
@@ -15,6 +15,7 @@ typedef SweptArrays = ({
 });
 
 /// How a [RibbonGeometry] orients its strip across the path.
+/// {@category Geometry}
 enum RibbonAlignment {
   /// The strip stays horizontal, its width running perpendicular to the
   /// path as seen from above. Suited to a route drawn on the ground.
@@ -30,6 +31,7 @@ enum RibbonAlignment {
 /// ordinary triangle mesh that works with any material; texture
 /// coordinates run `0..1` across the width and by arc-length distance
 /// along the path.
+/// {@category Geometry}
 class RibbonGeometry extends MeshGeometry {
   /// Sweeps a ribbon of the given [width] along [path].
   ///
@@ -229,6 +231,7 @@ class MeshAccumulator {
 ///
 /// Useful for a 3D route tube or pipe. Texture coordinates run `0..1`
 /// around the circumference and by arc-length distance along the path.
+/// {@category Geometry}
 class TubeGeometry extends MeshGeometry {
   /// Sweeps a tube of the given [radius] along [path].
   ///
@@ -428,6 +431,7 @@ void addFanCap(
 /// The profile is a closed polygon in the path's cross-section plane.
 /// Texture coordinates run `0..1` around the profile and by arc-length
 /// distance along the path. End caps assume a convex profile.
+/// {@category Geometry}
 class ExtrudeGeometry extends MeshGeometry {
   /// Sweeps [profile] along [path].
   ///

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -20,6 +20,7 @@ const String _sceneAssetSuffix = '.fsceneb';
 /// [loadScene]), so the app can re-apply per-instance customizations the
 /// patch may have discarded: re-apply a custom material, or re-grab inner
 /// nodes by name. [root] is the same root instance the app holds.
+/// {@category Assets and loading}
 typedef SceneReloadCallback = void Function(Node root);
 
 /// Shared per-asset scene templates: the composed document plus its
@@ -96,6 +97,7 @@ final class SceneEntry {
 
 /// Resolves DataAssets-backed `.fsceneb` files by source path, the `.fscene`
 /// counterpart of `ModelRegistry`.
+/// {@category Assets and loading}
 final class SceneRegistry {
   SceneRegistry._(this._entries);
 
@@ -162,6 +164,7 @@ final class SceneRegistry {
   /// realize app-defined component types, and [onReload] to re-apply
   /// per-instance customizations after a hot reload patches this instance in
   /// place.
+  /// {@category Assets and loading}
   Future<Node> loadScene(
     String sourcePath, {
     String? package,
@@ -402,6 +405,7 @@ Future<Node> loadScene(
 ///
 /// The streamed content hot-reloads: editing any of the prefab's assets
 /// re-streams the subtree in place while it is loaded.
+/// {@category Assets and loading}
 Future<void> loadSceneSubtree(
   Node node, {
   String? package,

--- a/packages/flutter_scene/lib/src/instanced_mesh.dart
+++ b/packages/flutter_scene/lib/src/instanced_mesh.dart
@@ -13,6 +13,7 @@ import 'package:vector_math/vector_math.dart';
 ///
 /// Phase 3c carries a per-instance transform only. The naive backend
 /// still issues one draw call per instance.
+/// {@category Scene graph}
 class InstancedMesh {
   /// Creates an instanced mesh that draws [geometry] shaded by
   /// [material]. It starts with no instances; add them with

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -23,6 +23,7 @@ import 'package:flutter_scene/src/material/environment.dart';
 /// radius [shadowSoftness], and shadowing fades back to lit at the far
 /// edge over [shadowFadeRange]. Cascaded shadows require the scene to
 /// render with a perspective projection.
+/// {@category Lighting and environment}
 class DirectionalLight {
   /// Creates a [DirectionalLight].
   ///
@@ -267,6 +268,7 @@ class DirectionalLight {
 /// A cascade owns the world -> light-clip-space matrix that renders and
 /// samples its shadow map tile, plus the camera view distance at which
 /// its coverage ends.
+/// {@category Lighting and environment}
 class ShadowCascade {
   /// Creates a cascade from its [lightSpaceMatrix], [splitDistance], and
   /// [boxSize].
@@ -295,6 +297,7 @@ class ShadowCascade {
 /// Bundles the image-based-lighting [EnvironmentMap] (and the scene's
 /// `environmentIntensity` multiplier) with the analytic lights and shadow
 /// resources, so material code has everything it needs in one place.
+/// {@category Lighting and environment}
 class Lighting {
   Lighting({
     required this.environmentMap,

--- a/packages/flutter_scene/lib/src/material/environment.dart
+++ b/packages/flutter_scene/lib/src/material/environment.dart
@@ -12,6 +12,7 @@ import 'package:vector_math/vector_math.dart';
 
 /// Number of L2 spherical-harmonic coefficients used for diffuse
 /// irradiance (bands 0..2).
+/// {@category Lighting and environment}
 const int kDiffuseShCoefficientCount = 9;
 
 /// A source of image-based lighting: diffuse irradiance plus prefiltered
@@ -32,6 +33,7 @@ const int kDiffuseShCoefficientCount = 9;
 /// Set one on a [Scene] via `Scene.environment` (it defaults to
 /// [EnvironmentMap.studio]); an individual [PhysicallyBasedMaterial] can
 /// override it via `PhysicallyBasedMaterial.environment`.
+/// {@category Lighting and environment}
 base class EnvironmentMap {
   EnvironmentMap._(this._prefilteredRadianceTexture, List<Vector3> sh)
     : assert(sh.length == kDiffuseShCoefficientCount),
@@ -546,5 +548,6 @@ final Expando<String> _environmentAssetPaths = Expando(
 
 /// The radiance asset path [environment] was loaded from through
 /// [EnvironmentMap.fromAssets], or null for environments built another way.
+/// {@category Lighting and environment}
 String? environmentAssetPathOf(EnvironmentMap environment) =>
     _environmentAssetPaths[environment];

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -20,6 +20,7 @@ import 'package:flutter_scene/src/material/unlit_material.dart';
 ///
 /// The default [bind] enables back-face culling with counter-clockwise
 /// winding, matching the [glTF coordinate convention](https://github.com/KhronosGroup/glTF/tree/main/specification/2.0#coordinate-system-and-units).
+/// {@category Materials}
 abstract class Material {
   static gpu.Texture? _whitePlaceholderTexture;
 

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:typed_data';
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
@@ -111,6 +112,7 @@ abstract class Material {
   ///
   /// Loaded by [initializeStaticResources]; throws if accessed before
   /// initialization completes.
+  @internal
   static gpu.Texture getBrdfLutTexture() {
     if (_brdfLutTexture == null) {
       throw Exception('BRDF LUT texture has not been initialized.');

--- a/packages/flutter_scene/lib/src/material/material_parameters.dart
+++ b/packages/flutter_scene/lib/src/material/material_parameters.dart
@@ -42,6 +42,7 @@ class _SamplerSlot {
 ///  * the dynamic [operator []=]: dispatches on the declared type and throws on
 ///    a mismatch;
 ///  * [rawBlock] / [offsetOf]: a raw escape hatch for hot loops.
+/// {@category Materials}
 class MaterialParameters {
   MaterialParameters._(
     this._blockName,

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -10,6 +10,7 @@ import 'package:vector_math/vector_math.dart';
 
 /// How a [PhysicallyBasedMaterial]'s alpha channel is interpreted,
 /// matching glTF's `alphaMode`.
+/// {@category Materials}
 enum AlphaMode {
   /// Alpha is ignored; the material renders fully opaque.
   opaque,
@@ -42,6 +43,7 @@ enum AlphaMode {
 ///
 /// Translucency is determined by [baseColorFactor]'s alpha component;
 /// the material is treated as opaque when alpha is exactly `1`.
+/// {@category Materials}
 class PhysicallyBasedMaterial extends Material {
   /// Creates a PBR material with the given textures.
   ///

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -29,6 +29,7 @@ import 'package:flutter_scene/src/material/material_parameters.dart';
 /// shader's `Surface()` fills the surface description); an `unlit` material
 /// outputs its `base_color` directly. The render state (blending, culling)
 /// comes from the material's metadata.
+/// {@category Materials}
 class PreprocessedMaterial extends Material implements HotReloadableFmat {
   PreprocessedMaterial({
     required gpu.Shader fragmentShader,

--- a/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
@@ -19,6 +19,7 @@ import 'package:flutter_scene/src/skybox.dart';
 ///
 /// Loaded via `loadFmatSky`, which registers it for in-place hot reload so a
 /// `.fmat` edit shows up without a restart.
+/// {@category Lighting and environment}
 class PreprocessedSky extends ShaderSkySource implements HotReloadableFmat {
   // fragmentShader is also consumed in the initializer (to build parameters),
   // so it can't be a super parameter.

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -72,6 +72,7 @@ import 'package:flutter_scene/src/material/material.dart';
 /// TODO(https://github.com/bdero/flutter_scene/issues/22): generate
 /// this packing code at build time from a declarative material
 /// source so callers don't write it by hand.
+/// {@category Materials}
 class ShaderMaterial extends Material {
   /// Creates a [ShaderMaterial] wrapping [fragmentShader].
   ///

--- a/packages/flutter_scene/lib/src/material/unlit_material.dart
+++ b/packages/flutter_scene/lib/src/material/unlit_material.dart
@@ -17,6 +17,7 @@ import 'package:vector_math/vector_math.dart';
 /// blended with the per-vertex color via [vertexColorWeight].
 ///
 /// Wraps the `UnlitFragment` shader from [baseShaderLibrary].
+/// {@category Materials}
 class UnlitMaterial extends Material {
   /// Creates an [UnlitMaterial], optionally textured.
   ///

--- a/packages/flutter_scene/lib/src/math_extensions.dart
+++ b/packages/flutter_scene/lib/src/math_extensions.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:vector_math/vector_math.dart';
 
 /// Per-component arithmetic helpers on [Vector3].
+/// {@category Scene graph}
 extension Vector3Lerp on Vector3 {
   /// Linearly interpolates each component of this vector toward [to].
   ///
@@ -25,6 +26,7 @@ extension Vector3Lerp on Vector3 {
 }
 
 /// Spherical interpolation helpers on [Quaternion].
+/// {@category Scene graph}
 extension QuaternionSlerp on Quaternion {
   /// Returns the 4D dot product of this quaternion and [other].
   ///

--- a/packages/flutter_scene/lib/src/mesh.dart
+++ b/packages/flutter_scene/lib/src/mesh.dart
@@ -13,6 +13,7 @@ import 'package:vector_math/vector_math.dart' as vm;
 /// paint [Material], the windows a transparent glass [Material], and the wheels a black rubber [Material].
 /// Each of these parts of the car has its own [Geometry] and [Material], and together
 /// they form the complete model.
+/// {@category Geometry}
 base class MeshPrimitive {
   /// Pairs [geometry] with the [material] used to shade it.
   MeshPrimitive(this.geometry, this.material);
@@ -29,6 +30,7 @@ base class MeshPrimitive {
 /// It consists of a list of [MeshPrimitive] instances, where each primitive
 /// contains the [Geometry] and the [Material] to render a specific part of
 /// the 3d model.
+/// {@category Geometry}
 base class Mesh {
   /// Creates a `Mesh` consisting of a single [MeshPrimitive] with the given [Geometry] and [Material].
   Mesh(Geometry geometry, Material material)

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -20,6 +20,7 @@ import 'package:vector_math/vector_math.dart' as vm;
 /// Each node can contain a transform (position, rotation, scale), a mesh (3D geometry and material),
 /// and child nodes. Nodes are used to build complex scenes by establishing relationships
 /// between different elements, allowing for transformations to propagate down the hierarchy.
+/// {@category Scene graph}
 base class Node implements SceneGraph {
   /// Creates a node with an optional [name], [localTransform], and [mesh].
   ///

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -151,6 +151,7 @@ base class Node implements SceneGraph {
   /// Whether this node's accumulated transform reverses triangle winding (a
   /// mirror / negative scale somewhere up the chain). The renderer flips cull
   /// winding for such nodes so their front faces are not culled.
+  @internal
   bool get windingFlipped {
     // Touch globalTransform to refresh the cache (which sets _windingFlipped).
     globalTransform;

--- a/packages/flutter_scene/lib/src/physics/basic/basic_collider.dart
+++ b/packages/flutter_scene/lib/src/physics/basic/basic_collider.dart
@@ -12,6 +12,7 @@ import 'package:vector_math/vector_math.dart';
 /// raycasting, overlap queries, and trigger events. Attaching one
 /// without a [BasicKinematicBody] on the same node yields a static
 /// collider (the basic backend has no dynamics solver).
+/// {@category Physics}
 class BasicCollider extends Collider {
   BasicCollider({
     required Shape shape,

--- a/packages/flutter_scene/lib/src/physics/basic/basic_kinematic_body.dart
+++ b/packages/flutter_scene/lib/src/physics/basic/basic_kinematic_body.dart
@@ -12,6 +12,7 @@ import 'package:vector_math/vector_math.dart';
 /// ships a constraint solver. The constructor rejects
 /// [BodyType.dynamic_] with a clear error to make the limitation
 /// obvious instead of silently producing wrong results.
+/// {@category Physics}
 class BasicKinematicBody extends RigidBody {
   BasicKinematicBody({
     BodyType type = BodyType.kinematic,

--- a/packages/flutter_scene/lib/src/physics/basic/basic_world.dart
+++ b/packages/flutter_scene/lib/src/physics/basic/basic_world.dart
@@ -21,6 +21,7 @@ import 'package:vector_math/vector_math.dart';
 /// [BasicKinematicBody]s to nodes you intend to move under your own
 /// control. For full rigid-body simulation, depend on a backend
 /// package with a solver.
+/// {@category Physics}
 class BasicPhysicsWorld extends PhysicsWorld {
   BasicPhysicsWorld({Vector3? gravity}) {
     if (gravity != null) this.gravity = gravity;

--- a/packages/flutter_scene/lib/src/physics/collider.dart
+++ b/packages/flutter_scene/lib/src/physics/collider.dart
@@ -11,6 +11,7 @@ import 'package:vector_math/vector_math.dart';
 ///
 /// Concrete subclasses live in backend packages. Hold a reference as
 /// [Collider] so user code stays portable between backends.
+/// {@category Physics}
 abstract class Collider extends Component {
   Shape get shape;
   set shape(Shape value);

--- a/packages/flutter_scene/lib/src/physics/events.dart
+++ b/packages/flutter_scene/lib/src/physics/events.dart
@@ -8,6 +8,7 @@ import 'package:vector_math/vector_math.dart';
 /// the normal impulse applied to resolve the contact this step (zero
 /// for trigger events). [separation] is positive when bodies are
 /// separated and negative when they are interpenetrating.
+/// {@category Physics}
 class ContactPoint {
   final Vector3 worldPosition;
   final Vector3 worldNormal;
@@ -27,6 +28,7 @@ class ContactPoint {
 /// Subscribe via `PhysicsWorld.collisions`. The same pair fires
 /// [CollisionBegan] / [CollisionEnded] for solid contacts and
 /// [TriggerEntered] / [TriggerExited] for trigger volumes.
+/// {@category Physics}
 sealed class CollisionEvent {
   /// The node owning [colliderA]. [nodeA] and [nodeB] may be the same
   /// when a compound body's children touch each other.
@@ -38,6 +40,7 @@ sealed class CollisionEvent {
 }
 
 /// Fired the first step a pair of solid colliders touch.
+/// {@category Physics}
 class CollisionBegan extends CollisionEvent {
   @override
   final Node nodeA;
@@ -61,6 +64,7 @@ class CollisionBegan extends CollisionEvent {
 }
 
 /// Fired the step a previously-touching solid pair separates.
+/// {@category Physics}
 class CollisionEnded extends CollisionEvent {
   @override
   final Node nodeA;
@@ -81,6 +85,7 @@ class CollisionEnded extends CollisionEvent {
 
 /// Fired the first step a non-trigger collider overlaps a trigger
 /// volume.
+/// {@category Physics}
 class TriggerEntered extends CollisionEvent {
   @override
   final Node nodeA;
@@ -101,6 +106,7 @@ class TriggerEntered extends CollisionEvent {
 
 /// Fired the step a previously-overlapping pair stops overlapping a
 /// trigger volume.
+/// {@category Physics}
 class TriggerExited extends CollisionEvent {
   @override
   final Node nodeA;

--- a/packages/flutter_scene/lib/src/physics/joint.dart
+++ b/packages/flutter_scene/lib/src/physics/joint.dart
@@ -9,6 +9,7 @@ import 'package:vector_math/vector_math.dart';
 ///
 /// Concrete joint classes live in backend packages. Hold a reference at
 /// the appropriate abstract subclass so user code stays portable.
+/// {@category Physics}
 abstract class Joint extends Component {
   /// The other node this joint connects to. When `null`, the joint
   /// anchors to the world (the other side behaves as a fixed body).
@@ -21,6 +22,7 @@ abstract class Joint extends Component {
 }
 
 /// Welds two bodies together with zero degrees of freedom.
+/// {@category Physics}
 abstract class FixedJoint extends Joint {}
 
 /// A ball-and-socket joint: three rotational degrees of freedom, zero
@@ -34,6 +36,7 @@ abstract class SphericalJoint extends Joint {
 }
 
 /// A hinge: one rotational degree of freedom around a shared axis.
+/// {@category Physics}
 abstract class RevoluteJoint extends Joint {
   Vector3 get localAnchorA;
   set localAnchorA(Vector3 value);
@@ -65,6 +68,7 @@ abstract class RevoluteJoint extends Joint {
 }
 
 /// A slider: one translational degree of freedom along a shared axis.
+/// {@category Physics}
 abstract class PrismaticJoint extends Joint {
   Vector3 get localAnchorA;
   set localAnchorA(Vector3 value);
@@ -95,6 +99,7 @@ abstract class PrismaticJoint extends Joint {
 /// linear axes are translations along, and the angular axes rotations
 /// about, the joint frame's local X / Y / Z (oriented by the joint's
 /// local bases on each body).
+/// {@category Physics}
 enum JointAxis { linearX, linearY, linearZ, angularX, angularY, angularZ }
 
 /// How a [JointMotor] turns its drive parameters into a force.
@@ -115,6 +120,7 @@ enum JointMotorModel {
 /// most [maxForce] (a force on a linear axis, a torque on an angular
 /// one). Leave [stiffness] at 0 for a pure velocity drive; set it for a
 /// positional spring (a soft constraint).
+/// {@category Physics}
 class JointMotor {
   /// Rest position the spring pulls toward: meters on a linear axis,
   /// radians on an angular one.
@@ -148,6 +154,7 @@ class JointMotor {
 }
 
 /// Whether a [GenericJoint] axis is locked, free, or limited.
+/// {@category Physics}
 enum JointAxisMotion { locked, free, limited }
 
 /// The configuration of one of a [GenericJoint]'s six axes.
@@ -155,6 +162,7 @@ enum JointAxisMotion { locked, free, limited }
 /// [motion] sets whether the axis is rigidly locked, free, or confined to
 /// a band. [lowerLimit] / [upperLimit] apply only when [motion] is
 /// [JointAxisMotion.limited]. An optional [motor] drives the axis.
+/// {@category Physics}
 class JointAxisConfig {
   final JointAxisMotion motion;
   final double lowerLimit;
@@ -190,6 +198,7 @@ class JointAxisConfig {
 /// limited and may carry a spring-damper [JointMotor]. This is the most
 /// general joint: the fixed, spherical, revolute, and prismatic joints
 /// are all special cases. Pass a null [otherNode] to anchor to the world.
+/// {@category Physics}
 abstract class GenericJoint extends Joint {
   Vector3 get localAnchorA;
   set localAnchorA(Vector3 value);

--- a/packages/flutter_scene/lib/src/physics/material.dart
+++ b/packages/flutter_scene/lib/src/physics/material.dart
@@ -1,11 +1,13 @@
 /// How a per-contact friction or restitution value is derived from the
 /// two participating materials.
+/// {@category Physics}
 enum CombineRule { average, min, max, multiply }
 
 /// Surface properties (friction, restitution, density) of a collider.
 ///
 /// Materials are immutable, identity-shared value objects: assign one
 /// instance to many colliders and the backend will cook it once.
+/// {@category Physics}
 class PhysicsMaterial {
   /// Coulomb friction coefficient. Typical range is `[0, 1]`; higher
   /// values produce more resistance to sliding.

--- a/packages/flutter_scene/lib/src/physics/physics_world.dart
+++ b/packages/flutter_scene/lib/src/physics/physics_world.dart
@@ -19,6 +19,7 @@ import 'package:vector_math/vector_math.dart';
 /// substepping to keep up when the frame interval exceeds
 /// [fixedTimestep] and interpolating transforms for the rendered frame.
 /// Concrete subclasses implement [step] and [interpolateTransforms].
+/// {@category Physics}
 abstract class PhysicsWorld extends Component {
   /// Identifier of the concrete backend, suitable for logging
   /// (for example `"basic"`).

--- a/packages/flutter_scene/lib/src/physics/queries.dart
+++ b/packages/flutter_scene/lib/src/physics/queries.dart
@@ -10,6 +10,7 @@ import 'package:vector_math/vector_math.dart';
 /// direction of travel). [distance] is positive and measured along the
 /// normalized direction. [Ray] is `vector_math`'s class; backends
 /// normalize its direction internally.
+/// {@category Physics}
 class RaycastHit {
   /// The node whose collider was hit.
   final Node node;
@@ -32,6 +33,7 @@ class RaycastHit {
 }
 
 /// One collider returned by an overlap query (sphere or box).
+/// {@category Physics}
 class OverlapHit {
   final Node node;
   final Component collider;
@@ -41,6 +43,7 @@ class OverlapHit {
 
 /// The first collider intersected by a shape cast, with the same fields
 /// as [RaycastHit] plus the cast direction's hit distance.
+/// {@category Physics}
 class ShapeCastHit extends RaycastHit {
   ShapeCastHit({
     required super.node,

--- a/packages/flutter_scene/lib/src/physics/rigid_body.dart
+++ b/packages/flutter_scene/lib/src/physics/rigid_body.dart
@@ -12,6 +12,7 @@ import 'package:vector_math/vector_math.dart';
 /// * [BodyType.dynamic_]: fully simulated. The backend writes the node's
 ///   transform each step in response to forces, contacts, and gravity.
 ///   The trailing underscore avoids the Dart `dynamic` keyword.
+/// {@category Physics}
 enum BodyType { fixed, kinematic, dynamic_ }
 
 /// A simulated rigid body attached to a [Node].
@@ -24,6 +25,7 @@ enum BodyType { fixed, kinematic, dynamic_ }
 /// a [BodyType.dynamic_] body's [Node.localTransform] is allowed but is
 /// treated as a teleport (the backend overrides velocity and wakes the
 /// body).
+/// {@category Physics}
 abstract class RigidBody extends Component {
   BodyType get type;
 

--- a/packages/flutter_scene/lib/src/physics/shape.dart
+++ b/packages/flutter_scene/lib/src/physics/shape.dart
@@ -8,6 +8,7 @@ import 'package:vector_math/vector_math.dart';
 /// single [Shape] instance can be shared across many colliders; backends
 /// cook each instance into a native acceleration structure on first use
 /// and cache the result keyed by identity.
+/// {@category Physics}
 sealed class Shape {
   const Shape();
 }
@@ -21,6 +22,7 @@ class SphereShape extends Shape {
 
 /// An axis-aligned box of the given [halfExtents] centered at the
 /// collider's local origin.
+/// {@category Physics}
 class BoxShape extends Shape {
   final Vector3 halfExtents;
 
@@ -29,6 +31,7 @@ class BoxShape extends Shape {
 
 /// A capsule aligned with the local Y axis. [halfHeight] is the half
 /// length of the cylindrical section, excluding the hemispherical caps.
+/// {@category Physics}
 class CapsuleShape extends Shape {
   final double radius;
   final double halfHeight;
@@ -38,6 +41,7 @@ class CapsuleShape extends Shape {
 
 /// A cylinder aligned with the local Y axis. [halfHeight] is half the
 /// total height.
+/// {@category Physics}
 class CylinderShape extends Shape {
   final double radius;
   final double halfHeight;
@@ -46,6 +50,7 @@ class CylinderShape extends Shape {
 }
 
 /// The convex hull of [points], stored as packed `xyz` triplets.
+/// {@category Physics}
 class ConvexHullShape extends Shape {
   final Float32List points;
 
@@ -54,6 +59,7 @@ class ConvexHullShape extends Shape {
 
 /// A triangle mesh defined by [vertices] (packed `xyz` triplets) and
 /// [indices] (groups of three vertex indices forming one triangle each).
+/// {@category Physics}
 class TriMeshShape extends Shape {
   final Float32List vertices;
   final Uint32List indices;
@@ -63,6 +69,7 @@ class TriMeshShape extends Shape {
 
 /// A row-major heightfield of [width] x [depth] samples, scaled by
 /// [scale]. Heights are sampled in the local XZ plane and offset along Y.
+/// {@category Physics}
 class HeightFieldShape extends Shape {
   final int width;
   final int depth;
@@ -79,6 +86,7 @@ class HeightFieldShape extends Shape {
 
 /// One child of a [CompoundShape]: a [shape] positioned by [localPose]
 /// relative to the compound's origin.
+/// {@category Physics}
 class CompoundChild {
   final Shape shape;
   final Matrix4 localPose;
@@ -90,6 +98,7 @@ class CompoundChild {
 ///
 /// Use this when one collider needs to represent a non-convex shape made
 /// of several primitives (for example an L-block made of two boxes).
+/// {@category Physics}
 class CompoundShape extends Shape {
   final List<CompoundChild> children;
 

--- a/packages/flutter_scene/lib/src/post_process/post_effect.dart
+++ b/packages/flutter_scene/lib/src/post_process/post_effect.dart
@@ -4,6 +4,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/shader_uniform_bindings.dart';
 
 /// Where in the post-processing chain a [PostEffect] runs.
+/// {@category Rendering}
 enum PostInsertion {
   /// Runs on the linear HDR scene color, before tone mapping. The shader
   /// should output linear HDR premultiplied by alpha, the same contract as
@@ -53,6 +54,7 @@ enum PostInsertion {
 /// A [PostInsertion.beforeTonemap] effect should output linear HDR
 /// premultiplied by alpha; a [PostInsertion.afterTonemap] effect works on
 /// the display-referred image.
+/// {@category Rendering}
 class PostEffect {
   PostEffect({
     gpu.Shader? fragmentShader,

--- a/packages/flutter_scene/lib/src/post_process/post_process.dart
+++ b/packages/flutter_scene/lib/src/post_process/post_process.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/post_process/post_effect.dart';
 /// Reachable through `Scene.postProcess`. Every effect is off by default,
 /// so a fresh scene does no extra post-processing work. Turn an effect on
 /// and adjust its fields to change the final image.
+/// {@category Rendering}
 class PostProcessSettings {
   /// Color grading applied to the linear HDR scene color before tone
   /// mapping.
@@ -36,6 +37,7 @@ class PostProcessSettings {
 ///
 /// The defaults are neutral: with [enabled] off, or every field left at
 /// its default, the image is unchanged.
+/// {@category Rendering}
 class ColorGradingSettings {
   /// Whether color grading runs. Off by default.
   bool enabled = false;
@@ -71,6 +73,7 @@ class ColorGradingSettings {
 
 /// Splits the red and blue channels toward the edges, like a simple lens.
 /// Sampled from the scene color before grading and tone mapping.
+/// {@category Rendering}
 class ChromaticAberrationSettings {
   /// Whether the effect runs. Off by default.
   bool enabled = false;
@@ -80,6 +83,7 @@ class ChromaticAberrationSettings {
 }
 
 /// Darkens the image toward the edges, after tone mapping.
+/// {@category Rendering}
 class VignetteSettings {
   /// Whether the vignette runs. Off by default.
   bool enabled = false;
@@ -96,6 +100,7 @@ class VignetteSettings {
 }
 
 /// Adds animated noise over the final image, after tone mapping.
+/// {@category Rendering}
 class FilmGrainSettings {
   /// Whether the grain runs. Off by default.
   bool enabled = false;
@@ -106,6 +111,7 @@ class FilmGrainSettings {
 
 /// Makes bright areas bleed light into their surroundings. Computed in a
 /// chain of HDR passes and added back to the scene before tone mapping.
+/// {@category Rendering}
 class BloomSettings {
   /// Whether bloom runs. Off by default.
   bool enabled = false;

--- a/packages/flutter_scene/lib/src/raycast.dart
+++ b/packages/flutter_scene/lib/src/raycast.dart
@@ -22,6 +22,7 @@ import 'package:flutter_scene/src/node.dart';
 import 'package:vector_math/vector_math.dart';
 
 /// A render-geometry intersection from [raycastNode] (or `Scene.raycast`).
+/// {@category Picking and input}
 class SceneRaycastHit {
   /// Creates a hit record.
   SceneRaycastHit({
@@ -73,6 +74,7 @@ class SceneRaycastHit {
 /// [Node.raycastable] set, and pass [where] when provided. Skinned meshes
 /// are tested at rest pose. Geometry with caller-managed vertex buffers
 /// (`setVertices`) or non-triangle topology is skipped.
+/// {@category Picking and input}
 // TODO(raycast): test InstancedMesh components (one local-space test per
 // instance transform).
 // TODO(raycast): a per-mesh triangle BVH for dense meshes; today each
@@ -96,6 +98,7 @@ SceneRaycastHit? raycastNode(
 
 /// Casts [ray] through [root]'s subtree and returns every hit, sorted
 /// nearest-first. Parameters as in [raycastNode].
+/// {@category Picking and input}
 List<SceneRaycastHit> raycastNodeAll(
   Node root,
   Ray ray, {

--- a/packages/flutter_scene/lib/src/render/env_prefilter.dart
+++ b/packages/flutter_scene/lib/src/render/env_prefilter.dart
@@ -67,6 +67,7 @@ final gpu.BufferView _fullscreenQuadView = gpu.BufferView(
 /// treated as sRGB-encoded; pass [sourceIsLinear] when it already holds
 /// linear radiance (an HDR environment), so it is not linearized twice.
 /// The atlas always stores linear radiance.
+/// {@category Lighting and environment}
 gpu.Texture prefilterEquirectRadiance(
   gpu.Texture sourceEquirect, {
   bool sourceIsLinear = false,

--- a/packages/flutter_scene/lib/src/render/render_layers.dart
+++ b/packages/flutter_scene/lib/src/render/render_layers.dart
@@ -4,7 +4,9 @@
 /// only when the node's layers intersect the view's layer mask. This lets a
 /// view (a capture, a minimap, an editor overlay) include or exclude
 /// specific nodes.
+/// {@category Rendering}
 const int kRenderLayerDefault = 1;
 
 /// A layer mask that selects every layer (the default render-view mask).
+/// {@category Rendering}
 const int kRenderLayerAll = 0xFFFFFFFF;

--- a/packages/flutter_scene/lib/src/render_view.dart
+++ b/packages/flutter_scene/lib/src/render_view.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene/src/render/render_layers.dart';
 /// picture, and more). Each view binds a camera to a [viewport]
 /// sub-rectangle of the target, a [layerMask] selecting which nodes it
 /// sees, and an [order] controlling how overlapping views composite.
+/// {@category Rendering}
 class RenderView {
   /// Creates a render view for [camera].
   RenderView({

--- a/packages/flutter_scene/lib/src/runtime_importer/gltf_resources.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/gltf_resources.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 /// resource's bytes. Supplied by the caller of [Node.fromGltfBytes] /
 /// `importGltf`; `data:` URIs are decoded internally and never reach
 /// the resolver.
+/// {@category Assets and loading}
 typedef GltfResourceResolver = Future<Uint8List> Function(String uri);
 
 /// Decodes a `data:` URI into its raw bytes.

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -37,6 +37,7 @@ import 'tone_mapping.dart';
 ///
 /// `SceneGraph` provides a set of methods that can be implemented by a class
 /// to manage a hierarchy of nodes within a 3D scene.
+/// {@category Scene graph}
 mixin SceneGraph {
   /// Add a child node.
   void add(Node child);
@@ -58,6 +59,7 @@ mixin SceneGraph {
 ///
 /// Set on a [Scene] via [Scene.antiAliasingMode]. The default is [msaa]
 /// when the GPU backend supports offscreen MSAA, otherwise [none].
+/// {@category Scene graph}
 enum AntiAliasingMode {
   /// No anti-aliasing. Geometry edges are rendered at the render target's
   /// native resolution.
@@ -74,6 +76,7 @@ enum AntiAliasingMode {
 /// `Scene` manages the scene graph and handles rendering operations.
 /// It contains a root [Node] that serves as the entry point for all nodes in this `Scene`, and
 /// it provides methods for adding and removing nodes from the scene graph.
+/// {@category Scene graph}
 base class Scene implements SceneGraph {
   Scene() {
     initializeStaticResources();

--- a/packages/flutter_scene/lib/src/scene_path.dart
+++ b/packages/flutter_scene/lib/src/scene_path.dart
@@ -6,6 +6,7 @@ import 'package:vector_math/vector_math.dart';
 /// runs along the path, and [normal] and [binormal] span the plane
 /// across it. Frames along a path are rotation-minimizing, so a profile
 /// swept through them does not twist.
+/// {@category Geometry}
 class ScenePathFrame {
   /// Creates a frame from its position and axes.
   const ScenePathFrame({
@@ -40,6 +41,7 @@ class ScenePathFrame {
 /// evenly along the curve ([positionAtDistance], [frameAtDistance]); use
 /// it when spacing must stay uniform around bends, such as for dashes or
 /// a swept profile.
+/// {@category Geometry}
 abstract class ScenePath {
   /// The point on the curve at natural parameter [t] (clamped to `0..1`).
   Vector3 positionAt(double t);
@@ -240,6 +242,7 @@ class _PathTable {
 }
 
 /// A path of straight segments connecting a list of points.
+/// {@category Geometry}
 class PolylinePath extends ScenePath {
   /// Creates a polyline through [points], which is copied. At least two
   /// points are required.
@@ -293,6 +296,7 @@ List<double> _subdividedParameters(int segments) {
 /// The curve interpolates its control points with uniform Catmull-Rom
 /// segments, so `positionAt` returns a control point exactly at that
 /// point's natural parameter.
+/// {@category Geometry}
 class CatmullRomPath extends ScenePath {
   /// Creates a Catmull-Rom curve through [points], which is copied. At
   /// least two points are required.
@@ -348,6 +352,7 @@ class CatmullRomPath extends ScenePath {
 /// Each segment is defined by four control points, and adjacent
 /// segments share an endpoint, so the control point count must be
 /// `3 * segments + 1`.
+/// {@category Geometry}
 class BezierPath extends ScenePath {
   /// Creates a Bezier path from [controlPoints], which is copied. The
   /// count must be `3 * segments + 1` for one or more segments.

--- a/packages/flutter_scene/lib/src/scene_pointer.dart
+++ b/packages/flutter_scene/lib/src/scene_pointer.dart
@@ -36,6 +36,7 @@ import 'package:vector_math/vector_math.dart' show Ray;
 /// caller (crosshair highlights, cursor feedback); it is not forwarded into
 /// the widgets (widget-level hover needs MouseTracker integration, a
 /// planned follow-up).
+/// {@category Picking and input}
 class ScenePointer {
   /// Creates a pointer into [scene].
   ScenePointer(

--- a/packages/flutter_scene/lib/src/shaders.dart
+++ b/packages/flutter_scene/lib/src/shaders.dart
@@ -17,6 +17,7 @@ gpu.ShaderLibrary? _baseShaderLibrary;
 /// must be loaded ahead of time by awaiting [Scene.initializeStaticResources]
 /// (which calls [loadBaseShaderLibrary]); accessing this getter before that
 /// completes throws.
+/// {@category Assets and loading}
 gpu.ShaderLibrary get baseShaderLibrary {
   final cached = _baseShaderLibrary;
   if (cached != null) {
@@ -39,6 +40,7 @@ gpu.ShaderLibrary get baseShaderLibrary {
 /// Called by [Scene.initializeStaticResources] so the synchronous
 /// [baseShaderLibrary] getter has a cached library to return (required on
 /// web, where shader assets can't be read synchronously).
+/// {@category Assets and loading}
 Future<void> loadBaseShaderLibrary() async {
   if (_baseShaderLibrary != null) {
     return;

--- a/packages/flutter_scene/lib/src/skin.dart
+++ b/packages/flutter_scene/lib/src/skin.dart
@@ -32,6 +32,7 @@ int _getNextPowerOfTwoSize(int x) {
 /// `Skin` instances are usually populated by an importer rather than
 /// constructed directly. They are attached to the mesh-bearing [Node] via
 /// [Node.skin].
+/// {@category Geometry}
 base class Skin {
   /// The bone nodes referenced by this skin, in shader-binding order.
   ///

--- a/packages/flutter_scene/lib/src/sky_environment.dart
+++ b/packages/flutter_scene/lib/src/sky_environment.dart
@@ -6,6 +6,7 @@ import 'package:flutter_scene/src/render/sky_bake.dart';
 import 'package:flutter_scene/src/skybox.dart';
 
 /// When a [SkyEnvironment] re-bakes the sky into the scene's lighting.
+/// {@category Lighting and environment}
 enum SkyEnvironmentRefresh {
   /// Bake once when the binding is set, then only when [SkyEnvironment.invalidate]
   /// is called. The right choice for a static sky.
@@ -41,6 +42,7 @@ enum SkyEnvironmentRefresh {
 /// // ... later, after changing the sky's parameters:
 /// scene.skyEnvironment!.invalidate();
 /// ```
+/// {@category Lighting and environment}
 class SkyEnvironment {
   SkyEnvironment(
     this.source, {

--- a/packages/flutter_scene/lib/src/sky_sources.dart
+++ b/packages/flutter_scene/lib/src/sky_sources.dart
@@ -19,6 +19,7 @@ import 'package:vector_math/vector_math.dart';
 ///
 /// Like every Geometry and Material constructor, construct only after
 /// `Scene.initializeStaticResources` completes.
+/// {@category Lighting and environment}
 class GradientSkySource extends ShaderSkySource {
   GradientSkySource({
     Vector3? zenithColor,
@@ -89,6 +90,7 @@ class GradientSkySource extends ShaderSkySource {
 ///
 /// Like every Geometry and Material constructor, construct only after
 /// `Scene.initializeStaticResources` completes.
+/// {@category Lighting and environment}
 class PhysicalSkySource extends ShaderSkySource {
   PhysicalSkySource({
     Vector3? sunDirection,

--- a/packages/flutter_scene/lib/src/skybox.dart
+++ b/packages/flutter_scene/lib/src/skybox.dart
@@ -13,6 +13,7 @@ import 'package:flutter_scene/src/material/material.dart';
 /// A [Skybox] wraps a source and the engine draws it behind all scene
 /// geometry. Built-in sources are [EnvironmentSkySource] (show the scene's
 /// environment) and [ShaderSkySource] (a custom fragment shader).
+/// {@category Lighting and environment}
 abstract class SkySource {
   const SkySource();
 }
@@ -25,6 +26,7 @@ abstract class SkySource {
 /// is: `0.0` shows the sharp environment, `1.0` shows the fully-blurred band.
 /// The same atlas drives specular reflections, so a blurred background stays
 /// consistent with what reflective surfaces show.
+/// {@category Lighting and environment}
 class EnvironmentSkySource extends SkySource {
   EnvironmentSkySource({this.blurriness = 0.0});
 
@@ -46,6 +48,7 @@ class EnvironmentSkySource extends SkySource {
 ///
 /// Unlike [EnvironmentSkySource], `Skybox.intensity` is not applied for you;
 /// the shader controls its own output brightness.
+/// {@category Lighting and environment}
 class ShaderSkySource extends SkySource {
   ShaderSkySource({required this.fragmentShader, this.useEnvironment = false});
 
@@ -160,6 +163,7 @@ class _SkyTexture {
 /// [EnvironmentSkySource] shows that same environment, but the two can be set
 /// independently. The engine draws the skybox behind all scene geometry at
 /// the far plane; you never place or order any geometry yourself.
+/// {@category Lighting and environment}
 class Skybox {
   Skybox(this.source, {this.intensity = 1.0});
 

--- a/packages/flutter_scene/lib/src/surface.dart
+++ b/packages/flutter_scene/lib/src/surface.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
@@ -41,6 +42,7 @@ class Surface {
   /// render-graph attachments: HDR scene color, depth, shadow maps,
   /// post-process buffers). Each view has its own pool so simultaneous
   /// views in a frame never share an attachment.
+  @internal
   TransientTexturePool transientTexturePool([int viewIndex = 0]) =>
       _view(viewIndex).pool;
 

--- a/packages/flutter_scene/lib/src/surface.dart
+++ b/packages/flutter_scene/lib/src/surface.dart
@@ -24,6 +24,7 @@ import 'package:flutter_scene/src/render/render_graph.dart';
 ///
 /// Applications typically don't interact with `Surface` directly; it is
 /// driven internally by [Scene.render] / [Scene.renderViews].
+/// {@category Rendering}
 class Surface {
   // TODO(bdero): There should be a method on the Flutter GPU context to pull
   //              this information.

--- a/packages/flutter_scene/lib/src/tone_mapping.dart
+++ b/packages/flutter_scene/lib/src/tone_mapping.dart
@@ -3,6 +3,7 @@
 ///
 /// The integer values are wire-compatible with the `tone_mapping_mode`
 /// uniform in the tone-mapping fragment shader; don't reorder.
+/// {@category Rendering}
 enum ToneMappingMode {
   /// Khronos PBR Neutral. Preserves base-color hue/saturation and only
   /// rolls off highlights. Good default for product/configurator

--- a/packages/flutter_scene/lib/src/widget_texture.dart
+++ b/packages/flutter_scene/lib/src/widget_texture.dart
@@ -9,6 +9,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 
 /// When a [WidgetTexture] (or a `WidgetComponent`) re-captures its child.
+/// {@category Widgets}
 sealed class WidgetUpdatePolicy {
   const WidgetUpdatePolicy._();
 
@@ -55,6 +56,7 @@ class _ManualUpdatePolicy extends WidgetUpdatePolicy {
 /// so treat this as a correct-but-slow path: captures are throttled to one in
 /// flight and only run when the child subtree actually repaints, but each one
 /// costs a readback on the raster thread plus a byte upload.
+/// {@category Widgets}
 // TODO(widget-textures): keep the snapshot on the GPU once the engine can
 // wrap a ui.Image's backing texture as a flutter_gpu texture (the planned
 // gpu.Texture.fromImage); the capture and binding API stays the same.
@@ -156,6 +158,7 @@ class WidgetTextureController extends ChangeNotifier {
 ///
 /// Pointer input does not reach the child (the subtree never appears on
 /// screen).
+/// {@category Widgets}
 // TODO(widget-textures): route pointer events from scene raycasts into the
 // hosted subtree so textured widgets become interactive.
 class WidgetTexture extends SingleChildRenderObjectWidget {

--- a/packages/flutter_scene/lib/src/widgets/scene_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view.dart
@@ -15,6 +15,7 @@ import 'package:flutter_scene/src/widget_texture.dart';
 /// view started ticking. Use this for time-based cameras (for example an
 /// orbiting view); pass a fixed [SceneView.camera] instead when the camera does
 /// not change over time.
+/// {@category Widgets}
 typedef SceneCameraBuilder = Camera Function(Duration elapsed);
 
 /// Builds the list of [RenderView]s to render for the current frame from the
@@ -27,6 +28,7 @@ typedef SceneViewsBuilder = List<RenderView> Function(Duration elapsed);
 /// since the previous tick. Drive per-frame app logic here, or advance the
 /// scene with a supplied timestep via [Scene.update] (after which [Scene.render]
 /// skips its implicit wall-clock tick for that frame).
+/// {@category Widgets}
 typedef SceneTickCallback =
     void Function(Duration elapsed, double deltaSeconds);
 
@@ -59,6 +61,7 @@ typedef SceneTickCallback =
 ///
 /// The active [scene] is exposed to descendants through [SceneScope], so widgets
 /// below can resolve the scene from their [BuildContext].
+/// {@category Widgets}
 //
 // TODO(declarative): a future declarative API will add a `SceneView.builder`
 // (or `child:`) form where SceneView owns an internal Scene that declarative
@@ -458,6 +461,7 @@ class _ScenePainter extends CustomPainter {
 /// Today [SceneView] is the only producer and there are no built-in consumers;
 /// this plumbing exists so a future declarative node API can attach widgets to
 /// the right scene subtree without restructuring the view.
+/// {@category Widgets}
 class SceneScope extends InheritedWidget {
   const SceneScope({
     super.key,

--- a/packages/flutter_scene/test/animation_clip_test.dart
+++ b/packages/flutter_scene/test/animation_clip_test.dart
@@ -5,6 +5,10 @@
 library;
 
 import 'package:flutter_scene/scene.dart';
+// The channel/resolver data model is internal; tests reach it directly.
+// ignore: implementation_imports
+import 'package:flutter_scene/src/animation.dart'
+    show AnimationChannel, BindKey, PropertyResolver;
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math.dart';
 

--- a/packages/flutter_scene/test/raycast_test.dart
+++ b/packages/flutter_scene/test/raycast_test.dart
@@ -10,6 +10,10 @@ import 'dart:typed_data';
 
 import 'package:flutter/widgets.dart' show Offset, Size;
 import 'package:flutter_scene/scene.dart' hide Material;
+// The packed-triangle intersector is test-only surface; reach it directly.
+// ignore: implementation_imports
+import 'package:flutter_scene/src/raycast.dart'
+    show PackedTriangleHit, intersectPackedTriangles;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu show IndexType;
 import 'package:vector_math/vector_math.dart';


### PR DESCRIPTION
Every export in `scene.dart` and `fscene.dart` now names the symbols it publishes (matching the already-curated `gpu.dart` and `build_hooks.dart`), so internal helpers no longer leak by default and new public API requires a deliberate barrel edit. `hide` combinators are gone; they leak new symbols by default.

Removed from the public surface, BREAKING for anyone who used them:
- `SceneEncoder`, `evictPipelinesForShaders`, `resolvePipeline` (draw recording and pipeline caching)
- `TransientTexturePool` and `Surface.transientTexturePool` (render-graph attachment pooling)
- the environment-prefilter internals (`createPrefilterAtlasTexture`, `prefilterEquirectRadianceBand`, the band constants); `prefilterEquirectRadiance` itself stays, pairing with `EnvironmentMap.fromGpuTextures`
- the imported-animation data model (`AnimationChannel`, `BindKey`, the property/timeline resolvers)
- the built-in `.fscene` codec classes (`registerBuiltinComponentCodecs` stays)
- `Material.getBrdfLutTexture` (engine lighting plumbing)

Cross-library members that must be public in Dart but are not API (`Geometry.localBoundsVersion`, `Node.windingFlipped`, and friends) now all carry `@internal`: consumers get an analyzer warning, the barrels are linted by `invalid_export_of_internal_element`, and dartdoc omits them.

If a symbol you used disappeared, please open an issue describing the use case; promoting it back into the barrel is a quick patch release. Verified with an API diff against 0.17.0 (every change intentional) and the example apps, which compiled unchanged.
