### PR TITLE
Pin the Flutter SDK constraint to the latest stable

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -37,6 +37,11 @@
   `Scene.initializeStaticResources()` before constructing geometry or
   materials; the native synchronous load on first access is gone.
 
+* The `flutter` SDK constraint is now `>=3.44.0` (the latest stable, so the
+  package can be analyzed and scored on pub.dev). The actual requirement is
+  newer, a Flutter master build from 2026-06-09 or later (render-to-mip-level
+  Flutter GPU support, flutter/flutter#187685); see the README.
+
 * Render targets serialize in `.fscene`. Documents gain a
   `renderTexture` resource kind (size, update policy, sampling) and a
   top-level `views` array binding camera nodes to targets with per-view

--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -45,7 +45,7 @@
 - On native platforms this package requires [Impeller](https://docs.flutter.dev/perf/impeller#availability) to be enabled. On the web it runs on a built-in WebGL2 backend instead.
 - This package uses the experimental [Dart "Native Assets"](https://github.com/dart-lang/sdk/issues/50565) feature to automate some build tasks.
 - Zero-manifest `.fmat` material builds use the experimental Dart DataAssets feature. On supported Flutter master builds, enable it with `flutter config --enable-dart-data-assets`.
-- Given the reliance on non-production features, switching to the [master channel](https://docs.flutter.dev/release/upgrade#other-channels) is recommended when using Flutter Scene.
+- Given the reliance on non-production features, Flutter Scene requires the Flutter [master channel](https://docs.flutter.dev/release/upgrade#other-channels). Version 0.18.0 needs a master build from 2026-06-09 or later, which is when render-to-mip-level Flutter GPU support landed (flutter/flutter#187685). The `flutter` lower bound in `pubspec.yaml` is set to the latest stable instead (so pub.dev can resolve and score the package), which is looser than the real requirement, so a recent master is what you actually want.
 
 ## Features
 

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -15,7 +15,11 @@ resolution: workspace
 
 environment:
   sdk: ^3.10.0
-  flutter: ">=3.29.0-1.0.pre.242"
+  # Pinned to the latest stable so pub.dev (which analyzes on stable) can
+  # resolve and score the package. The real requirement is newer, a Flutter
+  # master build from 2026-06-09 or later (render-to-mip-level GPU support,
+  # flutter/flutter#187685). See the README and the version-pinning note.
+  flutter: ">=3.44.0"
 
 dependencies:
   # Offline glTF -> .model import (build hook + CLI): arg parsing and image


### PR DESCRIPTION
Raise the `flutter` SDK lower bound from the stale `3.29.0-1.0.pre.242` to the latest stable `3.44.0`.

The package only runs on the Flutter master channel, but pub.dev scores packages by analyzing them on stable, so the `flutter` constraint has to stay satisfiable by stable to keep the pana score. The pinned value is a pana-safe floor, not the true runtime requirement.

The real requirement is newer, a master build from 2026-06-09 or later, which is when render-to-mip-level Flutter GPU support landed (flutter/flutter#187685). That is now spelled out in the README, a pubspec comment, and the CHANGELOG so consumers know what they actually need.

pana still scores 160/160 with this constraint.