### PR TITLE
Anti-aliasing modes, offscreen render targets, render scaling, and mip-level radiance

### DIFF
--- a/.github/workflows/rapier_native_binaries.yml
+++ b/.github/workflows/rapier_native_binaries.yml
@@ -95,7 +95,12 @@ jobs:
           fi
           env_triple=$(echo "$triple" | tr 'a-z-' 'A-Z_')
           export "CARGO_TARGET_${env_triple}_LINKER=$clang"
-          export "CARGO_TARGET_${env_triple}_RUSTFLAGS=-Clink-arg=--target=${clang_target}${ANDROID_API}"
+          # Align ELF load segments to 16 KB so the library loads on devices
+          # with 16 KB memory pages (Android 15+; required on Pixel 8 and
+          # newer). The default is 4 KB, which fails the loader's alignment
+          # check ("ELF alignment check failed"). Keep in sync with the
+          # source-build flags in hook/build.dart.
+          export "CARGO_TARGET_${env_triple}_RUSTFLAGS=-Clink-arg=--target=${clang_target}${ANDROID_API} -Clink-arg=-Wl,-z,max-page-size=16384"
           cargo build --release --target "$triple"
 
       - name: Build (cargo)

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ pubspec.lock
 .packages
 build/
 **/ephemeral/
+pubspec_overrides.yaml

--- a/examples/flutter_app/hook/build.dart
+++ b/examples/flutter_app/hook/build.dart
@@ -28,6 +28,8 @@ void main(List<String> args) {
       buildInput: config,
       buildOutput: output,
       manifestFileName: 'shaders/example.shaderbundle.json',
+      // Match the engine bundle's GLES dialect (see the flutter_scene hook).
+      glesLanguageVersion: 300,
     );
     // Compile .fmat custom materials into a bundle plus a parameter sidecar,
     // consumed by the "Toon (.fmat)" example through loadFmatMaterial. With no

--- a/examples/flutter_app/lib/example_car.dart
+++ b/examples/flutter_app/lib/example_car.dart
@@ -190,42 +190,52 @@ class ExampleCarState extends State<ExampleCar> {
                   'DoorBack.L',
                   'DoorBack.R',
                 ])
-                  Slider(
-                    value: nodes[doorName]!.amount,
-                    onChanged: (value) {
-                      setState(() => _applyDoorPose(doorName, value));
-                    },
+                  Expanded(
+                    child: Slider(
+                      value: nodes[doorName]!.amount,
+                      onChanged: (value) {
+                        setState(() => _applyDoorPose(doorName, value));
+                      },
+                    ),
                   ),
               ],
             ),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
-                Slider(
-                  value: nodes['Frunk']!.amount,
-                  onChanged: (value) {
-                    setState(() => _applyDoorPose('Frunk', value));
-                  },
+                Expanded(
+                  child: Slider(
+                    value: nodes['Frunk']!.amount,
+                    onChanged: (value) {
+                      setState(() => _applyDoorPose('Frunk', value));
+                    },
+                  ),
                 ),
-                Slider(
-                  value: nodes['Trunk']!.amount,
-                  onChanged: (value) {
-                    setState(() => _applyDoorPose('Trunk', value));
-                  },
+                Expanded(
+                  child: Slider(
+                    value: nodes['Trunk']!.amount,
+                    onChanged: (value) {
+                      setState(() => _applyDoorPose('Trunk', value));
+                    },
+                  ),
                 ),
-                Slider(
-                  value: nodes['WheelBack.L']!.amount,
-                  onChanged: (value) {
-                    setState(() => nodes['WheelBack.L']!.amount = value);
-                  },
+                Expanded(
+                  child: Slider(
+                    value: nodes['WheelBack.L']!.amount,
+                    onChanged: (value) {
+                      setState(() => nodes['WheelBack.L']!.amount = value);
+                    },
+                  ),
                 ),
-                Slider(
-                  min: -1,
-                  max: 1,
-                  value: nodes['WheelFront.L']!.amount,
-                  onChanged: (value) {
-                    setState(() => nodes['WheelFront.L']!.amount = value);
-                  },
+                Expanded(
+                  child: Slider(
+                    min: -1,
+                    max: 1,
+                    value: nodes['WheelFront.L']!.amount,
+                    onChanged: (value) {
+                      setState(() => nodes['WheelFront.L']!.amount = value);
+                    },
+                  ),
                 ),
               ],
             ),

--- a/examples/flutter_app/lib/example_render_target.dart
+++ b/examples/flutter_app/lib/example_render_target.dart
@@ -1,0 +1,134 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_cuboid.dart' show SpinComponent;
+import 'example_settings.dart';
+
+/// Offscreen render targets displayed as HUD widgets.
+///
+/// Three scene-owned views render into [RenderTexture]s alongside the main
+/// view, a top-down minimap on a 500 ms update interval, and a pair of
+/// fixed-camera insets comparing anti-aliasing off against the scene's
+/// mode. The comparison targets are deliberately low resolution and drawn
+/// upscaled with nearest sampling, so the effect of the AA mode is visible
+/// regardless of display density.
+class ExampleRenderTarget extends StatefulWidget {
+  const ExampleRenderTarget({super.key});
+
+  @override
+  ExampleRenderTargetState createState() => ExampleRenderTargetState();
+}
+
+class ExampleRenderTargetState extends State<ExampleRenderTarget> {
+  Scene scene = Scene();
+
+  final RenderTexture _minimap = RenderTexture(
+    width: 320,
+    height: 320,
+    update: const RenderTextureUpdate.interval(Duration(milliseconds: 500)),
+  );
+  final RenderTexture _aaOff = RenderTexture(width: 240, height: 180);
+  final RenderTexture _aaScene = RenderTexture(width: 240, height: 180);
+
+  @override
+  void initState() {
+    final mesh = Mesh(
+      CuboidGeometry(vm.Vector3(1, 1, 1), debugColors: true),
+      UnlitMaterial(),
+    );
+    scene.add(Node(mesh: mesh)..addComponent(SpinComponent(-1.5)));
+
+    final compareCamera = PerspectiveCamera(
+      position: vm.Vector3(2.2, 1.2, 2.2),
+      target: vm.Vector3(0, 0, 0),
+    );
+    scene.views.addAll([
+      RenderView(
+        camera: PerspectiveCamera(
+          position: vm.Vector3(0, 8, 0.01),
+          target: vm.Vector3(0, 0, 0),
+        ),
+        target: _minimap,
+      ),
+      RenderView(
+        camera: compareCamera,
+        target: _aaOff,
+        antiAliasingMode: AntiAliasingMode.none,
+      ),
+      RenderView(camera: compareCamera, target: _aaScene),
+    ]);
+
+    super.initState();
+  }
+
+  Widget _inset(String label, RenderTexture target, {required double width}) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: width,
+          height: width * target.height / target.width,
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.white54),
+            color: Colors.black26,
+          ),
+          // Nearest sampling keeps the upscale honest: each texture pixel
+          // maps to a visible block, so the AA comparison reads clearly.
+          child: RenderTextureView(
+            target,
+            fit: BoxFit.fill,
+            filterQuality: FilterQuality.none,
+          ),
+        ),
+        Container(
+          color: Colors.black54,
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white, fontSize: 12),
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        SceneView(
+          scene,
+          cameraBuilder: (elapsed) {
+            final t = elapsed.inMicroseconds / 1e6;
+            return PerspectiveCamera(
+              position: vm.Vector3(sin(t * 0.4) * 5, 2, cos(t * 0.4) * 5),
+              target: vm.Vector3(0, 0, 0),
+            );
+          },
+          onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+        ),
+        Positioned(
+          top: 12,
+          left: 12,
+          child: _inset('Top view (updates at 2 Hz)', _minimap, width: 160),
+        ),
+        Positioned(
+          bottom: 12,
+          left: 12,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              _inset('Anti-aliasing off', _aaOff, width: 240),
+              const SizedBox(width: 12),
+              _inset('Scene anti-aliasing', _aaScene, width: 240),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/examples/flutter_app/lib/example_render_target.dart
+++ b/examples/flutter_app/lib/example_render_target.dart
@@ -61,6 +61,20 @@ class ExampleRenderTargetState extends State<ExampleRenderTarget> {
     );
     scene.add(Node(mesh: mesh)..addComponent(SpinComponent(-1.5)));
 
+    // An in-scene monitor showing the minimap capture live: assigning the
+    // RenderTexture to a material slot samples its latest completed
+    // frame. The top-down camera sees this monitor too, so the capture
+    // contains itself, one frame stale (no feedback loop).
+    final monitorMaterial = UnlitMaterial();
+    monitorMaterial.baseColorTexture = _minimap;
+    final monitor = Node(
+      mesh: Mesh(PlaneGeometry(width: 2.4, depth: 1.8), monitorMaterial),
+    );
+    monitor.localTransform =
+        vm.Matrix4.translation(vm.Vector3(0, 0.4, -2.4)) *
+        vm.Matrix4.rotationX(pi / 2);
+    scene.add(monitor);
+
     final compareCamera = PerspectiveCamera(
       position: vm.Vector3(2.2, 1.2, 2.2),
       target: vm.Vector3(0, 0, 0),

--- a/examples/flutter_app/lib/example_render_target.dart
+++ b/examples/flutter_app/lib/example_render_target.dart
@@ -9,12 +9,12 @@ import 'example_settings.dart';
 
 /// Offscreen render targets displayed as HUD widgets.
 ///
-/// Three scene-owned views render into [RenderTexture]s alongside the main
-/// view, a top-down minimap on a 500 ms update interval, and a pair of
-/// fixed-camera insets comparing anti-aliasing off against the scene's
-/// mode. The comparison targets are deliberately low resolution and drawn
-/// upscaled with nearest sampling, so the effect of the AA mode is visible
-/// regardless of display density.
+/// A top-down minimap re-renders on a 500 ms interval, and two
+/// configurable panels render the same fixed camera side by side. Each
+/// panel has its own render resolution (the texture resizes while the
+/// on-screen area stays fixed, so low resolutions pixelate), display
+/// filtering, and per-view anti-aliasing mode, making the AA modes easy
+/// to compare regardless of display density.
 class ExampleRenderTarget extends StatefulWidget {
   const ExampleRenderTarget({super.key});
 
@@ -22,7 +22,25 @@ class ExampleRenderTarget extends StatefulWidget {
   ExampleRenderTargetState createState() => ExampleRenderTargetState();
 }
 
+/// One comparison panel's render target, view, and display settings.
+class _ComparePanel {
+  _ComparePanel({
+    required this.target,
+    required this.view,
+    required this.height,
+    required this.filter,
+  });
+
+  final RenderTexture target;
+  final RenderView view;
+  int height;
+  FilterQuality filter;
+}
+
 class ExampleRenderTargetState extends State<ExampleRenderTarget> {
+  static const double _aspect = 4 / 3;
+  static const List<int> _heights = [1080, 720, 540, 360, 240, 180, 120, 90];
+
   Scene scene = Scene();
 
   final RenderTexture _minimap = RenderTexture(
@@ -30,8 +48,10 @@ class ExampleRenderTargetState extends State<ExampleRenderTarget> {
     height: 320,
     update: const RenderTextureUpdate.interval(Duration(milliseconds: 500)),
   );
-  final RenderTexture _aaOff = RenderTexture(width: 240, height: 180);
-  final RenderTexture _aaScene = RenderTexture(width: 240, height: 180);
+
+  late final List<_ComparePanel> _panels;
+
+  static int _widthFor(int height) => (height * _aspect).round();
 
   @override
   void initState() {
@@ -45,6 +65,27 @@ class ExampleRenderTargetState extends State<ExampleRenderTarget> {
       position: vm.Vector3(2.2, 1.2, 2.2),
       target: vm.Vector3(0, 0, 0),
     );
+    _ComparePanel makePanel(AntiAliasingMode mode) {
+      const height = 180;
+      final target = RenderTexture(width: _widthFor(height), height: height);
+      final view = RenderView(
+        camera: compareCamera,
+        target: target,
+        antiAliasingMode: mode,
+      );
+      return _ComparePanel(
+        target: target,
+        view: view,
+        height: height,
+        filter: FilterQuality.none,
+      );
+    }
+
+    _panels = [
+      makePanel(AntiAliasingMode.none),
+      makePanel(AntiAliasingMode.auto),
+    ];
+
     scene.views.addAll([
       RenderView(
         camera: PerspectiveCamera(
@@ -53,43 +94,107 @@ class ExampleRenderTargetState extends State<ExampleRenderTarget> {
         ),
         target: _minimap,
       ),
-      RenderView(
-        camera: compareCamera,
-        target: _aaOff,
-        antiAliasingMode: AntiAliasingMode.none,
-      ),
-      RenderView(camera: compareCamera, target: _aaScene),
+      for (final panel in _panels) panel.view,
     ]);
 
     super.initState();
   }
 
-  Widget _inset(String label, RenderTexture target, {required double width}) {
+  Widget _label(String text) => Container(
+    color: Colors.black54,
+    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+    child: Text(
+      text,
+      style: const TextStyle(color: Colors.white, fontSize: 12),
+    ),
+  );
+
+  Widget _dropdownRow<T>({
+    required String label,
+    required T value,
+    required List<T> items,
+    required String Function(T) name,
+    required void Function(T) onChanged,
+  }) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 52,
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white, fontSize: 12),
+          ),
+        ),
+        DropdownButton<T>(
+          value: value,
+          isDense: true,
+          dropdownColor: Colors.black87,
+          style: const TextStyle(color: Colors.white, fontSize: 12),
+          items: [
+            for (final item in items)
+              DropdownMenuItem(value: item, child: Text(name(item))),
+          ],
+          onChanged: (value) {
+            if (value != null) {
+              setState(() => onChanged(value));
+            }
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _comparePanel(_ComparePanel panel) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Container(
-          width: width,
-          height: width * target.height / target.width,
+          width: 240,
+          height: 240 / _aspect,
           decoration: BoxDecoration(
             border: Border.all(color: Colors.white54),
             color: Colors.black26,
           ),
-          // Nearest sampling keeps the upscale honest: each texture pixel
-          // maps to a visible block, so the AA comparison reads clearly.
           child: RenderTextureView(
-            target,
+            panel.target,
             fit: BoxFit.fill,
-            filterQuality: FilterQuality.none,
+            filterQuality: panel.filter,
           ),
         ),
         Container(
           color: Colors.black54,
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-          child: Text(
-            label,
-            style: const TextStyle(color: Colors.white, fontSize: 12),
+          padding: const EdgeInsets.all(6),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _dropdownRow<int>(
+                label: 'Height',
+                value: panel.height,
+                items: _heights,
+                name: (h) => '${_widthFor(h)}x$h',
+                onChanged: (h) {
+                  panel.height = h;
+                  panel.target.resize(_widthFor(h), h);
+                },
+              ),
+              _dropdownRow<FilterQuality>(
+                label: 'Filter',
+                value: panel.filter,
+                items: FilterQuality.values,
+                name: (f) => f.name,
+                onChanged: (f) => panel.filter = f,
+              ),
+              _dropdownRow<AntiAliasingMode>(
+                label: 'AA',
+                value: panel.view.antiAliasingMode!,
+                items: AntiAliasingMode.values,
+                name: (m) => m.name,
+                onChanged: (m) => panel.view.antiAliasingMode = m,
+              ),
+            ],
           ),
         ),
       ],
@@ -114,21 +219,32 @@ class ExampleRenderTargetState extends State<ExampleRenderTarget> {
         Positioned(
           top: 12,
           left: 12,
-          child: _inset(
-            'Top-down view (re-renders every 500 ms)',
-            _minimap,
-            width: 160,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 160,
+                height: 160,
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.white54),
+                  color: Colors.black26,
+                ),
+                child: RenderTextureView(_minimap),
+              ),
+              _label('Top-down view (re-renders every 500 ms)'),
+            ],
           ),
         ),
         Positioned(
           bottom: 12,
           left: 12,
           child: Row(
-            crossAxisAlignment: CrossAxisAlignment.end,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _inset('Anti-aliasing off', _aaOff, width: 240),
+              _comparePanel(_panels[0]),
               const SizedBox(width: 12),
-              _inset('Scene anti-aliasing', _aaScene, width: 240),
+              _comparePanel(_panels[1]),
             ],
           ),
         ),

--- a/examples/flutter_app/lib/example_render_target.dart
+++ b/examples/flutter_app/lib/example_render_target.dart
@@ -230,33 +230,40 @@ class ExampleRenderTargetState extends State<ExampleRenderTarget> {
           },
           onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
         ),
+        // Scrolls horizontally so the panels fit a narrow (phone) screen
+        // instead of overflowing.
         Positioned(
           bottom: 12,
-          left: 12,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Container(
-                    width: 160,
-                    height: 160,
-                    decoration: BoxDecoration(
-                      border: Border.all(color: Colors.white54),
-                      color: Colors.black26,
+          left: 0,
+          right: 0,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      width: 160,
+                      height: 160,
+                      decoration: BoxDecoration(
+                        border: Border.all(color: Colors.white54),
+                        color: Colors.black26,
+                      ),
+                      child: RenderTextureView(_minimap),
                     ),
-                    child: RenderTextureView(_minimap),
-                  ),
-                  _label('Top-down view (re-renders every 500 ms)'),
-                ],
-              ),
-              const SizedBox(width: 12),
-              _comparePanel(_panels[0]),
-              const SizedBox(width: 12),
-              _comparePanel(_panels[1]),
-            ],
+                    _label('Top-down view (re-renders every 500 ms)'),
+                  ],
+                ),
+                const SizedBox(width: 12),
+                _comparePanel(_panels[0]),
+                const SizedBox(width: 12),
+                _comparePanel(_panels[1]),
+              ],
+            ),
           ),
         ),
       ],

--- a/examples/flutter_app/lib/example_render_target.dart
+++ b/examples/flutter_app/lib/example_render_target.dart
@@ -48,7 +48,7 @@ class ExampleRenderTargetState extends State<ExampleRenderTarget> {
     scene.views.addAll([
       RenderView(
         camera: PerspectiveCamera(
-          position: vm.Vector3(0, 8, 0.01),
+          position: vm.Vector3(0, 4, 0.01),
           target: vm.Vector3(0, 0, 0),
         ),
         target: _minimap,
@@ -114,7 +114,11 @@ class ExampleRenderTargetState extends State<ExampleRenderTarget> {
         Positioned(
           top: 12,
           left: 12,
-          child: _inset('Top view (updates at 2 Hz)', _minimap, width: 160),
+          child: _inset(
+            'Top-down view (re-renders every 500 ms)',
+            _minimap,
+            width: 160,
+          ),
         ),
         Positioned(
           bottom: 12,

--- a/examples/flutter_app/lib/example_render_target.dart
+++ b/examples/flutter_app/lib/example_render_target.dart
@@ -231,31 +231,28 @@ class ExampleRenderTargetState extends State<ExampleRenderTarget> {
           onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
         ),
         Positioned(
-          top: 12,
-          left: 12,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                width: 160,
-                height: 160,
-                decoration: BoxDecoration(
-                  border: Border.all(color: Colors.white54),
-                  color: Colors.black26,
-                ),
-                child: RenderTextureView(_minimap),
-              ),
-              _label('Top-down view (re-renders every 500 ms)'),
-            ],
-          ),
-        ),
-        Positioned(
           bottom: 12,
           left: 12,
           child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.end,
             children: [
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 160,
+                    height: 160,
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.white54),
+                      color: Colors.black26,
+                    ),
+                    child: RenderTextureView(_minimap),
+                  ),
+                  _label('Top-down view (re-renders every 500 ms)'),
+                ],
+              ),
+              const SizedBox(width: 12),
               _comparePanel(_panels[0]),
               const SizedBox(width: 12),
               _comparePanel(_panels[1]),

--- a/examples/flutter_app/lib/example_settings.dart
+++ b/examples/flutter_app/lib/example_settings.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'dart:ui' show FilterQuality;
 
 import 'package:flutter_scene/gpu.dart' as gpu;
 import 'package:flutter_scene/scene.dart';
