### PR TITLE
Skip the Argos upload when no smoke screenshots were rendered

### DIFF
--- a/.github/workflows/smoke_render_jobs.yml
+++ b/.github/workflows/smoke_render_jobs.yml
@@ -80,6 +80,13 @@ jobs:
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
         run: |
+          # Never upload an empty/partial build: a failed render must not
+          # overwrite the Argos baseline (see the android job, and
+          # notes/ci/argos_visual_baseline_tracking.md).
+          if [ ! -d build/smoke ] || ! find build/smoke -type f -name '*.png' | grep -q .; then
+            echo "No smoke screenshots found; skipping Argos upload."
+            exit 0
+          fi
           reference_args=()
           if [ -n "${{ inputs.reference_branch }}" ]; then
             reference_args=(--reference-branch "${{ inputs.reference_branch }}")
@@ -187,6 +194,9 @@ jobs:
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
         run: |
+          # Never upload an empty/partial build: a failed render must not
+          # overwrite the Argos baseline (see
+          # notes/ci/argos_visual_baseline_tracking.md).
           if [ ! -d build/smoke ] || ! find build/smoke -type f -name '*.png' | grep -q .; then
             echo "No smoke screenshots found; skipping Argos upload."
             exit 0
@@ -250,6 +260,13 @@ jobs:
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
         run: |
+          # Never upload an empty/partial build: a failed render must not
+          # overwrite the Argos baseline (see the android job, and
+          # notes/ci/argos_visual_baseline_tracking.md).
+          if [ ! -d build/smoke ] || ! find build/smoke -type f -name '*.png' | grep -q .; then
+            echo "No smoke screenshots found; skipping Argos upload."
+            exit 0
+          fi
           reference_args=()
           if [ -n "${{ inputs.reference_branch }}" ]; then
             reference_args=(--reference-branch "${{ inputs.reference_branch }}")


### PR DESCRIPTION
The `linux` and `web` smoke-render Argos upload steps uploaded `build/smoke` unconditionally. The upload step runs on `if: !cancelled()`, so it runs even when the render step fails, and without a guard a failed render uploaded an empty or partial build.

On a nightly master run that empty build became the new Argos baseline for that platform, after which every PR showed all of the platform's scenes as newly added. Approving them on the PR never stuck, because PR approvals do not update the master baseline; only the nightly does, and it kept re-uploading empty builds whenever the render failed. The `android` step already guarded against this, which is why only Linux rotted (web never fails to render).

This adds the same guard to `linux` and `web` so a failed render can no longer clobber the baseline. It is the repo-side half of the fix; the other half is an Argos project setting (require human review of the master baseline instead of auto-approving it), which is configured in the Argos dashboard, not this repo.