### PR TITLE
Make the stable smoke render dispatch-only

### DIFF
--- a/.github/workflows/stable_smoke_render.yml
+++ b/.github/workflows/stable_smoke_render.yml
@@ -4,15 +4,15 @@ name: stable smoke render
 # current 3.45 candidate branch and uploads them to Argos under stable-specific
 # build names, so stable baselines are tracked separately from the Flutter
 # master-channel smoke renders.
+#
+# Dormant: the stable branch is not being maintained or released from while
+# flutter_gpu's API is still churning, so every beta roll that touches web or
+# GLES breaks it for no actionable signal. The jobs are left intact; only the
+# automatic triggers are removed. Re-add the schedule/push/pull_request
+# triggers to revive this once a maintained stable line exists again.
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 7 * * *" # daily, 07:30 UTC
-  push:
-    branches: [stable]
-  pull_request:
-    branches: [stable]
 
 # A new push to a branch or PR supersedes its still-running render.
 concurrency:


### PR DESCRIPTION
The stable smoke render canary renders flutter_scene's stable branch against the Flutter beta channel, but the stable branch is not being maintained or released from right now while flutter_gpu's API is still churning upstream. With a high volume of breaking upstream changes landing on the web/GLES surface, every beta roll that touches it breaks this job for no actionable signal, pings Discord each morning, and uploads blank frames into the stable-prefixed Argos baselines (quietly corrupting them).

This drops the schedule/push/pull_request triggers and keeps only workflow_dispatch, so the canary stops running automatically but stays one click from revival. The jobs and the shared reusable smoke_render_jobs.yml are left fully intact; reviving it is just re-adding the triggers once a maintained stable line exists again.

The master-channel smoke render (daily schedule, every PR, and every push, full Metal/GLES/Vulkan/WebGL2 matrix) is unaffected and keeps running.