@@ -32,6 +33,14 @@ class ExampleSettings {
   /// Anti-aliasing mode shared across the examples.
   AntiAliasingMode antiAliasingMode = AntiAliasingMode.auto;
 
+  /// Render scale shared across the examples (resolution relative to the
+  /// display's native, applied to screen views).
+  double renderScale = 1.0;
+
+  /// Sampling quality the rendered image is composited with, shared
+  /// across the examples.
+  FilterQuality filterQuality = FilterQuality.medium;
+
   /// Whether the shared directional light is attached to the scene.
   bool directionalLightEnabled = true;
 
@@ -63,6 +72,8 @@ class ExampleSettings {
     if (scene.antiAliasingMode != antiAliasingMode) {
       scene.antiAliasingMode = antiAliasingMode;
     }
+    scene.renderScale = renderScale;
+    scene.filterQuality = filterQuality;
 
     final grading = scene.postProcess.colorGrading;
     grading.enabled = colorGrading.enabled;

--- a/examples/flutter_app/lib/example_settings.dart
+++ b/examples/flutter_app/lib/example_settings.dart
@@ -29,6 +29,9 @@ class ExampleSettings {
   /// Screen-space ambient occlusion shared across the examples.
   final AmbientOcclusionSettings ambientOcclusion = AmbientOcclusionSettings();
 
+  /// Anti-aliasing mode shared across the examples.
+  AntiAliasingMode antiAliasingMode = AntiAliasingMode.auto;
+
   /// Whether the shared directional light is attached to the scene.
   bool directionalLightEnabled = true;
 
@@ -57,6 +60,10 @@ class ExampleSettings {
 
   /// Copies the shared settings onto [scene] so its next frame uses them.
   void applyTo(Scene scene) {
+    if (scene.antiAliasingMode != antiAliasingMode) {
+      scene.antiAliasingMode = antiAliasingMode;
+    }
+
     final grading = scene.postProcess.colorGrading;
     grading.enabled = colorGrading.enabled;
     grading.brightness = colorGrading.brightness;

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -338,11 +338,12 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
               child: _slider(
                 'Render scale',
                 exampleSettings.renderScale,
-                0.25,
+                0.001,
                 2,
                 (v) {
                   exampleSettings.renderScale = v;
                 },
+                decimals: 3,
               ),
             ),
             IconButton(
@@ -631,8 +632,9 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
     double value,
     double min,
     double max,
-    ValueChanged<double> onChanged,
-  ) {
+    ValueChanged<double> onChanged, {
+    int decimals = 2,
+  }) {
     final textStyle = Theme.of(context).textTheme.bodySmall;
     return Row(
       children: [
@@ -648,7 +650,7 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
         SizedBox(
           width: 36,
           child: Text(
-            value.toStringAsFixed(2),
+            value.toStringAsFixed(decimals),
             style: textStyle,
             textAlign: TextAlign.right,
           ),

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -253,7 +253,7 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      _buildAntiAliasing(),
+                      _buildRendering(),
                       _buildDirectionalLight(),
                       _buildAmbientOcclusion(),
                       _buildPostProcessing(),
@@ -268,18 +268,18 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
     );
   }
 
-  Widget _buildAntiAliasing() {
+  Widget _buildRendering() {
     final msaaSupported = Scene.isAntiAliasingModeSupported(
       AntiAliasingMode.msaa,
     );
     return ExpansionTile(
-      title: const Text('Anti-aliasing'),
+      title: const Text('Rendering'),
       initiallyExpanded: true,
       childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
       children: [
         Row(
           children: [
-            const Text('Mode'),
+            const Text('Anti-aliasing'),
             const Spacer(),
             DropdownButton<AntiAliasingMode>(
               value: exampleSettings.antiAliasingMode,
@@ -303,6 +303,29 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
               'with FXAA.',
             ),
           ),
+        _slider('Render scale', exampleSettings.renderScale, 0.25, 2, (v) {
+          // Snap to quarter steps; each change reallocates the swapchain,
+          // so a continuous slider would thrash while dragging.
+          exampleSettings.renderScale = (v * 4).roundToDouble() / 4;
+        }),
+        Row(
+          children: [
+            const Text('Filter'),
+            const Spacer(),
+            DropdownButton<FilterQuality>(
+              value: exampleSettings.filterQuality,
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() => exampleSettings.filterQuality = value);
+                }
+              },
+              items: [
+                for (final quality in FilterQuality.values)
+                  DropdownMenuItem(value: quality, child: Text(quality.name)),
+              ],
+            ),
+          ],
+        ),
       ],
     );
   }

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -198,6 +198,7 @@ class _SettingsSidebar extends StatefulWidget {
 
 class _SettingsSidebarState extends State<_SettingsSidebar> {
   bool _expanded = false;
+  double _width = 320;
 
   @override
   Widget build(BuildContext context) {
@@ -218,47 +219,75 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
       );
     }
 
+    final maxWidth = MediaQuery.of(context).size.width - 32;
     return Material(
       color: surface,
       borderRadius: BorderRadius.circular(8),
       elevation: 2,
       child: SizedBox(
-        width: 320,
+        width: _width.clamp(280.0, maxWidth),
         child: ConstrainedBox(
           constraints: BoxConstraints(
             maxHeight: MediaQuery.of(context).size.height - 16,
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 4, 4, 0),
-                child: Row(
-                  children: [
-                    Text(
-                      'Settings',
-                      style: Theme.of(context).textTheme.titleMedium,
+              // Drag the panel's left edge to resize it.
+              MouseRegion(
+                cursor: SystemMouseCursors.resizeLeftRight,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onHorizontalDragUpdate: (details) => setState(() {
+                    _width = (_width - details.delta.dx).clamp(280.0, maxWidth);
+                  }),
+                  child: const SizedBox(
+                    width: 8,
+                    child: Center(
+                      child: SizedBox(
+                        width: 2,
+                        height: 32,
+                        child: ColoredBox(color: Colors.black26),
+                      ),
                     ),
-                    const Spacer(),
-                    IconButton(
-                      icon: const Icon(Icons.close),
-                      tooltip: 'Close settings',
-                      onPressed: () => setState(() => _expanded = false),
-                    ),
-                  ],
+                  ),
                 ),
               ),
-              Flexible(
-                child: SingleChildScrollView(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      _buildRendering(),
-                      _buildDirectionalLight(),
-                      _buildAmbientOcclusion(),
-                      _buildPostProcessing(),
-                    ],
-                  ),
+              Expanded(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(8, 4, 4, 0),
+                      child: Row(
+                        children: [
+                          Text(
+                            'Settings',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const Spacer(),
+                          IconButton(
+                            icon: const Icon(Icons.close),
+                            tooltip: 'Close settings',
+                            onPressed: () => setState(() => _expanded = false),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Flexible(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            _buildRendering(),
+                            _buildDirectionalLight(),
+                            _buildAmbientOcclusion(),
+                            _buildPostProcessing(),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],
@@ -303,11 +332,28 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
               'with FXAA.',
             ),
           ),
-        _slider('Render scale', exampleSettings.renderScale, 0.25, 2, (v) {
-          // Snap to quarter steps; each change reallocates the swapchain,
-          // so a continuous slider would thrash while dragging.
-          exampleSettings.renderScale = (v * 4).roundToDouble() / 4;
-        }),
+        Row(
+          children: [
+            Expanded(
+              child: _slider(
+                'Render scale',
+                exampleSettings.renderScale,
+                0.25,
+                2,
+                (v) {
+                  exampleSettings.renderScale = v;
+                },
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.restart_alt, size: 18),
+              tooltip: 'Reset render scale',
+              visualDensity: VisualDensity.compact,
+              onPressed: () =>
+                  setState(() => exampleSettings.renderScale = 1.0),
+            ),
+          ],
+        ),
         Row(
           children: [
             const Text('Filter'),

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -16,6 +16,7 @@ import 'example_instancing.dart';
 import 'example_logo.dart';
 import 'example_nav_route.dart';
 import 'example_physics.dart';
+import 'example_render_target.dart';
 import 'example_settings.dart';
 import 'example_skybox.dart';
 import 'example_widget_texture.dart';
@@ -60,6 +61,7 @@ class _MyAppState extends State<MyApp> {
       'Toon (.fmat)': (context) => const ExampleToonFmat(),
       'Custom Skybox': (context) => const ExampleSkybox(),
       'Widget Texture': (context) => const ExampleWidgetTexture(),
+      'Render Targets': (context) => const ExampleRenderTarget(),
       'Physics': (context) => FutureBuilder<void>(
         // The Rapier backend needs its wasm module loaded before a world
         // can be built on the web; wait on it here so only this example

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:example_app/example_car.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart'
-    show Scene, PostInsertion, SpecularAmbientOcclusionMode;
+    show AntiAliasingMode, Scene, PostInsertion, SpecularAmbientOcclusionMode;
 import 'package:flutter_scene_rapier/flutter_scene_rapier.dart'
     show RapierWorld;
 import 'package:example_app/example_animation.dart';
@@ -251,6 +251,7 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
+                      _buildAntiAliasing(),
                       _buildDirectionalLight(),
                       _buildAmbientOcclusion(),
                       _buildPostProcessing(),
@@ -262,6 +263,45 @@ class _SettingsSidebarState extends State<_SettingsSidebar> {
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildAntiAliasing() {
+    final msaaSupported = Scene.isAntiAliasingModeSupported(
+      AntiAliasingMode.msaa,
+    );
+    return ExpansionTile(
+      title: const Text('Anti-aliasing'),
+      initiallyExpanded: true,
+      childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      children: [
+        Row(
+          children: [
+            const Text('Mode'),
+            const Spacer(),
+            DropdownButton<AntiAliasingMode>(
+              value: exampleSettings.antiAliasingMode,
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() => exampleSettings.antiAliasingMode = value);
+                }
+              },
+              items: [
+                for (final mode in AntiAliasingMode.values)
+                  DropdownMenuItem(value: mode, child: Text(mode.name)),
+              ],
+            ),
+          ],
+        ),
+        if (!msaaSupported)
+          const Padding(
+            padding: EdgeInsets.only(top: 4),
+            child: Text(
+              'MSAA is unavailable on this backend; msaa and auto render '
+              'with FXAA.',
+            ),
+          ),
+      ],
     );
   }
 

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gpu_shaders: ^0.5.0
+  flutter_gpu_shaders: ^0.5.1
   flutter_scene: ^0.18.0
   # Native Rapier physics backend, used by the Physics example. Pulls
   # in a Rust build hook, so building this app now requires cargo.

--- a/examples/smoke_render/pubspec.yaml
+++ b/examples/smoke_render/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gpu_shaders: ^0.5.0
+  flutter_gpu_shaders: ^0.5.1
   flutter_scene: ^0.18.0
   hooks: ^2.0.0
   vector_math: ^2.1.4

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -11,6 +11,19 @@
   that sizes the target from widget layout). Views also gain a per-view
   `antiAliasingMode` override that defaults to the scene's setting.
 
+* Render targets serialize in `.fscene`. Documents gain a
+  `renderTexture` resource kind (size, update policy, sampling) and a
+  top-level `views` array binding camera nodes to targets with per-view
+  settings; material texture slots reference the same resource id the
+  producing view targets, so the wiring survives a round trip. Realize
+  with the new `realizeViews` (after `realizeScene`, sharing live
+  targets with the materials that sample them) and write back with
+  `serializeViews`. The stage now also carries the scene's
+  anti-aliasing mode, render scale, and filter quality. `CameraComponent.
+  toCamera()` now returns a `NodeCamera` that tracks its node live
+  (previously it snapshotted the transform), so node-driven cameras work
+  in persistent views.
+
 * Material texture slots now accept a `RenderTexture` for live
   render-to-texture sampling, the security-camera/monitor/mirror
   pattern. `PhysicallyBasedMaterial` and `UnlitMaterial` texture setters

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -11,6 +11,18 @@
   that sizes the target from widget layout). Views also gain a per-view
   `antiAliasingMode` override that defaults to the scene's setting.
 
+* Material texture slots now accept a `RenderTexture` for live
+  render-to-texture sampling, the security-camera/monitor/mirror
+  pattern. `PhysicallyBasedMaterial` and `UnlitMaterial` texture setters
+  (and `ShaderMaterial.setTexture`) take either a `gpu.Texture` or a
+  `RenderTexture`; a render texture resolves to its latest completed
+  frame at draw time and brings its own sampling options (the new
+  `RenderTexture.sampling`, bilinear + clamped by default). A capture
+  that can see its own consumer (including a target sampling itself)
+  reads the previous frame instead of forming a feedback loop, and a
+  target with no completed frame yet resolves to the slot's neutral
+  placeholder.
+
 * Added render scaling and composite filtering. `Scene.renderScale`
   (default 1.0) scales the resolution screen views render at relative to
   the display's native resolution, trading sharpness for fragment work

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -11,6 +11,18 @@
   that sizes the target from widget layout). Views also gain a per-view
   `antiAliasingMode` override that defaults to the scene's setting.
 
+* The prefiltered-radiance environment now stores its roughness bands as
+  mip levels of one equirect texture, sampled with hardware trilinear
+  `textureLod` (smoother roughness transitions, ~25% less memory, no
+  band-seam clamping). Enabled by the recent Flutter GPU mip support
+  (render-to-mip-level, mip samplers, and sampling manually-written mip
+  chains). The legacy stacked-band atlas remains supported, selectable
+  via the new `EnvironmentMap.useMipRadianceLayout` static (each
+  environment carries its own layout, and the
+  `SamplePrefilteredRadiance` shader contract for custom materials is
+  unchanged). The web backend gained render-to-mip-level attachments and
+  mip-aware sampler filtering.
+
 * Render targets serialize in `.fscene`. Documents gain a
   `renderTexture` resource kind (size, update policy, sampling) and a
   top-level `views` array binding camera nodes to targets with per-view

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 0.18.0
 
+* Added FXAA and an automatic anti-aliasing mode. `AntiAliasingMode` gains
+  `fxaa` (a post-process pass over the tone-mapped image, available on
+  every backend) and `auto` (MSAA where the backend supports it, FXAA
+  otherwise), and `auto` is the new default. Backends without offscreen
+  MSAA support previously rendered with no anti-aliasing at all; they now
+  get FXAA. `Scene.antiAliasingMode` now always keeps the requested mode
+  (instead of ignoring unsupported assignments), the new
+  `Scene.effectiveAntiAliasingMode` reports the technique that actually
+  runs, and the new static `Scene.isAntiAliasingModeSupported` answers
+  support queries without touching the Flutter GPU API.
+
 * Adopted hardware instancing: `InstancedMesh` draws upload every instance
   transform to an instance-rate vertex buffer and render with a single
   instanced draw call per winding-parity group (in the color, depth-prepass,

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -23,6 +23,14 @@
   unchanged). The web backend gained render-to-mip-level attachments and
   mip-aware sampler filtering.
 
+* Fixed dim image-based specular lighting on the web backend. The radiance
+  prefilter (a float render-to-texture) comes out degenerate on a cold
+  WebGL context, before the first frame has been composited, and is correct
+  once the context is warm. Environments built before then (the lazily
+  built default, or any an app builds up front) now retain their source and
+  re-bake their radiance once a frame has been presented, so the first frame
+  may show dim specular IBL but every frame after is correct.
+
 * Render targets serialize in `.fscene`. Documents gain a
   `renderTexture` resource kind (size, update policy, sampling) and a
   top-level `views` array binding camera nodes to targets with per-view

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -11,6 +11,14 @@
   that sizes the target from widget layout). Views also gain a per-view
   `antiAliasingMode` override that defaults to the scene's setting.
 
+* Added render scaling and composite filtering. `Scene.renderScale`
+  (default 1.0) scales the resolution screen views render at relative to
+  the display's native resolution, trading sharpness for fragment work
+  below 1.0 and supersampling above it, and `Scene.filterQuality`
+  (default medium) sets the sampling quality the rendered image is
+  composited onto the canvas with. Both have per-view overrides on
+  `RenderView` (`renderScale`, `filterQuality`).
+
 * Added FXAA and an automatic anti-aliasing mode. `AntiAliasingMode` gains
   `fxaa` (a post-process pass over the tone-mapped image, available on
   every backend) and `auto` (MSAA where the backend supports it, FXAA

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 0.18.0
 
+* Added offscreen render targets. A `RenderTexture` is a fixed-size target
+  a `RenderView` can render into (`RenderView.target`); add such views to
+  the new `Scene.views` list and they render whenever the scene renders,
+  ordered before the screen views. The target's `update` policy
+  (`everyFrame`, `interval`, or `manual` + `requestUpdate`, mirroring
+  `WidgetUpdatePolicy`) controls re-render cadence, and `resize`
+  reallocates on the fly. Display a live target in the widget tree with
+  the new `RenderTextureView` widget (with an opt-in `followLayout` mode
+  that sizes the target from widget layout). Views also gain a per-view
+  `antiAliasingMode` override that defaults to the scene's setting.
+
 * Added FXAA and an automatic anti-aliasing mode. `AntiAliasingMode` gains
   `fxaa` (a post-process pass over the tone-mapped image, available on
   every backend) and `auto` (MSAA where the backend supports it, FXAA

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -31,6 +31,12 @@
   re-bake their radiance once a frame has been presented, so the first frame
   may show dim specular IBL but every frame after is correct.
 
+* The base shader bundle now loads asynchronously on every backend,
+  following `ShaderLibrary.fromAsset` becoming async. Native joins web in
+  requiring the bundle to be loaded ahead of time by awaiting
+  `Scene.initializeStaticResources()` before constructing geometry or
+  materials; the native synchronous load on first access is gone.
+
 * Render targets serialize in `.fscene`. Documents gain a
   `renderTexture` resource kind (size, update policy, sampling) and a
   top-level `views` array binding camera nodes to targets with per-view

--- a/packages/flutter_scene/hook/build.dart
+++ b/packages/flutter_scene/hook/build.dart
@@ -8,6 +8,12 @@ void main(List<String> args) async {
       buildInput: config,
       buildOutput: output,
       manifestFileName: 'shaders/base.shaderbundle.json',
+      // GLSL ES 3.00 for the OpenGL ES dialect. The radiance sampling uses
+      // textureLod, which is core in 300 es; the 1.00 form needs
+      // GL_EXT_shader_texture_lod, which software GL stacks (Mesa llvmpipe,
+      // Android emulators) reject at compile time. Sets the native GLES
+      // floor at OpenGL ES 3.0.
+      glesLanguageVersion: 300,
     );
   });
 }

--- a/packages/flutter_scene/lib/fscene.dart
+++ b/packages/flutter_scene/lib/fscene.dart
@@ -68,6 +68,7 @@ export 'src/fscene/realize/realize.dart'
         serializeScene;
 export 'src/fscene/realize/resource_realizer.dart' show ResourceRealizer;
 export 'src/fscene/realize/stage.dart' show realizeStage, serializeStage;
+export 'src/fscene/realize/views.dart' show realizeViews, serializeViews;
 export 'src/fscene/scene_document.dart' show SceneDocument;
 export 'src/fscene/specs.dart'
     show
@@ -96,6 +97,8 @@ export 'src/fscene/specs.dart'
         PrefabInstanceSpec,
         ProceduralGeometry,
         PropertyOverride,
+        RenderTextureResource,
+        RenderViewSpec,
         ResourceSpec,
         SkinSpec,
         SkyEnvironmentSpec,

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -70,7 +70,8 @@ export 'src/instanced_mesh.dart' show InstancedMesh;
 export 'src/light.dart' show DirectionalLight, Lighting, ShadowCascade;
 export 'src/render/render_layers.dart'
     show kRenderLayerAll, kRenderLayerDefault;
-export 'src/render_texture.dart' show RenderTexture, RenderTextureUpdate;
+export 'src/render_texture.dart'
+    show RenderTexture, RenderTextureSampling, RenderTextureUpdate;
 export 'src/render_view.dart' show RenderView;
 export 'src/math_extensions.dart' show QuaternionSlerp, Vector3Lerp;
 export 'src/mesh.dart' show Mesh, MeshPrimitive;

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -58,7 +58,7 @@ export 'src/asset_helpers.dart'
         imageFromBytes;
 export 'src/camera.dart'
     show Camera, CameraProjection, PerspectiveCamera, PerspectiveProjection;
-export 'src/components/camera_component.dart' show CameraComponent;
+export 'src/components/camera_component.dart' show CameraComponent, NodeCamera;
 export 'src/components/component.dart' show Component;
 export 'src/components/directional_light_component.dart'
     show DirectionalLightComponent;

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -70,6 +70,7 @@ export 'src/instanced_mesh.dart' show InstancedMesh;
 export 'src/light.dart' show DirectionalLight, Lighting, ShadowCascade;
 export 'src/render/render_layers.dart'
     show kRenderLayerAll, kRenderLayerDefault;
+export 'src/render_texture.dart' show RenderTexture, RenderTextureUpdate;
 export 'src/render_view.dart' show RenderView;
 export 'src/math_extensions.dart' show QuaternionSlerp, Vector3Lerp;
 export 'src/mesh.dart' show Mesh, MeshPrimitive;
@@ -140,6 +141,7 @@ export 'src/sky_sources.dart' show GradientSkySource, PhysicalSkySource;
 export 'src/skybox.dart'
     show EnvironmentSkySource, ShaderSkySource, SkySource, Skybox;
 export 'src/surface.dart' show Surface;
+export 'src/widgets/render_texture_view.dart' show RenderTextureView;
 export 'src/widgets/scene_view.dart'
     show SceneCameraBuilder, SceneScope, SceneTickCallback, SceneView;
 export 'src/tone_mapping.dart' show ToneMappingMode;

--- a/packages/flutter_scene/lib/src/components/camera_component.dart
+++ b/packages/flutter_scene/lib/src/components/camera_component.dart
@@ -2,6 +2,7 @@ import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/node.dart';
 
 /// An engine [Component] that places a [Camera] in the scene.
 ///
@@ -11,9 +12,10 @@ import 'package:flutter_scene/src/components/component.dart';
 /// [projection] (the lens) is configured on the component. Move or rotate
 /// the node to move or aim the camera.
 ///
-/// Use [toCamera] to capture a [Camera] for the node's current transform to
-/// pass to `Scene.render`. (The node should not be scaled; a camera node is
-/// expected to carry only rotation and translation.)
+/// Use [toCamera] to get a [Camera] backed by the node, suitable for
+/// `Scene.render` or a persistent `RenderView`. (The node should not be
+/// scaled; a camera node is expected to carry only rotation and
+/// translation.)
 /// {@category Scene graph}
 class CameraComponent extends Component {
   /// Creates a camera component with the given [projection] (a
@@ -24,42 +26,49 @@ class CameraComponent extends Component {
   /// The lens projection for this camera.
   CameraProjection projection;
 
-  /// Returns a [Camera] for the owning node's current world transform.
+  /// Returns a [NodeCamera] backed by the owning node.
   ///
-  /// The returned camera snapshots the transform, so subsequently moving
-  /// the node does not change it; call [toCamera] again for an updated
-  /// view.
-  Camera toCamera() => _NodeCamera(node.globalTransform.clone(), projection);
+  /// The returned camera tracks the node: moving or rotating the node
+  /// moves the view on the next frame, so it is safe to hold in a
+  /// persistent `RenderView`.
+  NodeCamera toCamera() => NodeCamera(node, projection);
 }
 
-/// A [Camera] whose view comes from a world transform: the `+Z` axis is the
-/// look direction, `+Y` is up, and the translation is the eye. This is the
-/// inverse of the eye/target/up convention [PerspectiveCamera] builds, so a
-/// node placed at `inverse(camera.getViewMatrix())` yields the same view.
-class _NodeCamera extends Camera {
-  _NodeCamera(this._worldTransform, this.projection);
+/// A [Camera] whose view comes from a [node]'s world transform: the `+Z`
+/// axis is the look direction, `+Y` is up, and the translation is the eye.
+/// This is the inverse of the eye/target/up convention [PerspectiveCamera]
+/// builds, so a node placed at `inverse(camera.getViewMatrix())` yields
+/// the same view.
+///
+/// The transform is read at render time, so the camera tracks the node
+/// live. Usually obtained from [CameraComponent.toCamera].
+/// {@category Scene graph}
+class NodeCamera extends Camera {
+  /// Creates a camera that tracks [node] with the given [projection].
+  NodeCamera(this.node, this.projection);
 
-  final Matrix4 _worldTransform;
+  /// The node whose world transform drives the view.
+  final Node node;
 
   @override
   final CameraProjection projection;
+
+  Matrix4 get _worldTransform => node.globalTransform;
 
   @override
   Vector3 get position => _worldTransform.getTranslation();
 
   @override
-  Vector3 get forward => Vector3(
-    _worldTransform[8],
-    _worldTransform[9],
-    _worldTransform[10],
-  ).normalized();
+  Vector3 get forward {
+    final transform = _worldTransform;
+    return Vector3(transform[8], transform[9], transform[10]).normalized();
+  }
 
   @override
-  Vector3 get up => Vector3(
-    _worldTransform[4],
-    _worldTransform[5],
-    _worldTransform[6],
-  ).normalized();
+  Vector3 get up {
+    final transform = _worldTransform;
+    return Vector3(transform[4], transform[5], transform[6]).normalized();
+  }
 
   @override
   Matrix4 getViewMatrix() {

--- a/packages/flutter_scene/lib/src/fmat/build_materials.dart
+++ b/packages/flutter_scene/lib/src/fmat/build_materials.dart
@@ -314,6 +314,10 @@ Future<void> buildMaterials({
         buildOutput: buildOutput,
         manifestFileName: manifestRelativePath,
         includeDirectories: [frameworkShaders],
+        // Match the engine bundle's GLES dialect (GLSL ES 3.00); the
+        // framework radiance sampling these materials can `#include` uses
+        // textureLod, which is not available in 1.00 without an extension.
+        glesLanguageVersion: 300,
       );
     } catch (_) {
       // Roll back only when the failed compile actually disturbed the bundle;

--- a/packages/flutter_scene/lib/src/fscene/compose/compose.dart
+++ b/packages/flutter_scene/lib/src/fscene/compose/compose.dart
@@ -452,6 +452,15 @@ ResourceSpec _remapResource(ResourceSpec r, LocalId Function(LocalId) remap) =>
         properties: _remapProperties(r.properties, remap),
         asset: r.asset,
       ),
+      RenderTextureResource() => RenderTextureResource(
+        remap(r.id),
+        width: r.width,
+        height: r.height,
+        update: r.update,
+        intervalMilliseconds: r.intervalMilliseconds,
+        filter: r.filter,
+        wrap: r.wrap,
+      ),
     };
 
 PayloadSpec _remapPayload(PayloadSpec p, LocalId Function(LocalId) remap) =>

--- a/packages/flutter_scene/lib/src/fscene/json/fscene_json.dart
+++ b/packages/flutter_scene/lib/src/fscene/json/fscene_json.dart
@@ -19,6 +19,7 @@ const Set<String> supportedFeatures = {
   'skinning',
   'prefabInstances',
   'streaming',
+  'renderTextures',
 };
 
 /// Upgrades a raw decoded document one version forward (version `N` to
@@ -162,8 +163,24 @@ Map<String, dynamic> encodeDocument(SceneDocument doc) {
   if (doc.payloads.isNotEmpty) {
     json['payloads'] = _encodeIdMap(doc.payloads, idKey, _encodePayload);
   }
+  if (doc.views.isNotEmpty) {
+    json['views'] = [for (final view in doc.views) _encodeView(view, idKey)];
+  }
   return json;
 }
+
+Map<String, dynamic> _encodeView(
+  RenderViewSpec view,
+  String Function(LocalId) idKey,
+) => {
+  'camera': idKey(view.cameraNode),
+  if (view.target != null) 'target': idKey(view.target!),
+  if (view.layerMask != 0xFFFFFFFF) 'layerMask': view.layerMask,
+  if (view.order != 0) 'order': view.order,
+  if (view.antiAliasingMode != null) 'antiAliasing': view.antiAliasingMode,
+  if (view.renderScale != null) 'renderScale': view.renderScale,
+  if (view.filterQuality != null) 'filterQuality': view.filterQuality,
+};
 
 Map<LocalId, String> _buildPrefixMap(SceneDocument doc) {
   final prefixes = <LocalId, String>{};
@@ -175,6 +192,7 @@ Map<LocalId, String> _buildPrefixMap(SceneDocument doc) {
       GeometryResource() => 'geo',
       MaterialResource() => 'mat',
       TextureResource() => 'tex',
+      RenderTextureResource() => 'rt',
     };
   }
   for (final id in doc.skins.keys) {
@@ -213,6 +231,9 @@ Map<String, dynamic> encodeStage(StageMetadata s) => {
   'environmentIntensity': s.environmentIntensity,
   'exposure': s.exposure,
   'toneMapping': s.toneMapping,
+  if (s.antiAliasingMode != 'auto') 'antiAliasing': s.antiAliasingMode,
+  if (s.renderScale != 1.0) 'renderScale': s.renderScale,
+  if (s.filterQuality != 'medium') 'filterQuality': s.filterQuality,
   if (s.skybox != null)
     'skybox': {
       'source': encodeSkySource(s.skybox!.source),
@@ -301,6 +322,24 @@ Object _encodeResource(ResourceSpec r, String Function(LocalId) idKey) {
         'kind': 'texture',
         if (payload != null) 'payload': idKey(payload),
         if (asset != null) 'ref': asset.key,
+      };
+    case RenderTextureResource(
+      :final width,
+      :final height,
+      :final update,
+      :final intervalMilliseconds,
+      :final filter,
+      :final wrap,
+    ):
+      return {
+        'kind': 'renderTexture',
+        'width': width,
+        'height': height,
+        if (update != 'everyFrame') 'update': update,
+        if (intervalMilliseconds != null)
+          'intervalMilliseconds': intervalMilliseconds,
+        if (filter != 'linear') 'filter': filter,
+        if (wrap != 'clampToEdge') 'wrap': wrap,
       };
     case MaterialResource(:final type, :final properties, :final asset):
       return {
@@ -454,6 +493,11 @@ SceneDocument decodeDocument(Map<String, dynamic> json) {
 
   // Mint future ids with a fresh session that avoids every session already
   // present in the document, so new edits cannot collide with loaded ids.
+  final views = [
+    for (final view in (json['views'] as List? ?? const []))
+      _decodeView(Map<String, dynamic>.from(view as Map)),
+  ];
+
   final usedSessions = <int>{};
   void collect(LocalId id) => usedSessions.add(id.session);
   nodes.keys.forEach(collect);
@@ -461,6 +505,10 @@ SceneDocument decodeDocument(Map<String, dynamic> json) {
   skins.keys.forEach(collect);
   animations.keys.forEach(collect);
   payloads.keys.forEach(collect);
+  for (final view in views) {
+    collect(view.cameraNode);
+    if (view.target != null) collect(view.target!);
+  }
 
   final doc = SceneDocument(
     documentId: documentId,
@@ -479,8 +527,21 @@ SceneDocument decodeDocument(Map<String, dynamic> json) {
   doc.skins.addAll(skins);
   doc.animations.addAll(animations);
   doc.payloads.addAll(payloads);
+  doc.views.addAll(views);
   return doc;
 }
+
+RenderViewSpec _decodeView(Map<String, dynamic> json) => RenderViewSpec(
+  cameraNode: LocalId.parse(json['camera'] as String),
+  target: json['target'] != null
+      ? LocalId.parse(json['target'] as String)
+      : null,
+  layerMask: json['layerMask'] as int? ?? 0xFFFFFFFF,
+  order: json['order'] as int? ?? 0,
+  antiAliasingMode: json['antiAliasing'] as String?,
+  renderScale: json['renderScale'] != null ? _d(json['renderScale']) : null,
+  filterQuality: json['filterQuality'] as String?,
+);
 
 Map<LocalId, V> _decodeIdMap<V>(
   Object? json,
@@ -605,6 +666,16 @@ ResourceSpec _decodeResource(LocalId id, Map<String, dynamic> json) {
             ? LocalId.parse(json['payload'] as String)
             : null,
         asset: json['ref'] != null ? AssetRef(json['ref'] as String) : null,
+      );
+    case 'renderTexture':
+      return RenderTextureResource(
+        id,
+        width: json['width'] as int,
+        height: json['height'] as int,
+        update: json['update'] as String? ?? 'everyFrame',
+        intervalMilliseconds: json['intervalMilliseconds'] as int?,
+        filter: json['filter'] as String? ?? 'linear',
+        wrap: json['wrap'] as String? ?? 'clampToEdge',
       );
     case 'material':
       return MaterialResource(
@@ -735,6 +806,9 @@ StageMetadata _decodeStage(Map<String, dynamic> json) => StageMetadata(
   environmentIntensity: _d(json['environmentIntensity'] ?? 1.0),
   exposure: _d(json['exposure'] ?? 1.0),
   toneMapping: json['toneMapping'] as String? ?? 'pbrNeutral',
+  antiAliasingMode: json['antiAliasing'] as String? ?? 'auto',
+  renderScale: _d(json['renderScale'] ?? 1.0),
+  filterQuality: json['filterQuality'] as String? ?? 'medium',
   skybox: _decodeSkybox(json['skybox']),
   skyEnvironment: _decodeSkyEnvironment(json['skyEnvironment']),
 );

--- a/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
@@ -16,6 +16,8 @@ import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/components/mesh_component.dart';
 import 'package:flutter_scene/src/fscene/id.dart';
 import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_scene/src/fscene/realize/views.dart';
+import 'package:flutter_scene/src/render_texture.dart';
 import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
 import 'package:flutter_scene/src/fscene/realize/property_read.dart';
 import 'package:flutter_scene/src/fscene/realize/resource_copy.dart';
@@ -246,23 +248,33 @@ class MeshCodec extends ComponentCodec {
     _textureProperty(
       properties,
       'baseColorTexture',
-      m.baseColorTexture,
+      m.baseColorTextureSource,
       context,
     );
     _textureProperty(
       properties,
       'metallicRoughnessTexture',
-      m.metallicRoughnessTexture,
+      m.metallicRoughnessTextureSource,
       context,
     );
-    _textureProperty(properties, 'normalTexture', m.normalTexture, context);
+    _textureProperty(
+      properties,
+      'normalTexture',
+      m.normalTextureSource,
+      context,
+    );
     _textureProperty(
       properties,
       'occlusionTexture',
-      m.occlusionTexture,
+      m.occlusionTextureSource,
       context,
     );
-    _textureProperty(properties, 'emissiveTexture', m.emissiveTexture, context);
+    _textureProperty(
+      properties,
+      'emissiveTexture',
+      m.emissiveTextureSource,
+      context,
+    );
     return context.document
         .addResource(
           MaterialResource(
@@ -282,7 +294,7 @@ class MeshCodec extends ComponentCodec {
     _textureProperty(
       properties,
       'baseColorTexture',
-      m.baseColorTexture,
+      m.baseColorTextureSource,
       context,
     );
     return context.document
@@ -298,14 +310,22 @@ class MeshCodec extends ComponentCodec {
 
   ColorValue _color(Vector4 v) => ColorValue(v.x, v.y, v.z, v.w);
 
+  // [source] is the slot's raw value: a gpu.Texture, a live RenderTexture
+  // (serialized from its live state by id), or null.
   void _textureProperty(
     Map<String, PropertyValue> properties,
     String key,
-    gpu.Texture? texture,
+    Object? source,
     SerializeContext context,
   ) {
-    if (texture == null) return;
-    final id = _serializeTexture(texture, context);
+    if (source == null) return;
+    if (source is RenderTexture) {
+      properties[key] = ResourceRefValue(
+        serializeRenderTexture(source, context),
+      );
+      return;
+    }
+    final id = _serializeTexture(source as gpu.Texture, context);
     if (id == null) {
       debugPrint('fscene: material texture "$key" not serialized');
       return;

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -183,14 +183,19 @@ SceneDocument serializeScene(Node root, {FsceneComponentRegistry? registry}) {
   final context = SerializeContext(document);
 
   // First pass: assign every node its id, reusing realize-time identity tags
-  // where present (skipping duplicates from app-side clones).
+  // where present (skipping duplicates from app-side clones). Newly assigned
+  // ids are tagged back onto the nodes so follow-up passes (`serializeViews`
+  // referencing camera nodes) and future saves see stable ids.
   final ids = <Node, LocalId>{};
   final used = <LocalId>{};
   void assign(Node node) {
     final tagged = nodeFsceneId(node);
     final id = tagged != null && used.add(tagged) ? tagged : document.newId();
     ids[node] = id;
-    if (id != tagged) used.add(id);
+    if (id != tagged) {
+      used.add(id);
+      tagNodeId(node, id);
+    }
     for (final child in node.children) {
       assign(child);
     }

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_copy.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_copy.dart
@@ -53,10 +53,31 @@ LocalId copyResourceInto(
       dest.addResource(
         TextureResource(resourceId, payload: payload, asset: asset),
       );
+    case RenderTextureResource(
+      :final width,
+      :final height,
+      :final update,
+      :final intervalMilliseconds,
+      :final filter,
+      :final wrap,
+    ):
+      dest.addResource(
+        RenderTextureResource(
+          resourceId,
+          width: width,
+          height: height,
+          update: update,
+          intervalMilliseconds: intervalMilliseconds,
+          filter: filter,
+          wrap: wrap,
+        ),
+      );
     case MaterialResource(:final type, :final properties, :final asset):
       for (final value in properties.values) {
-        if (value is ResourceRefValue &&
-            source.resource(value.id) is TextureResource) {
+        if (value is! ResourceRefValue) continue;
+        final referenced = source.resource(value.id);
+        if (referenced is TextureResource ||
+            referenced is RenderTextureResource) {
           copyResourceInto(dest, source, value.id);
         }
       }

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene/src/fscene/property_value.dart';
 import 'package:flutter_scene/src/fscene/realize/fmat_overrides.dart';
 import 'package:flutter_scene/src/fscene/realize/property_read.dart';
 import 'package:flutter_scene/src/fscene/realize/resource_origin.dart';
+import 'package:flutter_scene/src/fscene/realize/views.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/fmat/material_registry.dart';
@@ -362,9 +363,16 @@ class ResourceRealizer {
     return texture;
   }
 
-  gpu.Texture? _textureRef(Map<String, PropertyValue> p, String key) {
+  // Resolves a texture property to either a gpu.Texture or, when the ref
+  // points at a render-texture resource, the live RenderTexture handle
+  // (material slots accept both).
+  Object? _textureRef(Map<String, PropertyValue> p, String key) {
     final v = p[key];
-    return v is ResourceRefValue ? texture(v.id) : null;
+    if (v is! ResourceRefValue) return null;
+    if (document.resource(v.id) is RenderTextureResource) {
+      return realizeRenderTexture(document, v.id);
+    }
+    return texture(v.id);
   }
 
   UnlitMaterial _unlit(Map<String, PropertyValue> p) {

--- a/packages/flutter_scene/lib/src/fscene/realize/stage.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/stage.dart
@@ -9,6 +9,8 @@
 /// scene's settings back into a document, the editor-save direction.
 library;
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show AssetBundle;
 
@@ -55,6 +57,17 @@ Future<void> realizeStage(
   scene.environmentIntensity = stage.environmentIntensity;
   scene.exposure = stage.exposure;
   scene.toneMapping = _toneMapping(stage.toneMapping);
+  scene.antiAliasingMode = _byName(
+    AntiAliasingMode.values,
+    stage.antiAliasingMode,
+    AntiAliasingMode.auto,
+  );
+  scene.renderScale = stage.renderScale;
+  scene.filterQuality = _byName(
+    ui.FilterQuality.values,
+    stage.filterQuality,
+    ui.FilterQuality.medium,
+  );
 
   // Realize each distinct sky source once so a skybox and sky lighting
   // describing the same sky share one live source.
@@ -114,6 +127,9 @@ void serializeStage(Scene scene, SceneDocument document) {
   stage.environmentIntensity = scene.environmentIntensity;
   stage.exposure = scene.exposure;
   stage.toneMapping = scene.toneMapping.name;
+  stage.antiAliasingMode = scene.antiAliasingMode.name;
+  stage.renderScale = scene.renderScale;
+  stage.filterQuality = scene.filterQuality.name;
 
   final skyEnvironment = scene.skyEnvironment;
   if (skyEnvironment == null) {
@@ -313,6 +329,14 @@ ToneMappingMode _toneMapping(String name) {
     debugPrint('fscene: unknown tone mapping "$name"; using pbrNeutral');
     return ToneMappingMode.pbrNeutral;
   }
+}
+
+T _byName<T extends Enum>(List<T> values, String name, T fallback) {
+  for (final value in values) {
+    if (value.name == name) return value;
+  }
+  debugPrint('fscene: unknown $T "$name"; using ${fallback.name}');
+  return fallback;
 }
 
 SkyEnvironmentRefresh _refresh(String name) {

--- a/packages/flutter_scene/lib/src/fscene/realize/views.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/views.dart
@@ -1,0 +1,214 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+
+import 'package:flutter_scene/src/components/camera_component.dart';
+import 'package:flutter_scene/src/fscene/id.dart';
+import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
+import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+import 'package:flutter_scene/src/fscene/realize/node_identity.dart';
+import 'package:flutter_scene/src/fscene/realize/resource_origin.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/node.dart';
+import 'package:flutter_scene/src/render_texture.dart';
+import 'package:flutter_scene/src/render_view.dart';
+import 'package:flutter_scene/src/scene.dart';
+
+// Live render textures realized per document instance, so the producing
+// view and every material sampling the same resource id share one handle.
+final Expando<Map<LocalId, RenderTexture>> _liveRenderTextures = Expando(
+  'fscene live render textures',
+);
+
+/// Returns the live [RenderTexture] for resource [id] of [document],
+/// creating (and memoizing) it on first use.
+///
+/// The same document instance always yields the same handle for an id, so
+/// the view targeting it and the materials sampling it stay wired to one
+/// target.
+@internal
+RenderTexture realizeRenderTexture(SceneDocument document, LocalId id) {
+  final cache = _liveRenderTextures[document] ??= {};
+  return cache.putIfAbsent(id, () {
+    final res = document.resource(id);
+    if (res is! RenderTextureResource) {
+      throw FsceneFormatException('Resource $id is not a render texture');
+    }
+    final renderTexture = RenderTexture(
+      width: res.width,
+      height: res.height,
+      update: switch (res.update) {
+        'interval' => RenderTextureUpdate.interval(
+          Duration(milliseconds: res.intervalMilliseconds ?? 1000),
+        ),
+        'manual' => RenderTextureUpdate.manual,
+        _ => RenderTextureUpdate.everyFrame,
+      },
+      sampling: RenderTextureSampling(
+        filter: res.filter == 'nearest'
+            ? gpu.MinMagFilter.nearest
+            : gpu.MinMagFilter.linear,
+        wrap: switch (res.wrap) {
+          'repeat' => gpu.SamplerAddressMode.repeat,
+          'mirror' => gpu.SamplerAddressMode.mirror,
+          _ => gpu.SamplerAddressMode.clampToEdge,
+        },
+      ),
+    );
+    return tagResourceOrigin(renderTexture, document, id);
+  });
+}
+
+/// Serializes [renderTexture] into [context]'s document (from its live
+/// state) and returns the resource id, reusing the id it originally
+/// realized from when present so references stay stable across saves.
+@internal
+LocalId serializeRenderTexture(
+  RenderTexture renderTexture,
+  SerializeContext context,
+) {
+  final cached = context.serializedResources[renderTexture];
+  if (cached != null) return cached;
+
+  final id =
+      resourceOrigin(renderTexture)?.resourceId ?? context.document.newId();
+  if (context.document.resource(id) == null) {
+    context.document.addResource(
+      RenderTextureResource(
+        id,
+        width: renderTexture.width,
+        height: renderTexture.height,
+        update: renderTexture.update.kindName,
+        intervalMilliseconds:
+            renderTexture.update.intervalDuration?.inMilliseconds,
+        filter: renderTexture.sampling.filter == gpu.MinMagFilter.nearest
+            ? 'nearest'
+            : 'linear',
+        wrap: switch (renderTexture.sampling.wrap) {
+          gpu.SamplerAddressMode.repeat => 'repeat',
+          gpu.SamplerAddressMode.mirror => 'mirror',
+          _ => 'clampToEdge',
+        },
+      ),
+    );
+  }
+  context.serializedResources[renderTexture] = id;
+  // Stamp the origin so later passes (and future saves) reuse this id.
+  tagResourceOrigin(renderTexture, context.document, id);
+  return id;
+}
+
+/// Realizes [document]'s serialized render views into [scene]'s view list.
+///
+/// Call after realizing the node graph (the views' cameras are
+/// `CameraComponent` nodes in [root], matched by their document ids) and
+/// adding [root] to [scene]. Views whose camera node or component is
+/// missing are skipped with a debug warning.
+void realizeViews(SceneDocument document, Scene scene, Node root) {
+  for (final spec in document.views) {
+    final node = _findNodeById(root, spec.cameraNode);
+    if (node == null) {
+      debugPrint(
+        'fscene: skipping render view; camera node ${spec.cameraNode} '
+        'was not found in the realized graph.',
+      );
+      continue;
+    }
+    final component = node.getComponents<CameraComponent>().firstOrNull;
+    if (component == null) {
+      debugPrint(
+        'fscene: skipping render view; node ${spec.cameraNode} has no '
+        'CameraComponent.',
+      );
+      continue;
+    }
+    scene.views.add(
+      RenderView(
+        camera: component.toCamera(),
+        target: spec.target == null
+            ? null
+            : realizeRenderTexture(document, spec.target!),
+        layerMask: spec.layerMask,
+        order: spec.order,
+        antiAliasingMode: spec.antiAliasingMode == null
+            ? null
+            : _enumByName(
+                AntiAliasingMode.values,
+                spec.antiAliasingMode!,
+                AntiAliasingMode.auto,
+              ),
+        renderScale: spec.renderScale,
+        filterQuality: spec.filterQuality == null
+            ? null
+            : _enumByName(
+                ui.FilterQuality.values,
+                spec.filterQuality!,
+                ui.FilterQuality.medium,
+              ),
+      ),
+    );
+  }
+}
+
+/// Serializes [scene]'s view list into [document]'s `views` array,
+/// replacing any existing entries.
+///
+/// Call after `serializeScene` (camera nodes are referenced by the ids
+/// that pass assigned). Views whose camera is not a node-backed
+/// `NodeCamera` within the serialized graph are skipped with a debug
+/// warning; render-texture targets are serialized from their live state.
+void serializeViews(Scene scene, SceneDocument document) {
+  final context = SerializeContext(document);
+  document.views.clear();
+  for (final view in scene.views) {
+    final camera = view.camera;
+    if (camera is! NodeCamera) {
+      debugPrint(
+        'fscene: skipping render view; its camera is not node-backed '
+        '(use a CameraComponent for serializable views).',
+      );
+      continue;
+    }
+    final cameraId = nodeFsceneId(camera.node);
+    if (cameraId == null || document.node(cameraId) == null) {
+      debugPrint(
+        'fscene: skipping render view; its camera node is not part of '
+        'the serialized graph.',
+      );
+      continue;
+    }
+    final target = view.target;
+    document.views.add(
+      RenderViewSpec(
+        cameraNode: cameraId,
+        target: target == null ? null : serializeRenderTexture(target, context),
+        layerMask: view.layerMask,
+        order: view.order,
+        antiAliasingMode: view.antiAliasingMode?.name,
+        renderScale: view.renderScale,
+        filterQuality: view.filterQuality?.name,
+      ),
+    );
+  }
+  if (document.views.isNotEmpty) {
+    document.featuresUsed.add('renderTextures');
+  }
+}
+
+Node? _findNodeById(Node root, LocalId id) {
+  if (nodeFsceneId(root) == id) return root;
+  for (final child in root.children) {
+    final found = _findNodeById(child, id);
+    if (found != null) return found;
+  }
+  return null;
+}
+
+T _enumByName<T extends Enum>(List<T> values, String name, T fallback) {
+  for (final value in values) {
+    if (value.name == name) return value;
+  }
+  return fallback;
+}

--- a/packages/flutter_scene/lib/src/fscene/scene_document.dart
+++ b/packages/flutter_scene/lib/src/fscene/scene_document.dart
@@ -64,6 +64,10 @@ class SceneDocument {
   /// The binary chunk manifest, keyed by id.
   final Map<LocalId, PayloadSpec> payloads = {};
 
+  /// Serialized render views, in order. Each binds a camera node to a
+  /// target (a [RenderTextureResource] id, or null for the screen).
+  final List<RenderViewSpec> views = [];
+
   /// Mints a fresh, document-unique [LocalId] from [allocator].
   LocalId newId() => allocator.mint();
 

--- a/packages/flutter_scene/lib/src/fscene/specs.dart
+++ b/packages/flutter_scene/lib/src/fscene/specs.dart
@@ -330,6 +330,40 @@ class TextureResource extends ResourceSpec {
   final AssetRef? asset;
 }
 
+/// An offscreen render target a serialized render view draws into and
+/// materials sample by id (the runtime `RenderTexture`).
+class RenderTextureResource extends ResourceSpec {
+  /// Creates a render-texture resource.
+  RenderTextureResource(
+    super.id, {
+    required this.width,
+    required this.height,
+    this.update = 'everyFrame',
+    this.intervalMilliseconds,
+    this.filter = 'linear',
+    this.wrap = 'clampToEdge',
+  });
+
+  /// Target width in physical pixels.
+  final int width;
+
+  /// Target height in physical pixels.
+  final int height;
+
+  /// The update policy name (`everyFrame`, `interval`, `manual`), mapped
+  /// to the runtime `RenderTextureUpdate` at realization.
+  final String update;
+
+  /// The interval for the `interval` policy, in milliseconds.
+  final int? intervalMilliseconds;
+
+  /// The sampling filter name (`linear`, `nearest`).
+  final String filter;
+
+  /// The sampling wrap-mode name (`clampToEdge`, `repeat`, `mirror`).
+  final String wrap;
+}
+
 /// A material: a [type] (for example `physicallyBased`, `unlit`, `fmat`)
 /// plus typed [properties]. An `fmat` material references its `.fmat` source
 /// via [asset].
@@ -717,6 +751,46 @@ class SkyEnvironmentSpec {
   int equirectWidth;
 }
 
+/// One serialized view of the scene: a camera node bound to a target and
+/// the view's render settings (the runtime `RenderView`).
+class RenderViewSpec {
+  /// Creates a render-view spec.
+  RenderViewSpec({
+    required this.cameraNode,
+    this.target,
+    this.layerMask = 0xFFFFFFFF,
+    this.order = 0,
+    this.antiAliasingMode,
+    this.renderScale,
+    this.filterQuality,
+  });
+
+  /// The node whose `CameraComponent` provides this view's camera.
+  final LocalId cameraNode;
+
+  /// The render-texture resource this view draws into, or null for the
+  /// screen.
+  final LocalId? target;
+
+  /// A bitmask selecting which node layers this view renders.
+  final int layerMask;
+
+  /// Compositing order among views sharing a target (lower first).
+  final int order;
+
+  /// The anti-aliasing mode name (`none`, `msaa`, `fxaa`, `auto`), or
+  /// null to inherit the stage's.
+  final String? antiAliasingMode;
+
+  /// Resolution scale relative to the display's native, or null to
+  /// inherit the stage's.
+  final double? renderScale;
+
+  /// The composite filter-quality name (`none`, `low`, `medium`, `high`),
+  /// or null to inherit the stage's.
+  final String? filterQuality;
+}
+
 /// Scene-wide, non-spatial render settings (lights and cameras are per-node
 /// components, not stage data).
 class StageMetadata {
@@ -729,6 +803,9 @@ class StageMetadata {
     this.environmentIntensity = 1.0,
     this.exposure = 1.0,
     this.toneMapping = 'pbrNeutral',
+    this.antiAliasingMode = 'auto',
+    this.renderScale = 1.0,
+    this.filterQuality = 'medium',
     this.skybox,
     this.skyEnvironment,
   });
@@ -754,6 +831,18 @@ class StageMetadata {
   /// The tone-mapping operator name (mapped to the runtime enum at
   /// realization).
   String toneMapping;
+
+  /// The anti-aliasing mode name (`none`, `msaa`, `fxaa`, `auto`), the
+  /// scene-wide default views inherit.
+  String antiAliasingMode;
+
+  /// Resolution scale relative to the display's native, the scene-wide
+  /// default views inherit.
+  double renderScale;
+
+  /// The composite filter-quality name (`none`, `low`, `medium`, `high`),
+  /// the scene-wide default views inherit.
+  String filterQuality;
 
   /// The visible background sky, when set.
   SkyboxSpec? skybox;

--- a/packages/flutter_scene/lib/src/gpu/impeller/shader_library_inline.dart
+++ b/packages/flutter_scene/lib/src/gpu/impeller/shader_library_inline.dart
@@ -14,9 +14,10 @@ ShaderLibrary compileShaderLibraryInline(
   );
 }
 
-/// Async shader-library loader. On native this just wraps flutter_gpu's
-/// synchronous `ShaderLibrary.fromAsset`; the web backend implements a
-/// genuinely async load.
+/// Async shader-library loader. On native this defers to flutter_gpu's
+/// `ShaderLibrary.fromAsset`; `Future.value` adopts its result whether that
+/// is a `ShaderLibrary?` or a `Future<ShaderLibrary?>`. The web backend
+/// implements its own async load.
 Future<ShaderLibrary?> loadShaderLibraryAsync(String assetName) {
   return Future.value(ShaderLibrary.fromAsset(assetName));
 }

--- a/packages/flutter_scene/lib/src/gpu/shared/glsl_transpile.dart
+++ b/packages/flutter_scene/lib/src/gpu/shared/glsl_transpile.dart
@@ -20,6 +20,11 @@ final RegExp _versionDirective = RegExp(
   multiLine: true,
 );
 
+final RegExp _version300Directive = RegExp(
+  r'^#version\s+300\s+es\b',
+  multiLine: true,
+);
+
 final RegExp _dropExtensionLines = RegExp(
   r'^#extension\s+'
   r'(?:GL_OES_standard_derivatives|GL_EXT_shader_texture_lod)'
@@ -76,7 +81,14 @@ String stripWebGl2CoreExtensions(String source) {
 ///
 /// [isFragment] selects the right `varying` translation and gates the
 /// fragment-output injection. Use `false` for vertex shaders.
+///
+/// Source that is already GLSL ES 3.00 (bundles compiled with
+/// `--gles-language-version=300`) is returned unchanged; everything this
+/// function rewrites is core in 300 es.
 String transpileGlslEs100To300(String source, {required bool isFragment}) {
+  if (_version300Directive.hasMatch(source)) {
+    return source;
+  }
   var out = source;
 
   out = out.replaceFirst(_versionDirective, '#version 300 es');

--- a/packages/flutter_scene/lib/src/gpu/stub/formats.dart
+++ b/packages/flutter_scene/lib/src/gpu/stub/formats.dart
@@ -40,7 +40,9 @@ enum PixelFormat {
   astc4x4LDR,
   astc4x4LDRSRGB,
   astc8x8LDR,
-  astc8x8LDRSRGB;
+  astc8x8LDRSRGB,
+  astc4x4HDR,
+  astc8x8HDR;
 
   /// Whether this is a block-compressed (sample-only) format.
   bool get isCompressed {
@@ -60,6 +62,8 @@ enum PixelFormat {
       case PixelFormat.astc4x4LDRSRGB:
       case PixelFormat.astc8x8LDR:
       case PixelFormat.astc8x8LDRSRGB:
+      case PixelFormat.astc4x4HDR:
+      case PixelFormat.astc8x8HDR:
         return true;
       default:
         return false;
@@ -68,7 +72,7 @@ enum PixelFormat {
 }
 
 /// Hardware families for block-compressed texture support.
-enum TextureCompressionFamily { bc, etc2, astc }
+enum TextureCompressionFamily { bc, etc2, astc, astcHdr }
 
 enum BlendFactor {
   zero,

--- a/packages/flutter_scene/lib/src/gpu/stub/shim_stubs.dart
+++ b/packages/flutter_scene/lib/src/gpu/stub/shim_stubs.dart
@@ -195,11 +195,15 @@ base class ColorAttachment {
     this.storeAction = StoreAction.store,
     Object? clearValue,
     required this.texture,
+    this.mipLevel = 0,
+    this.slice = 0,
     this.resolveTexture,
   });
   LoadAction loadAction;
   StoreAction storeAction;
   Texture texture;
+  int mipLevel;
+  int slice;
   Texture? resolveTexture;
 }
 
@@ -212,6 +216,8 @@ base class DepthStencilAttachment {
     this.stencilStoreAction = StoreAction.dontCare,
     this.stencilClearValue = 0,
     required this.texture,
+    this.mipLevel = 0,
+    this.slice = 0,
   });
   LoadAction depthLoadAction;
   StoreAction depthStoreAction;
@@ -220,6 +226,8 @@ base class DepthStencilAttachment {
   StoreAction stencilStoreAction;
   int stencilClearValue;
   Texture texture;
+  int mipLevel;
+  int slice;
 }
 
 base class StencilConfig {

--- a/packages/flutter_scene/lib/src/gpu/stub/shim_stubs.dart
+++ b/packages/flutter_scene/lib/src/gpu/stub/shim_stubs.dart
@@ -18,6 +18,8 @@ base class GpuContext {
   PixelFormat get defaultDepthStencilFormat => _stub();
   int get minimumUniformByteAlignment => _stub();
   bool get doesSupportOffscreenMSAA => _stub();
+  bool get doesSupportFramebufferRenderMipmap => _stub();
+  bool get doesSupportManuallyMippedTextures => _stub();
   DeviceBuffer createDeviceBuffer(StorageMode storageMode, int sizeInBytes) =>
       _stub();
   DeviceBuffer createDeviceBufferWithCopy(ByteData data) => _stub();

--- a/packages/flutter_scene/lib/src/gpu/web/formats.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/formats.dart
@@ -39,7 +39,9 @@ enum PixelFormat {
   astc4x4LDR,
   astc4x4LDRSRGB,
   astc8x8LDR,
-  astc8x8LDRSRGB;
+  astc8x8LDRSRGB,
+  astc4x4HDR,
+  astc8x8HDR;
 
   /// Whether this is a block-compressed (sample-only) format.
   bool get isCompressed {
@@ -59,6 +61,8 @@ enum PixelFormat {
       case PixelFormat.astc4x4LDRSRGB:
       case PixelFormat.astc8x8LDR:
       case PixelFormat.astc8x8LDRSRGB:
+      case PixelFormat.astc4x4HDR:
+      case PixelFormat.astc8x8HDR:
         return true;
       default:
         return false;
@@ -67,7 +71,7 @@ enum PixelFormat {
 }
 
 /// Hardware families for block-compressed texture support.
-enum TextureCompressionFamily { bc, etc2, astc }
+enum TextureCompressionFamily { bc, etc2, astc, astcHdr }
 
 enum BlendFactor {
   zero,

--- a/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
@@ -65,8 +65,10 @@ base class GpuContext {
         TextureCompressionFamily.bc => 'WEBGL_compressed_texture_s3tc',
         TextureCompressionFamily.etc2 => 'WEBGL_compressed_texture_etc',
         TextureCompressionFamily.astc => 'WEBGL_compressed_texture_astc',
+        // No WebGL extension exposes the ASTC HDR profile.
+        TextureCompressionFamily.astcHdr => null,
       };
-      return _gl.getExtension(name) != null;
+      return name != null && _gl.getExtension(name) != null;
     });
   }
 

--- a/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
@@ -178,14 +178,16 @@ base class GpuContext {
   // created (and leaked) a framebuffer and ran the synchronous
   // checkFramebufferStatus round trip every time; render targets recur every
   // frame, so both now happen once per attachment combination.
-  final Map<(Texture, Texture?), web.WebGLFramebuffer> _framebufferCache = {};
+  final Map<(Texture, int, Texture?), web.WebGLFramebuffer> _framebufferCache =
+      {};
 
   web.WebGLFramebuffer _framebufferFor(
     Texture color,
+    int mipLevel,
     Texture? depth,
     web.WebGLFramebuffer Function() create,
   ) {
-    final key = (color, depth);
+    final key = (color, mipLevel, depth);
     final cached = _framebufferCache[key];
     if (cached != null) return cached;
     if (_framebufferCache.length >= 64) {

--- a/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
@@ -54,6 +54,13 @@ base class GpuContext {
 
   bool get doesSupportOffscreenMSAA => true;
 
+  // WebGL2 framebufferTexture2D accepts any allocated mip level.
+  bool get doesSupportFramebufferRenderMipmap => true;
+
+  // texStorage2D allocates complete mip chains; per-level overwrite plus
+  // mipmap min filters sample correctly.
+  bool get doesSupportManuallyMippedTextures => true;
+
   final Map<TextureCompressionFamily, bool> _compressionSupport = {};
 
   /// Reports block-compression support by probing (and enabling) the matching

--- a/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
@@ -449,6 +449,27 @@ base class RenderPass {
     if (struct == null) return;
 
     final gl = _gpuContext._gl;
+
+    // GLSL ES 3.00 bundles expose the struct as a std140 uniform block;
+    // attach the emplaced bytes directly as a buffer range. The emplaced
+    // layout matches std140 (it is what the reflection metadata describes),
+    // and HostBuffer offsets are 256-aligned, satisfying WebGL2's
+    // UNIFORM_BUFFER_OFFSET_ALIGNMENT.
+    final blockBinding = pipeline._structBlockBindings[struct.name];
+    if (blockBinding != null) {
+      final glBuffer = bufferView.buffer._bindForTarget(
+        web.WebGL2RenderingContext.UNIFORM_BUFFER,
+      );
+      gl.bindBufferRange(
+        web.WebGL2RenderingContext.UNIFORM_BUFFER,
+        blockBinding,
+        glBuffer,
+        bufferView.offsetInBytes,
+        bufferView.lengthInBytes,
+      );
+      return;
+    }
+
     final floats = bufferView.buffer._stagingFloats;
     final base = bufferView.offsetInBytes;
     final locations = pipeline._structLocations[struct.name];

--- a/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
@@ -10,6 +10,8 @@ base class ColorAttachment {
     this.storeAction = StoreAction.store,
     vm.Vector4? clearValue,
     required this.texture,
+    this.mipLevel = 0,
+    this.slice = 0,
     this.resolveTexture,
   }) : clearValue = clearValue ?? vm.Vector4.zero();
 
@@ -17,6 +19,15 @@ base class ColorAttachment {
   StoreAction storeAction;
   vm.Vector4 clearValue;
   Texture texture;
+
+  /// The mip level of [texture] to render into.
+  int mipLevel;
+
+  /// The slice of [texture] to render into. Cubemap textures are not
+  /// supported on the web backend, so this must be 0.
+  // TODO(rendertarget): cubemap slices on the web backend.
+  int slice;
+
   Texture? resolveTexture;
 }
 
@@ -29,6 +40,8 @@ base class DepthStencilAttachment {
     this.stencilStoreAction = StoreAction.dontCare,
     this.stencilClearValue = 0,
     required this.texture,
+    this.mipLevel = 0,
+    this.slice = 0,
   });
 
   LoadAction depthLoadAction;
@@ -38,6 +51,13 @@ base class DepthStencilAttachment {
   StoreAction stencilStoreAction;
   int stencilClearValue;
   Texture texture;
+
+  /// The mip level of [texture] to render into.
+  int mipLevel;
+
+  /// The slice of [texture] to render into. Cubemap textures are not
+  /// supported on the web backend, so this must be 0.
+  int slice;
 }
 
 base class StencilConfig {
@@ -187,24 +207,44 @@ base class RenderPass {
     if (_target.colorAttachments.isEmpty) {
       throw Exception('RenderTarget must have at least one color attachment');
     }
-    final color = _target.colorAttachments.first.texture;
+    final colorAttachment = _target.colorAttachments.first;
+    final color = colorAttachment.texture;
+    final mipLevel = colorAttachment.mipLevel;
     final depth = _target.depthStencilAttachment?.texture;
+    if (colorAttachment.slice != 0 ||
+        (_target.depthStencilAttachment?.slice ?? 0) != 0) {
+      throw UnsupportedError(
+        'Rendering to texture slices is not supported on the web backend',
+      );
+    }
+    if ((_target.depthStencilAttachment?.mipLevel ?? 0) != 0) {
+      throw UnsupportedError(
+        'Rendering to a depth mip level is not supported on the web backend',
+      );
+    }
 
     // Configured framebuffers (including the completeness check, a
     // synchronous GPU round trip) are cached per attachment combination.
     final fbo = _gpuContext._framebufferFor(
       color,
+      mipLevel,
       depth,
-      () => _createFramebuffer(gl, color, depth),
+      () => _createFramebuffer(gl, color, mipLevel, depth),
     );
     _fbo = fbo;
     gl.bindFramebuffer(web.WebGL2RenderingContext.FRAMEBUFFER, fbo);
-    gl.viewport(0, 0, color.width, color.height);
+    gl.viewport(
+      0,
+      0,
+      (color.width >> mipLevel).clamp(1, color.width).toInt(),
+      (color.height >> mipLevel).clamp(1, color.height).toInt(),
+    );
   }
 
   static web.WebGLFramebuffer _createFramebuffer(
     web.WebGL2RenderingContext gl,
     Texture color,
+    int mipLevel,
     Texture? depth,
   ) {
     final fbo = gl.createFramebuffer();
@@ -219,9 +259,13 @@ base class RenderPass {
         web.WebGL2RenderingContext.COLOR_ATTACHMENT0,
         web.WebGL2RenderingContext.TEXTURE_2D,
         color.glTexture,
-        0,
+        mipLevel,
       );
     } else {
+      assert(
+        mipLevel == 0,
+        'Multisampled attachments cannot target a mip level',
+      );
       gl.framebufferRenderbuffer(
         web.WebGL2RenderingContext.FRAMEBUFFER,
         web.WebGL2RenderingContext.COLOR_ATTACHMENT0,
@@ -502,9 +546,7 @@ base class RenderPass {
       gl.texParameteri(
         web.WebGL2RenderingContext.TEXTURE_2D,
         web.WebGL2RenderingContext.TEXTURE_MIN_FILTER,
-        sampler.minFilter == MinMagFilter.nearest
-            ? web.WebGL2RenderingContext.NEAREST
-            : web.WebGL2RenderingContext.LINEAR,
+        _glMinFilter(sampler, texture),
       );
       gl.texParameteri(
         web.WebGL2RenderingContext.TEXTURE_2D,
@@ -524,6 +566,28 @@ base class RenderPass {
         _glAddressMode(sampler.heightAddressMode),
       );
     }
+  }
+
+  // The GL minification filter for [sampler]. Mipmap modes apply only when
+  // the texture actually has mip levels; a mipmap MIN_FILTER on a
+  // single-level texture is incomplete in GL and samples black.
+  static int _glMinFilter(SamplerOptions sampler, Texture texture) {
+    final nearest = sampler.minFilter == MinMagFilter.nearest;
+    if (texture.mipLevelCount <= 1) {
+      return nearest
+          ? web.WebGL2RenderingContext.NEAREST
+          : web.WebGL2RenderingContext.LINEAR;
+    }
+    return switch ((nearest, sampler.mipFilter)) {
+      (true, MipFilter.nearest) =>
+        web.WebGL2RenderingContext.NEAREST_MIPMAP_NEAREST,
+      (true, MipFilter.linear) =>
+        web.WebGL2RenderingContext.NEAREST_MIPMAP_LINEAR,
+      (false, MipFilter.nearest) =>
+        web.WebGL2RenderingContext.LINEAR_MIPMAP_NEAREST,
+      (false, MipFilter.linear) =>
+        web.WebGL2RenderingContext.LINEAR_MIPMAP_LINEAR,
+    };
   }
 
   static int _glAddressMode(SamplerAddressMode mode) {

--- a/packages/flutter_scene/lib/src/gpu/web/render_pipeline.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/render_pipeline.dart
@@ -65,6 +65,12 @@ base class RenderPipeline {
   /// list, so the per-draw uniform bind avoids building lookup strings.
   final Map<String, List<web.WebGLUniformLocation?>> _structLocations = {};
 
+  /// Uniform-block binding point per struct type name. Populated when the
+  /// linked program exposes the struct as a real uniform block (GLSL ES
+  /// 3.00 bundles), in which case the per-draw bind uses bindBufferRange
+  /// instead of per-member glUniform calls.
+  final Map<String, int> _structBlockBindings = {};
+
   /// Texture unit assigned to each reflected sampler name.
   final Map<String, int> _samplerUnits = {};
 
@@ -82,9 +88,25 @@ base class RenderPipeline {
       gl.uniform1f(yFlipLocation, -1.0);
     }
     var nextUnit = 0;
+    var nextBlockBinding = 0;
     for (final shader in [vertexShader, fragmentShader]) {
       for (final struct in shader.uniformStructs) {
-        // GL uniform names use the struct's instance name; reflection and
+        if (_structBlockBindings.containsKey(struct.name) ||
+            _structLocations.containsKey(struct.name)) {
+          continue; // already resolved via the other stage
+        }
+        // GLSL ES 3.00 bundles emit uniform structs as std140 uniform
+        // blocks (named by type). Assign each block a binding point once;
+        // the per-draw bind attaches the data with bindBufferRange.
+        final blockIndex = gl.getUniformBlockIndex(_program, struct.name);
+        if (blockIndex != web.WebGL2RenderingContext.INVALID_INDEX) {
+          final binding = nextBlockBinding++;
+          gl.uniformBlockBinding(_program, blockIndex, binding);
+          _structBlockBindings[struct.name] = binding;
+          continue;
+        }
+        // GLSL ES 1.00 bundles flatten the struct to plain uniforms. GL
+        // uniform names use the struct's instance name; reflection and
         // callers use its type name. Look up via instance, key by type.
         final instance =
             shader._structInstanceNames[struct.name] ?? struct.name;

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -88,6 +88,49 @@ class EngineLightingUniforms {
     fragInfo[159] = viewport.height > 0 ? 1.0 / viewport.height : 0.0;
   }
 
+  // Tiny constant uniform blocks (std140, 16 bytes) selecting the bound
+  // prefiltered radiance's layout in the shader (RadianceLayoutInfo in
+  // texture.glsl); device-resident so binding needs no per-frame buffer.
+  static final gpu.BufferView _mipLayoutOn = _layoutFlagBuffer(1.0);
+  static final gpu.BufferView _mipLayoutOff = _layoutFlagBuffer(0.0);
+
+  static gpu.BufferView _layoutFlagBuffer(double flag) {
+    final buffer = gpu.gpuContext.createDeviceBufferWithCopy(
+      ByteData.sublistView(Float32List(4)..[0] = flag),
+    );
+    return gpu.BufferView(buffer, offsetInBytes: 0, lengthInBytes: 16);
+  }
+
+  /// Binds the prefiltered radiance sampler plus the `RadianceLayoutInfo`
+  /// block that tells `SamplePrefilteredRadiance` which layout the bound
+  /// texture uses. Every engine site that binds `prefiltered_radiance`
+  /// goes through this so the texture and its layout flag never disagree.
+  static void bindPrefilteredRadiance(
+    gpu.RenderPass pass,
+    gpu.Shader shader,
+    EnvironmentMap env,
+  ) {
+    final mipLayout = env.usesMipRadianceLayout;
+    // Horizontal repeat (longitude wraps), vertical clamp. The mip layout
+    // needs a linear mip filter for textureLod to take effect; the legacy
+    // band atlas has a single level, where the mip filter is inert.
+    pass.bindTexture(
+      shader.getUniformSlot('prefiltered_radiance'),
+      env.prefilteredRadianceTexture,
+      sampler: gpu.SamplerOptions(
+        minFilter: gpu.MinMagFilter.linear,
+        magFilter: gpu.MinMagFilter.linear,
+        mipFilter: mipLayout ? gpu.MipFilter.linear : gpu.MipFilter.nearest,
+        widthAddressMode: gpu.SamplerAddressMode.repeat,
+        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+      ),
+    );
+    pass.bindUniform(
+      shader.getUniformSlot('RadianceLayoutInfo'),
+      mipLayout ? _mipLayoutOn : _mipLayoutOff,
+    );
+  }
+
   /// Binds the engine image-based-lighting and shadow samplers
   /// (`prefiltered_radiance`, `brdf_lut`, `shadow_map`) on [shader].
   static void bindEngineTextures(
@@ -96,18 +139,7 @@ class EngineLightingUniforms {
     Lighting lighting,
     EnvironmentMap env,
   ) {
-    // Specular IBL atlas: horizontal repeat (longitude wraps), vertical clamp
-    // (roughness bands must not bleed).
-    pass.bindTexture(
-      shader.getUniformSlot('prefiltered_radiance'),
-      env.prefilteredRadianceTexture,
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
-    );
+    bindPrefilteredRadiance(pass, shader, env);
     pass.bindTexture(
       shader.getUniformSlot('brdf_lut'),
       Material.getBrdfLutTexture(),

--- a/packages/flutter_scene/lib/src/material/environment.dart
+++ b/packages/flutter_scene/lib/src/material/environment.dart
@@ -36,10 +36,16 @@ const int kDiffuseShCoefficientCount = 9;
 /// override it via `PhysicallyBasedMaterial.environment`.
 /// {@category Lighting and environment}
 base class EnvironmentMap {
-  EnvironmentMap._(this._prefilteredRadianceTexture, List<Vector3> sh)
-    : assert(sh.length == kDiffuseShCoefficientCount),
-      _diffuseSphericalHarmonics = sh,
-      _diffuseShTexture = _shTextureFromList(sh);
+  EnvironmentMap._(
+    this._prefilteredRadianceTexture,
+    List<Vector3> sh, {
+    gpu.Texture? rebakeSource,
+    bool rebakeSourceIsLinear = false,
+  }) : assert(sh.length == kDiffuseShCoefficientCount),
+       _diffuseSphericalHarmonics = sh,
+       _diffuseShTexture = _shTextureFromList(sh) {
+    _registerForWarmupRebakeIfCold(rebakeSource, rebakeSourceIsLinear);
+  }
 
   // Wraps an already-built prefiltered atlas and a GPU-computed SH coefficient
   // texture (the diffuse term lives only on the GPU, so the coefficient list
@@ -136,7 +142,11 @@ base class EnvironmentMap {
     final sh =
         diffuseSphericalHarmonics ??
         await computeDiffuseSphericalHarmonics(radianceImage);
-    return EnvironmentMap._(prefilteredRadiance, sh);
+    return EnvironmentMap._(
+      prefilteredRadiance,
+      sh,
+      rebakeSource: radianceTexture,
+    );
   }
 
   /// Loads an [EnvironmentMap] from an equirectangular sRGB radiance image
@@ -188,7 +198,12 @@ base class EnvironmentMap {
     final sh =
         diffuseSphericalHarmonics ??
         _projectLinearEquirectToSphericalHarmonics(linearPixels, width, height);
-    return EnvironmentMap._(prefilteredRadiance, sh);
+    return EnvironmentMap._(
+      prefilteredRadiance,
+      sh,
+      rebakeSource: radianceTexture,
+      rebakeSourceIsLinear: true,
+    );
   }
 
   /// Bakes a sky into an environment for image-based lighting.
@@ -283,6 +298,7 @@ base class EnvironmentMap {
         _studioEnvWidth,
         _studioEnvHeight,
       ),
+      rebakeSource: radianceTexture,
     );
   }
 
@@ -524,9 +540,77 @@ base class EnvironmentMap {
 
   static double _srgbToLinear(double c) => math.pow(c, 2.2).toDouble();
 
-  final gpu.Texture _prefilteredRadianceTexture;
+  // Not final: re-baked in place once the web GL context is warm (see
+  // [markContextWarmAndRebakeRadiance]).
+  gpu.Texture _prefilteredRadianceTexture;
   final List<Vector3> _diffuseSphericalHarmonics;
   final gpu.Texture _diffuseShTexture;
+
+  // The equirect source this environment was prefiltered from, retained only
+  // while it awaits a warm-context re-bake (web only); dropped once re-baked
+  // or when built warm, so steady-state memory is unchanged.
+  gpu.Texture? _rebakeSource;
+  bool _rebakeSourceIsLinear = false;
+
+  // Environments built on a cold web GL context, before the first frame is
+  // composited, get a degenerate radiance prefilter (the float
+  // render-to-texture only works once the context is warm). They are tracked
+  // here and re-baked once on the first warm frame.
+  // TODO(web-warmup): this covers the equirect-source environments (studio,
+  // fromUIImages/fromAssets, fromEquirectHdr). A sky-baked environment
+  // (EnvironmentMap.fromSky, which has no equirect source) built cold is not
+  // re-baked here; a Scene.skyEnvironment with a refresh policy re-bakes
+  // itself, but a one-shot fromSky stays dim until the next bake. Retain the
+  // SkySource to re-bake it the same way if that becomes a real case.
+  static final List<EnvironmentMap> _coldBuiltEnvironments = <EnvironmentMap>[];
+  static bool _contextWarm = false;
+
+  void _registerForWarmupRebakeIfCold(gpu.Texture? source, bool isLinear) {
+    // Only the web backend has the cold-context prefilter problem; elsewhere
+    // the source is never retained and nothing is re-baked.
+    if (source == null || !kIsWeb || _contextWarm) {
+      return;
+    }
+    _rebakeSource = source;
+    _rebakeSourceIsLinear = isLinear;
+    _coldBuiltEnvironments.add(this);
+  }
+
+  void _rebakeRadianceForWarmup() {
+    final source = _rebakeSource;
+    if (source == null) {
+      return;
+    }
+    _rebakeSource = null;
+    _prefilteredRadianceTexture = prefilterEquirectRadiance(
+      source,
+      sourceIsLinear: _rebakeSourceIsLinear,
+      mipLayout: EnvironmentMap.effectiveMipRadianceLayout,
+    );
+  }
+
+  /// Marks the GL context warm and re-bakes the radiance of every environment
+  /// built while it was cold.
+  ///
+  /// On the web backend the radiance prefilter (a float render-to-texture) is
+  /// degenerate until the context has presented and the browser composited its
+  /// first frame; environments built before then (the lazily built default,
+  /// or any the app built in `initState`) hold their source equirect and
+  /// re-bake here once warm, fixing the dim image-based specular lighting.
+  /// Called from `Scene.renderViews` after the first frame is presented; a
+  /// no-op once run and on backends that never registered an environment
+  /// (everything but web).
+  @internal
+  static void markContextWarmAndRebakeRadiance() {
+    if (_contextWarm) {
+      return;
+    }
+    _contextWarm = true;
+    for (final environment in _coldBuiltEnvironments) {
+      environment._rebakeRadianceForWarmup();
+    }
+    _coldBuiltEnvironments.clear();
+  }
 
   // TODO(bdero): Replace the equirectangular prefilter with a real
   // prefiltered cubemap (render-to-slice and mipmapped textures make it

--- a/packages/flutter_scene/lib/src/material/environment.dart
+++ b/packages/flutter_scene/lib/src/material/environment.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/asset_helpers.dart';
 import 'package:flutter_scene/src/material/material.dart';
@@ -62,13 +63,31 @@ base class EnvironmentMap {
   /// Whether newly built environments store their prefiltered roughness
   /// bands as mip levels of one equirect (sampled with hardware trilinear
   /// `textureLod`) rather than the legacy vertically stacked band atlas.
-  /// Defaults to true.
+  /// Defaults to true, and applies only where the backend supports the
+  /// layout (see [mipRadianceLayoutSupported]).
   ///
-  /// The legacy layout remains supported for comparison and as a fallback
-  /// while backends are verified. Each environment carries its own layout
-  /// (detected from its texture), so flipping this affects only
-  /// environments built afterwards.
+  /// The legacy layout remains supported for comparison and as the
+  /// fallback. Each environment carries its own layout (detected from its
+  /// texture), so flipping this affects only environments built
+  /// afterwards.
   static bool useMipRadianceLayout = true;
+
+  /// Whether the active Flutter GPU backend can build and sample the mip
+  /// radiance layout: rendering into non-zero mip levels plus sampling
+  /// hand-written mip chains.
+  ///
+  /// Currently false on the native GLES backend (Impeller does not yet
+  /// implement render-to-mip-level there), where new environments build
+  /// the legacy band atlas regardless of [useMipRadianceLayout].
+  static bool get mipRadianceLayoutSupported =>
+      gpu.gpuContext.doesSupportFramebufferRenderMipmap &&
+      gpu.gpuContext.doesSupportManuallyMippedTextures;
+
+  /// The layout new environments build: [useMipRadianceLayout] resolved
+  /// against backend support.
+  @internal
+  static bool get effectiveMipRadianceLayout =>
+      useMipRadianceLayout && mipRadianceLayoutSupported;
 
   /// Wraps an already-built prefiltered radiance texture.
   ///
@@ -112,7 +131,7 @@ base class EnvironmentMap {
     final radianceTexture = await gpuTextureFromImage(radianceImage);
     final prefilteredRadiance = prefilterEquirectRadiance(
       radianceTexture,
-      mipLayout: EnvironmentMap.useMipRadianceLayout,
+      mipLayout: EnvironmentMap.effectiveMipRadianceLayout,
     );
     final sh =
         diffuseSphericalHarmonics ??
@@ -164,7 +183,7 @@ base class EnvironmentMap {
     final prefilteredRadiance = prefilterEquirectRadiance(
       radianceTexture,
       sourceIsLinear: true,
-      mipLayout: EnvironmentMap.useMipRadianceLayout,
+      mipLayout: EnvironmentMap.effectiveMipRadianceLayout,
     );
     final sh =
         diffuseSphericalHarmonics ??
@@ -257,7 +276,7 @@ base class EnvironmentMap {
     return EnvironmentMap._(
       prefilterEquirectRadiance(
         radianceTexture,
-        mipLayout: EnvironmentMap.useMipRadianceLayout,
+        mipLayout: EnvironmentMap.effectiveMipRadianceLayout,
       ),
       _projectEquirectToSphericalHarmonics(
         pixels,

--- a/packages/flutter_scene/lib/src/material/environment.dart
+++ b/packages/flutter_scene/lib/src/material/environment.dart
@@ -59,10 +59,22 @@ base class EnvironmentMap {
     );
   }
 
-  /// Wraps an already-built prefiltered-radiance atlas.
+  /// Whether newly built environments store their prefiltered roughness
+  /// bands as mip levels of one equirect (sampled with hardware trilinear
+  /// `textureLod`) rather than the legacy vertically stacked band atlas.
+  /// Defaults to true.
   ///
-  /// [prefilteredRadiance] must be a roughness-band atlas as produced by
-  /// [prefilterEquirectRadiance]. The diffuse term comes from
+  /// The legacy layout remains supported for comparison and as a fallback
+  /// while backends are verified. Each environment carries its own layout
+  /// (detected from its texture), so flipping this affects only
+  /// environments built afterwards.
+  static bool useMipRadianceLayout = true;
+
+  /// Wraps an already-built prefiltered radiance texture.
+  ///
+  /// [prefilteredRadiance] is either layout produced by
+  /// [prefilterEquirectRadiance] (mip levels or the legacy band atlas,
+  /// detected from the texture's mip count). The diffuse term comes from
   /// [diffuseSphericalHarmonics] ([kDiffuseShCoefficientCount] RGB
   /// coefficients with the Lambertian convolution and `1/pi` already folded
   /// in, as [computeDiffuseSphericalHarmonics] returns), or from
@@ -98,7 +110,10 @@ base class EnvironmentMap {
     List<Vector3>? diffuseSphericalHarmonics,
   }) async {
     final radianceTexture = await gpuTextureFromImage(radianceImage);
-    final prefilteredRadiance = prefilterEquirectRadiance(radianceTexture);
+    final prefilteredRadiance = prefilterEquirectRadiance(
+      radianceTexture,
+      mipLayout: EnvironmentMap.useMipRadianceLayout,
+    );
     final sh =
         diffuseSphericalHarmonics ??
         await computeDiffuseSphericalHarmonics(radianceImage);
@@ -149,6 +164,7 @@ base class EnvironmentMap {
     final prefilteredRadiance = prefilterEquirectRadiance(
       radianceTexture,
       sourceIsLinear: true,
+      mipLayout: EnvironmentMap.useMipRadianceLayout,
     );
     final sh =
         diffuseSphericalHarmonics ??
@@ -239,7 +255,10 @@ base class EnvironmentMap {
       _studioEnvHeight,
     )..overwrite(ByteData.sublistView(pixels));
     return EnvironmentMap._(
-      prefilterEquirectRadiance(radianceTexture),
+      prefilterEquirectRadiance(
+        radianceTexture,
+        mipLayout: EnvironmentMap.useMipRadianceLayout,
+      ),
       _projectEquirectToSphericalHarmonics(
         pixels,
         _studioEnvWidth,
@@ -490,15 +509,22 @@ base class EnvironmentMap {
   final List<Vector3> _diffuseSphericalHarmonics;
   final gpu.Texture _diffuseShTexture;
 
-  // TODO(bdero): Once mipmapped cubemaps land in Flutter GPU, replace this
-  // equirectangular atlas with a real prefiltered cubemap.
+  // TODO(bdero): Replace the equirectangular prefilter with a real
+  // prefiltered cubemap (render-to-slice and mipmapped textures make it
+  // possible now), removing the pole distortion.
   // (https://github.com/flutter/flutter/issues/145027)
-  /// The prefiltered-radiance atlas sampled for specular IBL.
+  /// The prefiltered radiance texture sampled for specular IBL.
   ///
-  /// A vertical atlas of equirectangular roughness bands (see
-  /// [prefilterEquirectRadiance]); the standard fragment shader samples it
+  /// Equirectangular roughness bands, stored as mip levels or as the
+  /// legacy vertical band atlas (see [prefilterEquirectRadiance] and
+  /// [usesMipRadianceLayout]); the standard fragment shader samples it
   /// via `SamplePrefilteredRadiance`.
   gpu.Texture get prefilteredRadianceTexture => _prefilteredRadianceTexture;
+
+  /// Whether [prefilteredRadianceTexture] stores its roughness bands as
+  /// mip levels (see [useMipRadianceLayout]).
+  bool get usesMipRadianceLayout =>
+      _prefilteredRadianceTexture.mipLevelCount > 1;
 
   /// The [kDiffuseShCoefficientCount] RGB L2 spherical-harmonic
   /// coefficients describing the diffuse (Lambertian) irradiance.

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -8,6 +8,40 @@ import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/physically_based_material.dart';
 import 'package:flutter_scene/src/material/unlit_material.dart';
+import 'package:flutter_scene/src/render_texture.dart';
+
+/// Validates a value assigned to a material texture slot.
+///
+/// Slots accept a [gpu.Texture], a [RenderTexture] (sampled live), or
+/// null; anything else throws an [ArgumentError]. Returns [value]. The
+/// setters are typed `Object?` because Dart has no overloads and the two
+/// accepted types share no usable supertype.
+@internal
+Object? checkTextureSource(Object? value, String name) {
+  if (value == null || value is gpu.Texture || value is RenderTexture) {
+    return value;
+  }
+  throw ArgumentError.value(
+    value,
+    name,
+    'Expected a gpu.Texture or a RenderTexture',
+  );
+}
+
+/// Resolves a texture-slot value to the texture to sample this frame.
+///
+/// A [RenderTexture] resolves to its latest completed frame (null before
+/// the first render, so the slot's placeholder applies).
+@internal
+gpu.Texture? resolveTextureSource(Object? source) =>
+    source is RenderTexture ? source.texture : source as gpu.Texture?;
+
+/// The sampler a texture-slot value asks for, or null to use the
+/// material's default. A [RenderTexture] carries its own
+/// [RenderTexture.sampling].
+@internal
+gpu.SamplerOptions? textureSourceSampler(Object? source) =>
+    source is RenderTexture ? source.sampling.toSamplerOptions() : null;
 
 /// Base class for shading a [MeshPrimitive].
 ///

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -52,19 +52,37 @@ class PhysicallyBasedMaterial extends Material {
   /// (e.g. [metallicFactor], [roughnessFactor]) default to neutral and
   /// can be tweaked after construction.
   PhysicallyBasedMaterial({
-    this.baseColorTexture,
-    this.metallicRoughnessTexture,
-    this.normalTexture,
-    this.emissiveTexture,
-    this.occlusionTexture,
+    gpu.Texture? baseColorTexture,
+    gpu.Texture? metallicRoughnessTexture,
+    gpu.Texture? normalTexture,
+    gpu.Texture? emissiveTexture,
+    gpu.Texture? occlusionTexture,
     this.environment,
-  }) {
+  }) : _baseColorSource = baseColorTexture,
+       _metallicRoughnessSource = metallicRoughnessTexture,
+       _normalSource = normalTexture,
+       _emissiveSource = emissiveTexture,
+       _occlusionSource = occlusionTexture {
     setFragmentShader(baseShaderLibrary['StandardFragment']!);
   }
 
+  // Texture slots hold either a gpu.Texture or a live RenderTexture; the
+  // getters resolve to the texture sampled this frame, and the setters
+  // accept both (see checkTextureSource).
+  Object? _baseColorSource;
+  Object? _metallicRoughnessSource;
+  Object? _normalSource;
+  Object? _emissiveSource;
+  Object? _occlusionSource;
+
   /// The albedo (base color) texture, sampled in linear space and
   /// multiplied by [baseColorFactor]. Defaults to white when null.
-  gpu.Texture? baseColorTexture;
+  ///
+  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live); the
+  /// getter resolves to the texture sampled this frame.
+  gpu.Texture? get baseColorTexture => resolveTextureSource(_baseColorSource);
+  set baseColorTexture(Object? value) =>
+      _baseColorSource = checkTextureSource(value, 'baseColorTexture');
 
   /// Linear RGBA tint multiplied with [baseColorTexture]. Alpha controls
   /// translucency: values below `1` push the material into the depth-
@@ -78,7 +96,12 @@ class PhysicallyBasedMaterial extends Material {
 
   /// The combined metallic-roughness texture (B = metallic,
   /// G = roughness). Defaults to white when null.
-  gpu.Texture? metallicRoughnessTexture;
+  ///
+  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live).
+  gpu.Texture? get metallicRoughnessTexture =>
+      resolveTextureSource(_metallicRoughnessSource);
+  set metallicRoughnessTexture(Object? value) => _metallicRoughnessSource =
+      checkTextureSource(value, 'metallicRoughnessTexture');
 
   /// Scalar multiplier applied to the metallic channel. `0` is fully
   /// dielectric, `1` is fully metallic.
@@ -89,7 +112,11 @@ class PhysicallyBasedMaterial extends Material {
   double roughnessFactor = 1.0;
 
   /// Tangent-space normal map. Defaults to a flat normal when null.
-  gpu.Texture? normalTexture;
+  ///
+  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live).
+  gpu.Texture? get normalTexture => resolveTextureSource(_normalSource);
+  set normalTexture(Object? value) =>
+      _normalSource = checkTextureSource(value, 'normalTexture');
 
   /// Strength of [normalTexture]'s perturbation. `1` is the unmodified
   /// map.
@@ -97,7 +124,11 @@ class PhysicallyBasedMaterial extends Material {
 
   /// Optional emissive texture. Defaults to white when null and is
   /// gated by [emissiveFactor].
-  gpu.Texture? emissiveTexture;
+  ///
+  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live).
+  gpu.Texture? get emissiveTexture => resolveTextureSource(_emissiveSource);
+  set emissiveTexture(Object? value) =>
+      _emissiveSource = checkTextureSource(value, 'emissiveTexture');
 
   /// Linear RGBA emissive tint. Alpha is unused; the default
   /// `Vector4.zero()` disables emission.
@@ -105,7 +136,11 @@ class PhysicallyBasedMaterial extends Material {
 
   /// Optional ambient-occlusion texture (R channel). Defaults to white
   /// when null.
-  gpu.Texture? occlusionTexture;
+  ///
+  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live).
+  gpu.Texture? get occlusionTexture => resolveTextureSource(_occlusionSource);
+  set occlusionTexture(Object? value) =>
+      _occlusionSource = checkTextureSource(value, 'occlusionTexture');
 
   /// Strength of [occlusionTexture]'s effect. `0` ignores the map; `1`
   /// applies it fully.
@@ -172,46 +207,11 @@ class PhysicallyBasedMaterial extends Material {
       transientsBuffer.emplace(ByteData.sublistView(fragInfo)),
     );
 
-    pass.bindTexture(
-      fragmentShader.getUniformSlot('base_color_texture'),
-      Material.whitePlaceholder(baseColorTexture),
-      sampler: gpu.SamplerOptions(
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.repeat,
-      ),
-    );
-    pass.bindTexture(
-      fragmentShader.getUniformSlot('emissive_texture'),
-      Material.whitePlaceholder(emissiveTexture),
-      sampler: gpu.SamplerOptions(
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.repeat,
-      ),
-    );
-    pass.bindTexture(
-      fragmentShader.getUniformSlot('metallic_roughness_texture'),
-      Material.whitePlaceholder(metallicRoughnessTexture),
-      sampler: gpu.SamplerOptions(
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.repeat,
-      ),
-    );
-    pass.bindTexture(
-      fragmentShader.getUniformSlot('normal_texture'),
-      Material.normalPlaceholder(normalTexture),
-      sampler: gpu.SamplerOptions(
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.repeat,
-      ),
-    );
-    pass.bindTexture(
-      fragmentShader.getUniformSlot('occlusion_texture'),
-      Material.whitePlaceholder(occlusionTexture),
-      sampler: gpu.SamplerOptions(
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.repeat,
-      ),
-    );
+    _bindSlot(pass, 'base_color_texture', _baseColorSource);
+    _bindSlot(pass, 'emissive_texture', _emissiveSource);
+    _bindSlot(pass, 'metallic_roughness_texture', _metallicRoughnessSource);
+    _bindSlot(pass, 'normal_texture', _normalSource, normal: true);
+    _bindSlot(pass, 'occlusion_texture', _occlusionSource);
     // Image-based-lighting atlas, BRDF LUT, and shadow map. Shared with
     // PreprocessedMaterial: the sampler choices (radiance repeat/clamp, LUT
     // clamp/clamp, shadow bilinear/clamp) and the white shadow placeholder
@@ -221,6 +221,31 @@ class PhysicallyBasedMaterial extends Material {
       fragmentShader,
       lighting,
       env,
+    );
+  }
+
+  static final gpu.SamplerOptions _repeatSampler = gpu.SamplerOptions(
+    widthAddressMode: gpu.SamplerAddressMode.repeat,
+    heightAddressMode: gpu.SamplerAddressMode.repeat,
+  );
+
+  // Binds one texture slot, substituting the neutral placeholder when the
+  // slot is empty (or its render texture has no completed frame yet). A
+  // RenderTexture source brings its own sampler; static textures use the
+  // material's repeat default.
+  void _bindSlot(
+    gpu.RenderPass pass,
+    String name,
+    Object? source, {
+    bool normal = false,
+  }) {
+    final resolved = resolveTextureSource(source);
+    pass.bindTexture(
+      fragmentShader.getUniformSlot(name),
+      normal
+          ? Material.normalPlaceholder(resolved)
+          : Material.whitePlaceholder(resolved),
+      sampler: textureSourceSampler(source) ?? _repeatSampler,
     );
   }
 

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -75,6 +75,20 @@ class PhysicallyBasedMaterial extends Material {
   Object? _emissiveSource;
   Object? _occlusionSource;
 
+  /// The raw slot sources (a gpu.Texture, a RenderTexture, or null), for
+  /// serialization, which must see the handle rather than the resolved
+  /// frame.
+  @internal
+  Object? get baseColorTextureSource => _baseColorSource;
+  @internal
+  Object? get metallicRoughnessTextureSource => _metallicRoughnessSource;
+  @internal
+  Object? get normalTextureSource => _normalSource;
+  @internal
+  Object? get emissiveTextureSource => _emissiveSource;
+  @internal
+  Object? get occlusionTextureSource => _occlusionSource;
+
   /// The albedo (base color) texture, sampled in linear space and
   /// multiplied by [baseColorFactor]. Defaults to white when null.
   ///

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -16,7 +16,7 @@ import 'package:flutter_scene/src/material/material_parameters.dart';
 /// parameters by name through [parameters]:
 ///
 /// ```dart
-/// final library = gpu.ShaderLibrary.fromAsset('build/shaderbundles/materials.shaderbundle')!;
+/// final library = (await gpu.loadShaderLibraryAsync('build/shaderbundles/materials.shaderbundle'))!;
 /// final metadata = jsonDecode(await rootBundle.loadString(
 ///     'build/shaderbundles/materials.fmat.json')) as Map<String, Object?>;
 /// final toon = PreprocessedMaterial(

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -147,22 +147,27 @@ class ShaderMaterial extends Material {
 
   /// Assign a texture to a sampler uniform by name.
   ///
-  /// Pass `null` for [texture] to clear the binding.
-  void setTexture(
-    String name,
-    gpu.Texture? texture, {
-    gpu.SamplerOptions? sampler,
-  }) {
+  /// [texture] accepts a [gpu.Texture] or a `RenderTexture` (sampled
+  /// live; an explicit [sampler] overrides the render texture's own
+  /// sampling). Pass `null` to clear the binding.
+  void setTexture(String name, Object? texture, {gpu.SamplerOptions? sampler}) {
     if (texture == null) {
       _textures.remove(name);
     } else {
-      _textures[name] = _BoundTexture(texture, sampler);
+      _textures[name] = _BoundTexture(
+        checkTextureSource(texture, 'texture')!,
+        sampler,
+      );
     }
   }
 
   /// Read back a previously-set texture binding, or `null` when none
   /// has been set.
-  gpu.Texture? getTexture(String name) => _textures[name]?.texture;
+  ///
+  /// A slot holding a `RenderTexture` resolves to its latest completed
+  /// frame (null before the first render).
+  gpu.Texture? getTexture(String name) =>
+      resolveTextureSource(_textures[name]?.source);
 
   /// All currently-bound sampler names. Order is insertion order.
   Iterable<String> get textureNames => _textures.keys;
@@ -187,10 +192,16 @@ class ShaderMaterial extends Material {
     }
 
     for (final entry in _textures.entries) {
+      // An empty render texture (no completed frame yet) binds the white
+      // placeholder so the sampler slot is never left dangling.
+      final resolved = resolveTextureSource(entry.value.source);
       pass.bindTexture(
         fragmentShader.getUniformSlot(entry.key),
-        entry.value.texture,
-        sampler: entry.value.sampler ?? gpu.SamplerOptions(),
+        Material.whitePlaceholder(resolved),
+        sampler:
+            entry.value.sampler ??
+            textureSourceSampler(entry.value.source) ??
+            gpu.SamplerOptions(),
       );
     }
 
@@ -224,7 +235,9 @@ class ShaderMaterial extends Material {
 }
 
 class _BoundTexture {
-  _BoundTexture(this.texture, this.sampler);
-  final gpu.Texture texture;
+  _BoundTexture(this.source, this.sampler);
+
+  /// A gpu.Texture or a RenderTexture (see checkTextureSource).
+  final Object source;
   final gpu.SamplerOptions? sampler;
 }

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 
 import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/material.dart';
 
 /// A [Material] backed by a caller-supplied fragment shader.
@@ -211,15 +212,10 @@ class ShaderMaterial extends Material {
   }
 
   void _bindEnvironmentTextures(gpu.RenderPass pass, Lighting lighting) {
-    pass.bindTexture(
-      fragmentShader.getUniformSlot('prefiltered_radiance'),
-      lighting.environmentMap.prefilteredRadianceTexture,
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
+    EngineLightingUniforms.bindPrefilteredRadiance(
+      pass,
+      fragmentShader,
+      lighting.environmentMap,
     );
     pass.bindTexture(
       fragmentShader.getUniformSlot('brdf_lut'),

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -23,7 +23,7 @@ import 'package:flutter_scene/src/material/material.dart';
 /// 2. Compile the shader through the `flutter_gpu_shaders` build
 ///    hook into a `.shaderbundle` packaged with your app.
 /// 3. Load the bundle at runtime with
-///    `gpu.ShaderLibrary.fromAsset('path/to/your.shaderbundle')` and
+///    `await gpu.loadShaderLibraryAsync('path/to/your.shaderbundle')` and
 ///    pull out the fragment shader entry.
 /// 4. Construct a `ShaderMaterial` pointing at the shader, populate
 ///    its uniform blocks and textures by name, and attach it to a

--- a/packages/flutter_scene/lib/src/material/unlit_material.dart
+++ b/packages/flutter_scene/lib/src/material/unlit_material.dart
@@ -1,5 +1,4 @@
-import 'dart:typed_data';
-
+import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/material.dart';
@@ -28,6 +27,12 @@ class UnlitMaterial extends Material {
   }
 
   Object? _baseColorSource;
+
+  /// The raw slot source (a gpu.Texture, a RenderTexture, or null), for
+  /// serialization, which must see the handle rather than the resolved
+  /// frame.
+  @internal
+  Object? get baseColorTextureSource => _baseColorSource;
 
   /// The base color texture, sampled and multiplied by [baseColorFactor].
   ///

--- a/packages/flutter_scene/lib/src/material/unlit_material.dart
+++ b/packages/flutter_scene/lib/src/material/unlit_material.dart
@@ -23,16 +23,22 @@ class UnlitMaterial extends Material {
   ///
   /// When [colorTexture] is null a 1×1 white placeholder is used so the
   /// final color reduces to [baseColorFactor].
-  UnlitMaterial({gpu.Texture? colorTexture}) {
+  UnlitMaterial({gpu.Texture? colorTexture}) : _baseColorSource = colorTexture {
     setFragmentShader(baseShaderLibrary['UnlitFragment']!);
-    baseColorTexture = Material.whitePlaceholder(colorTexture);
   }
+
+  Object? _baseColorSource;
 
   /// The base color texture, sampled and multiplied by [baseColorFactor].
   ///
-  /// Always non-null after construction; pass `null` to the constructor
-  /// to fall back to a 1×1 white placeholder.
-  late gpu.Texture baseColorTexture;
+  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live). The
+  /// getter never returns null; an empty slot (or a render texture with
+  /// no completed frame yet) resolves to a 1×1 white placeholder so the
+  /// final color reduces to [baseColorFactor].
+  gpu.Texture get baseColorTexture =>
+      Material.whitePlaceholder(resolveTextureSource(_baseColorSource));
+  set baseColorTexture(Object? value) =>
+      _baseColorSource = checkTextureSource(value, 'baseColorTexture');
 
   /// How the material's alpha is interpreted. [AlphaMode.opaque] ignores
   /// alpha; [AlphaMode.blend] routes the material through the depth-sorted
@@ -74,10 +80,12 @@ class UnlitMaterial extends Material {
     pass.bindTexture(
       fragmentShader.getUniformSlot('base_color_texture'),
       baseColorTexture,
-      sampler: gpu.SamplerOptions(
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.repeat,
-      ),
+      sampler:
+          textureSourceSampler(_baseColorSource) ??
+          gpu.SamplerOptions(
+            widthAddressMode: gpu.SamplerAddressMode.repeat,
+            heightAddressMode: gpu.SamplerAddressMode.repeat,
+          ),
     );
   }
 }

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -239,12 +239,12 @@ class _DepthPrepassEncoder {
         nodeWindingFlipped: item.windingFlipped,
       );
       if (packed.ccwCount > 0) {
-        bindInstanceTransforms(_renderPass, _transientsBuffer, packed.ccw);
+        bindInstanceTransforms(_renderPass, packed.ccw);
         _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
         item.geometry.draw(_renderPass, instanceCount: packed.ccwCount);
       }
       if (packed.cwCount > 0) {
-        bindInstanceTransforms(_renderPass, _transientsBuffer, packed.cw);
+        bindInstanceTransforms(_renderPass, packed.cw);
         _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
         item.geometry.draw(_renderPass, instanceCount: packed.cwCount);
       }
@@ -259,11 +259,7 @@ class _DepthPrepassEncoder {
       _cameraPosition,
     );
     if (item.geometry.instancedVertexLayout != null) {
-      bindSingleInstanceTransform(
-        _renderPass,
-        _transientsBuffer,
-        item.worldTransform,
-      );
+      bindSingleInstanceTransform(_renderPass, item.worldTransform);
     }
     _renderPass.setWindingOrder(
       item.windingFlipped

--- a/packages/flutter_scene/lib/src/render/env_prefilter.dart
+++ b/packages/flutter_scene/lib/src/render/env_prefilter.dart
@@ -42,50 +42,76 @@ final gpu.BufferView _fullscreenQuadView = gpu.BufferView(
 //    equirect (mapping each GGX sample's cone solid angle to a mip LOD)
 //    so a sample integrates an area instead of a point. That removes the
 //    residual sampling noise and lets kPrefilterSamples drop back to
-//    ~32. Blocked on two Flutter GPU gaps worth upstreaming: `textureLod`
-//    is unavailable in the shader dialect (see `SampleEnvironmentTextureLod`
-//    in texture.glsl), and there is no API to generate or upload texture
-//    mip levels.
-//  - A prefiltered cubemap instead of this equirectangular atlas: removes
-//    the pole distortion (smearing on near-vertical reflections) and the
-//    resolution ceiling. Needs mipmapped cubemap texture support in
-//    Flutter GPU (https://github.com/flutter/flutter/issues/145027).
-//  - A mip-style atlas: one large sharp band plus progressively smaller
-//    rough bands, rather than equal-size bands, so mirror reflections get
-//    real resolution without bloating the rough bands.
-/// Prefilters an equirectangular radiance texture into a vertical
-/// roughness-band atlas for image-based specular lighting.
+//    ~32. Unblocked: textureLod compiles on every backend dialect now and
+//    mip levels can be rendered to or uploaded; the remaining work is
+//    building the source mip chain and the cone-angle-to-lod mapping.
+//  - A prefiltered cubemap instead of the equirect: removes the pole
+//    distortion (smearing on near-vertical reflections) and the
+//    resolution ceiling. Render-to-slice and mipmapped textures make this
+//    possible now (https://github.com/flutter/flutter/issues/145027).
+/// Prefilters an equirectangular radiance texture for image-based
+/// specular lighting.
 ///
-/// Renders [kPrefilterBandCount] GGX-prefiltered equirectangular bands
-/// stacked vertically into a single `r16g16b16a16Float` texture in one
-/// full-screen GPU pass (see `flutter_scene_prefilter_env.frag`). Intended
-/// to run once when an [EnvironmentMap] is constructed; the result is cached
-/// on the environment and sampled at draw time by the standard shader's
+/// Renders [kPrefilterBandCount] GGX-prefiltered roughness bands (see
+/// `flutter_scene_prefilter_env.frag`). With [mipLayout] (the default
+/// layout new environments use, see `EnvironmentMap.useMipRadianceLayout`)
+/// the bands are the mip levels of one equirect texture, sampled with
+/// hardware trilinear `textureLod`; otherwise the bands are stacked
+/// vertically into the legacy atlas. Intended to run once when an
+/// `EnvironmentMap` is constructed; the result is cached on the
+/// environment and sampled at draw time by the standard shader's
 /// `SamplePrefilteredRadiance`.
 ///
 /// [sourceEquirect] is an equirectangular radiance map. By default it is
 /// treated as sRGB-encoded; pass [sourceIsLinear] when it already holds
 /// linear radiance (an HDR environment), so it is not linearized twice.
-/// The atlas always stores linear radiance.
+/// The result always stores linear radiance.
 /// {@category Lighting and environment}
 gpu.Texture prefilterEquirectRadiance(
   gpu.Texture sourceEquirect, {
   bool sourceIsLinear = false,
+  bool mipLayout = false,
 }) {
-  final atlas = createPrefilterAtlasTexture();
-  _prefilterPass(
-    sourceEquirect,
-    atlas,
-    band: -1,
-    clear: true,
-    sourceIsLinear: sourceIsLinear,
-  );
+  final atlas = createPrefilterAtlasTexture(mipLayout: mipLayout);
+  if (mipLayout) {
+    for (var band = 0; band < kPrefilterBandCount; band++) {
+      _prefilterPass(
+        sourceEquirect,
+        atlas,
+        band: band,
+        clear: true,
+        sourceIsLinear: sourceIsLinear,
+      );
+    }
+  } else {
+    _prefilterPass(
+      sourceEquirect,
+      atlas,
+      band: -1,
+      clear: true,
+      sourceIsLinear: sourceIsLinear,
+    );
+  }
   return atlas;
 }
 
-/// Creates an empty roughness-band atlas render target, for incremental
+/// Creates an empty prefiltered-radiance render target, for incremental
 /// prefiltering via [prefilterEquirectRadianceBand].
-gpu.Texture createPrefilterAtlasTexture() {
+///
+/// With [mipLayout], an equirect with one mip level per roughness band;
+/// otherwise the legacy stacked-band atlas.
+gpu.Texture createPrefilterAtlasTexture({bool mipLayout = false}) {
+  if (mipLayout) {
+    return gpu.gpuContext.createTexture(
+      gpu.StorageMode.devicePrivate,
+      kPrefilterBandWidth,
+      kPrefilterBandHeight,
+      format: gpu.PixelFormat.r16g16b16a16Float,
+      mipLevelCount: kPrefilterBandCount,
+      enableRenderTargetUsage: true,
+      enableShaderReadUsage: true,
+    );
+  }
   return gpu.gpuContext.createTexture(
     gpu.StorageMode.devicePrivate,
     kPrefilterBandWidth,
@@ -99,10 +125,13 @@ gpu.Texture createPrefilterAtlasTexture() {
 /// Prefilters a single roughness [band] of [atlas] from [sourceEquirect],
 /// preserving the other bands.
 ///
-/// One band costs roughly `1/kPrefilterBandCount` of the full prefilter
-/// (texels outside the band discard before the sample loop), so an
-/// incremental bake can spread the atlas across frames, one band per frame.
-/// The atlas holds a complete result only once every band has been written.
+/// The atlas's layout is detected from its mip count (see
+/// [createPrefilterAtlasTexture]): a mip-layout target renders the band
+/// into mip level [band]; the legacy atlas discards texels outside the
+/// band before the sample loop. Either way one band costs roughly
+/// `1/kPrefilterBandCount` of the full prefilter, so an incremental bake
+/// can spread the work across frames, one band per frame. The result is
+/// complete only once every band has been written.
 void prefilterEquirectRadianceBand(
   gpu.Texture sourceEquirect,
   gpu.Texture atlas,
@@ -114,7 +143,7 @@ void prefilterEquirectRadianceBand(
     sourceEquirect,
     atlas,
     band: band,
-    clear: false,
+    clear: atlas.mipLevelCount > 1,
     sourceIsLinear: sourceIsLinear,
   );
 }
@@ -128,14 +157,23 @@ void _prefilterPass(
 }) {
   final vertexShader = baseShaderLibrary['FullscreenVertex']!;
   final fragmentShader = baseShaderLibrary['PrefilterEnvFragment']!;
+  // With a mip-layout target, each band renders into its own mip level
+  // and covers the whole render area (no atlas math, no discard).
+  final mipLayout = atlas.mipLevelCount > 1;
+  assert(!mipLayout || band >= 0, 'Mip-layout prefilters render per band');
   final commandBuffer = gpu.gpuContext.createCommandBuffer();
   final renderPass = commandBuffer.createRenderPass(
     gpu.RenderTarget.singleColor(
       clear
-          ? gpu.ColorAttachment(texture: atlas, clearValue: Vector4.zero())
+          ? gpu.ColorAttachment(
+              texture: atlas,
+              clearValue: Vector4.zero(),
+              mipLevel: mipLayout ? band : 0,
+            )
           : gpu.ColorAttachment(
               texture: atlas,
               loadAction: gpu.LoadAction.load,
+              mipLevel: mipLayout ? band : 0,
             ),
     ),
   );
@@ -153,11 +191,13 @@ void _prefilterPass(
       heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
     ),
   );
-  // Two floats (std140-padded to 16 bytes): the sRGB-vs-linear flag and the
-  // band index (negative computes the whole atlas in one pass).
+  // Three floats (std140-padded to 16 bytes): the sRGB-vs-linear flag, the
+  // band index (negative computes the whole legacy atlas in one pass), and
+  // the whole-target flag (mip layout, the band covers the render area).
   final info = Float32List(4)
     ..[0] = sourceIsLinear ? 1.0 : 0.0
-    ..[1] = band.toDouble();
+    ..[1] = band.toDouble()
+    ..[2] = mipLayout ? 1.0 : 0.0;
   renderPass.bindUniform(
     fragmentShader.getUniformSlot('PrefilterInfo'),
     gpu.gpuContext.createHostBuffer().emplace(ByteData.sublistView(info)),

--- a/packages/flutter_scene/lib/src/render/fxaa_pass.dart
+++ b/packages/flutter_scene/lib/src/render/fxaa_pass.dart
@@ -1,0 +1,90 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
+
+import 'package:flutter_scene/src/render/render_graph.dart';
+import 'package:flutter_scene/src/render/resolve_pass.dart';
+import 'package:flutter_scene/src/shaders.dart';
+
+/// Anti-aliases the display-referred image as a single full-screen FXAA
+/// pass. Reads the resolve output from the blackboard, writes [_output],
+/// and republishes it so after-tone-mapping effects receive the
+/// anti-aliased image.
+class FxaaPass extends RenderGraphPass {
+  FxaaPass({required gpu.Texture output, required ui.Size dimensions})
+    : _output = output,
+      _dimensions = dimensions;
+
+  final gpu.Texture _output;
+  final ui.Size _dimensions;
+
+  static final gpu.Shader _vertexShader =
+      baseShaderLibrary['FullscreenVertex']!;
+  static final gpu.Shader _fragmentShader = baseShaderLibrary['FxaaFragment']!;
+
+  // Two triangles of NDC positions covering the screen (6 vec2s).
+  static final gpu.DeviceBuffer _quadBuffer = gpu.gpuContext
+      .createDeviceBufferWithCopy(
+        ByteData.sublistView(
+          Float32List.fromList(<double>[
+            -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, //
+            -1.0, 1.0, 1.0, -1.0, 1.0, 1.0, //
+          ]),
+        ),
+      );
+  static final gpu.BufferView _quadView = gpu.BufferView(
+    _quadBuffer,
+    offsetInBytes: 0,
+    lengthInBytes: 6 * 2 * 4,
+  );
+
+  static final gpu.SamplerOptions _linearClamp = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.linear,
+    magFilter: gpu.MinMagFilter.linear,
+    widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+    heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  );
+
+  @override
+  String get name => 'FxaaPass';
+
+  @override
+  void execute(RenderGraphContext context) {
+    final input = context.blackboard.require<gpu.Texture>(
+      kDisplayColorBlackboardKey,
+    );
+
+    final commandBuffer = gpu.gpuContext.createCommandBuffer();
+    final renderPass = commandBuffer.createRenderPass(
+      gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: _output)),
+    );
+    renderPass.bindPipeline(
+      gpu.gpuContext.createRenderPipeline(_vertexShader, _fragmentShader),
+    );
+    bindVertexBufferCompat(renderPass, _quadView, 6);
+
+    renderPass.bindTexture(
+      _fragmentShader.getUniformSlot('scene_color'),
+      input,
+      sampler: _linearClamp,
+    );
+
+    // FxaaInfo std140: { vec2 inv_target_size; vec2 pad; }, 16 bytes.
+    final w = _dimensions.width;
+    final h = _dimensions.height;
+    final info = Float32List(4)
+      ..[0] = w == 0 ? 0.0 : 1.0 / w
+      ..[1] = h == 0 ? 0.0 : 1.0 / h;
+    renderPass.bindUniform(
+      _fragmentShader.getUniformSlot('FxaaInfo'),
+      context.transientsBuffer.emplace(ByteData.sublistView(info)),
+    );
+
+    drawCompat(renderPass, 6);
+    commandBuffer.submit();
+
+    context.blackboard.set(kDisplayColorBlackboardKey, _output);
+  }
+}

--- a/packages/flutter_scene/lib/src/render/instance_packing.dart
+++ b/packages/flutter_scene/lib/src/render/instance_packing.dart
@@ -70,29 +70,80 @@ void bindSingleInstanceTransform(gpu.RenderPass pass, Matrix4 worldTransform) {
 
 /// Uploads [packed] transforms and binds them to the instance-rate slot.
 ///
-/// The transforms go into a dedicated [gpu.DeviceBuffer] rather than the
-/// per-frame transient uniform `HostBuffer`. On the GLES backend a vertex
-/// buffer sourced from that shared host buffer reads corrupted data,
-/// because the same buffer also serves the uniform emplacements issued
-/// later in the same draw (`Material.bind`) and GLES binds vertex
-/// attributes by stateful pointer into the live buffer object; the
-/// symptom was objects toggling between transforms. A standalone buffer
-/// is never disturbed by other emplacements, so the binding stays valid
-/// on every backend. The render pass keeps the buffer alive through
-/// submission via the recorded binding.
-// TODO(instance-buffer-pool): this allocates a device buffer per draw per
-// frame. Fine for typical scenes; pool these for instance-heavy scenes.
+/// The transforms come from [instanceTransformBuffers], a dedicated pool of
+/// [gpu.DeviceBuffer]s, not the per-frame transient uniform `HostBuffer`.
+/// On the GLES backend a vertex buffer sourced from that shared host
+/// buffer reads corrupted data, because the same buffer also serves the
+/// uniform emplacements issued later in the same draw (`Material.bind`) and
+/// GLES binds vertex attributes by stateful pointer into the live buffer
+/// object; the symptom was objects toggling between transforms. Metal and
+/// Vulkan resolve buffer+offset at submit and were unaffected. A dedicated
+/// buffer bound at offset 0, never touched by another emplacement, keeps
+/// the binding valid on every backend; the pool reuses buffers across
+/// frames so the hot draw path does not allocate.
 void bindInstanceTransforms(gpu.RenderPass pass, Float32List packed) {
   if (packed.isEmpty) return;
-  final buffer = gpu.gpuContext.createDeviceBufferWithCopy(
-    ByteData.sublistView(packed),
-  );
   pass.bindVertexBuffer(
-    gpu.BufferView(
-      buffer,
-      offsetInBytes: 0,
-      lengthInBytes: packed.lengthInBytes,
-    ),
+    instanceTransformBuffers.acquire(ByteData.sublistView(packed)),
     slot: 1,
   );
 }
+
+/// A pool of [gpu.DeviceBuffer]s for instance-rate transforms, reused
+/// across frames so the per-draw binding (see [bindInstanceTransforms])
+/// never allocates in the hot path.
+///
+/// Each draw within a frame gets a distinct buffer (so binding one draw's
+/// transforms is never disturbed by a later draw), and a ring of
+/// [framesInFlight] buffer sets keeps the GPU's in-flight reads off the
+/// buffers the next frame overwrites. Call [beginFrame] once per frame
+/// before any [acquire].
+class InstanceTransformBuffers {
+  InstanceTransformBuffers({this.framesInFlight = 3});
+
+  final int framesInFlight;
+  final List<List<gpu.DeviceBuffer>> _rings = [];
+  int _frame = 0;
+  int _cursor = 0;
+
+  /// Advances to the next frame's buffer set. Call once per frame.
+  void beginFrame() {
+    while (_rings.length < framesInFlight) {
+      _rings.add(<gpu.DeviceBuffer>[]);
+    }
+    _frame = (_frame + 1) % framesInFlight;
+    _cursor = 0;
+  }
+
+  /// Returns a buffer view holding [data] at offset 0, reusing a pooled
+  /// buffer when one of sufficient size is free this frame.
+  gpu.BufferView acquire(ByteData data) {
+    if (_rings.isEmpty) beginFrame();
+    final ring = _rings[_frame];
+    gpu.DeviceBuffer buffer;
+    if (_cursor < ring.length &&
+        ring[_cursor].sizeInBytes >= data.lengthInBytes) {
+      buffer = ring[_cursor];
+      buffer.overwrite(data);
+    } else {
+      buffer = gpu.gpuContext.createDeviceBufferWithCopy(data);
+      if (_cursor < ring.length) {
+        ring[_cursor] = buffer;
+      } else {
+        ring.add(buffer);
+      }
+    }
+    _cursor++;
+    return gpu.BufferView(
+      buffer,
+      offsetInBytes: 0,
+      lengthInBytes: data.lengthInBytes,
+    );
+  }
+}
+
+/// The process-wide instance-transform buffer pool. One GPU context per
+/// process, so a single pool serves every scene; [beginFrame] is driven
+/// from the per-frame render setup.
+final InstanceTransformBuffers instanceTransformBuffers =
+    InstanceTransformBuffers();

--- a/packages/flutter_scene/lib/src/render/instance_packing.dart
+++ b/packages/flutter_scene/lib/src/render/instance_packing.dart
@@ -72,17 +72,14 @@ void bindSingleInstanceTransform(gpu.RenderPass pass, Matrix4 worldTransform) {
 ///
 /// The transforms are emplaced into [instanceTransformBuffers], a `HostBuffer`
 /// dedicated to instance vertex data, separate from the per-frame transient
-/// uniform `HostBuffer`. On the GLES backend, sourcing this vertex buffer
-/// from the same `HostBuffer` that also serves uniform emplacements
-/// corrupts the model matrix (objects toggle between transforms), because
-/// the uniform emplacements `Material.bind` issues later in the same draw
-/// disturb the vertex binding into the shared GL buffer object. Metal and
-/// Vulkan resolve buffer+offset at submit and were unaffected. A separate
-/// buffer that only ever holds vertex data removes the interference on
-/// every backend, while keeping the cheap per-frame `HostBuffer`
-/// sub-allocation (no per-draw device-buffer creation, which stalls the
-/// GLES backend).
+/// uniform `HostBuffer`. The split dates from debugging stale instance
+/// transforms on the GLES backend, which turned out to be an engine bug
+/// (flutter/flutter#187931, buffer writes racing the GL upload) that a
+/// dedicated buffer does not actually avoid. Kept for now since it is
+/// harmless and the engine fix has not shipped in the SDK yet.
 void bindInstanceTransforms(gpu.RenderPass pass, Float32List packed) {
+  // TODO(gles-dirty-range): fold instance transforms back into the shared
+  // transients HostBuffer once flutter/flutter#187931 is fixed in the SDK.
   if (packed.isEmpty) return;
   pass.bindVertexBuffer(
     instanceTransformBuffers.emplace(ByteData.sublistView(packed)),

--- a/packages/flutter_scene/lib/src/render/instance_packing.dart
+++ b/packages/flutter_scene/lib/src/render/instance_packing.dart
@@ -70,80 +70,50 @@ void bindSingleInstanceTransform(gpu.RenderPass pass, Matrix4 worldTransform) {
 
 /// Uploads [packed] transforms and binds them to the instance-rate slot.
 ///
-/// The transforms come from [instanceTransformBuffers], a dedicated pool of
-/// [gpu.DeviceBuffer]s, not the per-frame transient uniform `HostBuffer`.
-/// On the GLES backend a vertex buffer sourced from that shared host
-/// buffer reads corrupted data, because the same buffer also serves the
-/// uniform emplacements issued later in the same draw (`Material.bind`) and
-/// GLES binds vertex attributes by stateful pointer into the live buffer
-/// object; the symptom was objects toggling between transforms. Metal and
-/// Vulkan resolve buffer+offset at submit and were unaffected. A dedicated
-/// buffer bound at offset 0, never touched by another emplacement, keeps
-/// the binding valid on every backend; the pool reuses buffers across
-/// frames so the hot draw path does not allocate.
+/// The transforms are emplaced into [instanceTransformBuffers], a `HostBuffer`
+/// dedicated to instance vertex data, separate from the per-frame transient
+/// uniform `HostBuffer`. On the GLES backend, sourcing this vertex buffer
+/// from the same `HostBuffer` that also serves uniform emplacements
+/// corrupts the model matrix (objects toggle between transforms), because
+/// the uniform emplacements `Material.bind` issues later in the same draw
+/// disturb the vertex binding into the shared GL buffer object. Metal and
+/// Vulkan resolve buffer+offset at submit and were unaffected. A separate
+/// buffer that only ever holds vertex data removes the interference on
+/// every backend, while keeping the cheap per-frame `HostBuffer`
+/// sub-allocation (no per-draw device-buffer creation, which stalls the
+/// GLES backend).
 void bindInstanceTransforms(gpu.RenderPass pass, Float32List packed) {
   if (packed.isEmpty) return;
   pass.bindVertexBuffer(
-    instanceTransformBuffers.acquire(ByteData.sublistView(packed)),
+    instanceTransformBuffers.emplace(ByteData.sublistView(packed)),
     slot: 1,
   );
 }
 
-/// A pool of [gpu.DeviceBuffer]s for instance-rate transforms, reused
-/// across frames so the per-draw binding (see [bindInstanceTransforms])
-/// never allocates in the hot path.
-///
-/// Each draw within a frame gets a distinct buffer (so binding one draw's
-/// transforms is never disturbed by a later draw), and a ring of
-/// [framesInFlight] buffer sets keeps the GPU's in-flight reads off the
-/// buffers the next frame overwrites. Call [beginFrame] once per frame
-/// before any [acquire].
+/// A `HostBuffer` dedicated to instance-rate transform vertex data, kept
+/// apart from the uniform transients buffer (see [bindInstanceTransforms]
+/// for why). [beginFrame] cycles it to the next frame's backing storage
+/// and is driven once per frame from the render setup.
 class InstanceTransformBuffers {
-  InstanceTransformBuffers({this.framesInFlight = 3});
+  // Created lazily: the GPU context initializes on the raster thread after
+  // the first frame on some backends, so it isn't available at startup.
+  gpu.HostBuffer? _buffer;
+  gpu.HostBuffer get _host => _buffer ??= gpu.gpuContext.createHostBuffer();
 
-  final int framesInFlight;
-  final List<List<gpu.DeviceBuffer>> _rings = [];
-  int _frame = 0;
-  int _cursor = 0;
+  /// Cycles to the next frame's backing storage. Call once per frame
+  /// before any [emplace].
+  void beginFrame() => _host.reset();
 
-  /// Advances to the next frame's buffer set. Call once per frame.
-  void beginFrame() {
-    while (_rings.length < framesInFlight) {
-      _rings.add(<gpu.DeviceBuffer>[]);
-    }
-    _frame = (_frame + 1) % framesInFlight;
-    _cursor = 0;
-  }
-
-  /// Returns a buffer view holding [data] at offset 0, reusing a pooled
-  /// buffer when one of sufficient size is free this frame.
-  gpu.BufferView acquire(ByteData data) {
-    if (_rings.isEmpty) beginFrame();
-    final ring = _rings[_frame];
-    gpu.DeviceBuffer buffer;
-    if (_cursor < ring.length &&
-        ring[_cursor].sizeInBytes >= data.lengthInBytes) {
-      buffer = ring[_cursor];
-      buffer.overwrite(data);
-    } else {
-      buffer = gpu.gpuContext.createDeviceBufferWithCopy(data);
-      if (_cursor < ring.length) {
-        ring[_cursor] = buffer;
-      } else {
-        ring.add(buffer);
-      }
-    }
-    _cursor++;
-    return gpu.BufferView(
-      buffer,
-      offsetInBytes: 0,
-      lengthInBytes: data.lengthInBytes,
-    );
-  }
+  /// Emplaces [data] and returns a view to bind as the instance-rate
+  /// vertex buffer.
+  gpu.BufferView emplace(ByteData data) => _host.emplace(data);
 }
 
-/// The process-wide instance-transform buffer pool. One GPU context per
-/// process, so a single pool serves every scene; [beginFrame] is driven
+/// The process-wide instance-transform vertex buffer. One GPU context per
+/// process, so a single buffer serves every scene; [beginFrame] is driven
 /// from the per-frame render setup.
+// TODO(instance-buffer-ownership): a single process-wide buffer means two
+// Scenes rendering in the same frame both reset it; make it per-Surface if
+// multi-scene-per-frame becomes common.
 final InstanceTransformBuffers instanceTransformBuffers =
     InstanceTransformBuffers();

--- a/packages/flutter_scene/lib/src/render/instance_packing.dart
+++ b/packages/flutter_scene/lib/src/render/instance_packing.dart
@@ -64,23 +64,35 @@ PackedInstanceTransforms packInstanceTransforms(
 /// Every draw through the unskinned vertex shader needs this: the model
 /// matrix arrives via instance attributes whether or not the draw is
 /// instanced.
-void bindSingleInstanceTransform(
-  gpu.RenderPass pass,
-  gpu.HostBuffer transientsBuffer,
-  Matrix4 worldTransform,
-) {
-  final view = transientsBuffer.emplace(
-    Float32List.fromList(worldTransform.storage).buffer.asByteData(),
-  );
-  pass.bindVertexBuffer(view, slot: 1);
+void bindSingleInstanceTransform(gpu.RenderPass pass, Matrix4 worldTransform) {
+  bindInstanceTransforms(pass, Float32List.fromList(worldTransform.storage));
 }
 
 /// Uploads [packed] transforms and binds them to the instance-rate slot.
-void bindInstanceTransforms(
-  gpu.RenderPass pass,
-  gpu.HostBuffer transientsBuffer,
-  Float32List packed,
-) {
-  final view = transientsBuffer.emplace(packed.buffer.asByteData());
-  pass.bindVertexBuffer(view, slot: 1);
+///
+/// The transforms go into a dedicated [gpu.DeviceBuffer] rather than the
+/// per-frame transient uniform `HostBuffer`. On the GLES backend a vertex
+/// buffer sourced from that shared host buffer reads corrupted data,
+/// because the same buffer also serves the uniform emplacements issued
+/// later in the same draw (`Material.bind`) and GLES binds vertex
+/// attributes by stateful pointer into the live buffer object; the
+/// symptom was objects toggling between transforms. A standalone buffer
+/// is never disturbed by other emplacements, so the binding stays valid
+/// on every backend. The render pass keeps the buffer alive through
+/// submission via the recorded binding.
+// TODO(instance-buffer-pool): this allocates a device buffer per draw per
+// frame. Fine for typical scenes; pool these for instance-heavy scenes.
+void bindInstanceTransforms(gpu.RenderPass pass, Float32List packed) {
+  if (packed.isEmpty) return;
+  final buffer = gpu.gpuContext.createDeviceBufferWithCopy(
+    ByteData.sublistView(packed),
+  );
+  pass.bindVertexBuffer(
+    gpu.BufferView(
+      buffer,
+      offsetInBytes: 0,
+      lengthInBytes: packed.lengthInBytes,
+    ),
+    slot: 1,
+  );
 }

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -121,12 +121,12 @@ class ShadowEncoder {
         nodeWindingFlipped: item.windingFlipped,
       );
       if (packed.ccwCount > 0) {
-        bindInstanceTransforms(_renderPass, _transientsBuffer, packed.ccw);
+        bindInstanceTransforms(_renderPass, packed.ccw);
         _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
         item.geometry.draw(_renderPass, instanceCount: packed.ccwCount);
       }
       if (packed.cwCount > 0) {
-        bindInstanceTransforms(_renderPass, _transientsBuffer, packed.cw);
+        bindInstanceTransforms(_renderPass, packed.cw);
         _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
         item.geometry.draw(_renderPass, instanceCount: packed.cwCount);
       }
@@ -141,11 +141,7 @@ class ShadowEncoder {
       _cameraPositionPlaceholder,
     );
     if (item.geometry.instancedVertexLayout != null) {
-      bindSingleInstanceTransform(
-        _renderPass,
-        _transientsBuffer,
-        item.worldTransform,
-      );
+      bindSingleInstanceTransform(_renderPass, item.worldTransform);
     }
     // Mirrored casters reverse winding; flip the cull order so the same faces
     // that are visible also cast shadows.

--- a/packages/flutter_scene/lib/src/render/sky_bake.dart
+++ b/packages/flutter_scene/lib/src/render/sky_bake.dart
@@ -236,7 +236,11 @@ void _projectSh(gpu.Texture equirect, gpu.Texture sh) {
   final sh = _createShTarget();
   _projectSh(equirect, sh);
   return (
-    atlas: prefilterEquirectRadiance(equirect, sourceIsLinear: true),
+    atlas: prefilterEquirectRadiance(
+      equirect,
+      sourceIsLinear: true,
+      mipLayout: EnvironmentMap.useMipRadianceLayout,
+    ),
     sh: sh,
   );
 }
@@ -292,7 +296,9 @@ class SkyBakeJob {
       _equirect = _hdrRenderTarget(equirectWidth, equirectWidth ~/ 2);
     }
     _writeIndex = 1 - _writeIndex;
-    _atlases[_writeIndex] ??= createPrefilterAtlasTexture();
+    _atlases[_writeIndex] ??= createPrefilterAtlasTexture(
+      mipLayout: EnvironmentMap.useMipRadianceLayout,
+    );
     _shs[_writeIndex] ??= _createShTarget();
     _step = 0;
   }

--- a/packages/flutter_scene/lib/src/render/sky_bake.dart
+++ b/packages/flutter_scene/lib/src/render/sky_bake.dart
@@ -239,7 +239,7 @@ void _projectSh(gpu.Texture equirect, gpu.Texture sh) {
     atlas: prefilterEquirectRadiance(
       equirect,
       sourceIsLinear: true,
-      mipLayout: EnvironmentMap.useMipRadianceLayout,
+      mipLayout: EnvironmentMap.effectiveMipRadianceLayout,
     ),
     sh: sh,
   );
@@ -297,7 +297,7 @@ class SkyBakeJob {
     }
     _writeIndex = 1 - _writeIndex;
     _atlases[_writeIndex] ??= createPrefilterAtlasTexture(
-      mipLayout: EnvironmentMap.useMipRadianceLayout,
+      mipLayout: EnvironmentMap.effectiveMipRadianceLayout,
     );
     _shs[_writeIndex] ??= _createShTarget();
     _step = 0;

--- a/packages/flutter_scene/lib/src/render/skybox_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/skybox_encoder.dart
@@ -6,6 +6,7 @@ import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/scene_encoder.dart' show resolvePipeline;
 import 'package:flutter_scene/src/shaders.dart';
@@ -173,17 +174,11 @@ void _bindEnvironmentSource(
     transientsBuffer.emplace(ByteData.sublistView(skyboxInfo)),
   );
 
-  // The prefiltered-radiance atlas: horizontal repeat (longitude wraps),
-  // vertical clamp (roughness bands must not bleed). Matches the standard
-  // material's binding so the sky and reflections sample identically.
-  renderPass.bindTexture(
-    fragmentShader.getUniformSlot('prefiltered_radiance'),
-    environment.prefilteredRadianceTexture,
-    sampler: gpu.SamplerOptions(
-      minFilter: gpu.MinMagFilter.linear,
-      magFilter: gpu.MinMagFilter.linear,
-      widthAddressMode: gpu.SamplerAddressMode.repeat,
-      heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-    ),
+  // The prefiltered radiance, bound through the shared helper so the sky
+  // and reflections sample identically (including the layout flag).
+  EngineLightingUniforms.bindPrefilteredRadiance(
+    renderPass,
+    fragmentShader,
+    environment,
   );
 }

--- a/packages/flutter_scene/lib/src/render_texture.dart
+++ b/packages/flutter_scene/lib/src/render_texture.dart
@@ -1,0 +1,156 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+
+import 'package:flutter_scene/src/render/render_graph.dart';
+import 'package:flutter_scene/src/surface.dart';
+
+/// When a [RenderTexture] re-renders.
+///
+/// The same shape as `WidgetUpdatePolicy` (the widget-to-texture
+/// direction), so both capture pipelines share one mental model.
+/// {@category Rendering}
+sealed class RenderTextureUpdate {
+  const RenderTextureUpdate._();
+
+  /// Re-render every frame the owning scene renders (the default). Use for
+  /// mirrors and live monitors; each enabled target adds a full render
+  /// pass per frame, so prefer [interval] or [manual] for content that
+  /// changes rarely.
+  static const RenderTextureUpdate everyFrame = _EveryFrameUpdate();
+
+  /// Re-render at most once per [duration] (a minimap or telemetry view
+  /// that doesn't need every frame).
+  const factory RenderTextureUpdate.interval(Duration duration) =
+      _IntervalUpdate;
+
+  /// Render once when first wired, then only when
+  /// [RenderTexture.requestUpdate] is called.
+  static const RenderTextureUpdate manual = _ManualUpdate();
+}
+
+class _EveryFrameUpdate extends RenderTextureUpdate {
+  const _EveryFrameUpdate() : super._();
+}
+
+class _IntervalUpdate extends RenderTextureUpdate {
+  const _IntervalUpdate(this.duration) : super._();
+  final Duration duration;
+}
+
+class _ManualUpdate extends RenderTextureUpdate {
+  const _ManualUpdate() : super._();
+}
+
+/// An offscreen render target a `RenderView` can render into.
+///
+/// Create one, set it as a view's `RenderView.target`, and add the view to
+/// `Scene.views`; the scene renders it (subject to [update]) whenever the
+/// scene itself renders. Display it in the widget tree with a
+/// `RenderTextureView`.
+///
+/// The texture holds the same display-referred premultiplied image a
+/// screen view shows (tone mapping and anti-aliasing applied), sized at
+/// exactly [width] x [height] physical pixels.
+///
+/// The engine owns the GPU textures behind this handle (a small ring, so
+/// writing a new frame never races a still-displayed previous frame).
+/// Consumers hold the [RenderTexture] itself and resolve [texture] when
+/// they draw; notifications fire after each re-render.
+/// {@category Rendering}
+class RenderTexture extends ChangeNotifier {
+  /// Creates a render target of [width] x [height] physical pixels.
+  RenderTexture({
+    required int width,
+    required int height,
+    this.update = RenderTextureUpdate.everyFrame,
+  }) : assert(width > 0 && height > 0, 'RenderTexture size must be positive'),
+       _size = ui.Size(width.toDouble(), height.toDouble());
+
+  // The ring + transient pool live in a single-view Surface, the same
+  // machinery (and frames-in-flight depth) backing the screen swapchain.
+  final Surface _surface = Surface();
+
+  ui.Size _size;
+
+  /// When this target re-renders. See [RenderTextureUpdate].
+  RenderTextureUpdate update;
+
+  DateTime? _lastUpdateTime;
+  bool _updateRequested = false;
+  bool _hasRendered = false;
+
+  /// The target width in physical pixels.
+  int get width => _size.width.toInt();
+
+  /// The target height in physical pixels.
+  int get height => _size.height.toInt();
+
+  /// The most recently rendered texture, or null before the first render.
+  ///
+  /// The returned object changes identity across frames (the ring
+  /// advances), so hold the [RenderTexture] and re-read this when drawing
+  /// rather than caching the result.
+  gpu.Texture? get texture => _surface.lastSwapchainColorTexture();
+
+  /// Reallocates the target at a new size. Consumers pick up the new
+  /// textures on the next render; the next [update] check re-renders
+  /// regardless of policy so the target is never displayed stale-sized.
+  void resize(int width, int height) {
+    assert(width > 0 && height > 0, 'RenderTexture size must be positive');
+    final newSize = ui.Size(width.toDouble(), height.toDouble());
+    if (newSize == _size) {
+      return;
+    }
+    _size = newSize;
+    // The Surface ring detects the size change on next acquire; force a
+    // re-render so manual/interval targets don't keep a stale-sized image.
+    _updateRequested = true;
+  }
+
+  /// With [RenderTextureUpdate.manual], renders once on the scene's next
+  /// frame. Has no effect with the other policies (they re-render on
+  /// their own schedule).
+  void requestUpdate() {
+    _updateRequested = true;
+  }
+
+  /// Whether the owning scene should re-render this target now. Consumes
+  /// a pending [requestUpdate] when it returns true.
+  @internal
+  bool shouldUpdate(DateTime now) {
+    if (_updateRequested) {
+      _updateRequested = false;
+      return true;
+    }
+    switch (update) {
+      case _EveryFrameUpdate():
+        return true;
+      case _IntervalUpdate(:final duration):
+        final last = _lastUpdateTime;
+        return last == null || now.difference(last) >= duration;
+      case _ManualUpdate():
+        return !_hasRendered;
+    }
+  }
+
+  /// The next ring texture to render into. Advances the ring and the
+  /// transient pool's frame.
+  @internal
+  gpu.Texture acquireNextTexture() =>
+      _surface.getNextSwapchainColorTexture(_size);
+
+  /// The transient texture pool for this target's render passes.
+  @internal
+  TransientTexturePool get transientTexturePool =>
+      _surface.transientTexturePool();
+
+  /// Records that a render completed and notifies consumers.
+  @internal
+  void markUpdated(DateTime now) {
+    _lastUpdateTime = now;
+    _hasRendered = true;
+    notifyListeners();
+  }
+}

--- a/packages/flutter_scene/lib/src/render_texture.dart
+++ b/packages/flutter_scene/lib/src/render_texture.dart
@@ -43,12 +43,46 @@ class _ManualUpdate extends RenderTextureUpdate {
   const _ManualUpdate() : super._();
 }
 
+/// Sampling options used when a material samples a [RenderTexture].
+///
+/// Captures default to bilinear filtering with clamped edges (the right
+/// choice for screen-like content, where wrapping would bleed opposite
+/// edges together). Use [gpu.MinMagFilter.nearest] for a pixelated look.
+/// {@category Rendering}
+class RenderTextureSampling {
+  /// Creates sampling options.
+  const RenderTextureSampling({
+    this.filter = gpu.MinMagFilter.linear,
+    this.wrap = gpu.SamplerAddressMode.clampToEdge,
+  });
+
+  /// The minification/magnification filter.
+  final gpu.MinMagFilter filter;
+
+  /// The addressing mode for texture coordinates outside `0..1`, applied
+  /// to both axes.
+  final gpu.SamplerAddressMode wrap;
+
+  /// The equivalent sampler description.
+  @internal
+  gpu.SamplerOptions toSamplerOptions() => gpu.SamplerOptions(
+    minFilter: filter,
+    magFilter: filter,
+    widthAddressMode: wrap,
+    heightAddressMode: wrap,
+  );
+}
+
 /// An offscreen render target a `RenderView` can render into.
 ///
 /// Create one, set it as a view's `RenderView.target`, and add the view to
 /// `Scene.views`; the scene renders it (subject to [update]) whenever the
 /// scene itself renders. Display it in the widget tree with a
-/// `RenderTextureView`.
+/// `RenderTextureView`, or assign it to a material texture slot (for
+/// example `PhysicallyBasedMaterial.baseColorTexture` or
+/// `UnlitMaterial.baseColorTexture`) to show the live capture on scene
+/// geometry, the security-camera/monitor/mirror pattern. Material
+/// sampling uses [sampling].
 ///
 /// The texture holds the same display-referred premultiplied image a
 /// screen view shows (tone mapping and anti-aliasing applied), sized at
@@ -58,6 +92,13 @@ class _ManualUpdate extends RenderTextureUpdate {
 /// writing a new frame never races a still-displayed previous frame).
 /// Consumers hold the [RenderTexture] itself and resolve [texture] when
 /// they draw; notifications fire after each re-render.
+///
+/// Texture-target views render in `RenderView.order` before the screen
+/// views, and [texture] always returns the most recently *completed*
+/// frame. So a consumer drawn after this target's producing view samples
+/// this frame's capture, while a consumer visible *inside* the capture
+/// (including the target sampling itself, a mirror facing a mirror)
+/// samples the previous frame instead of forming a feedback loop.
 /// {@category Rendering}
 class RenderTexture extends ChangeNotifier {
   /// Creates a render target of [width] x [height] physical pixels.
@@ -65,6 +106,7 @@ class RenderTexture extends ChangeNotifier {
     required int width,
     required int height,
     this.update = RenderTextureUpdate.everyFrame,
+    this.sampling = const RenderTextureSampling(),
   }) : assert(width > 0 && height > 0, 'RenderTexture size must be positive'),
        _size = ui.Size(width.toDouble(), height.toDouble());
 
@@ -77,9 +119,14 @@ class RenderTexture extends ChangeNotifier {
   /// When this target re-renders. See [RenderTextureUpdate].
   RenderTextureUpdate update;
 
+  /// Sampling options used when a material samples this target.
+  RenderTextureSampling sampling;
+
   DateTime? _lastUpdateTime;
   bool _updateRequested = false;
   bool _hasRendered = false;
+  gpu.Texture? _latest;
+  gpu.Texture? _pending;
 
   /// The target width in physical pixels.
   int get width => _size.width.toInt();
@@ -87,12 +134,15 @@ class RenderTexture extends ChangeNotifier {
   /// The target height in physical pixels.
   int get height => _size.height.toInt();
 
-  /// The most recently rendered texture, or null before the first render.
+  /// The most recently completed frame, or null before the first render.
   ///
   /// The returned object changes identity across frames (the ring
   /// advances), so hold the [RenderTexture] and re-read this when drawing
-  /// rather than caching the result.
-  gpu.Texture? get texture => _surface.lastSwapchainColorTexture();
+  /// rather than caching the result. While this target's own producing
+  /// view is being encoded, this still returns the previous frame, which
+  /// is what makes self-sampling read one frame stale instead of forming
+  /// a feedback loop (see the class doc).
+  gpu.Texture? get texture => _latest;
 
   /// Reallocates the target at a new size. Consumers pick up the new
   /// textures on the next render; the next [update] check re-renders
@@ -136,21 +186,25 @@ class RenderTexture extends ChangeNotifier {
   }
 
   /// The next ring texture to render into. Advances the ring and the
-  /// transient pool's frame.
+  /// transient pool's frame. [texture] keeps returning the previous frame
+  /// until [markUpdated] publishes the new one.
   @internal
   gpu.Texture acquireNextTexture() =>
-      _surface.getNextSwapchainColorTexture(_size);
+      _pending = _surface.getNextSwapchainColorTexture(_size);
 
   /// The transient texture pool for this target's render passes.
   @internal
   TransientTexturePool get transientTexturePool =>
       _surface.transientTexturePool();
 
-  /// Records that a render completed and notifies consumers.
+  /// Publishes the frame written since [acquireNextTexture] and notifies
+  /// consumers.
   @internal
   void markUpdated(DateTime now) {
     _lastUpdateTime = now;
     _hasRendered = true;
+    _latest = _pending ?? _latest;
+    _pending = null;
     notifyListeners();
   }
 }

--- a/packages/flutter_scene/lib/src/render_texture.dart
+++ b/packages/flutter_scene/lib/src/render_texture.dart
@@ -28,6 +28,21 @@ sealed class RenderTextureUpdate {
   /// Render once when first wired, then only when
   /// [RenderTexture.requestUpdate] is called.
   static const RenderTextureUpdate manual = _ManualUpdate();
+
+  /// The policy's serialized name (`everyFrame`, `interval`, `manual`).
+  @internal
+  String get kindName => switch (this) {
+    _EveryFrameUpdate() => 'everyFrame',
+    _IntervalUpdate() => 'interval',
+    _ManualUpdate() => 'manual',
+  };
+
+  /// The interval for [RenderTextureUpdate.interval] policies, else null.
+  @internal
+  Duration? get intervalDuration => switch (this) {
+    _IntervalUpdate(:final duration) => duration,
+    _ => null,
+  };
 }
 
 class _EveryFrameUpdate extends RenderTextureUpdate {

--- a/packages/flutter_scene/lib/src/render_view.dart
+++ b/packages/flutter_scene/lib/src/render_view.dart
@@ -79,7 +79,8 @@ class RenderView {
 
   /// The sampling quality this view's image is composited onto the canvas
   /// with, or null (the default) to inherit the scene's
-  /// `Scene.filterQuality`.
+  /// `Scene.filterQuality` (which documents how the values map to
+  /// concrete sampling modes per backend).
   ///
   /// Ignored when [target] is set; display filtering of a render texture
   /// belongs to its consumer (for example `RenderTextureView`).

--- a/packages/flutter_scene/lib/src/render_view.dart
+++ b/packages/flutter_scene/lib/src/render_view.dart
@@ -2,29 +2,49 @@ import 'dart:ui' as ui;
 
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/render/render_layers.dart';
+import 'package:flutter_scene/src/render_texture.dart';
+import 'package:flutter_scene/src/scene.dart' show AntiAliasingMode, Scene;
 
 /// One view of a `Scene`: a [camera] plus where and how its image is drawn.
 ///
 /// A scene can be rendered as a list of views (split-screen, picture-in-
-/// picture, and more). Each view binds a camera to a [viewport]
-/// sub-rectangle of the target, a [layerMask] selecting which nodes it
-/// sees, and an [order] controlling how overlapping views composite.
+/// picture, and more). Each view binds a camera to a [target] (an offscreen
+/// [RenderTexture], or null for the screen), a [viewport] sub-rectangle of
+/// the target, a [layerMask] selecting which nodes it sees, an [order]
+/// controlling how overlapping views composite, and an optional
+/// [antiAliasingMode] override.
 /// {@category Rendering}
 class RenderView {
   /// Creates a render view for [camera].
   RenderView({
     required this.camera,
+    this.target,
     this.viewport,
     this.layerMask = kRenderLayerAll,
     this.order = 0,
+    this.antiAliasingMode,
   });
 
   /// The camera whose view and projection this view renders.
   Camera camera;
 
+  /// The offscreen texture this view renders into, or null to render to
+  /// the screen.
+  ///
+  /// A view with a target renders whenever the owning scene renders,
+  /// subject to the target's `RenderTexture.update` policy. Add such views
+  /// to `Scene.views` so they render without being passed to every
+  /// `Scene.renderViews` call.
+  RenderTexture? target;
+
   /// The sub-rectangle of the render target this view draws into, in
   /// normalized coordinates (`0..1`, with a top-left origin). `null` fills
   /// the whole target.
+  ///
+  /// Ignored when [target] is set; a view renders the full extent of its
+  /// render texture.
+  // TODO(rendertarget): support viewport sub-rects on texture targets
+  // (requires compositing multiple views into one texture).
   ui.Rect? viewport;
 
   /// A bitmask selecting which `Node` layers this view renders. A node is
@@ -35,4 +55,12 @@ class RenderView {
   /// The compositing order among views sharing a target: a lower [order]
   /// renders first, a higher one draws on top.
   int order;
+
+  /// The anti-aliasing strategy for this view, or null (the default) to
+  /// inherit the scene's `Scene.antiAliasingMode`.
+  ///
+  /// Resolution against backend support follows the same rules as the
+  /// scene-level setting (an unsupported [AntiAliasingMode.msaa] renders
+  /// with FXAA); check [Scene.isAntiAliasingModeSupported] up front.
+  AntiAliasingMode? antiAliasingMode;
 }

--- a/packages/flutter_scene/lib/src/render_view.dart
+++ b/packages/flutter_scene/lib/src/render_view.dart
@@ -23,7 +23,12 @@ class RenderView {
     this.layerMask = kRenderLayerAll,
     this.order = 0,
     this.antiAliasingMode,
-  });
+    this.renderScale,
+    this.filterQuality,
+  }) : assert(
+         renderScale == null || (renderScale.isFinite && renderScale > 0.0),
+         'renderScale must be a positive, finite number.',
+       );
 
   /// The camera whose view and projection this view renders.
   Camera camera;
@@ -63,4 +68,20 @@ class RenderView {
   /// scene-level setting (an unsupported [AntiAliasingMode.msaa] renders
   /// with FXAA); check [Scene.isAntiAliasingModeSupported] up front.
   AntiAliasingMode? antiAliasingMode;
+
+  /// Scales the resolution this view renders at relative to the display's
+  /// native resolution, or null (the default) to inherit the scene's
+  /// `Scene.renderScale`.
+  ///
+  /// Ignored when [target] is set; a render texture's resolution is its
+  /// explicit size.
+  double? renderScale;
+
+  /// The sampling quality this view's image is composited onto the canvas
+  /// with, or null (the default) to inherit the scene's
+  /// `Scene.filterQuality`.
+  ///
+  /// Ignored when [target] is set; display filtering of a render texture
+  /// belongs to its consumer (for example `RenderTextureView`).
+  ui.FilterQuality? filterQuality;
 }

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -223,12 +223,19 @@ base class Scene implements SceneGraph {
   /// The sampling quality used when compositing screen views onto the
   /// canvas. Defaults to [ui.FilterQuality.medium].
   ///
-  /// This matters most when [renderScale] is not `1.0`:
-  /// [ui.FilterQuality.none] shows the rendered pixels as hard blocks,
-  /// the other modes smooth the scale. Per-view overrides via
-  /// `RenderView.filterQuality`. Ignored by views targeting a
-  /// `RenderTexture` (display filtering belongs to the consumer there,
-  /// for example `RenderTextureView.filterQuality`).
+  /// This matters most when [renderScale] is not `1.0`. The values map to
+  /// concrete sampling modes, [ui.FilterQuality.none] is nearest-neighbor
+  /// (hard pixel blocks), [ui.FilterQuality.low] is bilinear,
+  /// [ui.FilterQuality.medium] adds mipmaps, and [ui.FilterQuality.high]
+  /// is bicubic where the backend implements it. On native (Impeller),
+  /// `high` currently behaves like `medium`, and since the composited
+  /// image has no mipmaps every value except `none` resolves to plain
+  /// bilinear there; the web renderers (CanvasKit and Skwasm, both
+  /// Skia-backed) implement the tiers distinctly, including bicubic.
+  ///
+  /// Per-view overrides via `RenderView.filterQuality`. Ignored by views
+  /// targeting a `RenderTexture` (display filtering belongs to the
+  /// consumer there, for example `RenderTextureView.filterQuality`).
   ui.FilterQuality filterQuality = ui.FilterQuality.medium;
 
   /// Views this scene owns and renders every frame, in addition to the

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -19,6 +19,7 @@ import 'post_process/post_effect.dart';
 import 'post_process/post_process.dart';
 import 'render/bloom_pass.dart';
 import 'render/depth_prepass.dart';
+import 'render/fxaa_pass.dart';
 import 'render/post_effect_pass.dart';
 import 'render/render_graph.dart';
 import 'render/render_scene.dart';
@@ -57,18 +58,31 @@ mixin SceneGraph {
 
 /// Anti-aliasing strategy used when rendering a [Scene].
 ///
-/// Set on a [Scene] via [Scene.antiAliasingMode]. The default is [msaa]
-/// when the GPU backend supports offscreen MSAA, otherwise [none].
+/// Set on a [Scene] via [Scene.antiAliasingMode]. The default is [auto],
+/// which selects [msaa] when the GPU backend supports offscreen MSAA and
+/// [fxaa] otherwise, so every backend gets anti-aliasing out of the box.
+/// Query support with [Scene.isAntiAliasingModeSupported] and read the
+/// technique that actually runs from [Scene.effectiveAntiAliasingMode].
 /// {@category Scene graph}
 enum AntiAliasingMode {
   /// No anti-aliasing. Geometry edges are rendered at the render target's
   /// native resolution.
   none,
 
-  /// 4x multi-sample anti-aliasing. Requires offscreen MSAA support on
-  /// the active Flutter GPU backend; setting this mode is silently
-  /// ignored (with a debug warning) when MSAA is unavailable.
+  /// 4x multi-sample anti-aliasing on the scene pass. The highest quality
+  /// option for geometry edges, and cheap on mobile GPUs. Not supported
+  /// on every Flutter GPU backend; where it is unavailable, rendering
+  /// falls back to [fxaa] (see [Scene.effectiveAntiAliasingMode]).
   msaa,
+
+  /// Fast approximate anti-aliasing, a single post-process pass over the
+  /// tone-mapped image. Supported on every backend. Softens all
+  /// high-contrast edges, including texture detail, so prefer [msaa]
+  /// where it is available.
+  fxaa,
+
+  /// Selects [msaa] when the backend supports it and [fxaa] otherwise.
+  auto,
 }
 
 /// Represents a 3D scene, which is a collection of nodes that can be rendered onto the screen.
@@ -81,7 +95,6 @@ base class Scene implements SceneGraph {
   Scene() {
     initializeStaticResources();
     root.registerAsRoot(this);
-    antiAliasingMode = AntiAliasingMode.msaa;
   }
 
   static Future<void>? _initializeStaticResources;
@@ -108,32 +121,73 @@ base class Scene implements SceneGraph {
     return 1.0 / (1.2 * math.pow(2.0, ev100));
   }
 
-  AntiAliasingMode _antiAliasingMode = AntiAliasingMode.none;
+  // Resolved once at construction; the capability is fixed per context, so
+  // this avoids a backend query per frame. The eager read also makes
+  // Scene() fail fast when no usable Flutter GPU context exists, which the
+  // GPU-gated test suites rely on to skip without a device.
+  final bool _offscreenMsaaSupported = gpu.gpuContext.doesSupportOffscreenMSAA;
 
-  /// The anti-aliasing strategy used when rendering this [Scene].
+  AntiAliasingMode _antiAliasingMode = AntiAliasingMode.auto;
+  bool _warnedUnsupportedAntiAliasing = false;
+
+  /// The requested anti-aliasing strategy for this [Scene].
   ///
-  /// Defaults to [AntiAliasingMode.msaa] (set in the constructor) and falls
-  /// back to [AntiAliasingMode.none] when the active Flutter GPU backend
-  /// does not support offscreen MSAA. Assigning [AntiAliasingMode.msaa]
-  /// on an unsupported backend is silently ignored, leaving the previous
-  /// value in place.
+  /// Defaults to [AntiAliasingMode.auto]. The requested mode is always
+  /// kept; when it isn't supported by the active Flutter GPU backend
+  /// (currently only [AntiAliasingMode.msaa] can be unsupported),
+  /// rendering uses [AntiAliasingMode.fxaa] instead and a warning is
+  /// printed once in debug mode. Read [effectiveAntiAliasingMode] for the
+  /// technique that actually runs, and check support up front with
+  /// [isAntiAliasingModeSupported].
   set antiAliasingMode(AntiAliasingMode value) {
-    switch (value) {
-      case AntiAliasingMode.none:
-        break;
-      case AntiAliasingMode.msaa:
-        if (!gpu.gpuContext.doesSupportOffscreenMSAA) {
-          debugPrint("MSAA is not currently supported on this backend.");
-          return;
-        }
-        break;
-    }
-
     _antiAliasingMode = value;
+    final supported = value != AntiAliasingMode.msaa || _offscreenMsaaSupported;
+    if (!supported && !_warnedUnsupportedAntiAliasing) {
+      _warnedUnsupportedAntiAliasing = true;
+      debugPrint(
+        'Scene.antiAliasingMode: $value is not supported by the active GPU '
+        'backend; rendering with $effectiveAntiAliasingMode instead. Use '
+        'Scene.isAntiAliasingModeSupported to query support.',
+      );
+    }
   }
 
   AntiAliasingMode get antiAliasingMode {
     return _antiAliasingMode;
+  }
+
+  /// The anti-aliasing technique that actually runs when this [Scene]
+  /// renders.
+  ///
+  /// Resolves the requested [antiAliasingMode] against backend support:
+  /// [AntiAliasingMode.auto] becomes [AntiAliasingMode.msaa] where
+  /// offscreen MSAA is supported and [AntiAliasingMode.fxaa] otherwise,
+  /// and an unsupported [AntiAliasingMode.msaa] request also resolves to
+  /// [AntiAliasingMode.fxaa]. Never returns [AntiAliasingMode.auto].
+  AntiAliasingMode get effectiveAntiAliasingMode {
+    switch (_antiAliasingMode) {
+      case AntiAliasingMode.none:
+        return AntiAliasingMode.none;
+      case AntiAliasingMode.fxaa:
+        return AntiAliasingMode.fxaa;
+      case AntiAliasingMode.msaa:
+      case AntiAliasingMode.auto:
+        return _offscreenMsaaSupported
+            ? AntiAliasingMode.msaa
+            : AntiAliasingMode.fxaa;
+    }
+  }
+
+  /// Whether [mode] is supported by the active Flutter GPU backend.
+  ///
+  /// Every mode except [AntiAliasingMode.msaa] is supported everywhere;
+  /// MSAA requires offscreen MSAA support, which a subset of GLES-only
+  /// devices lacks. [AntiAliasingMode.auto] always reports supported
+  /// since it resolves to a supported technique by definition. Useful for
+  /// building settings UI without touching the Flutter GPU API directly.
+  static bool isAntiAliasingModeSupported(AntiAliasingMode mode) {
+    return mode != AntiAliasingMode.msaa ||
+        gpu.gpuContext.doesSupportOffscreenMSAA;
   }
 
   /// Casts [ray] through the scene's render geometry and returns the nearest
@@ -607,7 +661,9 @@ base class Scene implements SceneGraph {
       return;
     }
 
-    final enableMsaa = _antiAliasingMode == AntiAliasingMode.msaa;
+    final effectiveAa = effectiveAntiAliasingMode;
+    final enableMsaa = effectiveAa == AntiAliasingMode.msaa;
+    final enableFxaa = effectiveAa == AntiAliasingMode.fxaa;
     final gpu.Texture swapchainColor = surface.getNextSwapchainColorTexture(
       pixelSize,
       viewIndex,
@@ -740,9 +796,9 @@ base class Scene implements SceneGraph {
       );
     }
 
-    // The resolve writes the swapchain directly unless after-tone-mapping
-    // effects need an intermediate buffer to chain on.
-    final gpu.Texture resolveOutput = afterTonemap.isEmpty
+    // The resolve writes the swapchain directly unless FXAA or
+    // after-tone-mapping effects need an intermediate buffer to chain on.
+    final gpu.Texture resolveOutput = afterTonemap.isEmpty && !enableFxaa
         ? swapchainColor
         : pool.acquire(
             TransientTextureDescriptor.color(
@@ -760,6 +816,25 @@ base class Scene implements SceneGraph {
         postProcess: postProcess,
       ),
     );
+
+    // FXAA runs right after the resolve so custom after-tone-mapping
+    // effects receive the anti-aliased image. The resolve applies film
+    // grain and vignette first, so heavy grain is softened slightly here.
+    // TODO(antialiasing): if that softening bothers anyone, move grain
+    // application after the FXAA pass.
+    if (enableFxaa) {
+      final gpu.Texture fxaaOutput = afterTonemap.isEmpty
+          ? swapchainColor
+          : pool.acquire(
+              TransientTextureDescriptor.color(
+                width: width,
+                height: height,
+                format: swapchainColor.format,
+                debugName: 'fxaa_out',
+              ),
+            );
+      graph.addPass(FxaaPass(output: fxaaOutput, dimensions: pixelSize));
+    }
 
     // Custom effects on the display-referred image. The last one writes
     // the swapchain that gets composited onto the canvas.

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -27,6 +27,7 @@ import 'render/scene_pass.dart';
 import 'render/shadow_pass.dart';
 import 'render/ssao_pass.dart';
 import 'render/resolve_pass.dart';
+import 'render_texture.dart';
 import 'render_view.dart';
 import 'shaders.dart';
 import 'sky_environment.dart';
@@ -164,8 +165,11 @@ base class Scene implements SceneGraph {
   /// offscreen MSAA is supported and [AntiAliasingMode.fxaa] otherwise,
   /// and an unsupported [AntiAliasingMode.msaa] request also resolves to
   /// [AntiAliasingMode.fxaa]. Never returns [AntiAliasingMode.auto].
-  AntiAliasingMode get effectiveAntiAliasingMode {
-    switch (_antiAliasingMode) {
+  AntiAliasingMode get effectiveAntiAliasingMode =>
+      _resolveAntiAliasingMode(_antiAliasingMode);
+
+  AntiAliasingMode _resolveAntiAliasingMode(AntiAliasingMode requested) {
+    switch (requested) {
       case AntiAliasingMode.none:
         return AntiAliasingMode.none;
       case AntiAliasingMode.fxaa:
@@ -189,6 +193,17 @@ base class Scene implements SceneGraph {
     return mode != AntiAliasingMode.msaa ||
         gpu.gpuContext.doesSupportOffscreenMSAA;
   }
+
+  /// Views this scene owns and renders every frame, in addition to the
+  /// views passed to each [renderViews] call.
+  ///
+  /// This is the home for views targeting a [RenderTexture]
+  /// ([RenderView.target]): add one here and it re-renders whenever the
+  /// scene renders, subject to the target's [RenderTexture.update] policy,
+  /// without being threaded through every render call. Views in this list
+  /// without a target are ignored by [renderViews] (the screen views come
+  /// from the call's argument).
+  final List<RenderView> views = [];
 
   /// Casts [ray] through the scene's render geometry and returns the nearest
   /// hit, or null.
@@ -593,11 +608,43 @@ base class Scene implements SceneGraph {
         ? null
         : renderScene.directionalLights.first;
 
-    // Composite lower-order views first.
-    final ordered = views.length == 1
-        ? views
-        : (List<RenderView>.of(views)
-            ..sort((a, b) => a.order.compareTo(b.order)));
+    // Texture-target views render first so screen views (and the HUD)
+    // composite this frame's captures, the simple form of the
+    // produce-before-consume rule.
+    // TODO(rendertarget): order texture views among themselves by
+    // resource read/write edges once materials can sample render textures.
+    final textureViews = <RenderView>[
+      for (final view in this.views)
+        if (view.target != null) view,
+      for (final view in views)
+        if (view.target != null) view,
+    ]..sort((a, b) => a.order.compareTo(b.order));
+    final now = DateTime.now();
+    for (final view in textureViews) {
+      final target = view.target!;
+      if (!target.shouldUpdate(now)) {
+        continue;
+      }
+      _renderViewToTexture(
+        view: view,
+        outputColor: target.acquireNextTexture(),
+        pixelSize: ui.Size(target.width.toDouble(), target.height.toDouble()),
+        pool: target.transientTexturePool,
+        environmentMap: environmentMap,
+        transientsBuffer: transientsBuffer,
+        lightComponent: lightComponent,
+      );
+      target.markUpdated(now);
+    }
+
+    // Composite lower-order screen views first.
+    final screenViews = [
+      for (final view in views)
+        if (view.target == null) view,
+    ];
+    final ordered = screenViews.length == 1
+        ? screenViews
+        : (screenViews..sort((a, b) => a.order.compareTo(b.order)));
 
     for (var i = 0; i < ordered.length; i++) {
       final view = ordered[i];
@@ -646,8 +693,6 @@ base class Scene implements SceneGraph {
     required gpu.HostBuffer transientsBuffer,
     required DirectionalLightComponent? lightComponent,
   }) {
-    final camera = view.camera;
-
     // Allocate the offscreen render target at physical-pixel resolution so
     // the rasterized 3D content matches Flutter's framebuffer density.
     // Without this, the texture is sized in logical pixels and the
@@ -661,14 +706,45 @@ base class Scene implements SceneGraph {
       return;
     }
 
-    final effectiveAa = effectiveAntiAliasingMode;
-    final enableMsaa = effectiveAa == AntiAliasingMode.msaa;
-    final enableFxaa = effectiveAa == AntiAliasingMode.fxaa;
     final gpu.Texture swapchainColor = surface.getNextSwapchainColorTexture(
       pixelSize,
       viewIndex,
     );
-    final pool = surface.transientTexturePool(viewIndex);
+    _renderViewToTexture(
+      view: view,
+      outputColor: swapchainColor,
+      pixelSize: pixelSize,
+      pool: surface.transientTexturePool(viewIndex),
+      environmentMap: environmentMap,
+      transientsBuffer: transientsBuffer,
+      lightComponent: lightComponent,
+    );
+
+    final image = swapchainColor.asImage();
+    final srcRect = ui.Rect.fromLTWH(0, 0, pixelSize.width, pixelSize.height);
+    final paint = ui.Paint()..filterQuality = ui.FilterQuality.medium;
+    canvas.drawImageRect(image, srcRect, drawArea, paint);
+  }
+
+  // Builds and submits one view's render graph into [outputColor] (a
+  // swapchain texture for screen views, or a [RenderTexture] ring slot).
+  // [pool] supplies the view's transient attachments; each view (and each
+  // render texture) has its own so simultaneous renders never share one.
+  void _renderViewToTexture({
+    required RenderView view,
+    required gpu.Texture outputColor,
+    required ui.Size pixelSize,
+    required TransientTexturePool pool,
+    required EnvironmentMap environmentMap,
+    required gpu.HostBuffer transientsBuffer,
+    required DirectionalLightComponent? lightComponent,
+  }) {
+    final camera = view.camera;
+    final effectiveAa = _resolveAntiAliasingMode(
+      view.antiAliasingMode ?? _antiAliasingMode,
+    );
+    final enableMsaa = effectiveAa == AntiAliasingMode.msaa;
+    final enableFxaa = effectiveAa == AntiAliasingMode.fxaa;
 
     final light = lightComponent?.light;
     final lightDirection = lightComponent?.worldDirection;
@@ -796,15 +872,15 @@ base class Scene implements SceneGraph {
       );
     }
 
-    // The resolve writes the swapchain directly unless FXAA or
+    // The resolve writes the output directly unless FXAA or
     // after-tone-mapping effects need an intermediate buffer to chain on.
     final gpu.Texture resolveOutput = afterTonemap.isEmpty && !enableFxaa
-        ? swapchainColor
+        ? outputColor
         : pool.acquire(
             TransientTextureDescriptor.color(
               width: width,
               height: height,
-              format: swapchainColor.format,
+              format: outputColor.format,
               debugName: 'post_ldr_resolve',
             ),
           );
@@ -824,12 +900,12 @@ base class Scene implements SceneGraph {
     // application after the FXAA pass.
     if (enableFxaa) {
       final gpu.Texture fxaaOutput = afterTonemap.isEmpty
-          ? swapchainColor
+          ? outputColor
           : pool.acquire(
               TransientTextureDescriptor.color(
                 width: width,
                 height: height,
-                format: swapchainColor.format,
+                format: outputColor.format,
                 debugName: 'fxaa_out',
               ),
             );
@@ -837,16 +913,16 @@ base class Scene implements SceneGraph {
     }
 
     // Custom effects on the display-referred image. The last one writes
-    // the swapchain that gets composited onto the canvas.
+    // the output texture.
     for (var i = 0; i < afterTonemap.length; i++) {
       final isLast = i == afterTonemap.length - 1;
       final output = isLast
-          ? swapchainColor
+          ? outputColor
           : pool.acquire(
               TransientTextureDescriptor.color(
                 width: width,
                 height: height,
-                format: swapchainColor.format,
+                format: outputColor.format,
                 debugName: i.isEven ? 'post_ldr_a' : 'post_ldr_b',
               ),
             );
@@ -863,10 +939,5 @@ base class Scene implements SceneGraph {
     }
 
     graph.execute(transientsBuffer: transientsBuffer, texturePool: pool);
-
-    final image = swapchainColor.asImage();
-    final srcRect = ui.Rect.fromLTWH(0, 0, pixelSize.width, pixelSize.height);
-    final paint = ui.Paint()..filterQuality = ui.FilterQuality.medium;
-    canvas.drawImageRect(image, srcRect, drawArea, paint);
   }
 }

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -194,6 +194,43 @@ base class Scene implements SceneGraph {
         gpu.gpuContext.doesSupportOffscreenMSAA;
   }
 
+  double _renderScale = 1.0;
+
+  /// Scales the resolution screen views render at, relative to the
+  /// display's native resolution. Defaults to `1.0`.
+  ///
+  /// Values below `1.0` trade sharpness for proportionally less fragment
+  /// work on every device (the multiplier applies on top of the device
+  /// pixel ratio, so the cost saving is display-relative); values above
+  /// `1.0` supersample. Combine a low scale with
+  /// [FilterQuality.none] in [filterQuality] for a pixelated look.
+  ///
+  /// Per-view overrides via `RenderView.renderScale`. Ignored by views
+  /// targeting a `RenderTexture`, whose resolution is the texture's
+  /// explicit size. Changing the scale reallocates the view's swapchain
+  /// at the new size, so treat it as a settings-style knob rather than a
+  /// per-frame animation target.
+  double get renderScale => _renderScale;
+
+  set renderScale(double value) {
+    assert(
+      value.isFinite && value > 0.0,
+      'renderScale must be a positive, finite number.',
+    );
+    _renderScale = value;
+  }
+
+  /// The sampling quality used when compositing screen views onto the
+  /// canvas. Defaults to [ui.FilterQuality.medium].
+  ///
+  /// This matters most when [renderScale] is not `1.0`:
+  /// [ui.FilterQuality.none] shows the rendered pixels as hard blocks,
+  /// the other modes smooth the scale. Per-view overrides via
+  /// `RenderView.filterQuality`. Ignored by views targeting a
+  /// `RenderTexture` (display filtering belongs to the consumer there,
+  /// for example `RenderTextureView.filterQuality`).
+  ui.FilterQuality filterQuality = ui.FilterQuality.medium;
+
   /// Views this scene owns and renders every frame, in addition to the
   /// views passed to each [renderViews] call.
   ///
@@ -698,9 +735,12 @@ base class Scene implements SceneGraph {
     // Without this, the texture is sized in logical pixels and the
     // framebuffer compositor upscales it (visible as pixelation on
     // high-DPI devices). See: https://github.com/bdero/flutter_scene/issues/60
+    // The render scale multiplies on top, trading resolution for fragment
+    // work (or supersampling above 1.0).
+    final scale = dpr * (view.renderScale ?? _renderScale);
     final pixelSize = ui.Size(
-      (drawArea.width * dpr).ceilToDouble(),
-      (drawArea.height * dpr).ceilToDouble(),
+      (drawArea.width * scale).ceilToDouble(),
+      (drawArea.height * scale).ceilToDouble(),
     );
     if (pixelSize.width < 1 || pixelSize.height < 1) {
       return;
@@ -722,7 +762,8 @@ base class Scene implements SceneGraph {
 
     final image = swapchainColor.asImage();
     final srcRect = ui.Rect.fromLTWH(0, 0, pixelSize.width, pixelSize.height);
-    final paint = ui.Paint()..filterQuality = ui.FilterQuality.medium;
+    final paint = ui.Paint()
+      ..filterQuality = view.filterQuality ?? filterQuality;
     canvas.drawImageRect(image, srcRect, drawArea, paint);
   }
 

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -618,6 +618,16 @@ base class Scene implements SceneGraph {
       }
     }
 
+    // The web radiance prefilter is degenerate when built on a cold WebGL
+    // context (before the first frame composites); environments built then
+    // (the lazily built default below, or any the app built up front) are
+    // re-baked once a frame has been presented and the context is warm. No-op
+    // on other backends and after the one-time rebuild. See
+    // EnvironmentMap.markContextWarmAndRebakeRadiance.
+    if (_hasPresentedFrame) {
+      EnvironmentMap.markContextWarmAndRebakeRadiance();
+    }
+
     // Resolve the IBL environment up front (before building any render
     // graph): the default is built lazily here on first use, which submits
     // a one-time prefilter pass that must not be nested inside the frame's
@@ -712,7 +722,15 @@ base class Scene implements SceneGraph {
         lightComponent: lightComponent,
       );
     }
+
+    // A frame has now been submitted; the next one runs on a warm context (see
+    // the rebuild near the environment resolution above).
+    _hasPresentedFrame = true;
   }
+
+  // Whether at least one frame has been rendered and presented, so the web
+  // GL context is warm enough for a correct radiance prefilter.
+  static bool _hasPresentedFrame = false;
 
   // Maps a view's normalized viewport rectangle (0..1) into a canvas
   // sub-rectangle of [area]; a null viewport fills [area].

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -23,6 +23,7 @@ import 'render/fxaa_pass.dart';
 import 'render/post_effect_pass.dart';
 import 'render/render_graph.dart';
 import 'render/render_scene.dart';
+import 'render/instance_packing.dart';
 import 'render/scene_pass.dart';
 import 'render/shadow_pass.dart';
 import 'render/ssao_pass.dart';
@@ -630,6 +631,10 @@ base class Scene implements SceneGraph {
     final transientsBuffer = _transientsBuffer ??= gpu.gpuContext
         .createHostBuffer();
     transientsBuffer.reset();
+    // Advance the instance-transform buffer pool to this frame's set (it
+    // backs the instance-rate vertex buffer, separate from the uniform
+    // host buffer above; see instance_packing.dart).
+    instanceTransformBuffers.beginFrame();
 
     // Advance the scene once per frame (not once per view): tick components
     // and animations and refresh the flat render list before the passes

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -246,11 +246,7 @@ base class SceneEncoder {
     );
     if (geometry.instancedVertexLayout != null) {
       // The model matrix arrives through the instance-rate vertex buffer.
-      bindSingleInstanceTransform(
-        _renderPass,
-        _transientsBuffer,
-        worldTransform,
-      );
+      bindSingleInstanceTransform(_renderPass, worldTransform);
     }
     material.bind(_renderPass, _transientsBuffer, _lighting);
     if (windingFlipped) {
@@ -316,12 +312,12 @@ base class SceneEncoder {
       nodeWindingFlipped: windingFlipped,
     );
     if (packed.ccwCount > 0) {
-      bindInstanceTransforms(_renderPass, _transientsBuffer, packed.ccw);
+      bindInstanceTransforms(_renderPass, packed.ccw);
       _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
       geometry.draw(_renderPass, instanceCount: packed.ccwCount);
     }
     if (packed.cwCount > 0) {
-      bindInstanceTransforms(_renderPass, _transientsBuffer, packed.cw);
+      bindInstanceTransforms(_renderPass, packed.cw);
       _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
       geometry.draw(_renderPass, instanceCount: packed.cwCount);
     }

--- a/packages/flutter_scene/lib/src/shaders.dart
+++ b/packages/flutter_scene/lib/src/shaders.dart
@@ -12,34 +12,27 @@ gpu.ShaderLibrary? _baseShaderLibrary;
 /// (`StandardFragment`, `UnlitFragment`). Custom [Geometry] or [Material]
 /// subclasses can pull additional shaders from this library.
 ///
-/// On native (Impeller) platforms the bundle loads synchronously on first
-/// access. On web, synchronous asset reads aren't possible, so the bundle
-/// must be loaded ahead of time by awaiting [Scene.initializeStaticResources]
-/// (which calls [loadBaseShaderLibrary]); accessing this getter before that
-/// completes throws.
+/// Reading a shader bundle from an asset is asynchronous on every backend,
+/// so the bundle must be loaded ahead of time by awaiting
+/// [Scene.initializeStaticResources] (which calls [loadBaseShaderLibrary]);
+/// accessing this getter before that completes throws.
 /// {@category Assets and loading}
 gpu.ShaderLibrary get baseShaderLibrary {
   final cached = _baseShaderLibrary;
-  if (cached != null) {
-    return cached;
-  }
-  // Native fast path preserves the old lazy behavior. On web,
-  // ShaderLibrary.fromAsset throws (asset reads are async) - callers must
-  // await Scene.initializeStaticResources() before touching shaders.
-  final lib = gpu.ShaderLibrary.fromAsset(_kBaseShaderBundlePath);
-  if (lib == null) {
+  if (cached == null) {
     throw Exception(
-      "Failed to load base shader bundle! ($_kBaseShaderBundlePath)",
+      'The base shader bundle has not been loaded yet. Await '
+      'Scene.initializeStaticResources() before constructing geometry or '
+      'materials that touch the base shader library.',
     );
   }
-  _baseShaderLibrary = lib;
-  return lib;
+  return cached;
 }
 
 /// Asynchronously loads and caches the base shader bundle. Idempotent.
 /// Called by [Scene.initializeStaticResources] so the synchronous
-/// [baseShaderLibrary] getter has a cached library to return (required on
-/// web, where shader assets can't be read synchronously).
+/// [baseShaderLibrary] getter has a cached library to return (shader assets
+/// can't be read synchronously on any backend).
 /// {@category Assets and loading}
 Future<void> loadBaseShaderLibrary() async {
   if (_baseShaderLibrary != null) {

--- a/packages/flutter_scene/lib/src/skybox.dart
+++ b/packages/flutter_scene/lib/src/skybox.dart
@@ -5,6 +5,7 @@ library;
 import 'dart:typed_data';
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material.dart';
 
@@ -126,15 +127,10 @@ class ShaderSkySource extends SkySource {
       );
     }
     if (useEnvironment) {
-      pass.bindTexture(
-        fragmentShader.getUniformSlot('prefiltered_radiance'),
-        environment.prefilteredRadianceTexture,
-        sampler: gpu.SamplerOptions(
-          minFilter: gpu.MinMagFilter.linear,
-          magFilter: gpu.MinMagFilter.linear,
-          widthAddressMode: gpu.SamplerAddressMode.repeat,
-          heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-        ),
+      EngineLightingUniforms.bindPrefilteredRadiance(
+        pass,
+        fragmentShader,
+        environment,
       );
       pass.bindTexture(
         fragmentShader.getUniformSlot('brdf_lut'),

--- a/packages/flutter_scene/lib/src/texture/compressed_texture.dart
+++ b/packages/flutter_scene/lib/src/texture/compressed_texture.dart
@@ -75,6 +75,10 @@ int _selectMode() {
         return _modeBc1;
       case gpu.TextureCompressionFamily.etc2:
         return _modeEtc2;
+      case gpu.TextureCompressionFamily.astcHdr:
+        // The transcoder emits LDR formats only; HDR ASTC is not a
+        // transcode target, so skip to the next preferred family.
+        break;
     }
   }
   return _modeRgba8;

--- a/packages/flutter_scene/lib/src/widgets/render_texture_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/render_texture_view.dart
@@ -39,6 +39,11 @@ class RenderTextureView extends StatefulWidget {
   final BoxFit fit;
 
   /// The sampling quality the texture is drawn with.
+  ///
+  /// [FilterQuality.none] is nearest-neighbor (hard pixel blocks when the
+  /// texture is smaller than the widget) and the other values smooth the
+  /// scale; `Scene.filterQuality` documents how they map to concrete
+  /// sampling modes per backend.
   final FilterQuality filterQuality;
 
   /// Whether to resize [renderTexture] to the widget's layout size (times

--- a/packages/flutter_scene/lib/src/widgets/render_texture_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/render_texture_view.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:flutter_scene/src/render_texture.dart';
@@ -71,7 +72,20 @@ class _RenderTextureViewState extends State<RenderTextureView> {
   }
 
   void _onUpdated() {
-    if (mounted) {
+    if (!mounted) {
+      return;
+    }
+    // The target re-renders inside the scene's paint, so this notification
+    // usually arrives mid-frame, where setState is not allowed. Defer the
+    // rebuild to the end of the frame; the new image shows next frame.
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {});
+        }
+      });
+    } else {
       setState(() {});
     }
   }

--- a/packages/flutter_scene/lib/src/widgets/render_texture_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/render_texture_view.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:flutter_scene/src/render_texture.dart';
+
+/// Displays a live [RenderTexture] in the widget tree.
+///
+/// The widget repaints whenever the target re-renders (per its
+/// `RenderTexture.update` policy) and shows nothing until the first render
+/// completes. It fills the constraints it is given, scaling the texture
+/// with [fit].
+///
+/// ```dart
+/// final minimap = RenderTexture(width: 480, height: 270);
+/// scene.views.add(RenderView(camera: topCamera, target: minimap));
+/// // ... in the widget tree, typically stacked over the SceneView:
+/// SizedBox(width: 240, height: 135, child: RenderTextureView(minimap))
+/// ```
+///
+/// With [followLayout] enabled, the target is resized to match the
+/// widget's layout size (times the device pixel ratio), so the capture is
+/// always rendered at display resolution. Off by default, so a fixed-size
+/// target is never silently reallocated by layout changes.
+/// {@category Widgets}
+class RenderTextureView extends StatefulWidget {
+  /// Displays [renderTexture], repainting whenever it re-renders.
+  const RenderTextureView(
+    this.renderTexture, {
+    super.key,
+    this.fit = BoxFit.contain,
+    this.filterQuality = FilterQuality.medium,
+    this.followLayout = false,
+  });
+
+  /// The render target to display.
+  final RenderTexture renderTexture;
+
+  /// How the texture is inscribed into the widget's bounds.
+  final BoxFit fit;
+
+  /// The sampling quality the texture is drawn with.
+  final FilterQuality filterQuality;
+
+  /// Whether to resize [renderTexture] to the widget's layout size (times
+  /// the device pixel ratio). See the class doc.
+  final bool followLayout;
+
+  @override
+  State<RenderTextureView> createState() => _RenderTextureViewState();
+}
+
+class _RenderTextureViewState extends State<RenderTextureView> {
+  @override
+  void initState() {
+    super.initState();
+    widget.renderTexture.addListener(_onUpdated);
+  }
+
+  @override
+  void didUpdateWidget(RenderTextureView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.renderTexture != oldWidget.renderTexture) {
+      oldWidget.renderTexture.removeListener(_onUpdated);
+      widget.renderTexture.addListener(_onUpdated);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.renderTexture.removeListener(_onUpdated);
+    super.dispose();
+  }
+
+  void _onUpdated() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void _followLayout(BoxConstraints constraints, double dpr) {
+    final width = (constraints.biggest.width * dpr).ceil();
+    final height = (constraints.biggest.height * dpr).ceil();
+    if (width > 0 && height > 0) {
+      // Resizing only reallocates the texture ring (no relayout), so doing
+      // it during build is safe; the next scene render picks it up.
+      widget.renderTexture.resize(width, height);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (widget.followLayout && constraints.biggest.isFinite) {
+          _followLayout(constraints, MediaQuery.devicePixelRatioOf(context));
+        }
+        final texture = widget.renderTexture.texture;
+        return SizedBox.expand(
+          child: texture == null
+              ? null
+              : RawImage(
+                  image: texture.asImage(),
+                  fit: widget.fit,
+                  filterQuality: widget.filterQuality,
+                ),
+        );
+      },
+    );
+  }
+}

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
     sdk: flutter
   # 0.4.5 includes the DataAssets shader-bundle mode used by the new
   # zero-manifest .fmat workflow.
-  flutter_gpu_shaders: ^0.5.0
+  flutter_gpu_shaders: ^0.5.1
   hooks: ^2.0.0
   image: ^4.5.0
   logging: ^1.2.0

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -39,6 +39,10 @@
         "type": "fragment",
         "file": "shaders/flutter_scene_resolve.frag"
     },
+    "FxaaFragment": {
+        "type": "fragment",
+        "file": "shaders/flutter_scene_fxaa.frag"
+    },
     "PrefilterEnvFragment": {
         "type": "fragment",
         "file": "shaders/flutter_scene_prefilter_env.frag"

--- a/packages/flutter_scene/shaders/flutter_scene_fxaa.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_fxaa.frag
@@ -1,0 +1,233 @@
+// FXAA pass: anti-aliases the display-referred image produced by the
+// resolve pass as a single full-screen pass, using the FXAA 3.11 quality
+// algorithm (luma-contrast edge detection, an edge-endpoint walk, and a
+// subpixel blend). Luma is computed from rgb per tap; the alpha channel
+// carries real premultiplied coverage for compositing, so it can't hold
+// precomputed luma. The input texture must have a single mip level
+// (sampling here happens inside divergent control flow, which is only
+// well-defined because there are no mips to select between).
+//
+// Derived from NVIDIA FXAA 3.11 by Timothy Lottes, as published under the
+// BSD 3-clause license:
+//
+//   Copyright (c) 2014-2015, NVIDIA CORPORATION. All rights reserved.
+//
+//   Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//   are met:
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in
+//      the documentation and/or other materials provided with the
+//      distribution.
+//    * Neither the name of NVIDIA CORPORATION nor the names of its
+//      contributors may be used to endorse or promote products derived
+//      from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+//   EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//   PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+//   OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+uniform FxaaInfo {
+  // 1 / render target size in pixels (x = 1/width, y = 1/height).
+  vec2 inv_target_size;
+  float _pad0;
+  float _pad1;
+}
+fxaa_info;
+
+uniform sampler2D scene_color;
+
+in vec2 v_uv;
+
+out vec4 frag_color;
+
+// Edge detection thresholds and subpixel blend strength (the FXAA 3.11
+// quality defaults).
+// TODO(antialiasing): expose these as settings if tuning demand appears.
+const float kEdgeThreshold = 0.166;
+const float kEdgeThresholdMin = 0.0833;
+const float kSubpixelQuality = 0.75;
+
+// Edge-walk iterations and per-iteration step scale (quality preset 39).
+const int kIterations = 12;
+
+float StepSize(int i) {
+  if (i < 5) {
+    return 1.0;
+  }
+  if (i == 5) {
+    return 1.5;
+  }
+  if (i < 10) {
+    return 2.0;
+  }
+  if (i == 10) {
+    return 4.0;
+  }
+  return 8.0;
+}
+
+float Luma(vec3 color) {
+  return dot(color, vec3(0.299, 0.587, 0.114));
+}
+
+float LumaAt(vec2 uv) {
+  return Luma(texture(scene_color, uv).rgb);
+}
+
+void main() {
+  vec2 inv_size = fxaa_info.inv_target_size;
+  vec4 center = texture(scene_color, v_uv);
+  float luma_center = Luma(center.rgb);
+
+  float luma_down = LumaAt(v_uv + vec2(0.0, -inv_size.y));
+  float luma_up = LumaAt(v_uv + vec2(0.0, inv_size.y));
+  float luma_left = LumaAt(v_uv + vec2(-inv_size.x, 0.0));
+  float luma_right = LumaAt(v_uv + vec2(inv_size.x, 0.0));
+
+  float luma_min = min(
+      luma_center,
+      min(min(luma_down, luma_up), min(luma_left, luma_right)));
+  float luma_max = max(
+      luma_center,
+      max(max(luma_down, luma_up), max(luma_left, luma_right)));
+  float luma_range = luma_max - luma_min;
+
+  // Skip pixels that aren't on a visible-contrast edge.
+  if (luma_range < max(kEdgeThresholdMin, luma_max * kEdgeThreshold)) {
+    frag_color = center;
+    return;
+  }
+
+  float luma_down_left = LumaAt(v_uv + vec2(-inv_size.x, -inv_size.y));
+  float luma_up_right = LumaAt(v_uv + vec2(inv_size.x, inv_size.y));
+  float luma_up_left = LumaAt(v_uv + vec2(-inv_size.x, inv_size.y));
+  float luma_down_right = LumaAt(v_uv + vec2(inv_size.x, -inv_size.y));
+
+  float luma_down_up = luma_down + luma_up;
+  float luma_left_right = luma_left + luma_right;
+  float luma_left_corners = luma_down_left + luma_up_left;
+  float luma_down_corners = luma_down_left + luma_down_right;
+  float luma_right_corners = luma_down_right + luma_up_right;
+  float luma_up_corners = luma_up_right + luma_up_left;
+
+  // Second-derivative estimate along each axis classifies the edge as
+  // horizontal or vertical.
+  float edge_horizontal = abs(-2.0 * luma_left + luma_left_corners) +
+                          abs(-2.0 * luma_center + luma_down_up) * 2.0 +
+                          abs(-2.0 * luma_right + luma_right_corners);
+  float edge_vertical = abs(-2.0 * luma_up + luma_up_corners) +
+                        abs(-2.0 * luma_center + luma_left_right) * 2.0 +
+                        abs(-2.0 * luma_down + luma_down_corners);
+  bool is_horizontal = edge_horizontal >= edge_vertical;
+
+  // Of the two pixels across the edge, find the steeper side.
+  float luma1 = is_horizontal ? luma_down : luma_left;
+  float luma2 = is_horizontal ? luma_up : luma_right;
+  float gradient1 = luma1 - luma_center;
+  float gradient2 = luma2 - luma_center;
+  bool is_1_steepest = abs(gradient1) >= abs(gradient2);
+  float gradient_scaled = 0.25 * max(abs(gradient1), abs(gradient2));
+
+  float step_length = is_horizontal ? inv_size.y : inv_size.x;
+  float luma_local_average;
+  if (is_1_steepest) {
+    step_length = -step_length;
+    luma_local_average = 0.5 * (luma1 + luma_center);
+  } else {
+    luma_local_average = 0.5 * (luma2 + luma_center);
+  }
+
+  // Start at the edge midpoint between the two pixels.
+  vec2 current_uv = v_uv;
+  if (is_horizontal) {
+    current_uv.y += step_length * 0.5;
+  } else {
+    current_uv.x += step_length * 0.5;
+  }
+
+  // Walk along the edge in both directions until the luma delta against
+  // the local average exceeds the gradient (the edge endpoint).
+  vec2 offset = is_horizontal ? vec2(inv_size.x, 0.0) : vec2(0.0, inv_size.y);
+  vec2 uv1 = current_uv - offset;
+  vec2 uv2 = current_uv + offset;
+
+  float luma_end1 = LumaAt(uv1) - luma_local_average;
+  float luma_end2 = LumaAt(uv2) - luma_local_average;
+  bool reached1 = abs(luma_end1) >= gradient_scaled;
+  bool reached2 = abs(luma_end2) >= gradient_scaled;
+  bool reached_both = reached1 && reached2;
+  if (!reached1) {
+    uv1 -= offset;
+  }
+  if (!reached2) {
+    uv2 += offset;
+  }
+
+  if (!reached_both) {
+    for (int i = 2; i < kIterations; i++) {
+      if (!reached1) {
+        luma_end1 = LumaAt(uv1) - luma_local_average;
+      }
+      if (!reached2) {
+        luma_end2 = LumaAt(uv2) - luma_local_average;
+      }
+      reached1 = abs(luma_end1) >= gradient_scaled;
+      reached2 = abs(luma_end2) >= gradient_scaled;
+      reached_both = reached1 && reached2;
+      if (reached_both) {
+        break;
+      }
+      if (!reached1) {
+        uv1 -= offset * StepSize(i);
+      }
+      if (!reached2) {
+        uv2 += offset * StepSize(i);
+      }
+    }
+  }
+
+  float distance1 = is_horizontal ? (v_uv.x - uv1.x) : (v_uv.y - uv1.y);
+  float distance2 = is_horizontal ? (uv2.x - v_uv.x) : (uv2.y - v_uv.y);
+  bool is_direction1 = distance1 < distance2;
+  float distance_final = min(distance1, distance2);
+  float edge_length = distance1 + distance2;
+  float pixel_offset = -distance_final / edge_length + 0.5;
+
+  // Only offset when the endpoint luma variation is consistent with the
+  // center pixel sitting on the darker/lighter side of the edge.
+  bool is_center_smaller = luma_center < luma_local_average;
+  bool correct_variation =
+      ((is_direction1 ? luma_end1 : luma_end2) < 0.0) != is_center_smaller;
+  float final_offset = correct_variation ? pixel_offset : 0.0;
+
+  // Subpixel anti-aliasing for high-frequency detail the edge walk misses.
+  float luma_average =
+      (1.0 / 12.0) * (2.0 * (luma_down_up + luma_left_right) +
+                      luma_left_corners + luma_right_corners);
+  float subpixel1 =
+      clamp(abs(luma_average - luma_center) / luma_range, 0.0, 1.0);
+  float subpixel2 = (-2.0 * subpixel1 + 3.0) * subpixel1 * subpixel1;
+  float subpixel_offset = subpixel2 * subpixel2 * kSubpixelQuality;
+  final_offset = max(final_offset, subpixel_offset);
+
+  // Resample shifted perpendicular to the edge. The premultiplied rgba is
+  // filtered as a unit, so coverage stays consistent with color.
+  vec2 final_uv = v_uv;
+  if (is_horizontal) {
+    final_uv.y += final_offset * step_length;
+  } else {
+    final_uv.x += final_offset * step_length;
+  }
+  frag_color = texture(scene_color, final_uv);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_prefilter_env.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_prefilter_env.frag
@@ -16,6 +16,11 @@ uniform PrefilterInfo {
   // per frame, LoadAction.load preserving the others) costs roughly
   // 1/kPrefilterBands of the full pass.
   float band_index;
+  // 1.0 when the render target is a single band covering the whole target
+  // (the mip layout: the pass renders band_index into one mip level of an
+  // equirect, so there is no atlas math and no discard). band_index must
+  // be non-negative in this mode.
+  float whole_target;
 }
 prefilter_info;
 
@@ -81,12 +86,19 @@ vec3 ImportanceSampleGGX(vec2 xi, vec3 n, float roughness) {
 }
 
 void main() {
-  float band_index = floor(v_uv.y * kPrefilterBands);
-  if (prefilter_info.band_index >= 0.0 &&
-      band_index != prefilter_info.band_index) {
-    discard;
+  float band_index;
+  float band_v;
+  if (prefilter_info.whole_target > 0.5) {
+    band_index = prefilter_info.band_index;
+    band_v = v_uv.y;
+  } else {
+    band_index = floor(v_uv.y * kPrefilterBands);
+    if (prefilter_info.band_index >= 0.0 &&
+        band_index != prefilter_info.band_index) {
+      discard;
+    }
+    band_v = fract(v_uv.y * kPrefilterBands);
   }
-  float band_v = fract(v_uv.y * kPrefilterBands);
   vec3 n = normalize(EquirectangularToSpherical(vec2(v_uv.x, band_v)));
   // Standard "view == normal" prefiltering assumption.
   vec3 v = n;

--- a/packages/flutter_scene/shaders/texture.glsl
+++ b/packages/flutter_scene/shaders/texture.glsl
@@ -19,11 +19,10 @@ vec3 SampleEnvironmentTexture(sampler2D tex, vec3 direction) {
 
 vec3 SampleEnvironmentTextureLod(sampler2D tex, vec3 direction, float lod) {
   vec2 uv = SphericalToEquirectangular(direction);
-  // textureLod is not supported in GLSL ES 1.0. But it doesn't matter anyway,
-  // since this function will eventually use `textureCubeLod` once environment
-  // maps are fixed.
-  //return textureLod(tex, uv, lod).rgb;
-  return texture(tex, uv).rgb;
+  // Compiles to texture2DLodEXT (GL_EXT_shader_texture_lod) on the GLES
+  // 1.00 dialect; the sampler must use a mipmap min filter for the lod to
+  // take effect.
+  return textureLod(tex, uv, lod).rgb;
 }
 
 // Inverse of SphericalToEquirectangular: maps an equirectangular UV back to
@@ -36,26 +35,53 @@ vec3 EquirectangularToSpherical(vec2 uv) {
 }
 
 //------------------------------------------------------------------------------
-/// Prefiltered radiance atlas.
+/// Prefiltered radiance.
 ///
-/// The specular IBL is sampled from a "PMREM-style" atlas: kPrefilterBands
-/// equirectangular bands stacked vertically, band i prefiltered for
-/// perceptual roughness i / (kPrefilterBands - 1) (band 0 = mirror, the last
-/// band = fully rough). Generated once by flutter_scene_prefilter_env.frag;
-/// the layout here must match env_prefilter.dart.
+/// The specular IBL is sampled from a "PMREM-style" prefiltered equirect:
+/// kPrefilterBands roughness bands, band i prefiltered for perceptual
+/// roughness i / (kPrefilterBands - 1) (band 0 = mirror, the last band =
+/// fully rough). Two layouts exist (see env_prefilter.dart, which this must
+/// match):
+///  * mip layout: one equirect whose mip level i is band i, sampled with
+///    textureLod (hardware trilinear between bands).
+///  * legacy band atlas: the bands stacked vertically in one texture,
+///    sampled with a manual two-band lerp.
+/// The engine binds RadianceLayoutInfo alongside the prefiltered_radiance
+/// sampler to select the bound texture's layout.
 ///
 
 const float kPrefilterBands = 8.0;
 const float kPrefilterBandHeight = 256.0;
 // Keep bilinear taps from bleeding across the seam between bands: clamp the
-// in-band V to one texel from each edge.
+// in-band V to one texel from each edge (legacy band-atlas layout only).
 const float kPrefilterBandEdgeClamp = 1.0 / kPrefilterBandHeight;
 
-// Samples the prefiltered radiance atlas for reflection `direction` at the
-// given perceptual `roughness`, interpolating between the two nearest
-// bands. Sample the atlas with a horizontal-repeat / vertical-clamp sampler.
+uniform RadianceLayoutInfo {
+  // 1.0 when the bound prefiltered_radiance stores its roughness bands as
+  // mip levels; 0.0 for the legacy stacked-band atlas.
+  float mip_layout;
+}
+radiance_layout_info;
+
+// Samples a mip-layout prefiltered radiance texture (band i in mip level
+// i) for reflection `direction` at the given perceptual `roughness`. The
+// sampler must use a linear mip filter for the lod to take effect.
+vec3 SamplePrefilteredRadianceLod(sampler2D radiance, vec3 direction,
+                                  float roughness) {
+  vec2 eq = SphericalToEquirectangular(direction);
+  float lod = clamp(roughness, 0.0, 1.0) * (kPrefilterBands - 1.0);
+  return textureLod(radiance, eq, lod).rgb;
+}
+
+// Samples the prefiltered radiance for reflection `direction` at the given
+// perceptual `roughness`, dispatching on the bound texture's layout (see
+// RadianceLayoutInfo). Sample with a horizontal-repeat / vertical-clamp
+// sampler.
 vec3 SamplePrefilteredRadiance(sampler2D atlas, vec3 direction,
                                float roughness) {
+  if (radiance_layout_info.mip_layout > 0.5) {
+    return SamplePrefilteredRadianceLod(atlas, direction, roughness);
+  }
   vec2 eq = SphericalToEquirectangular(direction);
   eq.y = clamp(eq.y, kPrefilterBandEdgeClamp, 1.0 - kPrefilterBandEdgeClamp);
   float band = clamp(roughness, 0.0, 1.0) * (kPrefilterBands - 1.0);

--- a/packages/flutter_scene/test/anti_aliasing_test.dart
+++ b/packages/flutter_scene/test/anti_aliasing_test.dart
@@ -1,0 +1,80 @@
+// Covers the anti-aliasing mode API: the auto default, requested vs
+// effective resolution, and the support query. GPU-gated like the other
+// suites; resolving the effective mode reads backend capabilities, so the
+// whole suite skips without a device.
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+bool _gpuAvailable() {
+  try {
+    Scene();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+void main() {
+  if (!_gpuAvailable()) {
+    test(
+      'anti-aliasing suite (skipped: no GPU device)',
+      () {},
+      skip: 'Requires a GPU device.',
+    );
+    return;
+  }
+
+  test('defaults to auto', () {
+    final scene = Scene();
+    expect(scene.antiAliasingMode, AntiAliasingMode.auto);
+  });
+
+  test('effective mode never reports auto', () {
+    final scene = Scene();
+    for (final mode in AntiAliasingMode.values) {
+      scene.antiAliasingMode = mode;
+      expect(scene.effectiveAntiAliasingMode, isNot(AntiAliasingMode.auto));
+    }
+  });
+
+  test('requested mode is kept verbatim', () {
+    final scene = Scene();
+    for (final mode in AntiAliasingMode.values) {
+      scene.antiAliasingMode = mode;
+      expect(scene.antiAliasingMode, mode);
+    }
+  });
+
+  test('auto resolves to msaa exactly when msaa is supported', () {
+    final scene = Scene();
+    scene.antiAliasingMode = AntiAliasingMode.auto;
+    final expected = Scene.isAntiAliasingModeSupported(AntiAliasingMode.msaa)
+        ? AntiAliasingMode.msaa
+        : AntiAliasingMode.fxaa;
+    expect(scene.effectiveAntiAliasingMode, expected);
+  });
+
+  test('msaa request resolves like auto (fxaa fallback when unsupported)', () {
+    final scene = Scene();
+    scene.antiAliasingMode = AntiAliasingMode.msaa;
+    final expected = Scene.isAntiAliasingModeSupported(AntiAliasingMode.msaa)
+        ? AntiAliasingMode.msaa
+        : AntiAliasingMode.fxaa;
+    expect(scene.effectiveAntiAliasingMode, expected);
+  });
+
+  test('none and fxaa resolve to themselves', () {
+    final scene = Scene();
+    scene.antiAliasingMode = AntiAliasingMode.none;
+    expect(scene.effectiveAntiAliasingMode, AntiAliasingMode.none);
+    scene.antiAliasingMode = AntiAliasingMode.fxaa;
+    expect(scene.effectiveAntiAliasingMode, AntiAliasingMode.fxaa);
+  });
+
+  test('every mode except msaa is unconditionally supported', () {
+    expect(Scene.isAntiAliasingModeSupported(AntiAliasingMode.none), isTrue);
+    expect(Scene.isAntiAliasingModeSupported(AntiAliasingMode.fxaa), isTrue);
+    expect(Scene.isAntiAliasingModeSupported(AntiAliasingMode.auto), isTrue);
+  });
+}

--- a/packages/flutter_scene/test/fscene/render_view_test.dart
+++ b/packages/flutter_scene/test/fscene/render_view_test.dart
@@ -1,0 +1,175 @@
+// Covers .fscene render-target serialization: the renderTexture resource
+// kind and views array (JSON round-trip, GPU-free), and realizing views
+// into a live Scene plus serializing them back (GPU-gated, Scene
+// construction reads backend capabilities).
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
+import 'package:flutter_scene/src/fscene/realize/realize.dart';
+import 'package:flutter_scene/src/fscene/realize/stage.dart';
+import 'package:flutter_scene/src/fscene/realize/views.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/fscene/property_value.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+bool _gpuAvailable() {
+  try {
+    Scene();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+// Builds: world (root) -> eye (camera), plus a render texture targeted by
+// a view from the eye.
+SceneDocument _documentWithView() {
+  final doc = SceneDocument();
+  final world = doc.createNode(name: 'world', root: true);
+  final eye = doc.createNode(
+    name: 'eye',
+    components: [
+      ComponentSpec(
+        'camera',
+        properties: {'fovRadiansY': const DoubleValue(1.2)},
+      ),
+    ],
+  );
+  world.children.add(eye.id);
+
+  final target = doc.addResource(
+    RenderTextureResource(
+      doc.newId(),
+      width: 64,
+      height: 32,
+      update: 'interval',
+      intervalMilliseconds: 250,
+      filter: 'nearest',
+      wrap: 'repeat',
+    ),
+  );
+  doc.views.add(
+    RenderViewSpec(
+      cameraNode: eye.id,
+      target: target.id,
+      layerMask: 0x3,
+      order: -1,
+      antiAliasingMode: 'fxaa',
+      renderScale: 0.5,
+      filterQuality: 'none',
+    ),
+  );
+  return doc;
+}
+
+void main() {
+  test('render texture resources and views round-trip through JSON', () {
+    final doc = _documentWithView();
+    doc.stage.antiAliasingMode = 'msaa';
+    doc.stage.renderScale = 1.5;
+    doc.stage.filterQuality = 'high';
+
+    final restored = readFscene(writeFscene(doc));
+
+    final target = restored.resources.values
+        .whereType<RenderTextureResource>()
+        .single;
+    expect(target.width, 64);
+    expect(target.height, 32);
+    expect(target.update, 'interval');
+    expect(target.intervalMilliseconds, 250);
+    expect(target.filter, 'nearest');
+    expect(target.wrap, 'repeat');
+
+    final view = restored.views.single;
+    expect(view.target, target.id);
+    expect(view.layerMask, 0x3);
+    expect(view.order, -1);
+    expect(view.antiAliasingMode, 'fxaa');
+    expect(view.renderScale, 0.5);
+    expect(view.filterQuality, 'none');
+
+    expect(restored.stage.antiAliasingMode, 'msaa');
+    expect(restored.stage.renderScale, 1.5);
+    expect(restored.stage.filterQuality, 'high');
+  });
+
+  if (!_gpuAvailable()) {
+    test(
+      'render view realize suite (skipped: no GPU device)',
+      () {},
+      skip: 'Requires a GPU device.',
+    );
+    return;
+  }
+
+  test('views realize into the scene and serialize back', () {
+    final doc = _documentWithView();
+    final root = realizeScene(doc);
+    final scene = Scene();
+    scene.add(root);
+    realizeViews(doc, scene, root);
+
+    final view = scene.views.single;
+    expect(view.camera, isA<NodeCamera>());
+    expect((view.camera as NodeCamera).node.name, 'eye');
+    expect(view.layerMask, 0x3);
+    expect(view.order, -1);
+    expect(view.antiAliasingMode, AntiAliasingMode.fxaa);
+    expect(view.renderScale, 0.5);
+
+    final target = view.target!;
+    expect(target.width, 64);
+    expect(target.height, 32);
+    expect(target.update.kindName, 'interval');
+    expect(target.update.intervalDuration, const Duration(milliseconds: 250));
+    expect(target.sampling.filter.name, 'nearest');
+
+    // The producing view and a material sampling the same resource id
+    // share one live handle.
+    final rtId = doc.resources.values
+        .whereType<RenderTextureResource>()
+        .single
+        .id;
+    expect(realizeRenderTexture(doc, rtId), same(target));
+
+    // Round-trip: serialize the graph, stage, and views into a new
+    // document, and confirm the view's wiring survives.
+    final back = serializeScene(root);
+    serializeStage(scene, back);
+    serializeViews(scene, back);
+
+    final restoredView = back.views.single;
+    expect(back.node(restoredView.cameraNode)!.name, 'eye');
+    expect(restoredView.antiAliasingMode, 'fxaa');
+    expect(restoredView.renderScale, 0.5);
+    final restoredTarget =
+        back.resource(restoredView.target!)! as RenderTextureResource;
+    expect(restoredTarget.width, 64);
+    expect(restoredTarget.update, 'interval');
+    expect(restoredTarget.intervalMilliseconds, 250);
+    expect(restoredTarget.filter, 'nearest');
+    expect(back.featuresUsed, contains('renderTextures'));
+  });
+
+  test('a hand-built scene with views serializes camera and target', () {
+    final scene = Scene();
+    final cameraNode = Node()..name = 'cam';
+    final component = CameraComponent();
+    cameraNode.addComponent(component);
+    scene.add(cameraNode);
+
+    final target = RenderTexture(width: 16, height: 16);
+    scene.views.add(RenderView(camera: component.toCamera(), target: target));
+
+    final doc = serializeScene(scene.root);
+    serializeViews(scene, doc);
+
+    final view = doc.views.single;
+    expect(doc.node(view.cameraNode)!.name, 'cam');
+    final spec = doc.resource(view.target!)! as RenderTextureResource;
+    expect(spec.width, 16);
+    expect(spec.update, 'everyFrame');
+  });
+}

--- a/packages/flutter_scene/test/render_scale_test.dart
+++ b/packages/flutter_scene/test/render_scale_test.dart
@@ -1,0 +1,100 @@
+// Covers the render-scale and composite-filter settings: defaults, the
+// scene-default/per-view-override pattern, and (GPU-gated) that the scale
+// actually drives the screen view's swapchain resolution.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+bool _gpuAvailable() {
+  try {
+    Scene();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+void main() {
+  test('RenderView scale and filter default to inherit (null)', () {
+    final view = RenderView(camera: PerspectiveCamera());
+    expect(view.renderScale, isNull);
+    expect(view.filterQuality, isNull);
+  });
+
+  test('RenderView rejects a non-positive renderScale', () {
+    expect(
+      () => RenderView(camera: PerspectiveCamera(), renderScale: 0.0),
+      throwsAssertionError,
+    );
+  });
+
+  if (!_gpuAvailable()) {
+    test(
+      'render scale suite (skipped: no GPU device)',
+      () {},
+      skip: 'Requires a GPU device.',
+    );
+    return;
+  }
+
+  test('scene defaults', () {
+    final scene = Scene();
+    expect(scene.renderScale, 1.0);
+    expect(scene.filterQuality, ui.FilterQuality.medium);
+    expect(() => scene.renderScale = 0.0, throwsAssertionError);
+  });
+
+  testWidgets('renderScale drives the swapchain resolution', (tester) async {
+    await Scene.initializeStaticResources();
+
+    final scene = Scene();
+    scene.renderScale = 0.5;
+
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
+    scene.render(
+      PerspectiveCamera(position: Vector3(0, 0, 5)),
+      canvas,
+      viewport: const ui.Rect.fromLTWH(0, 0, 32, 32),
+      pixelRatio: 1.0,
+    );
+    recorder.endRecording();
+
+    final swapchain = scene.surface.lastSwapchainColorTexture();
+    expect(swapchain, isNotNull);
+    expect(swapchain!.width, 16);
+    expect(swapchain.height, 16);
+  });
+
+  testWidgets('per-view renderScale overrides the scene default', (
+    tester,
+  ) async {
+    await Scene.initializeStaticResources();
+
+    final scene = Scene();
+    scene.renderScale = 0.5;
+
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
+    scene.renderViews(
+      [
+        RenderView(
+          camera: PerspectiveCamera(position: Vector3(0, 0, 5)),
+          renderScale: 2.0,
+        ),
+      ],
+      canvas,
+      region: const ui.Rect.fromLTWH(0, 0, 32, 32),
+      pixelRatio: 1.0,
+    );
+    recorder.endRecording();
+
+    final swapchain = scene.surface.lastSwapchainColorTexture();
+    expect(swapchain, isNotNull);
+    expect(swapchain!.width, 64);
+    expect(swapchain.height, 64);
+  });
+}

--- a/packages/flutter_scene/test/render_texture_test.dart
+++ b/packages/flutter_scene/test/render_texture_test.dart
@@ -117,6 +117,49 @@ void main() {
     return;
   }
 
+  test('material texture slots accept render textures', () async {
+    await Scene.initializeStaticResources();
+
+    final target = RenderTexture(width: 8, height: 8);
+    final pbr = PhysicallyBasedMaterial();
+
+    // No completed frame yet resolves to null (placeholder applies at
+    // draw time).
+    pbr.baseColorTexture = target;
+    expect(pbr.baseColorTexture, isNull);
+
+    // Static textures keep working verbatim, and bogus values throw.
+    final white = Material.getWhitePlaceholderTexture();
+    pbr.baseColorTexture = white;
+    expect(pbr.baseColorTexture, same(white));
+    expect(() => pbr.baseColorTexture = 'nope', throwsArgumentError);
+
+    final unlit = UnlitMaterial();
+    unlit.baseColorTexture = target;
+    // Unlit's getter never returns null; an empty render texture resolves
+    // to the white placeholder.
+    expect(unlit.baseColorTexture, same(white));
+  });
+
+  test('texture publishes on markUpdated, not on acquire', () async {
+    await Scene.initializeStaticResources();
+
+    final target = RenderTexture(width: 8, height: 8);
+    final first = target.acquireNextTexture();
+    // Mid-render (acquired but not published), consumers still see the
+    // previous frame, which is null before the first completes.
+    expect(target.texture, isNull);
+    target.markUpdated(DateTime(2026));
+    expect(target.texture, same(first));
+
+    final second = target.acquireNextTexture();
+    expect(second, isNot(same(first)));
+    // The ring's previous frame stays visible while the next is written.
+    expect(target.texture, same(first));
+    target.markUpdated(DateTime(2026));
+    expect(target.texture, same(second));
+  });
+
   testWidgets('a scene-owned texture view renders into its target', (
     tester,
   ) async {

--- a/packages/flutter_scene/test/render_texture_test.dart
+++ b/packages/flutter_scene/test/render_texture_test.dart
@@ -1,0 +1,152 @@
+// Covers RenderTexture: update-policy resolution (everyFrame/interval/
+// manual + requestUpdate + resize forcing), the texture lifecycle, and the
+// scene integration (a Scene.views entry targeting a texture renders when
+// the scene renders). Policy logic is pure Dart; the render integration is
+// GPU-gated like the other suites.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/widgets.dart' show SizedBox;
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+bool _gpuAvailable() {
+  try {
+    Scene();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+void main() {
+  group('update policy', () {
+    final t0 = DateTime(2026, 1, 1);
+
+    test('everyFrame updates every check', () {
+      final target = RenderTexture(width: 8, height: 8);
+      expect(target.shouldUpdate(t0), isTrue);
+      target.markUpdated(t0);
+      expect(target.shouldUpdate(t0), isTrue);
+    });
+
+    test('interval waits out the duration', () {
+      final target = RenderTexture(
+        width: 8,
+        height: 8,
+        update: const RenderTextureUpdate.interval(Duration(seconds: 1)),
+      );
+      expect(target.shouldUpdate(t0), isTrue);
+      target.markUpdated(t0);
+      expect(
+        target.shouldUpdate(t0.add(const Duration(milliseconds: 500))),
+        isFalse,
+      );
+      expect(target.shouldUpdate(t0.add(const Duration(seconds: 1))), isTrue);
+    });
+
+    test('manual renders once, then only on request', () {
+      final target = RenderTexture(
+        width: 8,
+        height: 8,
+        update: RenderTextureUpdate.manual,
+      );
+      expect(target.shouldUpdate(t0), isTrue);
+      target.markUpdated(t0);
+      expect(target.shouldUpdate(t0), isFalse);
+      target.requestUpdate();
+      expect(target.shouldUpdate(t0), isTrue);
+      expect(target.shouldUpdate(t0), isFalse);
+    });
+
+    test('resize forces the next update regardless of policy', () {
+      final target = RenderTexture(
+        width: 8,
+        height: 8,
+        update: RenderTextureUpdate.manual,
+      );
+      target.markUpdated(t0);
+      expect(target.shouldUpdate(t0), isFalse);
+      target.resize(16, 16);
+      expect(target.width, 16);
+      expect(target.shouldUpdate(t0), isTrue);
+    });
+
+    test('resize to the same size is a no-op', () {
+      final target = RenderTexture(
+        width: 8,
+        height: 8,
+        update: RenderTextureUpdate.manual,
+      );
+      target.markUpdated(t0);
+      target.resize(8, 8);
+      expect(target.shouldUpdate(t0), isFalse);
+    });
+
+    test('markUpdated notifies listeners', () {
+      final target = RenderTexture(width: 8, height: 8);
+      var notified = 0;
+      target.addListener(() => notified++);
+      target.markUpdated(t0);
+      expect(notified, 1);
+    });
+  });
+
+  test('texture is null before the first render', () {
+    final target = RenderTexture(width: 8, height: 8);
+    expect(target.texture, isNull);
+  });
+
+  testWidgets('RenderTextureView shows nothing before the first render', (
+    tester,
+  ) async {
+    final target = RenderTexture(width: 8, height: 8);
+    await tester.pumpWidget(
+      SizedBox(width: 32, height: 32, child: RenderTextureView(target)),
+    );
+    expect(find.byType(RenderTextureView), findsOneWidget);
+  });
+
+  if (!_gpuAvailable()) {
+    test(
+      'render integration (skipped: no GPU device)',
+      () {},
+      skip: 'Requires a GPU device.',
+    );
+    return;
+  }
+
+  testWidgets('a scene-owned texture view renders into its target', (
+    tester,
+  ) async {
+    await Scene.initializeStaticResources();
+
+    final scene = Scene();
+    final target = RenderTexture(width: 16, height: 16);
+    scene.views.add(
+      RenderView(
+        camera: PerspectiveCamera(position: Vector3(0, 0, 5)),
+        target: target,
+        antiAliasingMode: AntiAliasingMode.fxaa,
+      ),
+    );
+
+    var notified = 0;
+    target.addListener(() => notified++);
+
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
+    scene.render(
+      PerspectiveCamera(position: Vector3(0, 0, 5)),
+      canvas,
+      viewport: const ui.Rect.fromLTWH(0, 0, 32, 32),
+      pixelRatio: 1.0,
+    );
+    recorder.endRecording();
+
+    expect(target.texture, isNotNull);
+    expect(target.texture!.width, 16);
+    expect(notified, 1);
+  });
+}

--- a/packages/flutter_scene_rapier/hook/build.dart
+++ b/packages/flutter_scene_rapier/hook/build.dart
@@ -228,8 +228,13 @@ Map<String, String> _cargoEnvironment(CodeConfig code, String triple) {
     final api = code.android.targetNdkApi;
     final cargoTriple = triple.toUpperCase().replaceAll('-', '_');
     environment['CARGO_TARGET_${cargoTriple}_LINKER'] = compiler.toFilePath();
+    // Align ELF load segments to 16 KB so the library loads on devices with
+    // 16 KB memory pages (Android 15+; required on Pixel 8 and newer, and
+    // for Play uploads). The Rust/NDK default is 4 KB, which the loader
+    // rejects on those devices ("ELF alignment check failed").
     environment['CARGO_TARGET_${cargoTriple}_RUSTFLAGS'] =
-        '-Clink-arg=--target=${_androidClangTarget(triple)}$api';
+        '-Clink-arg=--target=${_androidClangTarget(triple)}$api '
+        '-Clink-arg=-Wl,-z,max-page-size=16384';
     // TODO(android-cc-crate): rapier3d and its dependencies are pure Rust
     // today, so only the final link needs the NDK. If a dependency ever
     // pulls in a C build (a build.rs using the cc crate), also set


### PR DESCRIPTION
Resolves #169.

The 0.18.0 feature push.

- FXAA, plus an automatic anti-aliasing mode that picks MSAA where supported and falls back to FXAA. Includes an effective-mode getter and a support query.
- Offscreen render targets with a `RenderTextureView` widget, per-view anti-aliasing overrides, and display or linear HDR formats. Targets keep a small texture ring so a view sampling its own target reads the previous frame. Materials can sample render textures, and render targets/views serialize in `.fscene`.
- Render scaling (`Scene.renderScale`) and composite filtering (`Scene.filterQuality`), with per-view overrides.
- Prefiltered radiance bands stored as texture mip levels and sampled with `textureLod`, gated on backend support. Backends without render-to-mip keep the legacy band atlas.
- Fixed dim image-based specular lighting on the web backend. The radiance prefilter (a float render-to-texture) is degenerate on a cold WebGL context before the first frame is composited; environments built from an equirect source now re-bake their radiance once the context is warm (the frame after the first present). The first frame may show dim specular IBL, every frame after is correct.
- flutter_scene_rapier Android binaries build with 16 KB ELF page alignment.
- Example app fixes for narrow phone layouts. Instance transforms move to a dedicated `HostBuffer`.