### PR TITLE
Describe vertex layouts, grow the geometry system, and add geometry LOD

### DIFF
--- a/examples/flutter_app/lib/example_lod.dart
+++ b/examples/flutter_app/lib/example_lod.dart
@@ -25,6 +25,12 @@ class _ExampleLodState extends State<ExampleLod> {
   )..speed = 12.0;
   final FocusNode _sceneFocus = FocusNode(debugLabel: 'lod-scene');
 
+  // The spawned LOD components, so the controls can update them all.
+  final List<LodComponent> _lods = [];
+  bool _crossFade = true;
+  double _blendRange = 0.12;
+  double _lodBias = 1.0;
+
   // Color per level: green (highest detail) down to red (lowest).
   static final List<vm.Vector4> _levelColors = [
     vm.Vector4(0.36, 0.80, 0.42, 1),
@@ -68,9 +74,17 @@ class _ExampleLodState extends State<ExampleLod> {
       for (var c = 0; c < columns; c++) {
         final x = (c - (columns - 1) / 2) * spacing;
         final z = -r * spacing;
+        // blendRange cross-fades adjacent levels with a screen-space dither,
+        // so the color bands dissolve into each other instead of popping; 0
+        // hard-switches. Toggled live by the checkbox.
+        final lod = LodComponent(
+          levels,
+          blendRange: _crossFade ? _blendRange : 0.0,
+        );
+        _lods.add(lod);
         scene.add(
           Node(localTransform: vm.Matrix4.translation(vm.Vector3(x, 1, z)))
-            ..addComponent(LodComponent(levels)),
+            ..addComponent(lod),
         );
       }
     }
@@ -80,6 +94,35 @@ class _ExampleLodState extends State<ExampleLod> {
   void dispose() {
     _sceneFocus.dispose();
     super.dispose();
+  }
+
+  void _setCrossFade(bool on) {
+    setState(() {
+      _crossFade = on;
+      for (final lod in _lods) {
+        lod.blendRange = on ? _blendRange : 0.0;
+      }
+    });
+  }
+
+  void _setBlendRange(double value) {
+    setState(() {
+      _blendRange = value;
+      if (_crossFade) {
+        for (final lod in _lods) {
+          lod.blendRange = value;
+        }
+      }
+    });
+  }
+
+  void _setLodBias(double value) {
+    setState(() {
+      _lodBias = value;
+      for (final lod in _lods) {
+        lod.lodBias = value;
+      }
+    });
   }
 
   @override
@@ -115,23 +158,100 @@ class _ExampleLodState extends State<ExampleLod> {
           right: 0,
           child: Align(
             alignment: Alignment.topCenter,
-            child: Card(
-              color: Colors.black54,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 8,
-                ),
-                child: Text(
-                  'Each sphere swaps detail by on-screen size  •  fly with '
-                  'WASD/QE, drag to look',
-                  style: TextStyle(color: Colors.white.withValues(alpha: 0.7)),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 360),
+              child: Card(
+                color: Colors.black54,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        'Each sphere swaps detail by on-screen size  •  fly '
+                        'with WASD/QE, drag to look',
+                        style: TextStyle(
+                          color: Colors.white.withValues(alpha: 0.7),
+                        ),
+                      ),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Checkbox(
+                            value: _crossFade,
+                            onChanged: (v) => _setCrossFade(v ?? false),
+                            side: const BorderSide(color: Colors.white70),
+                            checkColor: Colors.black,
+                            activeColor: Colors.white,
+                            visualDensity: VisualDensity.compact,
+                          ),
+                          const Text(
+                            'Cross-fade (dither)',
+                            style: TextStyle(color: Colors.white),
+                          ),
+                        ],
+                      ),
+                      _slider('LOD bias', _lodBias, 0.3, 3.0, _setLodBias),
+                      _slider(
+                        'Blend range',
+                        _blendRange,
+                        0.02,
+                        0.3,
+                        _setBlendRange,
+                        enabled: _crossFade,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
           ),
         ),
         Positioned(left: 16, bottom: 16, child: _legend()),
+      ],
+    );
+  }
+
+  Widget _slider(
+    String label,
+    double value,
+    double min,
+    double max,
+    ValueChanged<double> onChanged, {
+    bool enabled = true,
+  }) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 84,
+          child: Text(
+            label,
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: enabled ? 1.0 : 0.4),
+              fontSize: 12,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Slider(
+            value: value.clamp(min, max),
+            min: min,
+            max: max,
+            onChanged: enabled ? onChanged : null,
+          ),
+        ),
+        SizedBox(
+          width: 34,
+          child: Text(
+            value.toStringAsFixed(2),
+            style: const TextStyle(color: Colors.white70, fontSize: 11),
+            textAlign: TextAlign.right,
+          ),
+        ),
       ],
     );
   }

--- a/examples/flutter_app/lib/example_lod.dart
+++ b/examples/flutter_app/lib/example_lod.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+import 'quake_camera.dart';
+
+/// A field of identical icospheres receding into the distance, each an
+/// [LodComponent] that swaps its geometry by projected screen size. Each
+/// level is tinted a different color (green is highest detail, red is
+/// lowest) so the switches and the cull floor are visible at a glance. Fly
+/// with WASD/QE and drag to look; the colored bands move with the camera.
+class ExampleLod extends StatefulWidget {
+  const ExampleLod({super.key});
+
+  @override
+  State<ExampleLod> createState() => _ExampleLodState();
+}
+
+class _ExampleLodState extends State<ExampleLod> {
+  final Scene scene = Scene();
+  final QuakeCamera _quakeCamera = QuakeCamera(
+    position: vm.Vector3(0, 5, 7),
+    pitch: -0.3,
+  )..speed = 12.0;
+  final FocusNode _sceneFocus = FocusNode(debugLabel: 'lod-scene');
+
+  // Color per level: green (highest detail) down to red (lowest).
+  static final List<vm.Vector4> _levelColors = [
+    vm.Vector4(0.36, 0.80, 0.42, 1),
+    vm.Vector4(0.96, 0.82, 0.25, 1),
+    vm.Vector4(0.95, 0.55, 0.22, 1),
+    vm.Vector4(0.88, 0.30, 0.32, 1),
+  ];
+
+  // Icosphere subdivisions and the screen-size threshold (fraction of the
+  // viewport height) at which each level takes over. Descending thresholds,
+  // highest detail first; below the last one the sphere is culled.
+  static const List<({int subdivisions, double screenSize})> _levels = [
+    (subdivisions: 4, screenSize: 0.35),
+    (subdivisions: 2, screenSize: 0.18),
+    (subdivisions: 1, screenSize: 0.09),
+    (subdivisions: 0, screenSize: 0.05),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    // Shared geometry and material per level, reused by every sphere.
+    final levels = [
+      for (var i = 0; i < _levels.length; i++)
+        LodLevel(
+          geometry: IcosphereGeometry(
+            radius: 1.0,
+            subdivisions: _levels[i].subdivisions,
+          ),
+          material: PhysicallyBasedMaterial()
+            ..baseColorFactor = _levelColors[i]
+            ..roughnessFactor = 0.5,
+          screenSize: _levels[i].screenSize,
+        ),
+    ];
+
+    const columns = 7;
+    const rows = 12;
+    const spacing = 3.2;
+    for (var r = 0; r < rows; r++) {
+      for (var c = 0; c < columns; c++) {
+        final x = (c - (columns - 1) / 2) * spacing;
+        final z = -r * spacing;
+        scene.add(
+          Node(localTransform: vm.Matrix4.translation(vm.Vector3(x, 1, z)))
+            ..addComponent(LodComponent(levels)),
+        );
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _sceneFocus.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Focus(
+            focusNode: _sceneFocus,
+            autofocus: true,
+            onKeyEvent: _quakeCamera.onKeyEvent,
+            child: Listener(
+              onPointerDown: (_) => _sceneFocus.requestFocus(),
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onPanUpdate: (details) => _quakeCamera.look(details.delta),
+                child: SceneView(
+                  scene,
+                  cameraBuilder: (elapsed) {
+                    _quakeCamera.move(elapsed.inMicroseconds / 1e6);
+                    return _quakeCamera.camera;
+                  },
+                  onTick: (elapsed, deltaSeconds) =>
+                      exampleSettings.applyTo(scene),
+                ),
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          top: 8,
+          left: 0,
+          right: 0,
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: Card(
+              color: Colors.black54,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                child: Text(
+                  'Each sphere swaps detail by on-screen size  •  fly with '
+                  'WASD/QE, drag to look',
+                  style: TextStyle(color: Colors.white.withValues(alpha: 0.7)),
+                ),
+              ),
+            ),
+          ),
+        ),
+        Positioned(left: 16, bottom: 16, child: _legend()),
+      ],
+    );
+  }
+
+  Widget _legend() {
+    Color toColor(vm.Vector4 c) => Color.fromARGB(
+      255,
+      (c.r * 255).round(),
+      (c.g * 255).round(),
+      (c.b * 255).round(),
+    );
+    Widget row(String label, Color? swatch) => Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          Container(
+            width: 14,
+            height: 14,
+            decoration: BoxDecoration(
+              color: swatch ?? Colors.transparent,
+              border: swatch == null ? Border.all(color: Colors.white38) : null,
+              borderRadius: BorderRadius.circular(3),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: const TextStyle(color: Colors.white, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+    return Card(
+      color: Colors.black54,
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Detail level',
+              style: TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+            const SizedBox(height: 4),
+            for (var i = 0; i < _levels.length; i++)
+              row(
+                'L$i  (${_levels[i].subdivisions} subdiv)',
+                toColor(_levelColors[i]),
+              ),
+            row('culled', null),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/examples/flutter_app/lib/example_shapes.dart
+++ b/examples/flutter_app/lib/example_shapes.dart
@@ -1,0 +1,851 @@
+// The procedural array builders back the wireframe preview, and PrimitiveType
+// selects the line topology; neither is part of the curated public API. In-repo
+// apps may reach into lib/src, so the implementation_imports lint is waived for
+// this file.
+// ignore_for_file: implementation_imports
+import 'dart:async';
+import 'dart:math' as math;
+
+// flutter_scene's physics BoxShape clashes with Flutter's painting BoxShape,
+// and flutter_scene's Material clashes with the Flutter Material widget, so
+// each conflicting name is hidden from the other import (as in the Physics
+// example).
+import 'package:flutter/material.dart' hide BoxShape;
+import 'package:flutter_scene/scene.dart' hide Material;
+import 'package:flutter_scene/src/geometry/primitives.dart' as prim;
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene_rapier/flutter_scene_rapier.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'environment_menu.dart';
+import 'example_settings.dart';
+import 'quake_camera.dart';
+
+/// A shapes playground. Pick a primitive and tune its dimensions, watch a
+/// wireframe preview, then click anywhere to drop one into the scene with a
+/// matching physics collision hull. Drag to look and WASD/QE to fly the
+/// camera. The bottom-left switches the image-based-lighting environment.
+class ExampleShapes extends StatefulWidget {
+  const ExampleShapes({super.key});
+
+  @override
+  State<ExampleShapes> createState() => _ExampleShapesState();
+}
+
+/// The primitives offered for spawning. Only shapes with an analytic
+/// collision hull are listed, so every spawn gets a proper physics body.
+enum _ShapeKind {
+  box('Box'),
+  sphere('Sphere'),
+  icosphere('Icosphere'),
+  cylinder('Cylinder'),
+  cone('Cone'),
+  capsule('Capsule'),
+  torus('Torus'),
+  disc('Disc'),
+  ring('Ring'),
+  wedge('Wedge');
+
+  const _ShapeKind(this.label);
+  final String label;
+}
+
+/// Mutable dimensions and tessellation for a shape. One instance is kept per
+/// [_ShapeKind] so switching shapes preserves each one's settings.
+class _ShapeParams {
+  double radius = 0.5;
+  double height = 1.0;
+  double width = 1.0;
+  double depth = 1.0;
+  double run = 1.0;
+  double tubeRadius = 0.2;
+  double innerRadius = 0.3;
+  double outerRadius = 0.6;
+  int subdivisions = 2;
+  int segments = 32; // sphere longitude; disc and ring wedges
+  int rings = 16; // sphere latitude
+  int radialSegments = 24; // cylinder/cone/capsule/torus, around
+  int heightSegments = 1; // cylinder/cone, along Y
+  int capRings = 8; // capsule hemisphere rings
+  int tubularSegments = 16; // torus tube cross-section
+}
+
+class _ExampleShapesState extends State<ExampleShapes> {
+  final Scene scene = Scene();
+  late final RapierWorld world;
+
+  final QuakeCamera _quakeCamera = QuakeCamera(
+    position: vm.Vector3(0, 4, 11),
+    pitch: -0.25,
+  )..speed = 8.0;
+  // Holds keyboard focus for the camera. Clicking the scene reclaims it from
+  // any slider or dropdown that grabbed it, so WASD keeps working.
+  final FocusNode _sceneFocus = FocusNode(debugLabel: 'shapes-scene');
+  PerspectiveCamera? _camera;
+  Size _viewSize = Size.zero;
+
+  _ShapeKind _kind = _ShapeKind.box;
+  final Map<_ShapeKind, _ShapeParams> _params = {
+    for (final k in _ShapeKind.values) k: _ShapeParams(),
+  };
+
+  final EnvironmentSelector _environment = EnvironmentSelector();
+
+  // The spinning wireframe preview lives in its own little scene. The node is
+  // retained so a settings change can keep its current rotation.
+  final Scene _previewScene = Scene();
+  Node? _previewNode;
+
+  // Spawned bodies, retired oldest-first past the cap so the playground
+  // stays light.
+  static const int _maxBodies = 60;
+  final List<Node> _spawned = [];
+  final math.Random _rng = math.Random(7);
+
+  // Physics properties applied to the ground (live) and to newly spawned
+  // bodies. Existing bodies keep the values they were dropped with.
+  double _friction = 0.5;
+  double _restitution = 0.2;
+  double _density = 1.0;
+  double _linearDamping = 0.0;
+  double _angularDamping = 0.0;
+  RapierCollider? _groundCollider;
+
+  PhysicsMaterial get _physicsMaterial => PhysicsMaterial(
+    friction: _friction,
+    restitution: _restitution,
+    density: _density,
+  );
+
+  static final List<vm.Vector4> _palette = [
+    vm.Vector4(0.91, 0.30, 0.35, 1),
+    vm.Vector4(0.95, 0.61, 0.24, 1),
+    vm.Vector4(0.96, 0.82, 0.25, 1),
+    vm.Vector4(0.42, 0.74, 0.40, 1),
+    vm.Vector4(0.30, 0.62, 0.86, 1),
+    vm.Vector4(0.56, 0.42, 0.80, 1),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    world = RapierWorld(gravity: vm.Vector3(0, -9.81, 0));
+    scene.root.addComponent(world);
+    _buildGround();
+    _rebuildPreview();
+  }
+
+  @override
+  void dispose() {
+    _sceneFocus.dispose();
+    _environment.dispose();
+    super.dispose();
+  }
+
+  // --- Scene construction ---------------------------------------------------
+
+  void _buildGround() {
+    final half = vm.Vector3(20, 0.5, 20);
+    final material = PhysicallyBasedMaterial()
+      ..baseColorFactor = vm.Vector4(0.55, 0.58, 0.62, 1)
+      ..roughnessFactor = 0.9
+      ..metallicFactor = 0.0;
+    final node = Node(
+      mesh: Mesh(CuboidGeometry(half * 2.0), material),
+      localTransform: vm.Matrix4.translation(vm.Vector3(0, -0.5, 0)),
+    );
+    final collider = RapierCollider(
+      shape: BoxShape(halfExtents: half),
+      material: _physicsMaterial,
+    );
+    node.addComponent(RapierRigidBody(type: BodyType.fixed));
+    node.addComponent(collider);
+    scene.add(node);
+    _groundCollider = collider;
+  }
+
+  /// The solid geometry plus its matching collision shape for [kind].
+  ({Geometry geometry, Shape collisionShape}) _buildSolid(
+    _ShapeKind kind,
+    _ShapeParams p,
+  ) {
+    switch (kind) {
+      case _ShapeKind.box:
+        final g = CuboidGeometry(vm.Vector3(p.width, p.height, p.depth));
+        return (geometry: g, collisionShape: g.collisionShape);
+      case _ShapeKind.sphere:
+        final g = SphereGeometry(
+          radius: p.radius,
+          segments: p.segments,
+          rings: p.rings,
+        );
+        return (geometry: g, collisionShape: g.collisionShape);
+      case _ShapeKind.icosphere:
+        final g = IcosphereGeometry(
+          radius: p.radius,
+          subdivisions: p.subdivisions,
+        );
+        return (geometry: g, collisionShape: g.collisionShape);
+      case _ShapeKind.cylinder:
+        final g = CylinderGeometry(
+          bottomRadius: p.radius,
+          topRadius: p.radius,
+          height: p.height,
+          radialSegments: p.radialSegments,
+          heightSegments: p.heightSegments,
+        );
+        return (geometry: g, collisionShape: g.collisionShape);
+      case _ShapeKind.cone:
+        final g = CylinderGeometry(
+          bottomRadius: p.radius,
+          topRadius: 0,
+          height: p.height,
+          radialSegments: p.radialSegments,
+          heightSegments: p.heightSegments,
+        );
+        return (geometry: g, collisionShape: g.collisionShape);
+      case _ShapeKind.capsule:
+        final g = CapsuleGeometry(
+          radius: p.radius,
+          height: p.height,
+          radialSegments: p.radialSegments,
+          capRings: p.capRings,
+        );
+        return (geometry: g, collisionShape: g.collisionShape);
+      case _ShapeKind.torus:
+        final g = TorusGeometry(
+          radius: p.radius,
+          tubeRadius: p.tubeRadius,
+          radialSegments: p.radialSegments,
+          tubularSegments: p.tubularSegments,
+        );
+        return (geometry: g, collisionShape: g.collisionShape);
+      case _ShapeKind.disc:
+        final g = DiscGeometry(radius: p.radius, segments: p.segments);
+        return (geometry: g, collisionShape: g.collisionShape);
+      case _ShapeKind.ring:
+        final g = RingGeometry(
+          innerRadius: p.innerRadius,
+          outerRadius: p.outerRadius,
+          segments: p.segments,
+        );
+        return (geometry: g, collisionShape: g.collisionShape);
+      case _ShapeKind.wedge:
+        final g = WedgeGeometry(vm.Vector3(p.width, p.height, p.run));
+        return (geometry: g, collisionShape: g.collisionShape);
+    }
+  }
+
+  /// The procedural arrays for [kind] at the current tessellation, traced as
+  /// a wireframe in the preview.
+  prim.PrimitiveArrays _buildArrays(_ShapeKind kind, _ShapeParams p) {
+    switch (kind) {
+      case _ShapeKind.box:
+        return prim.buildCuboidArrays(vm.Vector3(p.width, p.height, p.depth));
+      case _ShapeKind.sphere:
+        return prim.buildSphereArrays(
+          radius: p.radius,
+          segments: p.segments,
+          rings: p.rings,
+        );
+      case _ShapeKind.icosphere:
+        return prim.buildIcosphereArrays(
+          radius: p.radius,
+          subdivisions: p.subdivisions,
+        );
+      case _ShapeKind.cylinder:
+        return prim.buildCylinderArrays(
+          bottomRadius: p.radius,
+          topRadius: p.radius,
+          height: p.height,
+          radialSegments: p.radialSegments,
+          heightSegments: p.heightSegments,
+          bottomCap: true,
+          topCap: true,
+        );
+      case _ShapeKind.cone:
+        return prim.buildCylinderArrays(
+          bottomRadius: p.radius,
+          topRadius: 0,
+          height: p.height,
+          radialSegments: p.radialSegments,
+          heightSegments: p.heightSegments,
+          bottomCap: true,
+          topCap: true,
+        );
+      case _ShapeKind.capsule:
+        return prim.buildCapsuleArrays(
+          radius: p.radius,
+          height: p.height,
+          radialSegments: p.radialSegments,
+          capRings: p.capRings,
+        );
+      case _ShapeKind.torus:
+        return prim.buildTorusArrays(
+          radius: p.radius,
+          tubeRadius: p.tubeRadius,
+          radialSegments: p.radialSegments,
+          tubularSegments: p.tubularSegments,
+        );
+      case _ShapeKind.disc:
+        return prim.buildDiscArrays(radius: p.radius, segments: p.segments);
+      case _ShapeKind.ring:
+        return prim.buildRingArrays(
+          innerRadius: p.innerRadius,
+          outerRadius: p.outerRadius,
+          segments: p.segments,
+        );
+      case _ShapeKind.wedge:
+        return prim.buildWedgeArrays(vm.Vector3(p.width, p.height, p.run));
+    }
+  }
+
+  // A line-list geometry tracing every triangle edge, for the preview.
+  MeshGeometry _wireframe(prim.PrimitiveArrays a) {
+    final edges = <int>[];
+    for (var t = 0; t + 2 < a.indices.length; t += 3) {
+      final i0 = a.indices[t];
+      final i1 = a.indices[t + 1];
+      final i2 = a.indices[t + 2];
+      edges
+        ..addAll([i0, i1])
+        ..addAll([i1, i2])
+        ..addAll([i2, i0]);
+    }
+    return MeshGeometry.fromArrays(
+      positions: a.positions,
+      indices: edges,
+      primitiveType: gpu.PrimitiveType.line,
+    );
+  }
+
+  void _rebuildPreview() {
+    // Carry the current rotation across the rebuild so tuning sliders does
+    // not snap the preview back to its start pose.
+    final previous = _previewNode?.localTransform.clone();
+    _previewScene.removeAll();
+    final wire = _wireframe(_buildArrays(_kind, _params[_kind]!));
+    final material = UnlitMaterial()
+      ..baseColorFactor = vm.Vector4(0.55, 0.9, 1.0, 1);
+    final node = Node(mesh: Mesh(wire, material), localTransform: previous)
+      ..addComponent(_SpinComponent(0.7));
+    _previewNode = node;
+    _previewScene.add(node);
+  }
+
+  // The bounding radius used to frame the preview camera.
+  double _previewRadius(_ShapeKind kind, _ShapeParams p) {
+    switch (kind) {
+      case _ShapeKind.box:
+        return vm.Vector3(p.width, p.height, p.depth).length / 2;
+      case _ShapeKind.wedge:
+        return vm.Vector3(p.width, p.height, p.run).length / 2;
+      case _ShapeKind.sphere:
+      case _ShapeKind.icosphere:
+      case _ShapeKind.disc:
+        return p.radius;
+      case _ShapeKind.cylinder:
+      case _ShapeKind.cone:
+        return math.max(p.radius, p.height / 2);
+      case _ShapeKind.capsule:
+        return p.radius + p.height / 2;
+      case _ShapeKind.torus:
+        return p.radius + p.tubeRadius;
+      case _ShapeKind.ring:
+        return p.outerRadius;
+    }
+  }
+
+  // --- Interaction ----------------------------------------------------------
+
+  void _onTick(Duration elapsed, double deltaSeconds) {
+    // Step physics and per-frame components with the clamped ticker delta;
+    // render then skips its implicit tick.
+    scene.update(deltaSeconds.clamp(0.0, 0.05));
+    exampleSettings.applyTo(scene);
+  }
+
+  // Drops the selected shape from above wherever the click ray meets the
+  // scene (existing geometry or the ground plane).
+  void _spawnAt(Offset screenPosition) {
+    final camera = _camera;
+    if (camera == null || _viewSize.isEmpty) return;
+    final ray = camera.screenPointToRay(screenPosition, _viewSize);
+    final hit = scene.raycast(ray);
+    final target = hit?.worldPoint ?? _intersectGround(ray);
+    if (target == null) return;
+    _spawn(
+      _kind,
+      _params[_kind]!,
+      vm.Vector3(target.x, target.y + 6.0, target.z),
+    );
+  }
+
+  // Intersects [ray] with the y = 0 ground plane, or null if it points away.
+  vm.Vector3? _intersectGround(vm.Ray ray) {
+    final dirY = ray.direction.y;
+    if (dirY.abs() < 1e-6) return null;
+    final t = -ray.origin.y / dirY;
+    if (t < 0) return null;
+    return ray.origin + ray.direction.scaled(t);
+  }
+
+  // Disc and ring are flat (two-dimensional), so they need double-sided
+  // rendering to be visible from below.
+  bool _isFlat(_ShapeKind kind) =>
+      kind == _ShapeKind.disc || kind == _ShapeKind.ring;
+
+  void _spawn(_ShapeKind kind, _ShapeParams p, vm.Vector3 position) {
+    final solid = _buildSolid(kind, p);
+    final material = PhysicallyBasedMaterial()
+      ..baseColorFactor = _palette[_rng.nextInt(_palette.length)]
+      ..roughnessFactor = 0.45
+      ..metallicFactor = 0.05
+      // Flat shapes have no back, so render both faces to avoid a
+      // disappearing underside as they tumble.
+      ..doubleSided = _isFlat(kind);
+    final rotation = vm.Quaternion.euler(
+      _rng.nextDouble() * math.pi * 2,
+      _rng.nextDouble() * math.pi * 2,
+      _rng.nextDouble() * math.pi * 2,
+    );
+    final node = Node(
+      mesh: Mesh(solid.geometry, material),
+      localTransform: vm.Matrix4.compose(
+        position,
+        rotation,
+        vm.Vector3.all(1.0),
+      ),
+    );
+    // No explicit mass, so the material density derives it from the shape.
+    node.addComponent(
+      RapierRigidBody(
+        type: BodyType.dynamic_,
+        linearDamping: _linearDamping,
+        angularDamping: _angularDamping,
+      ),
+    );
+    node.addComponent(
+      RapierCollider(shape: solid.collisionShape, material: _physicsMaterial),
+    );
+    scene.add(node);
+    _spawned.add(node);
+    if (_spawned.length > _maxBodies) {
+      scene.remove(_spawned.removeAt(0));
+    }
+    setState(() {});
+  }
+
+  void _clear() {
+    setState(() {
+      for (final node in _spawned) {
+        scene.remove(node);
+      }
+      _spawned.clear();
+    });
+  }
+
+  Future<void> _selectEnvironment(ExampleEnvironment environment) async {
+    try {
+      await _environment.select(environment, scene);
+    } catch (_) {
+      // Ignore download/decode failures in the demo; the previous
+      // environment stays active.
+    }
+  }
+
+  // --- Build ----------------------------------------------------------------
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Focus(
+            focusNode: _sceneFocus,
+            autofocus: true,
+            onKeyEvent: _quakeCamera.onKeyEvent,
+            child: Listener(
+              // Any press on the scene reclaims keyboard focus from a slider
+              // or dropdown so the camera keys keep working.
+              onPointerDown: (_) => _sceneFocus.requestFocus(),
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                // A tap (press and release without a drag) drops a shape; the
+                // gesture arena routes a drag to the camera look instead.
+                onTapUp: (details) => _spawnAt(details.localPosition),
+                onPanUpdate: (details) => _quakeCamera.look(details.delta),
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    _viewSize = constraints.biggest;
+                    return SceneView(
+                      scene,
+                      cameraBuilder: (elapsed) {
+                        _quakeCamera.move(elapsed.inMicroseconds / 1e6);
+                        return _camera = _quakeCamera.camera;
+                      },
+                      onTick: _onTick,
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          top: 8,
+          left: 0,
+          right: 0,
+          child: Align(alignment: Alignment.topCenter, child: _controlPanel()),
+        ),
+        Positioned(
+          left: 16,
+          bottom: 16,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _physicsPanel(),
+              const SizedBox(height: 8),
+              _environmentPanel(),
+            ],
+          ),
+        ),
+        Positioned(right: 16, bottom: 16, child: _previewPanel()),
+      ],
+    );
+  }
+
+  Widget _controlPanel() {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 360),
+      child: Card(
+        color: Colors.black54,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  const Text('Shape:', style: TextStyle(color: Colors.white)),
+                  const SizedBox(width: 8),
+                  DropdownButton<_ShapeKind>(
+                    value: _kind,
+                    dropdownColor: Colors.black87,
+                    style: const TextStyle(color: Colors.white),
+                    onChanged: (kind) {
+                      if (kind != null) {
+                        setState(() {
+                          _kind = kind;
+                          _rebuildPreview();
+                        });
+                      }
+                    },
+                    items: [
+                      for (final kind in _ShapeKind.values)
+                        DropdownMenuItem(value: kind, child: Text(kind.label)),
+                    ],
+                  ),
+                  const Spacer(),
+                  TextButton(
+                    onPressed: _spawned.isEmpty ? null : _clear,
+                    child: const Text('Clear'),
+                  ),
+                ],
+              ),
+              ..._buildSliders(),
+              const SizedBox(height: 4),
+              const Text(
+                'Tap to drop  •  drag to look  •  WASD/QE to move',
+                style: TextStyle(color: Colors.white54, fontSize: 11),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildSliders() {
+    final p = _params[_kind]!;
+    ValueChanged<double> set(void Function(double) apply) => (v) {
+      setState(() {
+        apply(v);
+        _rebuildPreview();
+      });
+    };
+    Widget dim(
+      String label,
+      double value,
+      double min,
+      double max,
+      void Function(double) apply,
+    ) => _slider(label, value, min, max, set(apply));
+    Widget count(
+      String label,
+      int value,
+      int min,
+      int max,
+      void Function(int) apply,
+    ) => _slider(
+      label,
+      value.toDouble(),
+      min.toDouble(),
+      max.toDouble(),
+      set((v) => apply(v.round())),
+      divisions: max - min,
+    );
+
+    switch (_kind) {
+      case _ShapeKind.box:
+        return [
+          dim('Width', p.width, 0.3, 3, (v) => p.width = v),
+          dim('Height', p.height, 0.3, 3, (v) => p.height = v),
+          dim('Depth', p.depth, 0.3, 3, (v) => p.depth = v),
+        ];
+      case _ShapeKind.sphere:
+        return [
+          dim('Radius', p.radius, 0.25, 2, (v) => p.radius = v),
+          count('Segments', p.segments, 3, 48, (v) => p.segments = v),
+          count('Rings', p.rings, 2, 32, (v) => p.rings = v),
+        ];
+      case _ShapeKind.icosphere:
+        return [
+          dim('Radius', p.radius, 0.25, 2, (v) => p.radius = v),
+          count('Subdiv', p.subdivisions, 0, 4, (v) => p.subdivisions = v),
+        ];
+      case _ShapeKind.cylinder:
+      case _ShapeKind.cone:
+        return [
+          dim('Radius', p.radius, 0.25, 2, (v) => p.radius = v),
+          dim('Height', p.height, 0.3, 3, (v) => p.height = v),
+          count('Radial', p.radialSegments, 3, 48, (v) => p.radialSegments = v),
+          count(
+            'Height seg',
+            p.heightSegments,
+            1,
+            6,
+            (v) => p.heightSegments = v,
+          ),
+        ];
+      case _ShapeKind.capsule:
+        return [
+          dim('Radius', p.radius, 0.25, 1.2, (v) => p.radius = v),
+          dim('Height', p.height, 0.2, 3, (v) => p.height = v),
+          count('Radial', p.radialSegments, 3, 48, (v) => p.radialSegments = v),
+          count('Cap rings', p.capRings, 1, 16, (v) => p.capRings = v),
+        ];
+      case _ShapeKind.torus:
+        return [
+          dim('Radius', p.radius, 0.3, 2, (v) => p.radius = v),
+          dim('Tube', p.tubeRadius, 0.05, 0.8, (v) => p.tubeRadius = v),
+          count('Radial', p.radialSegments, 3, 48, (v) => p.radialSegments = v),
+          count(
+            'Tubular',
+            p.tubularSegments,
+            3,
+            24,
+            (v) => p.tubularSegments = v,
+          ),
+        ];
+      case _ShapeKind.disc:
+        return [
+          dim('Radius', p.radius, 0.25, 2, (v) => p.radius = v),
+          count('Segments', p.segments, 3, 64, (v) => p.segments = v),
+        ];
+      case _ShapeKind.ring:
+        return [
+          dim(
+            'Inner',
+            p.innerRadius,
+            0.05,
+            1.4,
+            (v) => p.innerRadius = math.min(v, p.outerRadius - 0.05),
+          ),
+          dim(
+            'Outer',
+            p.outerRadius,
+            0.1,
+            1.5,
+            (v) => p.outerRadius = math.max(v, p.innerRadius + 0.05),
+          ),
+          count('Segments', p.segments, 3, 64, (v) => p.segments = v),
+        ];
+      case _ShapeKind.wedge:
+        return [
+          dim('Width', p.width, 0.3, 3, (v) => p.width = v),
+          dim('Height', p.height, 0.3, 3, (v) => p.height = v),
+          dim('Run', p.run, 0.3, 3, (v) => p.run = v),
+        ];
+    }
+  }
+
+  Widget _slider(
+    String label,
+    double value,
+    double min,
+    double max,
+    ValueChanged<double> onChanged, {
+    int? divisions,
+  }) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 64,
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white, fontSize: 12),
+          ),
+        ),
+        Expanded(
+          child: Slider(
+            value: value.clamp(min, max),
+            min: min,
+            max: max,
+            divisions: divisions,
+            onChanged: onChanged,
+          ),
+        ),
+        SizedBox(
+          width: 32,
+          child: Text(
+            value.toStringAsFixed(divisions == null ? 2 : 0),
+            style: const TextStyle(color: Colors.white70, fontSize: 11),
+            textAlign: TextAlign.right,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _physicsPanel() {
+    // Changing a property updates the ground collider live; new spawns pick
+    // up the values at drop time.
+    ValueChanged<double> set(void Function(double) apply) => (v) {
+      setState(() {
+        apply(v);
+        _groundCollider?.material = _physicsMaterial;
+      });
+    };
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 280),
+      child: Card(
+        color: Colors.black54,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Text(
+                'Physics',
+                style: TextStyle(color: Colors.white70, fontSize: 12),
+              ),
+              _slider('Friction', _friction, 0, 1, set((v) => _friction = v)),
+              _slider(
+                'Bounce',
+                _restitution,
+                0,
+                1,
+                set((v) => _restitution = v),
+              ),
+              _slider('Density', _density, 0.1, 5, set((v) => _density = v)),
+              _slider(
+                'Lin damp',
+                _linearDamping,
+                0,
+                2,
+                set((v) => _linearDamping = v),
+              ),
+              _slider(
+                'Ang damp',
+                _angularDamping,
+                0,
+                2,
+                set((v) => _angularDamping = v),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _environmentPanel() {
+    return AnimatedBuilder(
+      animation: _environment,
+      builder: (context, _) => Card(
+        color: Colors.black54,
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Environment',
+                style: TextStyle(color: Colors.white70, fontSize: 12),
+              ),
+              const SizedBox(height: 4),
+              EnvironmentMenu(
+                active: _environment.active,
+                loading: _environment.loading,
+                onSelected: (env) => unawaited(_selectEnvironment(env)),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _previewPanel() {
+    return Card(
+      color: Colors.black54,
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Preview',
+              style: TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+            const SizedBox(height: 4),
+            SizedBox(
+              width: 150,
+              height: 150,
+              child: SceneView(
+                _previewScene,
+                cameraBuilder: (elapsed) {
+                  final r = _previewRadius(_kind, _params[_kind]!);
+                  final distance = r * 3.4 + 0.6;
+                  return PerspectiveCamera(
+                    position: vm.Vector3(0, r * 0.4, distance),
+                    target: vm.Vector3(0, 0, 0),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// Spins the preview node around Y so every face is visible.
+class _SpinComponent extends Component {
+  _SpinComponent(this.radiansPerSecond);
+
+  final double radiansPerSecond;
+
+  @override
+  void update(double deltaSeconds) {
+    node.localTransform =
+        node.localTransform *
+        vm.Matrix4.rotationY(radiansPerSecond * deltaSeconds);
+  }
+}

--- a/examples/flutter_app/lib/example_skybox.dart
+++ b/examples/flutter_app/lib/example_skybox.dart
@@ -115,6 +115,10 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
     _skyEnvironment = SkyEnvironment(
       source,
       refresh: _skyEnvironment?.refresh ?? SkyEnvironmentRefresh.manual,
+      // Bake the procedural sky at a higher resolution than the default so the
+      // sun and horizon stay crisp and the poles do not pinch into a sunburst.
+      faceResolution: 256,
+      equirectWidth: 1024,
     );
     scene.skyEnvironment = _skyEnvironment;
   }

--- a/examples/flutter_app/lib/example_skybox.dart
+++ b/examples/flutter_app/lib/example_skybox.dart
@@ -115,10 +115,6 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
     _skyEnvironment = SkyEnvironment(
       source,
       refresh: _skyEnvironment?.refresh ?? SkyEnvironmentRefresh.manual,
-      // Bake the procedural sky at a higher resolution than the default so the
-      // sun and horizon stay crisp and the poles do not pinch into a sunburst.
-      faceResolution: 256,
-      equirectWidth: 1024,
     );
     scene.skyEnvironment = _skyEnvironment;
   }

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -13,6 +13,7 @@ import 'example_fscene_import.dart';
 import 'example_fscene_prefab.dart';
 import 'example_fscene_stream.dart';
 import 'example_instancing.dart';
+import 'example_lod.dart';
 import 'example_logo.dart';
 import 'example_nav_route.dart';
 import 'example_physics.dart';
@@ -57,6 +58,7 @@ class _MyAppState extends State<MyApp> {
       'Flutter Logo': (context) => const ExampleLogo(),
       'Cuboid': (context) => const ExampleCuboid(),
       'Instancing': (context) => const ExampleInstancing(),
+      'Geometry LOD': (context) => const ExampleLod(),
       'Navigation Route': (context) => const ExampleNavRoute(),
       'Toon': (context) => const ExampleToon(),
       'Toon (.fmat)': (context) => const ExampleToonFmat(),

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -1,7 +1,12 @@
 import 'package:example_app/example_car.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart'
-    show AntiAliasingMode, Scene, PostInsertion, SpecularAmbientOcclusionMode;
+    show
+        AntiAliasingMode,
+        EnvironmentMap,
+        Scene,
+        PostInsertion,
+        SpecularAmbientOcclusionMode;
 import 'package:flutter_scene_rapier/flutter_scene_rapier.dart'
     show RapierWorld;
 import 'package:example_app/example_animation.dart';
@@ -26,6 +31,10 @@ import 'example_toon.dart';
 import 'example_toon_fmat.dart';
 
 void main() {
+  // Prefilter image-based lighting into a larger radiance cube than the
+  // default so reflections and the panorama skybox stay sharp in the examples
+  // (the default trades resolution for memory; the editor exposes this knob).
+  EnvironmentMap.radianceCubeSize = 1024;
   runApp(const MyApp());
 }
 

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -1,12 +1,7 @@
 import 'package:example_app/example_car.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart'
-    show
-        AntiAliasingMode,
-        EnvironmentMap,
-        Scene,
-        PostInsertion,
-        SpecularAmbientOcclusionMode;
+    show AntiAliasingMode, Scene, PostInsertion, SpecularAmbientOcclusionMode;
 import 'package:flutter_scene_rapier/flutter_scene_rapier.dart'
     show RapierWorld;
 import 'package:example_app/example_animation.dart';
@@ -31,10 +26,6 @@ import 'example_toon.dart';
 import 'example_toon_fmat.dart';
 
 void main() {
-  // Prefilter image-based lighting into a larger radiance cube than the
-  // default so reflections and the panorama skybox stay sharp in the examples
-  // (the default trades resolution for memory; the editor exposes this knob).
-  EnvironmentMap.radianceCubeSize = 1024;
   runApp(const MyApp());
 }
 

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -18,6 +18,7 @@ import 'example_nav_route.dart';
 import 'example_physics.dart';
 import 'example_render_target.dart';
 import 'example_settings.dart';
+import 'example_shapes.dart';
 import 'example_skybox.dart';
 import 'example_widget_texture.dart';
 import 'example_split_screen.dart';
@@ -72,6 +73,17 @@ class _MyAppState extends State<MyApp> {
             return const Center(child: CircularProgressIndicator());
           }
           return const ExamplePhysics();
+        },
+      ),
+      'Shapes': (context) => FutureBuilder<void>(
+        // Shares the Rapier backend with the Physics example, so it waits on
+        // the same wasm load before building its world.
+        future: _physicsReady,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          return const ExampleShapes();
         },
       ),
       'fscene': (context) => const ExampleFscene(),

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -24,6 +24,7 @@ export 'src/animation.dart' show Animation, AnimationClip, AnimationPlayer;
 
 export 'src/geometry/geometry.dart'
     show Geometry, SkinnedGeometry, UnskinnedGeometry;
+export 'src/geometry/mesh_data.dart' show MeshData;
 export 'src/geometry/mesh_geometry.dart'
     show GeometryBuilder, GeometryStorage, MeshGeometry;
 export 'src/geometry/primitives.dart'

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -85,7 +85,9 @@ export 'src/components/environment_volume_component.dart'
     show EnvironmentVolumeComponent, EnvironmentVolumeShape;
 export 'src/components/instanced_mesh_component.dart'
     show InstancedMeshComponent;
+export 'src/components/lod_component.dart' show LodComponent;
 export 'src/components/mesh_component.dart' show MeshComponent;
+export 'src/render/lod.dart' show LodLevel;
 export 'src/components/widget_component.dart' show WidgetComponent, WidgetInput;
 export 'src/instanced_mesh.dart' show InstancedMesh;
 export 'src/light.dart' show DirectionalLight, Lighting, ShadowCascade;

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -27,7 +27,17 @@ export 'src/geometry/geometry.dart'
 export 'src/geometry/mesh_geometry.dart'
     show GeometryBuilder, GeometryStorage, MeshGeometry;
 export 'src/geometry/primitives.dart'
-    show CuboidGeometry, PlaneGeometry, SphereGeometry, WedgeGeometry;
+    show
+        CapsuleGeometry,
+        CuboidGeometry,
+        CylinderGeometry,
+        DiscGeometry,
+        IcosphereGeometry,
+        PlaneGeometry,
+        RingGeometry,
+        SphereGeometry,
+        TorusGeometry,
+        WedgeGeometry;
 export 'src/geometry/polyline_geometry.dart'
     show DashPattern, PolylineCap, PolylineGeometry, PolylineWidthMode;
 export 'src/geometry/swept_geometry.dart'

--- a/packages/flutter_scene/lib/src/components/lod_component.dart
+++ b/packages/flutter_scene/lib/src/components/lod_component.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_scene/src/components/mesh_component.dart';
+import 'package:flutter_scene/src/mesh.dart';
+import 'package:flutter_scene/src/render/lod.dart';
+
+/// A [MeshComponent] that draws one of several level-of-detail variants of an
+/// object, chosen each frame from how large the object appears on screen.
+///
+/// Supply [LodLevel]s highest detail first, with strictly descending
+/// [LodLevel.screenSize] thresholds (a fraction of the viewport height). The
+/// engine picks the highest-detail level whose threshold the object's
+/// projected size still meets, and draws nothing once the size falls below
+/// the smallest threshold (the cull floor; set the last level's threshold to
+/// `0` to never cull). Selection is per view, so the same object can pick
+/// different levels in a split-screen frame.
+///
+/// [lodBias] scales the projected size before selection (above `1` keeps
+/// detail at a greater distance), and [hysteresis] is a dead-band around each
+/// threshold so an object hovering on a boundary does not flip-flop.
+///
+/// Because selection is screen-size based it is field-of-view aware and
+/// resolution independent. The highest-detail level's bounds are used for
+/// frustum culling, so culling stays conservative.
+///
+/// ```dart
+/// node.addComponent(LodComponent([
+///   LodLevel(geometry: high, material: mat, screenSize: 0.4),
+///   LodLevel(geometry: mid, material: mat, screenSize: 0.15),
+///   LodLevel(geometry: low, material: mat, screenSize: 0.04),
+/// ]));
+/// ```
+/// {@category Scene graph}
+class LodComponent extends MeshComponent {
+  /// Creates an LOD component over [levels] (highest detail first).
+  LodComponent(
+    List<LodLevel> levels, {
+    double lodBias = 1.0,
+    double hysteresis = 0.1,
+  }) : _selection = LodSelection(
+         levels,
+         lodBias: lodBias,
+         hysteresis: hysteresis,
+       ),
+       super(Mesh(levels.first.geometry, levels.first.material));
+
+  final LodSelection _selection;
+
+  @override
+  void onMount() {
+    super.onMount();
+    // Tag the item the base class just registered so the encoder selects a
+    // level per view instead of drawing the highest-detail fallback.
+    for (final item in renderItems) {
+      item.lod = _selection;
+    }
+  }
+}

--- a/packages/flutter_scene/lib/src/components/lod_component.dart
+++ b/packages/flutter_scene/lib/src/components/lod_component.dart
@@ -44,18 +44,36 @@ import 'package:flutter_scene/src/render/lod.dart';
 /// {@category Scene graph}
 class LodComponent extends MeshComponent {
   /// Creates an LOD component over [levels] (highest detail first).
+  ///
+  /// [blendRange] above `0` cross-fades adjacent levels with a screen-space
+  /// dither across a band that wide (as a fraction of each threshold) instead
+  /// of hard-switching, removing the pop. Cross-fade is honored by the
+  /// built-in lit and unlit materials.
   LodComponent(
     List<LodLevel> levels, {
     double lodBias = 1.0,
     double hysteresis = 0.1,
+    double blendRange = 0.0,
   }) : _selection = LodSelection(
          levels,
          lodBias: lodBias,
          hysteresis: hysteresis,
+         blendRange: blendRange,
        ),
        super(Mesh(levels.first.geometry, levels.first.material));
 
   final LodSelection _selection;
+
+  /// Half-width of the cross-fade band as a fraction of each threshold. `0`
+  /// hard-switches between levels; a positive value dither-blends adjacent
+  /// levels. Settable to toggle or tune cross-fade at runtime.
+  double get blendRange => _selection.blendRange;
+  set blendRange(double value) => _selection.blendRange = value;
+
+  /// Multiplies the projected size before selection. Above `1` keeps higher
+  /// detail farther away; below `1` drops detail sooner. Settable at runtime.
+  double get lodBias => _selection.lodBias;
+  set lodBias(double value) => _selection.lodBias = value;
 
   @override
   void onMount() {

--- a/packages/flutter_scene/lib/src/components/lod_component.dart
+++ b/packages/flutter_scene/lib/src/components/lod_component.dart
@@ -21,6 +21,19 @@ import 'package:flutter_scene/src/render/lod.dart';
 /// resolution independent. The highest-detail level's bounds are used for
 /// frustum culling, so culling stays conservative.
 ///
+/// Current limitations:
+/// - The shadow and depth-prepass passes always draw the highest-detail
+///   level and ignore the LOD cull, so a tiny object culled in the color
+///   pass can still cast a shadow or write depth (a per-pass LOD bias is
+///   future work).
+/// - Selection memory (for the [hysteresis] dead-band) is shared across
+///   views, so a multi-view frame can see one view's last choice bias
+///   another's.
+/// - Hardware-instanced draws are not supported here; a [LodComponent]
+///   draws a single mesh, so it picks one level for the whole node.
+/// - A non-perspective camera disables the metric and draws the
+///   highest-detail level.
+///
 /// ```dart
 /// node.addComponent(LodComponent([
 ///   LodLevel(geometry: high, material: mat, screenSize: 0.4),

--- a/packages/flutter_scene/lib/src/components/mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/mesh_component.dart
@@ -36,6 +36,12 @@ class MeshComponent extends Component {
   // mounted.
   final List<RenderItem> _renderItems = [];
 
+  /// The render items registered for this component's mesh primitives, empty
+  /// while not mounted. Exposed so a subclass (the LOD component) can tag the
+  /// items it just registered.
+  @protected
+  List<RenderItem> get renderItems => _renderItems;
+
   @override
   void onMount() => _registerRenderItems();
 

--- a/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/fmat/material_registry.dart'
     show fmatSourcePathOf;
 import 'package:flutter_scene/src/fscene/realize/fmat_overrides.dart';
+import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/material/physically_based_material.dart';
@@ -312,12 +313,14 @@ class MeshCodec extends ComponentCodec {
   }
 
   LocalId? _serializeMeshGeometry(MeshGeometry geometry, SceneDocument dest) {
-    final packed = geometry.packedData;
+    // Emit the de-interleaved (structure-of-arrays) vertex payload so the
+    // realizer uploads each attribute straight to its GPU buffer.
+    final packed = geometry.soaData;
     final vertices = dest.addPayload(
       PayloadSpec(
         dest.newId(),
         encoding: PayloadEncoding.vertexBuffer,
-        layout: 'unskinned',
+        layout: InterleavedLayoutAdapter.unskinnedSoaLayout,
         length: packed.vertexBytes.length,
         bytes: packed.vertexBytes,
       ),

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -19,6 +19,7 @@ import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/fmat/material_registry.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
+import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/geometry/primitives.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/importer/constants.dart';
@@ -288,7 +289,11 @@ class ResourceRealizer {
     }
     final vertexBytes = _payloadBytes(vertexId, 'vertex');
     final vertexPayload = document.payload(vertexId)!;
-    final skinned = vertexPayload.layout == 'skinned';
+    final layout = vertexPayload.layout;
+    final soa = layout == InterleavedLayoutAdapter.unskinnedSoaLayout;
+    final skinned = layout == 'skinned';
+    // The de-interleaved and interleaved unskinned payloads carry the same
+    // 48 bytes per vertex, just reordered; skinned is 80.
     final perVertexBytes = skinned
         ? kSkinnedPerVertexSize
         : kUnskinnedPerVertexSize;
@@ -306,7 +311,7 @@ class ResourceRealizer {
     }
 
     // Set baked bounds before upload so the position scan is skipped; without
-    // bounds, uploadVertexData scans unskinned positions (and leaves skinned
+    // bounds, the upload scans unskinned positions (and leaves skinned
     // geometry unbounded, matching the importer).
     final bounds = res.bounds;
     if (bounds != null) {
@@ -314,12 +319,28 @@ class ResourceRealizer {
       geometry.setLocalBounds(aabb, _circumscribedSphere(aabb));
     }
 
-    geometry.uploadVertexData(
-      ByteData.sublistView(vertexBytes),
-      vertexCount,
-      indexBytes,
-      indexType: indexType,
-    );
+    if (soa) {
+      // De-interleaved payload: upload each attribute stream straight to its
+      // GPU buffer, no realize-time reshuffle.
+      (geometry as UnskinnedGeometry).uploadUnskinnedAttributeStreams(
+        InterleavedLayoutAdapter.sliceUnskinnedStreams(
+          vertexBytes,
+          vertexCount,
+        ),
+        vertexCount,
+        indices: indexBytes,
+        indexType: indexType,
+      );
+    } else {
+      // Interleaved payload (skinned, or a pre-SoA unskinned document): the
+      // unskinned path de-interleaves once here.
+      geometry.uploadVertexData(
+        ByteData.sublistView(vertexBytes),
+        vertexCount,
+        indexBytes,
+        indexType: indexType,
+      );
+    }
     geometry.primitiveType = _topology(res.topology);
     return geometry;
   }

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -45,6 +45,13 @@ abstract class Geometry {
   ByteData? _cpuVertices;
   ByteData? _cpuIndices;
 
+  // Structure-of-arrays CPU copies for raycasting, set by the SoA upload path
+  // instead of the interleaved [_cpuVertices]. Position is required to
+  // raycast; texture coordinates let a hit report a UV. Null for interleaved
+  // geometry (which raycasts off [_cpuVertices]) or non-raycastable geometry.
+  Float32List? _cpuPositions;
+  Float32List? _cpuTexCoords;
+
   gpu.Shader? _vertexShader;
 
   /// How the vertex/index data is assembled into primitives when drawn.
@@ -164,7 +171,29 @@ abstract class Geometry {
     _cpuVertices = vertices;
     _cpuIndices = indices;
 
-    final streams = _vertexStreamBytes(vertices, vertexCount);
+    _uploadStreams(
+      _vertexStreamBytes(vertices, vertexCount),
+      vertexCount,
+      indices,
+      indexType,
+    );
+
+    if (_localBounds == null && vertexCount > 0 && _autoScanBoundsOnUpload) {
+      _scanLocalBoundsFromVertices(vertices, vertexCount);
+    }
+  }
+
+  /// Packs [streams] (one tightly packed buffer per vertex slot) and any
+  /// [indices] back-to-back into a single host-visible [gpu.DeviceBuffer],
+  /// binding the streams via [setVertexStreams] and the indices via
+  /// [setIndices]. Shared by the interleaved and structure-of-arrays upload
+  /// paths.
+  void _uploadStreams(
+    List<ByteData> streams,
+    int vertexCount,
+    ByteData? indices,
+    gpu.IndexType indexType,
+  ) {
     var vertexBytes = 0;
     for (final stream in streams) {
       vertexBytes += stream.lengthInBytes;
@@ -201,10 +230,6 @@ abstract class Geometry {
         indexType,
       );
     }
-
-    if (_localBounds == null && vertexCount > 0 && _autoScanBoundsOnUpload) {
-      _scanLocalBoundsFromVertices(vertices, vertexCount);
-    }
   }
 
   /// Splits the interleaved [vertices] into the tightly packed vertex streams
@@ -218,21 +243,38 @@ abstract class Geometry {
     vertices,
   ];
 
-  /// Internal: retains CPU vertex/index data for scene raycasts. Subclasses
-  /// with their own upload paths (see MeshGeometry's updatable buffers) call
-  /// this when they bypass [uploadVertexData].
+  /// Internal: retains interleaved CPU vertex/index data for scene raycasts.
+  /// Subclasses with their own upload paths (see MeshGeometry's updatable
+  /// buffers) call this when they bypass [uploadVertexData].
   @internal
   void retainCpuMeshData(ByteData? vertices, ByteData? indices) {
     _cpuVertices = vertices;
     _cpuIndices = indices;
+    _cpuPositions = null;
+    _cpuTexCoords = null;
   }
 
-  /// Internal: the retained CPU vertex/index data for scene raycasts, or
-  /// null vertices when this geometry is not raycastable (caller-managed
-  /// buffers via [setVertices], or no upload yet).
+  /// Internal: retains structure-of-arrays CPU attributes for raycasts, used
+  /// by the de-interleaved upload path instead of an interleaved copy.
+  @internal
+  void setRaycastAttributes({
+    required Float32List positions,
+    Float32List? texCoords,
+  }) {
+    _cpuPositions = positions;
+    _cpuTexCoords = texCoords;
+    _cpuVertices = null;
+  }
+
+  /// Internal: the retained CPU vertex/index data for scene raycasts. Either
+  /// [vertices] (interleaved) or [positions] (structure of arrays) is set
+  /// when the geometry is raycastable; both are null for caller-managed
+  /// buffers or before the first upload.
   @internal
   ({
     ByteData? vertices,
+    Float32List? positions,
+    Float32List? texCoords,
     ByteData? indices,
     gpu.IndexType indexType,
     int vertexCount,
@@ -240,11 +282,43 @@ abstract class Geometry {
   })
   get cpuMeshData => (
     vertices: _cpuVertices,
+    positions: _cpuPositions,
+    texCoords: _cpuTexCoords,
     indices: _cpuIndices,
     indexType: _indexType,
     vertexCount: _vertexCount,
     indexCount: _indexCount,
   );
+
+  /// Internal: populate bounds from a tightly packed position list (three
+  /// floats per vertex), used by the structure-of-arrays upload path.
+  @internal
+  void scanLocalBoundsFromPositions(Float32List positions, int vertexCount) {
+    if (vertexCount == 0) return;
+    double minX = double.infinity,
+        minY = double.infinity,
+        minZ = double.infinity;
+    double maxX = double.negativeInfinity,
+        maxY = double.negativeInfinity,
+        maxZ = double.negativeInfinity;
+    for (var i = 0; i < vertexCount; i++) {
+      final x = positions[i * 3],
+          y = positions[i * 3 + 1],
+          z = positions[i * 3 + 2];
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+      if (z > maxZ) maxZ = z;
+    }
+    final aabb = vm.Aabb3.minMax(
+      vm.Vector3(minX, minY, minZ),
+      vm.Vector3(maxX, maxY, maxZ),
+    );
+    _localBounds = aabb;
+    _localBoundingSphere ??= _circumscribedSphere(aabb);
+  }
 
   /// Whether [uploadVertexData] should auto-populate [localBounds] from
   /// the vertex positions when no bound has been set yet. True by
@@ -416,27 +490,78 @@ class UnskinnedGeometry extends Geometry {
     setVertexShader(baseShaderLibrary['UnskinnedVertex']!);
   }
 
-  // Whether this geometry stores position de-interleaved into its own stream
-  // (uploaded through [uploadVertexData]) versus a single interleaved stream
-  // (a caller-managed [setVertices] buffer, or the updatable MeshGeometry
-  // path). The two store the same bytes but bind different layouts.
+  // Whether this geometry stores its attributes de-interleaved into separate
+  // per-attribute streams (uploaded through [uploadVertexData] or
+  // [uploadUnskinnedAttributes]) versus a single interleaved stream (a
+  // caller-managed [setVertices] buffer, or the updatable MeshGeometry path).
+  // The two store the same bytes but bind different layouts.
   bool get _isDeInterleaved => vertexStreamCount >= 2;
 
   @override
   List<ByteData> _vertexStreamBytes(ByteData vertices, int vertexCount) {
-    final split = InterleavedLayoutAdapter.splitUnskinnedStreams(
+    final streams = InterleavedLayoutAdapter.splitUnskinnedAttributes(
       vertices,
       vertexCount,
     );
     return [
-      ByteData.sublistView(split.position),
-      ByteData.sublistView(split.rest),
+      ByteData.sublistView(streams.position),
+      ByteData.sublistView(streams.normal),
+      ByteData.sublistView(streams.texCoord),
+      ByteData.sublistView(streams.color),
     ];
+  }
+
+  /// Uploads the four unskinned attributes from structure-of-arrays lists
+  /// directly into per-attribute streams, with no interleave step.
+  ///
+  /// This is the efficient path for a structure-of-arrays source (a
+  /// procedural mesh, a generator): each attribute is written straight to its
+  /// own buffer. Absent attributes get defaults (normal `(0, 0, 1)`, texture
+  /// coordinate `(0, 0)`, color opaque white). The position and texture
+  /// coordinate streams are retained on the CPU for raycasting.
+  @internal
+  void uploadUnskinnedAttributes({
+    required Float32List positions,
+    required int vertexCount,
+    Float32List? normals,
+    Float32List? texCoords,
+    Float32List? colors,
+    ByteData? indices,
+    gpu.IndexType indexType = gpu.IndexType.int16,
+  }) {
+    final streams = InterleavedLayoutAdapter.unskinnedAttributeStreams(
+      positions: positions,
+      vertexCount: vertexCount,
+      normals: normals,
+      texCoords: texCoords,
+      colors: colors,
+    );
+    _uploadStreams(
+      [
+        ByteData.sublistView(streams.position),
+        ByteData.sublistView(streams.normal),
+        ByteData.sublistView(streams.texCoord),
+        ByteData.sublistView(streams.color),
+      ],
+      vertexCount,
+      indices,
+      indexType,
+    );
+    setRaycastAttributes(
+      positions: Float32List.sublistView(streams.position),
+      texCoords: Float32List.sublistView(streams.texCoord),
+    );
+    if (localBounds == null && vertexCount > 0) {
+      scanLocalBoundsFromPositions(
+        Float32List.sublistView(streams.position),
+        vertexCount,
+      );
+    }
   }
 
   @override
   VertexLayoutDescriptor? get instancedVertexLayout =>
-      _isDeInterleaved ? kUnskinnedSplitColorLayout : kUnskinnedInstancedLayout;
+      _isDeInterleaved ? kUnskinnedSoAColorLayout : kUnskinnedInstancedLayout;
 
   // Cached once: the depth-style passes use the same position-only shader for
   // every unskinned geometry. The layout still depends on whether position is
@@ -447,7 +572,7 @@ class UnskinnedGeometry extends Geometry {
   ({gpu.Shader shader, VertexLayoutDescriptor layout})? get depthOnlyVertex => (
     shader: _depthVertexShader ??= baseShaderLibrary['UnskinnedDepthVertex']!,
     layout: _isDeInterleaved
-        ? kUnskinnedSplitDepthLayout
+        ? kUnskinnedSoADepthLayout
         : kUnskinnedPositionOnlyLayout,
   );
 
@@ -623,29 +748,36 @@ const VertexBufferDescriptor _kPositionBuffer = VertexBufferDescriptor(
   ],
 );
 
-/// The de-interleaved unskinned attribute stream (everything but position):
-/// normal (`vec3`), texture coordinates (`vec2`), color (`vec4`), 36 bytes
-/// per vertex. The slot-1 buffer of the de-interleaved color layout.
-const VertexBufferDescriptor _kUnskinnedAttributeBuffer =
-    VertexBufferDescriptor(
-      strideInBytes: 36,
-      attributes: [
-        VertexAttributeDescriptor(
-          name: 'normal',
-          format: gpu.VertexFormat.float32x3,
-        ),
-        VertexAttributeDescriptor(
-          name: 'texture_coords',
-          format: gpu.VertexFormat.float32x2,
-          offsetInBytes: 12,
-        ),
-        VertexAttributeDescriptor(
-          name: 'color',
-          format: gpu.VertexFormat.float32x4,
-          offsetInBytes: 20,
-        ),
-      ],
-    );
+/// The tightly packed per-attribute streams (structure of arrays) that make
+/// up the de-interleaved unskinned layout, each its own buffer slot: normal
+/// (12 bytes), texture coordinates (8 bytes), color (16 bytes).
+const VertexBufferDescriptor _kNormalBuffer = VertexBufferDescriptor(
+  strideInBytes: 12,
+  attributes: [
+    VertexAttributeDescriptor(
+      name: 'normal',
+      format: gpu.VertexFormat.float32x3,
+    ),
+  ],
+);
+const VertexBufferDescriptor _kTexCoordBuffer = VertexBufferDescriptor(
+  strideInBytes: 8,
+  attributes: [
+    VertexAttributeDescriptor(
+      name: 'texture_coords',
+      format: gpu.VertexFormat.float32x2,
+    ),
+  ],
+);
+const VertexBufferDescriptor _kColorBuffer = VertexBufferDescriptor(
+  strideInBytes: 16,
+  attributes: [
+    VertexAttributeDescriptor(
+      name: 'color',
+      format: gpu.VertexFormat.float32x4,
+    ),
+  ],
+);
 
 /// The interleaved two-buffer pipeline layout for the unskinned vertex
 /// shader: slot 0 carries the interleaved 48-byte vertex stream (position,
@@ -695,8 +827,8 @@ final VertexLayoutDescriptor kUnskinnedInstancedLayout = VertexLayoutDescriptor(
 /// [Geometry.setVertices] buffer, or the updatable MeshGeometry path).
 ///
 /// Geometry uploaded through [Geometry.uploadVertexData] is de-interleaved
-/// and uses [kUnskinnedSplitDepthLayout] instead, whose slot-0 stride is 12
-/// for the locality win.
+/// into per-attribute streams and uses [kUnskinnedSoADepthLayout] instead,
+/// whose slot-0 stride is 12 for the locality win.
 @internal
 final VertexLayoutDescriptor kUnskinnedPositionOnlyLayout =
     VertexLayoutDescriptor(
@@ -714,32 +846,37 @@ final VertexLayoutDescriptor kUnskinnedPositionOnlyLayout =
       ],
     );
 
-/// The de-interleaved color layout for the unskinned vertex shader: slot 0
-/// the tightly packed position stream (12 bytes), slot 1 the remaining
-/// attributes (normal, texture coords, color; 36 bytes), slot 2 the
-/// instance-rate model matrix. Used for geometry uploaded through
-/// [Geometry.uploadVertexData], which de-interleaves position into its own
-/// buffer.
+/// The structure-of-arrays color layout for the unskinned vertex shader: one
+/// tightly packed buffer per attribute (position 12, normal 12, texture
+/// coords 8, color 16) plus the instance-rate model matrix. Used for geometry
+/// uploaded through [Geometry.uploadVertexData] or the structure-of-arrays
+/// upload, which store each attribute in its own stream.
+///
+/// The attributes could equally be grouped into one interleaved "rest" buffer
+/// (one fetch on a tiler); because the layout is interned and the pipeline
+/// specialized per draw, that regrouping would be a layout-only change with no
+/// API impact. Per-attribute streams are the default for cheap single-
+/// attribute updates and zero-interleave uploads.
 @internal
-final VertexLayoutDescriptor kUnskinnedSplitColorLayout =
-    VertexLayoutDescriptor(
-      buffers: const [
-        _kPositionBuffer,
-        _kUnskinnedAttributeBuffer,
-        _kInstanceModelTransformBuffer,
-      ],
-    );
+final VertexLayoutDescriptor kUnskinnedSoAColorLayout = VertexLayoutDescriptor(
+  buffers: const [
+    _kPositionBuffer,
+    _kNormalBuffer,
+    _kTexCoordBuffer,
+    _kColorBuffer,
+    _kInstanceModelTransformBuffer,
+  ],
+);
 
-/// The de-interleaved depth-style layout for the unskinned vertex shader:
-/// slot 0 the tightly packed position stream (12 bytes), slot 1 the
-/// instance-rate model matrix. The attribute stream is not bound, so these
-/// passes fetch only the 12-byte position per vertex. Paired with the
+/// The structure-of-arrays depth-style layout for the unskinned vertex
+/// shader: slot 0 the tightly packed position stream (12 bytes), slot 1 the
+/// instance-rate model matrix. The other attribute streams are not bound, so
+/// these passes fetch only the 12-byte position per vertex. Paired with the
 /// `UnskinnedDepthVertex` shader.
 @internal
-final VertexLayoutDescriptor kUnskinnedSplitDepthLayout =
-    VertexLayoutDescriptor(
-      buffers: const [_kPositionBuffer, _kInstanceModelTransformBuffer],
-    );
+final VertexLayoutDescriptor kUnskinnedSoADepthLayout = VertexLayoutDescriptor(
+  buffers: const [_kPositionBuffer, _kInstanceModelTransformBuffer],
+);
 
 /// Emplaces and binds the unskinned `FrameInfo` uniform (camera transform
 /// plus camera position) onto [pass], resolving the slot against [shader].

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -564,6 +564,44 @@ class UnskinnedGeometry extends Geometry {
     }
   }
 
+  /// Uploads already-de-interleaved attribute streams (raw bytes) straight
+  /// into per-attribute GPU buffers, with no repacking.
+  ///
+  /// This is the realizer's path for a structure-of-arrays `.fscene` vertex
+  /// payload: the payload bytes are sliced into the four streams and uploaded
+  /// as-is. Position and texture coordinates are retained (as views into the
+  /// payload) for raycasting.
+  @internal
+  void uploadUnskinnedAttributeStreams(
+    UnskinnedAttributeStreams streams,
+    int vertexCount, {
+    ByteData? indices,
+    gpu.IndexType indexType = gpu.IndexType.int16,
+  }) {
+    _uploadStreams(
+      [
+        ByteData.sublistView(streams.position),
+        ByteData.sublistView(streams.normal),
+        ByteData.sublistView(streams.texCoord),
+        ByteData.sublistView(streams.color),
+      ],
+      vertexCount,
+      indices,
+      indexType,
+    );
+    setRaycastAttributes(
+      positions: Float32List.sublistView(streams.position),
+      texCoords: Float32List.sublistView(streams.texCoord),
+      indices: indices,
+    );
+    if (localBounds == null && vertexCount > 0) {
+      scanLocalBoundsFromPositions(
+        Float32List.sublistView(streams.position),
+        vertexCount,
+      );
+    }
+  }
+
   @override
   VertexLayoutDescriptor? get instancedVertexLayout =>
       _isDeInterleaved ? kUnskinnedSoAColorLayout : kUnskinnedInstancedLayout;

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -243,17 +243,6 @@ abstract class Geometry {
     vertices,
   ];
 
-  /// Internal: retains interleaved CPU vertex/index data for scene raycasts.
-  /// Subclasses with their own upload paths (see MeshGeometry's updatable
-  /// buffers) call this when they bypass [uploadVertexData].
-  @internal
-  void retainCpuMeshData(ByteData? vertices, ByteData? indices) {
-    _cpuVertices = vertices;
-    _cpuIndices = indices;
-    _cpuPositions = null;
-    _cpuTexCoords = null;
-  }
-
   /// Internal: retains structure-of-arrays CPU attributes (and the index
   /// data) for raycasts, used by the de-interleaved upload path instead of an
   /// interleaved copy. The indices must be retained too, or an indexed mesh

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -254,15 +254,19 @@ abstract class Geometry {
     _cpuTexCoords = null;
   }
 
-  /// Internal: retains structure-of-arrays CPU attributes for raycasts, used
-  /// by the de-interleaved upload path instead of an interleaved copy.
+  /// Internal: retains structure-of-arrays CPU attributes (and the index
+  /// data) for raycasts, used by the de-interleaved upload path instead of an
+  /// interleaved copy. The indices must be retained too, or an indexed mesh
+  /// raycasts as a non-indexed triangle list.
   @internal
   void setRaycastAttributes({
     required Float32List positions,
     Float32List? texCoords,
+    ByteData? indices,
   }) {
     _cpuPositions = positions;
     _cpuTexCoords = texCoords;
+    _cpuIndices = indices;
     _cpuVertices = null;
   }
 
@@ -550,6 +554,7 @@ class UnskinnedGeometry extends Geometry {
     setRaycastAttributes(
       positions: Float32List.sublistView(streams.position),
       texCoords: Float32List.sublistView(streams.texCoord),
+      indices: indices,
     );
     if (localBounds == null && vertexCount > 0) {
       scanLocalBoundsFromPositions(

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
 import 'package:flutter_scene/src/importer/constants.dart';
@@ -299,7 +300,7 @@ abstract class Geometry {
   /// model transform from the instance-rate vertex buffer (slot 1) rather
   /// than a per-draw uniform, so every draw must bind an instance buffer.
   @internal
-  gpu.VertexLayout? get instancedVertexLayout => null;
+  VertexLayoutDescriptor? get instancedVertexLayout => null;
 }
 
 /// Geometry whose vertices use the unskinned 48-byte layout: position
@@ -316,7 +317,8 @@ class UnskinnedGeometry extends Geometry {
   }
 
   @override
-  gpu.VertexLayout? get instancedVertexLayout => kUnskinnedInstancedLayout;
+  VertexLayoutDescriptor? get instancedVertexLayout =>
+      kUnskinnedInstancedLayout;
 
   @override
   void bind(
@@ -486,54 +488,59 @@ class SkinnedGeometry extends Geometry {
 }
 
 /// The two-buffer pipeline layout for the unskinned vertex shader: slot 0
-/// carries the interleaved 48-byte vertex stream, slot 1 carries the
-/// instance-rate model matrix as four vec4 columns (64 bytes per instance).
+/// carries the interleaved 48-byte vertex stream (position, normal, texture
+/// coords, color), slot 1 carries the instance-rate model matrix as four
+/// vec4 columns (64 bytes per instance).
+///
+/// This is the canonical described layout; its slot-0 stride is
+/// [kUnskinnedPerVertexSize] and its attribute offsets match the bytes
+/// [InterleavedLayoutAdapter.packUnskinned] emits.
 @internal
-final gpu.VertexLayout kUnskinnedInstancedLayout = gpu.VertexLayout(
-  buffers: [
-    gpu.VertexBuffer(
+final VertexLayoutDescriptor kUnskinnedInstancedLayout = VertexLayoutDescriptor(
+  buffers: const [
+    VertexBufferDescriptor(
       strideInBytes: kUnskinnedPerVertexSize,
-      attributes: const [
-        gpu.VertexAttribute(
+      attributes: [
+        VertexAttributeDescriptor(
           name: 'position',
           format: gpu.VertexFormat.float32x3,
         ),
-        gpu.VertexAttribute(
+        VertexAttributeDescriptor(
           name: 'normal',
           format: gpu.VertexFormat.float32x3,
           offsetInBytes: 12,
         ),
-        gpu.VertexAttribute(
+        VertexAttributeDescriptor(
           name: 'texture_coords',
           format: gpu.VertexFormat.float32x2,
           offsetInBytes: 24,
         ),
-        gpu.VertexAttribute(
+        VertexAttributeDescriptor(
           name: 'color',
           format: gpu.VertexFormat.float32x4,
           offsetInBytes: 32,
         ),
       ],
     ),
-    gpu.VertexBuffer(
+    VertexBufferDescriptor(
       strideInBytes: 64,
       stepMode: gpu.VertexStepMode.instance,
-      attributes: const [
-        gpu.VertexAttribute(
+      attributes: [
+        VertexAttributeDescriptor(
           name: 'model_transform_0',
           format: gpu.VertexFormat.float32x4,
         ),
-        gpu.VertexAttribute(
+        VertexAttributeDescriptor(
           name: 'model_transform_1',
           format: gpu.VertexFormat.float32x4,
           offsetInBytes: 16,
         ),
-        gpu.VertexAttribute(
+        VertexAttributeDescriptor(
           name: 'model_transform_2',
           format: gpu.VertexFormat.float32x4,
           offsetInBytes: 32,
         ),
-        gpu.VertexAttribute(
+        VertexAttributeDescriptor(
           name: 'model_transform_3',
           format: gpu.VertexFormat.float32x4,
           offsetInBytes: 48,

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -301,6 +301,37 @@ abstract class Geometry {
   /// than a per-draw uniform, so every draw must bind an instance buffer.
   @internal
   VertexLayoutDescriptor? get instancedVertexLayout => null;
+
+  /// Binds this geometry's vertex buffer (slot 0) and index buffer onto
+  /// [pass] without binding any uniforms.
+  ///
+  /// The color path goes through [bind], which also binds per-frame
+  /// uniforms against [vertexShader]. The depth-style passes drive a
+  /// different vertex shader (see [depthOnlyVertex]), so they bind the
+  /// buffers with this and supply their own uniforms against that shader.
+  @internal
+  void bindGeometryBuffers(gpu.RenderPass pass) {
+    if (_vertices == null) {
+      throw Exception('setVertices must be called before binding Geometry.');
+    }
+    bindVertexBufferCompat(pass, _vertices!, _vertexCount);
+    if (_indices != null) {
+      bindIndexBufferCompat(pass, _indices!, _indexType, _indexCount);
+    }
+  }
+
+  /// The vertex shader and layout the depth-style passes (the directional
+  /// shadow map, the camera depth prepass, and the object-selection mask)
+  /// should use for this geometry, or null to reuse [vertexShader] with
+  /// [instancedVertexLayout].
+  ///
+  /// Unskinned geometry returns a position-only shader and layout so those
+  /// passes fetch only the position attribute. Skinned geometry returns
+  /// null (its joints-driven shader has no position-only variant yet), so
+  /// the depth passes drive it through [bind] like the color pass.
+  @internal
+  ({gpu.Shader shader, VertexLayoutDescriptor layout})? get depthOnlyVertex =>
+      null;
 }
 
 /// Geometry whose vertices use the unskinned 48-byte layout: position
@@ -320,6 +351,18 @@ class UnskinnedGeometry extends Geometry {
   VertexLayoutDescriptor? get instancedVertexLayout =>
       kUnskinnedInstancedLayout;
 
+  // Cached once: the depth-style passes use the same position-only shader and
+  // layout for every unskinned geometry, so the record is shared rather than
+  // rebuilt per draw. The shader keeps its identity across hot reloads.
+  static ({gpu.Shader shader, VertexLayoutDescriptor layout})? _depthOnlyVertex;
+
+  @override
+  ({gpu.Shader shader, VertexLayoutDescriptor layout})? get depthOnlyVertex =>
+      _depthOnlyVertex ??= (
+        shader: baseShaderLibrary['UnskinnedDepthVertex']!,
+        layout: kUnskinnedPositionOnlyLayout,
+      );
+
   @override
   void bind(
     gpu.RenderPass pass,
@@ -328,46 +371,18 @@ class UnskinnedGeometry extends Geometry {
     vm.Matrix4 cameraTransform,
     vm.Vector3 cameraPosition,
   ) {
-    if (_vertices == null) {
-      throw Exception(
-        'SetVertices must be called before GetBufferView for Geometry.',
-      );
-    }
-
-    bindVertexBufferCompat(pass, _vertices!, _vertexCount);
-    if (_indices != null) {
-      bindIndexBufferCompat(pass, _indices!, _indexType, _indexCount);
-    }
+    bindGeometryBuffers(pass);
 
     // Unskinned vertex UBO. The model transform is NOT part of this block;
     // it arrives through the instance-rate vertex buffer (slot 1), bound by
     // the encoder for instanced and non-instanced draws alike.
-    final frameInfoSlot = vertexShader.getUniformSlot('FrameInfo');
-    final frameInfoFloats = Float32List.fromList([
-      cameraTransform.storage[0],
-      cameraTransform.storage[1],
-      cameraTransform.storage[2],
-      cameraTransform.storage[3],
-      cameraTransform.storage[4],
-      cameraTransform.storage[5],
-      cameraTransform.storage[6],
-      cameraTransform.storage[7],
-      cameraTransform.storage[8],
-      cameraTransform.storage[9],
-      cameraTransform.storage[10],
-      cameraTransform.storage[11],
-      cameraTransform.storage[12],
-      cameraTransform.storage[13],
-      cameraTransform.storage[14],
-      cameraTransform.storage[15],
-      cameraPosition.x,
-      cameraPosition.y,
-      cameraPosition.z,
-    ]);
-    final frameInfoView = transientsBuffer.emplace(
-      frameInfoFloats.buffer.asByteData(),
+    bindUnskinnedFrameInfo(
+      pass,
+      transientsBuffer,
+      vertexShader,
+      cameraTransform,
+      cameraPosition,
     );
-    pass.bindUniform(frameInfoSlot, frameInfoView);
   }
 }
 
@@ -487,6 +502,36 @@ class SkinnedGeometry extends Geometry {
   }
 }
 
+/// The instance-rate vertex buffer slot shared by every unskinned layout:
+/// the model matrix as four vec4 columns, 64 bytes per instance, advanced
+/// once per instance.
+const VertexBufferDescriptor _kInstanceModelTransformBuffer =
+    VertexBufferDescriptor(
+      strideInBytes: 64,
+      stepMode: gpu.VertexStepMode.instance,
+      attributes: [
+        VertexAttributeDescriptor(
+          name: 'model_transform_0',
+          format: gpu.VertexFormat.float32x4,
+        ),
+        VertexAttributeDescriptor(
+          name: 'model_transform_1',
+          format: gpu.VertexFormat.float32x4,
+          offsetInBytes: 16,
+        ),
+        VertexAttributeDescriptor(
+          name: 'model_transform_2',
+          format: gpu.VertexFormat.float32x4,
+          offsetInBytes: 32,
+        ),
+        VertexAttributeDescriptor(
+          name: 'model_transform_3',
+          format: gpu.VertexFormat.float32x4,
+          offsetInBytes: 48,
+        ),
+      ],
+    );
+
 /// The two-buffer pipeline layout for the unskinned vertex shader: slot 0
 /// carries the interleaved 48-byte vertex stream (position, normal, texture
 /// coords, color), slot 1 carries the instance-rate model matrix as four
@@ -522,30 +567,81 @@ final VertexLayoutDescriptor kUnskinnedInstancedLayout = VertexLayoutDescriptor(
         ),
       ],
     ),
-    VertexBufferDescriptor(
-      strideInBytes: 64,
-      stepMode: gpu.VertexStepMode.instance,
-      attributes: [
-        VertexAttributeDescriptor(
-          name: 'model_transform_0',
-          format: gpu.VertexFormat.float32x4,
-        ),
-        VertexAttributeDescriptor(
-          name: 'model_transform_1',
-          format: gpu.VertexFormat.float32x4,
-          offsetInBytes: 16,
-        ),
-        VertexAttributeDescriptor(
-          name: 'model_transform_2',
-          format: gpu.VertexFormat.float32x4,
-          offsetInBytes: 32,
-        ),
-        VertexAttributeDescriptor(
-          name: 'model_transform_3',
-          format: gpu.VertexFormat.float32x4,
-          offsetInBytes: 48,
-        ),
-      ],
-    ),
+    _kInstanceModelTransformBuffer,
   ],
 );
+
+/// The depth-style layout for the unskinned vertex shader: slot 0 reads only
+/// the position attribute from the interleaved 48-byte vertex stream (the
+/// other attributes are present in the buffer but not fetched), slot 1 the
+/// instance-rate model matrix. Paired with the `UnskinnedDepthVertex` shader
+/// by the shadow, depth-prepass, and object-mask passes so they fetch only
+/// position per vertex.
+///
+/// The bound buffers are identical to the color pass (the same interleaved
+/// vertex buffer at slot 0, the same instance buffer at slot 1); only the
+/// declared attribute set differs.
+///
+/// TODO(position-stream): once positions live in their own tightly packed
+/// 12-byte buffer (de-interleaved at upload, composing with the dynamic
+/// position-update path), drop slot 0's stride to 12 for the locality win.
+/// The descriptor and the binding stay otherwise the same.
+@internal
+final VertexLayoutDescriptor kUnskinnedPositionOnlyLayout =
+    VertexLayoutDescriptor(
+      buffers: const [
+        VertexBufferDescriptor(
+          strideInBytes: kUnskinnedPerVertexSize,
+          attributes: [
+            VertexAttributeDescriptor(
+              name: 'position',
+              format: gpu.VertexFormat.float32x3,
+            ),
+          ],
+        ),
+        _kInstanceModelTransformBuffer,
+      ],
+    );
+
+/// Emplaces and binds the unskinned `FrameInfo` uniform (camera transform
+/// plus camera position) onto [pass], resolving the slot against [shader].
+///
+/// Shared by the color path ([UnskinnedGeometry.bind]) and the depth-style
+/// passes, which drive the position-only shader but use the identical
+/// `FrameInfo` block; the slot is resolved against whichever shader the bound
+/// pipeline uses.
+@internal
+void bindUnskinnedFrameInfo(
+  gpu.RenderPass pass,
+  gpu.HostBuffer transientsBuffer,
+  gpu.Shader shader,
+  vm.Matrix4 cameraTransform,
+  vm.Vector3 cameraPosition,
+) {
+  final frameInfoSlot = shader.getUniformSlot('FrameInfo');
+  final frameInfoFloats = Float32List.fromList([
+    cameraTransform.storage[0],
+    cameraTransform.storage[1],
+    cameraTransform.storage[2],
+    cameraTransform.storage[3],
+    cameraTransform.storage[4],
+    cameraTransform.storage[5],
+    cameraTransform.storage[6],
+    cameraTransform.storage[7],
+    cameraTransform.storage[8],
+    cameraTransform.storage[9],
+    cameraTransform.storage[10],
+    cameraTransform.storage[11],
+    cameraTransform.storage[12],
+    cameraTransform.storage[13],
+    cameraTransform.storage[14],
+    cameraTransform.storage[15],
+    cameraPosition.x,
+    cameraPosition.y,
+    cameraPosition.z,
+  ]);
+  pass.bindUniform(
+    frameInfoSlot,
+    transientsBuffer.emplace(frameInfoFloats.buffer.asByteData()),
+  );
+}

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
@@ -25,7 +26,12 @@ import 'package:flutter_scene/src/shaders.dart';
 /// arrays without packing vertex bytes by hand.
 /// {@category Geometry}
 abstract class Geometry {
-  gpu.BufferView? _vertices;
+  // One or more vertex buffer streams, bound to consecutive slots (0, 1, ...)
+  // in order. Most geometry has a single interleaved stream; unskinned
+  // geometry uploaded through [uploadVertexData] is de-interleaved into a
+  // tight position stream plus an attribute stream (see
+  // [UnskinnedGeometry._vertexStreamBytes]).
+  List<gpu.BufferView> _vertexStreams = const [];
   int _vertexCount = 0;
 
   gpu.BufferView? _indices;
@@ -102,9 +108,27 @@ abstract class Geometry {
   /// turn-key path that allocates and uploads in one step, see
   /// [uploadVertexData].
   void setVertices(gpu.BufferView vertices, int vertexCount) {
-    _vertices = vertices;
+    _vertexStreams = [vertices];
     _vertexCount = vertexCount;
   }
+
+  /// Binds several already-uploaded vertex streams, in slot order (the first
+  /// is slot 0, the second slot 1, and so on).
+  ///
+  /// Used by the de-interleaved unskinned path, which stores position and the
+  /// remaining attributes in separate buffer slots. Single-stream geometry
+  /// uses [setVertices].
+  @internal
+  void setVertexStreams(List<gpu.BufferView> streams, int vertexCount) {
+    _vertexStreams = streams;
+    _vertexCount = vertexCount;
+  }
+
+  /// The number of vertex buffer streams this geometry binds (one for
+  /// interleaved geometry, more when de-interleaved). The instance-rate
+  /// transform buffer of the color pass binds to this slot.
+  @internal
+  int get vertexStreamCount => _vertexStreams.length;
 
   /// Binds an already-uploaded index buffer view, with element width
   /// determined by [indexType].
@@ -125,45 +149,53 @@ abstract class Geometry {
   /// Allocates a [gpu.DeviceBuffer] and uploads [vertices] (and optional
   /// [indices]) into it in one step.
   ///
-  /// The vertices must match this geometry subclass's expected layout
-  /// (48 bytes per vertex for [UnskinnedGeometry], 80 bytes for
-  /// [SkinnedGeometry]). When [indices] is supplied, the buffer is sized
-  /// to hold both ranges back-to-back and bound via [setIndices].
+  /// The vertices must match this geometry subclass's expected interleaved
+  /// layout (48 bytes per vertex for [UnskinnedGeometry], 80 bytes for
+  /// [SkinnedGeometry]). The subclass may split the interleaved bytes into
+  /// several tightly packed streams (see [_vertexStreamBytes]); the streams
+  /// and any [indices] are packed back-to-back into one buffer, the streams
+  /// bound via [setVertexStreams] and the indices via [setIndices].
   void uploadVertexData(
     ByteData vertices,
     int vertexCount,
     ByteData? indices, {
     gpu.IndexType indexType = gpu.IndexType.int16,
   }) {
-    gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
-      gpu.StorageMode.hostVisible,
-      indices == null
-          ? vertices.lengthInBytes
-          : vertices.lengthInBytes + indices.lengthInBytes,
-    );
-
     _cpuVertices = vertices;
     _cpuIndices = indices;
 
-    deviceBuffer.overwrite(vertices, destinationOffsetInBytes: 0);
-    setVertices(
-      gpu.BufferView(
-        deviceBuffer,
-        offsetInBytes: 0,
-        lengthInBytes: vertices.lengthInBytes,
-      ),
-      vertexCount,
+    final streams = _vertexStreamBytes(vertices, vertexCount);
+    var vertexBytes = 0;
+    for (final stream in streams) {
+      vertexBytes += stream.lengthInBytes;
+    }
+
+    final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
+      gpu.StorageMode.hostVisible,
+      vertexBytes + (indices?.lengthInBytes ?? 0),
     );
 
-    if (indices != null) {
-      deviceBuffer.overwrite(
-        indices,
-        destinationOffsetInBytes: vertices.lengthInBytes,
+    var offset = 0;
+    final views = <gpu.BufferView>[];
+    for (final stream in streams) {
+      deviceBuffer.overwrite(stream, destinationOffsetInBytes: offset);
+      views.add(
+        gpu.BufferView(
+          deviceBuffer,
+          offsetInBytes: offset,
+          lengthInBytes: stream.lengthInBytes,
+        ),
       );
+      offset += stream.lengthInBytes;
+    }
+    setVertexStreams(views, vertexCount);
+
+    if (indices != null) {
+      deviceBuffer.overwrite(indices, destinationOffsetInBytes: offset);
       setIndices(
         gpu.BufferView(
           deviceBuffer,
-          offsetInBytes: vertices.lengthInBytes,
+          offsetInBytes: offset,
           lengthInBytes: indices.lengthInBytes,
         ),
         indexType,
@@ -174,6 +206,17 @@ abstract class Geometry {
       _scanLocalBoundsFromVertices(vertices, vertexCount);
     }
   }
+
+  /// Splits the interleaved [vertices] into the tightly packed vertex streams
+  /// this geometry binds, in slot order.
+  ///
+  /// The default keeps the interleaved bytes as a single stream (slot 0);
+  /// [UnskinnedGeometry] overrides it to de-interleave position into its own
+  /// stream. Each returned [ByteData] is uploaded to its own buffer region by
+  /// [uploadVertexData].
+  List<ByteData> _vertexStreamBytes(ByteData vertices, int vertexCount) => [
+    vertices,
+  ];
 
   /// Internal: retains CPU vertex/index data for scene raycasts. Subclasses
   /// with their own upload paths (see MeshGeometry's updatable buffers) call
@@ -302,21 +345,47 @@ abstract class Geometry {
   @internal
   VertexLayoutDescriptor? get instancedVertexLayout => null;
 
-  /// Binds this geometry's vertex buffer (slot 0) and index buffer onto
-  /// [pass] without binding any uniforms.
+  /// Binds all of this geometry's vertex streams (to slots 0, 1, ...) and
+  /// its index buffer onto [pass] without binding any uniforms.
   ///
   /// The color path goes through [bind], which also binds per-frame
-  /// uniforms against [vertexShader]. The depth-style passes drive a
-  /// different vertex shader (see [depthOnlyVertex]), so they bind the
-  /// buffers with this and supply their own uniforms against that shader.
+  /// uniforms against [vertexShader]. Use this for the full attribute set;
+  /// the depth-style passes bind only the position stream with
+  /// [bindPositionStream].
   @internal
   void bindGeometryBuffers(gpu.RenderPass pass) {
-    if (_vertices == null) {
-      throw Exception('setVertices must be called before binding Geometry.');
+    _requireVertices();
+    for (var slot = 0; slot < _vertexStreams.length; slot++) {
+      bindVertexBufferCompat(
+        pass,
+        _vertexStreams[slot],
+        _vertexCount,
+        slot: slot,
+      );
     }
-    bindVertexBufferCompat(pass, _vertices!, _vertexCount);
     if (_indices != null) {
       bindIndexBufferCompat(pass, _indices!, _indexType, _indexCount);
+    }
+  }
+
+  /// Binds only this geometry's position stream (slot 0) and its index
+  /// buffer onto [pass].
+  ///
+  /// The depth-style passes use this with a position-only shader and layout
+  /// (see [depthOnlyVertex]) so they fetch only position. The first stream
+  /// holds position for both the interleaved and de-interleaved layouts.
+  @internal
+  void bindPositionStream(gpu.RenderPass pass) {
+    _requireVertices();
+    bindVertexBufferCompat(pass, _vertexStreams.first, _vertexCount, slot: 0);
+    if (_indices != null) {
+      bindIndexBufferCompat(pass, _indices!, _indexType, _indexCount);
+    }
+  }
+
+  void _requireVertices() {
+    if (_vertexStreams.isEmpty) {
+      throw Exception('setVertices must be called before binding Geometry.');
     }
   }
 
@@ -347,21 +416,40 @@ class UnskinnedGeometry extends Geometry {
     setVertexShader(baseShaderLibrary['UnskinnedVertex']!);
   }
 
+  // Whether this geometry stores position de-interleaved into its own stream
+  // (uploaded through [uploadVertexData]) versus a single interleaved stream
+  // (a caller-managed [setVertices] buffer, or the updatable MeshGeometry
+  // path). The two store the same bytes but bind different layouts.
+  bool get _isDeInterleaved => vertexStreamCount >= 2;
+
+  @override
+  List<ByteData> _vertexStreamBytes(ByteData vertices, int vertexCount) {
+    final split = InterleavedLayoutAdapter.splitUnskinnedStreams(
+      vertices,
+      vertexCount,
+    );
+    return [
+      ByteData.sublistView(split.position),
+      ByteData.sublistView(split.rest),
+    ];
+  }
+
   @override
   VertexLayoutDescriptor? get instancedVertexLayout =>
-      kUnskinnedInstancedLayout;
+      _isDeInterleaved ? kUnskinnedSplitColorLayout : kUnskinnedInstancedLayout;
 
-  // Cached once: the depth-style passes use the same position-only shader and
-  // layout for every unskinned geometry, so the record is shared rather than
-  // rebuilt per draw. The shader keeps its identity across hot reloads.
-  static ({gpu.Shader shader, VertexLayoutDescriptor layout})? _depthOnlyVertex;
+  // Cached once: the depth-style passes use the same position-only shader for
+  // every unskinned geometry. The layout still depends on whether position is
+  // de-interleaved, so only the shader is cached.
+  static gpu.Shader? _depthVertexShader;
 
   @override
-  ({gpu.Shader shader, VertexLayoutDescriptor layout})? get depthOnlyVertex =>
-      _depthOnlyVertex ??= (
-        shader: baseShaderLibrary['UnskinnedDepthVertex']!,
-        layout: kUnskinnedPositionOnlyLayout,
-      );
+  ({gpu.Shader shader, VertexLayoutDescriptor layout})? get depthOnlyVertex => (
+    shader: _depthVertexShader ??= baseShaderLibrary['UnskinnedDepthVertex']!,
+    layout: _isDeInterleaved
+        ? kUnskinnedSplitDepthLayout
+        : kUnskinnedPositionOnlyLayout,
+  );
 
   @override
   void bind(
@@ -374,8 +462,8 @@ class UnskinnedGeometry extends Geometry {
     bindGeometryBuffers(pass);
 
     // Unskinned vertex UBO. The model transform is NOT part of this block;
-    // it arrives through the instance-rate vertex buffer (slot 1), bound by
-    // the encoder for instanced and non-instanced draws alike.
+    // it arrives through the instance-rate vertex buffer (the last slot),
+    // bound by the encoder for instanced and non-instanced draws alike.
     bindUnskinnedFrameInfo(
       pass,
       transientsBuffer,
@@ -436,16 +524,7 @@ class SkinnedGeometry extends Geometry {
       ),
     );
 
-    if (_vertices == null) {
-      throw Exception(
-        'SetVertices must be called before GetBufferView for Geometry.',
-      );
-    }
-
-    bindVertexBufferCompat(pass, _vertices!, _vertexCount);
-    if (_indices != null) {
-      bindIndexBufferCompat(pass, _indices!, _indexType, _indexCount);
-    }
+    bindGeometryBuffers(pass);
 
     // Skinned vertex UBO. The model transform is identity on purpose:
     // the joint matrices from Skin.getJointsTexture are already full
@@ -532,10 +611,46 @@ const VertexBufferDescriptor _kInstanceModelTransformBuffer =
       ],
     );
 
-/// The two-buffer pipeline layout for the unskinned vertex shader: slot 0
-/// carries the interleaved 48-byte vertex stream (position, normal, texture
-/// coords, color), slot 1 carries the instance-rate model matrix as four
-/// vec4 columns (64 bytes per instance).
+/// The tightly packed de-interleaved position stream: one `vec3` (12 bytes)
+/// per vertex, the slot-0 buffer of the de-interleaved unskinned layouts.
+const VertexBufferDescriptor _kPositionBuffer = VertexBufferDescriptor(
+  strideInBytes: 12,
+  attributes: [
+    VertexAttributeDescriptor(
+      name: 'position',
+      format: gpu.VertexFormat.float32x3,
+    ),
+  ],
+);
+
+/// The de-interleaved unskinned attribute stream (everything but position):
+/// normal (`vec3`), texture coordinates (`vec2`), color (`vec4`), 36 bytes
+/// per vertex. The slot-1 buffer of the de-interleaved color layout.
+const VertexBufferDescriptor _kUnskinnedAttributeBuffer =
+    VertexBufferDescriptor(
+      strideInBytes: 36,
+      attributes: [
+        VertexAttributeDescriptor(
+          name: 'normal',
+          format: gpu.VertexFormat.float32x3,
+        ),
+        VertexAttributeDescriptor(
+          name: 'texture_coords',
+          format: gpu.VertexFormat.float32x2,
+          offsetInBytes: 12,
+        ),
+        VertexAttributeDescriptor(
+          name: 'color',
+          format: gpu.VertexFormat.float32x4,
+          offsetInBytes: 20,
+        ),
+      ],
+    );
+
+/// The interleaved two-buffer pipeline layout for the unskinned vertex
+/// shader: slot 0 carries the interleaved 48-byte vertex stream (position,
+/// normal, texture coords, color), slot 1 carries the instance-rate model
+/// matrix as four vec4 columns (64 bytes per instance).
 ///
 /// This is the canonical described layout; its slot-0 stride is
 /// [kUnskinnedPerVertexSize] and its attribute offsets match the bytes
@@ -571,21 +686,17 @@ final VertexLayoutDescriptor kUnskinnedInstancedLayout = VertexLayoutDescriptor(
   ],
 );
 
-/// The depth-style layout for the unskinned vertex shader: slot 0 reads only
-/// the position attribute from the interleaved 48-byte vertex stream (the
-/// other attributes are present in the buffer but not fetched), slot 1 the
-/// instance-rate model matrix. Paired with the `UnskinnedDepthVertex` shader
-/// by the shadow, depth-prepass, and object-mask passes so they fetch only
-/// position per vertex.
+/// The interleaved-mode depth-style layout for the unskinned vertex shader:
+/// slot 0 reads only the position attribute from the interleaved 48-byte
+/// vertex stream (the other attributes are present in the buffer but not
+/// fetched), slot 1 the instance-rate model matrix. Paired with the
+/// `UnskinnedDepthVertex` shader by the shadow, depth-prepass, and
+/// object-mask passes when position is not de-interleaved (a caller-managed
+/// [Geometry.setVertices] buffer, or the updatable MeshGeometry path).
 ///
-/// The bound buffers are identical to the color pass (the same interleaved
-/// vertex buffer at slot 0, the same instance buffer at slot 1); only the
-/// declared attribute set differs.
-///
-/// TODO(position-stream): once positions live in their own tightly packed
-/// 12-byte buffer (de-interleaved at upload, composing with the dynamic
-/// position-update path), drop slot 0's stride to 12 for the locality win.
-/// The descriptor and the binding stay otherwise the same.
+/// Geometry uploaded through [Geometry.uploadVertexData] is de-interleaved
+/// and uses [kUnskinnedSplitDepthLayout] instead, whose slot-0 stride is 12
+/// for the locality win.
 @internal
 final VertexLayoutDescriptor kUnskinnedPositionOnlyLayout =
     VertexLayoutDescriptor(
@@ -601,6 +712,33 @@ final VertexLayoutDescriptor kUnskinnedPositionOnlyLayout =
         ),
         _kInstanceModelTransformBuffer,
       ],
+    );
+
+/// The de-interleaved color layout for the unskinned vertex shader: slot 0
+/// the tightly packed position stream (12 bytes), slot 1 the remaining
+/// attributes (normal, texture coords, color; 36 bytes), slot 2 the
+/// instance-rate model matrix. Used for geometry uploaded through
+/// [Geometry.uploadVertexData], which de-interleaves position into its own
+/// buffer.
+@internal
+final VertexLayoutDescriptor kUnskinnedSplitColorLayout =
+    VertexLayoutDescriptor(
+      buffers: const [
+        _kPositionBuffer,
+        _kUnskinnedAttributeBuffer,
+        _kInstanceModelTransformBuffer,
+      ],
+    );
+
+/// The de-interleaved depth-style layout for the unskinned vertex shader:
+/// slot 0 the tightly packed position stream (12 bytes), slot 1 the
+/// instance-rate model matrix. The attribute stream is not bound, so these
+/// passes fetch only the 12-byte position per vertex. Paired with the
+/// `UnskinnedDepthVertex` shader.
+@internal
+final VertexLayoutDescriptor kUnskinnedSplitDepthLayout =
+    VertexLayoutDescriptor(
+      buffers: const [_kPositionBuffer, _kInstanceModelTransformBuffer],
     );
 
 /// Emplaces and binds the unskinned `FrameInfo` uniform (camera transform

--- a/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
+++ b/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
@@ -111,6 +111,57 @@ abstract final class InterleavedLayoutAdapter {
   static const int _texCoordByteOffset = 24;
   static const int _colorByteOffset = 32;
 
+  /// The `.fscene` payload layout string for a de-interleaved
+  /// (structure-of-arrays) unskinned vertex buffer: the four attribute
+  /// streams concatenated, position then normal then texcoord then color. The
+  /// older `unskinned` layout is the interleaved form.
+  static const String unskinnedSoaLayout = 'unskinned_soa';
+
+  /// Concatenates the four per-attribute streams into one buffer, position
+  /// then normal then texcoord then color. This is the on-disk
+  /// structure-of-arrays vertex payload; [sliceUnskinnedStreams] is the
+  /// inverse.
+  static Uint8List concatUnskinnedStreams(UnskinnedAttributeStreams streams) {
+    final out = Uint8List(
+      streams.position.length +
+          streams.normal.length +
+          streams.texCoord.length +
+          streams.color.length,
+    );
+    var offset = 0;
+    out.setAll(offset, streams.position);
+    offset += streams.position.length;
+    out.setAll(offset, streams.normal);
+    offset += streams.normal.length;
+    out.setAll(offset, streams.texCoord);
+    offset += streams.texCoord.length;
+    out.setAll(offset, streams.color);
+    return out;
+  }
+
+  /// Slices a concatenated structure-of-arrays unskinned vertex payload back
+  /// into its four attribute streams as views into [soa] (no copy). The
+  /// inverse of [concatUnskinnedStreams].
+  static UnskinnedAttributeStreams sliceUnskinnedStreams(
+    Uint8List soa,
+    int vertexCount,
+  ) {
+    final buffer = soa.buffer;
+    var offset = soa.offsetInBytes;
+    Uint8List take(int bytesPerVertex) {
+      final view = buffer.asUint8List(offset, bytesPerVertex * vertexCount);
+      offset += bytesPerVertex * vertexCount;
+      return view;
+    }
+
+    return UnskinnedAttributeStreams(
+      position: take(positionStreamBytes),
+      normal: take(normalStreamBytes),
+      texCoord: take(texCoordStreamBytes),
+      color: take(colorStreamBytes),
+    );
+  }
+
   /// Splits one interleaved unskinned vertex buffer into the four tightly
   /// packed per-attribute streams.
   ///

--- a/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
+++ b/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
@@ -18,6 +18,24 @@ import 'package:flutter_scene/src/importer/constants.dart';
 ///
 /// Every method here is pure and free of GPU resources, so the packing
 /// can be exercised without a render context.
+/// Four tightly packed per-attribute unskinned vertex streams (structure of
+/// arrays): [position] (12 bytes/vertex), [normal] (12), [texCoord] (8), and
+/// [color] (16). Each is contiguous, so the depth-style passes bind only
+/// [position] and a dynamic update can rewrite only the changed attribute.
+class UnskinnedAttributeStreams {
+  const UnskinnedAttributeStreams({
+    required this.position,
+    required this.normal,
+    required this.texCoord,
+    required this.color,
+  });
+
+  final Uint8List position;
+  final Uint8List normal;
+  final Uint8List texCoord;
+  final Uint8List color;
+}
+
 abstract final class InterleavedLayoutAdapter {
   /// Floats per vertex in the interleaved unskinned layout.
   static const int floatsPerVertex = kUnskinnedPerVertexSize ~/ 4;
@@ -80,25 +98,26 @@ abstract final class InterleavedLayoutAdapter {
     return out.buffer.asUint8List();
   }
 
-  /// Bytes per vertex of the de-interleaved position stream (one `vec3`).
+  /// Bytes per vertex of each de-interleaved unskinned attribute stream:
+  /// position (`vec3`), normal (`vec3`), texture coordinates (`vec2`), color
+  /// (`vec4`). Their sum is [kUnskinnedPerVertexSize].
   static const int positionStreamBytes = 12;
+  static const int normalStreamBytes = 12;
+  static const int texCoordStreamBytes = 8;
+  static const int colorStreamBytes = 16;
 
-  /// Bytes per vertex of the de-interleaved attribute stream: normal
-  /// (`vec3`), texture coordinates (`vec2`), color (`vec4`).
-  static const int attributeStreamBytes = kUnskinnedPerVertexSize - 12;
+  /// Byte offset of each attribute within the interleaved 48-byte vertex.
+  static const int _normalByteOffset = 12;
+  static const int _texCoordByteOffset = 24;
+  static const int _colorByteOffset = 32;
 
-  /// Splits one interleaved unskinned vertex buffer into a tightly packed
-  /// position stream and an attribute stream (normal, texture coordinates,
-  /// color).
+  /// Splits one interleaved unskinned vertex buffer into the four tightly
+  /// packed per-attribute streams.
   ///
   /// The interleaved input is [kUnskinnedPerVertexSize] (48) bytes per
-  /// vertex, ordered position, normal, texture coordinates, color. The
-  /// returned [position] stream is 12 bytes per vertex and [rest] is 36,
-  /// preserving the byte order within each. This lets the depth-style passes
-  /// bind only the small position stream and dynamic updates rewrite only
-  /// positions, while the color pass binds both. Pure, so it can run off the
-  /// render isolate.
-  static ({Uint8List position, Uint8List rest}) splitUnskinnedStreams(
+  /// vertex, ordered position, normal, texture coordinates, color. Pure, so
+  /// it can run off the render isolate.
+  static UnskinnedAttributeStreams splitUnskinnedAttributes(
     ByteData interleaved,
     int vertexCount,
   ) {
@@ -114,23 +133,83 @@ abstract final class InterleavedLayoutAdapter {
       interleaved.lengthInBytes,
     );
     final position = Uint8List(positionStreamBytes * vertexCount);
-    final rest = Uint8List(attributeStreamBytes * vertexCount);
+    final normal = Uint8List(normalStreamBytes * vertexCount);
+    final texCoord = Uint8List(texCoordStreamBytes * vertexCount);
+    final color = Uint8List(colorStreamBytes * vertexCount);
     for (var v = 0; v < vertexCount; v++) {
       final s = v * kUnskinnedPerVertexSize;
-      position.setRange(
-        v * positionStreamBytes,
-        v * positionStreamBytes + positionStreamBytes,
-        src,
-        s,
-      );
-      rest.setRange(
-        v * attributeStreamBytes,
-        v * attributeStreamBytes + attributeStreamBytes,
-        src,
-        s + positionStreamBytes,
-      );
+      position.setRange(v * 12, v * 12 + 12, src, s);
+      normal.setRange(v * 12, v * 12 + 12, src, s + _normalByteOffset);
+      texCoord.setRange(v * 8, v * 8 + 8, src, s + _texCoordByteOffset);
+      color.setRange(v * 16, v * 16 + 16, src, s + _colorByteOffset);
     }
-    return (position: position, rest: rest);
+    return UnskinnedAttributeStreams(
+      position: position,
+      normal: normal,
+      texCoord: texCoord,
+      color: color,
+    );
+  }
+
+  /// Builds the four per-attribute streams directly from structure-of-arrays
+  /// attribute lists, filling defaults for absent attributes (normal
+  /// `(0, 0, 1)`, texture coordinate `(0, 0)`, color opaque white).
+  ///
+  /// This is the structure-of-arrays counterpart to [packUnskinned]; it
+  /// avoids building an interleaved buffer at all, so a structure-of-arrays
+  /// source uploads each stream with no interleave/de-interleave round trip.
+  static UnskinnedAttributeStreams unskinnedAttributeStreams({
+    required Float32List positions,
+    required int vertexCount,
+    Float32List? normals,
+    Float32List? texCoords,
+    Float32List? colors,
+  }) {
+    _checkLength('positions', positions.length, 3 * vertexCount);
+    if (normals != null) {
+      _checkLength('normals', normals.length, 3 * vertexCount);
+    }
+    if (texCoords != null) {
+      _checkLength('texCoords', texCoords.length, 2 * vertexCount);
+    }
+    if (colors != null) {
+      _checkLength('colors', colors.length, 4 * vertexCount);
+    }
+
+    final position = Float32List(3 * vertexCount)..setAll(0, positions);
+    final normal = Float32List(3 * vertexCount);
+    final texCoord = Float32List(2 * vertexCount);
+    final color = Float32List(4 * vertexCount);
+    for (var v = 0; v < vertexCount; v++) {
+      if (normals != null) {
+        normal[v * 3] = normals[v * 3];
+        normal[v * 3 + 1] = normals[v * 3 + 1];
+        normal[v * 3 + 2] = normals[v * 3 + 2];
+      } else {
+        normal[v * 3 + 2] = 1.0;
+      }
+      if (texCoords != null) {
+        texCoord[v * 2] = texCoords[v * 2];
+        texCoord[v * 2 + 1] = texCoords[v * 2 + 1];
+      }
+      if (colors != null) {
+        color[v * 4] = colors[v * 4];
+        color[v * 4 + 1] = colors[v * 4 + 1];
+        color[v * 4 + 2] = colors[v * 4 + 2];
+        color[v * 4 + 3] = colors[v * 4 + 3];
+      } else {
+        color[v * 4] = 1.0;
+        color[v * 4 + 1] = 1.0;
+        color[v * 4 + 2] = 1.0;
+        color[v * 4 + 3] = 1.0;
+      }
+    }
+    return UnskinnedAttributeStreams(
+      position: position.buffer.asUint8List(),
+      normal: normal.buffer.asUint8List(),
+      texCoord: texCoord.buffer.asUint8List(),
+      color: color.buffer.asUint8List(),
+    );
   }
 
   /// Packs triangle [indices] into the narrowest index buffer that fits.

--- a/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
+++ b/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
@@ -80,6 +80,59 @@ abstract final class InterleavedLayoutAdapter {
     return out.buffer.asUint8List();
   }
 
+  /// Bytes per vertex of the de-interleaved position stream (one `vec3`).
+  static const int positionStreamBytes = 12;
+
+  /// Bytes per vertex of the de-interleaved attribute stream: normal
+  /// (`vec3`), texture coordinates (`vec2`), color (`vec4`).
+  static const int attributeStreamBytes = kUnskinnedPerVertexSize - 12;
+
+  /// Splits one interleaved unskinned vertex buffer into a tightly packed
+  /// position stream and an attribute stream (normal, texture coordinates,
+  /// color).
+  ///
+  /// The interleaved input is [kUnskinnedPerVertexSize] (48) bytes per
+  /// vertex, ordered position, normal, texture coordinates, color. The
+  /// returned [position] stream is 12 bytes per vertex and [rest] is 36,
+  /// preserving the byte order within each. This lets the depth-style passes
+  /// bind only the small position stream and dynamic updates rewrite only
+  /// positions, while the color pass binds both. Pure, so it can run off the
+  /// render isolate.
+  static ({Uint8List position, Uint8List rest}) splitUnskinnedStreams(
+    ByteData interleaved,
+    int vertexCount,
+  ) {
+    final expected = vertexCount * kUnskinnedPerVertexSize;
+    if (interleaved.lengthInBytes < expected) {
+      throw ArgumentError(
+        'interleaved holds ${interleaved.lengthInBytes} bytes; expected at '
+        'least $expected for $vertexCount unskinned vertices',
+      );
+    }
+    final src = interleaved.buffer.asUint8List(
+      interleaved.offsetInBytes,
+      interleaved.lengthInBytes,
+    );
+    final position = Uint8List(positionStreamBytes * vertexCount);
+    final rest = Uint8List(attributeStreamBytes * vertexCount);
+    for (var v = 0; v < vertexCount; v++) {
+      final s = v * kUnskinnedPerVertexSize;
+      position.setRange(
+        v * positionStreamBytes,
+        v * positionStreamBytes + positionStreamBytes,
+        src,
+        s,
+      );
+      rest.setRange(
+        v * attributeStreamBytes,
+        v * attributeStreamBytes + attributeStreamBytes,
+        src,
+        s + positionStreamBytes,
+      );
+    }
+    return (position: position, rest: rest);
+  }
+
   /// Packs triangle [indices] into the narrowest index buffer that fits.
   ///
   /// Returns the packed bytes and whether a 32-bit element width was

--- a/packages/flutter_scene/lib/src/geometry/mesh_data.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_data.dart
@@ -1,0 +1,109 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+
+/// An isolate-transferable snapshot of a mesh's vertex and index data.
+///
+/// `MeshData` separates the CPU work of building a mesh (assembling vertex
+/// arrays and generating normals) from the GPU upload. Its construction is
+/// pure and touches no GPU resources, so it can run on a background
+/// isolate; the result is sent back and turned into a live mesh on the
+/// render isolate. This keeps heavy meshing, such as remeshing a voxel
+/// chunk, off the render isolate.
+///
+/// Recipe (using `compute` from `package:flutter/foundation.dart`):
+///
+/// ```dart
+/// // Top-level or static, runs on the background isolate.
+/// MeshData buildChunk(ChunkInput input) {
+///   final positions = ...; // your generator
+///   final indices = ...;
+///   return MeshData.build(positions: positions, indices: indices);
+/// }
+///
+/// // On the render isolate:
+/// final data = await compute(buildChunk, input);
+/// final geometry = MeshGeometry.fromMeshData(data);
+/// // or, to update an existing updatable mesh in place:
+/// existing.applyMeshData(data);
+/// ```
+/// {@category Geometry}
+class MeshData {
+  /// Wraps already-prepared vertex arrays without generating anything.
+  ///
+  /// Prefer [MeshData.build], which fills in normals. Use this only when
+  /// every attribute is already in hand. [vertexCount] must equal
+  /// `positions.length ~/ 3`.
+  MeshData({
+    required this.positions,
+    required this.vertexCount,
+    this.normals,
+    this.texCoords,
+    this.colors,
+    this.indices,
+    this.primitiveType = gpu.PrimitiveType.triangle,
+  });
+
+  /// Builds a snapshot from vertex attribute arrays, generating
+  /// area-weighted normals from the faces when [normals] is absent and
+  /// [primitiveType] is a triangle list. The normal generation is the work
+  /// worth doing off the render isolate. The attribute-array contract
+  /// matches [MeshGeometry.fromArrays].
+  factory MeshData.build({
+    required Float32List positions,
+    Float32List? normals,
+    Float32List? texCoords,
+    Float32List? colors,
+    List<int>? indices,
+    gpu.PrimitiveType primitiveType = gpu.PrimitiveType.triangle,
+  }) {
+    if (positions.length % 3 != 0) {
+      throw ArgumentError(
+        'positions has ${positions.length} floats; expected a multiple of '
+        'three (one vec3 per vertex)',
+      );
+    }
+    final vertexCount = positions.length ~/ 3;
+    final resolvedNormals =
+        normals ??
+        (vertexCount > 0 && primitiveType == gpu.PrimitiveType.triangle
+            ? InterleavedLayoutAdapter.generateNormals(
+                positions: positions,
+                vertexCount: vertexCount,
+                indices: indices,
+              )
+            : null);
+    return MeshData(
+      positions: positions,
+      vertexCount: vertexCount,
+      normals: resolvedNormals,
+      texCoords: texCoords,
+      colors: colors,
+      indices: indices,
+      primitiveType: primitiveType,
+    );
+  }
+
+  /// Vertex positions, three floats each.
+  final Float32List positions;
+
+  /// The number of vertices, equal to `positions.length ~/ 3`.
+  final int vertexCount;
+
+  /// Vertex normals (three floats each), or null to let the upload
+  /// generate or default them.
+  final Float32List? normals;
+
+  /// Texture coordinates (two floats each), or null to default to `(0, 0)`.
+  final Float32List? texCoords;
+
+  /// Vertex colors (four floats each), or null to default to opaque white.
+  final Float32List? colors;
+
+  /// Triangle (or line/point) indices, or null for a non-indexed mesh.
+  final List<int>? indices;
+
+  /// How the vertices assemble into primitives when drawn.
+  final gpu.PrimitiveType primitiveType;
+}

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -517,6 +517,8 @@ class MeshGeometry extends UnskinnedGeometry {
         indexType != _indexType) {
       _indexCapacity = nextBufferCapacity(indices.length);
       _indexType = indexType;
+      // Host-visible for the same reason as the attribute streams (see
+      // [_RingBufferStream]); a rebuild may rewrite the index buffer.
       _indexBuffer = gpu.gpuContext.createDeviceBuffer(
         gpu.StorageMode.hostVisible,
         _indexCapacity * elementBytes,
@@ -676,6 +678,16 @@ int nextBufferCapacity(int needed, {int minimum = 16}) {
   );
 }
 
+// A ring of host-visible device buffers for one updatable attribute stream.
+//
+// Vertex data must be CPU-written every update, and `hostVisible` is the
+// only storage mode that allows that: flutter_gpu has no buffer-to-buffer
+// blit or read-back, so a `devicePrivate` buffer cannot be filled after
+// allocation. On the coherent and unified-memory backends this is the
+// shared CPU/GPU region, so the `flush` after a write is a no-op; on
+// non-coherent backends `flush` uploads only the written range. The ring
+// hands each update a buffer the GPU is not currently reading, avoiding the
+// write-vs-read race.
 class _RingBufferStream {
   _RingBufferStream(this.bytesPerVertex);
 

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -149,16 +149,27 @@ class MeshGeometry extends UnskinnedGeometry {
   // CPU-side copies of every attribute stream, sized to the live vertex
   // count. Retained so a single-attribute update can re-pack the
   // interleaved buffer, which holds every attribute together.
-  Uint8List _packedVertexBytes = Uint8List(0);
+  // The interleaved vertex bytes, built lazily from the structure-of-arrays
+  // CPU streams only when the scene serializer asks for them (the fixed path
+  // never interleaves otherwise). The updatable path sets it eagerly, since
+  // it interleaves into a single buffer anyway.
+  Uint8List? _packedVertexBytes;
   Uint8List? _packedIndexBytes;
   bool _packedIndices32Bit = false;
 
   /// The packed interleaved vertex bytes (and packed index bytes with their
-  /// width) as last uploaded, retained so the scene serializer can re-emit
-  /// this geometry as payload chunks.
+  /// width), retained so the scene serializer can re-emit this geometry as
+  /// payload chunks. Interleaved lazily from the per-attribute CPU streams on
+  /// first access.
   ({Uint8List vertexBytes, Uint8List? indexBytes, bool indices32Bit})
   get packedData => (
-    vertexBytes: _packedVertexBytes,
+    vertexBytes: _packedVertexBytes ??= InterleavedLayoutAdapter.packUnskinned(
+      positions: _cpuPositions,
+      vertexCount: _liveVertexCount,
+      normals: _cpuNormals,
+      texCoords: _cpuTexCoords,
+      colors: _cpuColors,
+    ),
     indexBytes: _packedIndexBytes,
     indices32Bit: _packedIndices32Bit,
   );
@@ -281,13 +292,10 @@ class MeshGeometry extends UnskinnedGeometry {
     List<int>? indices,
   ) {
     _liveVertexCount = vertexCount;
-    final vertexBytes = InterleavedLayoutAdapter.packUnskinned(
-      positions: positions,
-      vertexCount: vertexCount,
-      normals: normals,
-      texCoords: texCoords,
-      colors: colors,
-    );
+    // Retain the structure-of-arrays attributes (defaults filled). These back
+    // both lazy serialization (interleaved on demand) and raycasting, and they
+    // are uploaded straight to per-attribute GPU streams with no interleave.
+    _setCpuStreams(positions, vertexCount, normals, texCoords, colors);
     ByteData? indexBytes;
     var indexType = gpu.IndexType.int16;
     if (indices != null) {
@@ -297,13 +305,18 @@ class MeshGeometry extends UnskinnedGeometry {
       _packedIndexBytes = packed.bytes;
       _packedIndices32Bit = packed.is32Bit;
     }
-    _packedVertexBytes = vertexBytes;
-    uploadVertexData(
-      ByteData.sublistView(vertexBytes),
-      vertexCount,
-      indexBytes,
+    uploadUnskinnedAttributes(
+      positions: _cpuPositions,
+      vertexCount: vertexCount,
+      normals: _cpuNormals,
+      texCoords: _cpuTexCoords,
+      colors: _cpuColors,
+      indices: indexBytes,
       indexType: indexType,
     );
+    // Raycast off this geometry's own attribute arrays instead of the
+    // transient upload copies, so no extra position/texcoord copy lingers.
+    setRaycastAttributes(positions: _cpuPositions, texCoords: _cpuTexCoords);
   }
 
   // Re-packs the live CPU streams into the interleaved buffer and binds
@@ -339,7 +352,7 @@ class MeshGeometry extends UnskinnedGeometry {
     _packedIndexBytes = packed.bytes;
     _packedIndices32Bit = packed.is32Bit;
     retainCpuMeshData(
-      ByteData.sublistView(_packedVertexBytes),
+      ByteData.sublistView(packedData.vertexBytes),
       ByteData.sublistView(packed.bytes),
     );
     final indexType = packed.is32Bit

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -221,37 +221,84 @@ class MeshGeometry extends UnskinnedGeometry {
   /// current [vertexCount]. To change the vertex count, use [rebuild].
   /// Throws a [StateError] unless this geometry is
   /// [GeometryStorage.updatable].
-  void updatePositions(Float32List positions) {
+  ///
+  /// When only a contiguous span of vertices changed, pass [dirtyStart]
+  /// and [dirtyCount] (in vertices) to upload just that span. [positions]
+  /// must still hold every vertex (the full array backs raycasting and
+  /// bounds); the hint only narrows the GPU upload. Omit both to upload
+  /// the whole stream.
+  void updatePositions(
+    Float32List positions, {
+    int? dirtyStart,
+    int? dirtyCount,
+  }) {
     _ensureUpdatable('updatePositions');
     _checkAttributeLength('positions', positions.length, 3);
     _cpuPositions = Float32List.fromList(positions);
-    _writeStream(0, _positionRing, _cpuPositions);
+    _writeStream(
+      0,
+      _positionRing,
+      _cpuPositions,
+      dirtyStart: dirtyStart,
+      dirtyCount: dirtyCount,
+    );
     _recomputeBounds();
   }
 
   /// Replaces every vertex normal, keeping the vertex count unchanged.
-  void updateNormals(Float32List normals) {
+  ///
+  /// Pass [dirtyStart]/[dirtyCount] to upload only a contiguous span; see
+  /// [updatePositions].
+  void updateNormals(Float32List normals, {int? dirtyStart, int? dirtyCount}) {
     _ensureUpdatable('updateNormals');
     _checkAttributeLength('normals', normals.length, 3);
     _cpuNormals = Float32List.fromList(normals);
-    _writeStream(1, _normalRing, _cpuNormals);
+    _writeStream(
+      1,
+      _normalRing,
+      _cpuNormals,
+      dirtyStart: dirtyStart,
+      dirtyCount: dirtyCount,
+    );
   }
 
   /// Replaces every texture coordinate, keeping the vertex count
   /// unchanged.
-  void updateTexCoords(Float32List texCoords) {
+  ///
+  /// Pass [dirtyStart]/[dirtyCount] to upload only a contiguous span; see
+  /// [updatePositions].
+  void updateTexCoords(
+    Float32List texCoords, {
+    int? dirtyStart,
+    int? dirtyCount,
+  }) {
     _ensureUpdatable('updateTexCoords');
     _checkAttributeLength('texCoords', texCoords.length, 2);
     _cpuTexCoords = Float32List.fromList(texCoords);
-    _writeStream(2, _texCoordRing, _cpuTexCoords);
+    _writeStream(
+      2,
+      _texCoordRing,
+      _cpuTexCoords,
+      dirtyStart: dirtyStart,
+      dirtyCount: dirtyCount,
+    );
   }
 
   /// Replaces every vertex color, keeping the vertex count unchanged.
-  void updateColors(Float32List colors) {
+  ///
+  /// Pass [dirtyStart]/[dirtyCount] to upload only a contiguous span; see
+  /// [updatePositions].
+  void updateColors(Float32List colors, {int? dirtyStart, int? dirtyCount}) {
     _ensureUpdatable('updateColors');
     _checkAttributeLength('colors', colors.length, 4);
     _cpuColors = Float32List.fromList(colors);
-    _writeStream(3, _colorRing, _cpuColors);
+    _writeStream(
+      3,
+      _colorRing,
+      _cpuColors,
+      dirtyStart: dirtyStart,
+      dirtyCount: dirtyCount,
+    );
   }
 
   /// Replaces all of this geometry's data, allowing the vertex and index
@@ -366,12 +413,42 @@ class MeshGeometry extends UnskinnedGeometry {
   // Writes one changed attribute into its ring's next buffer and rebinds the
   // streams. The other attributes keep their current ring buffers, so only
   // the dirty stream's bytes are re-uploaded.
-  void _writeStream(int slot, _RingBufferStream ring, Float32List attribute) {
+  void _writeStream(
+    int slot,
+    _RingBufferStream ring,
+    Float32List attribute, {
+    int? dirtyStart,
+    int? dirtyCount,
+  }) {
+    final (start, end) = _resolveDirtyRange(dirtyStart, dirtyCount);
     _streamViews = List<gpu.BufferView>.of(_streamViews);
-    _streamViews[slot] = ring.write(_bytesOf(attribute), _liveVertexCount);
+    _streamViews[slot] = ring.writeRange(
+      _bytesOf(attribute),
+      _liveVertexCount,
+      start,
+      end,
+    );
     setVertexStreams(_streamViews, _liveVertexCount);
     _refreshRaycastData();
     _packedVertexBytes = null;
+  }
+
+  // Resolves an optional caller dirty range (in vertices) to a half-open
+  // span, defaulting to the whole stream when unspecified. Validates the
+  // span lies within the current vertex count.
+  (int, int) _resolveDirtyRange(int? dirtyStart, int? dirtyCount) {
+    if (dirtyStart == null && dirtyCount == null) {
+      return (0, _liveVertexCount);
+    }
+    final start = dirtyStart ?? 0;
+    final count = dirtyCount ?? (_liveVertexCount - start);
+    if (start < 0 || count < 0 || start + count > _liveVertexCount) {
+      throw RangeError(
+        'dirty range [$start, ${start + count}) is outside the '
+        '$_liveVertexCount vertices',
+      );
+    }
+    return (start, start + count);
   }
 
   void _refreshRaycastData() {
@@ -544,6 +621,23 @@ int nextBufferCapacity(int needed, {int minimum = 16}) {
 /// transient `HostBuffer` cycles through, which bounds the GPU's in-flight
 /// reads. The ring reallocates (at a power-of-two capacity) only when the
 /// vertex count outgrows it, so steady-state updates never allocate.
+/// The bounding vertex range that covers both [a] and [b]. An empty input
+/// (`start >= end`) contributes nothing. Ranges are half-open
+/// `[start, end)`. Used to accumulate which span of a ring buffer is stale
+/// relative to the CPU copy, so a partial update uploads only what a given
+/// buffer is missing.
+({int start, int end}) unionVertexRange(
+  ({int start, int end}) a,
+  ({int start, int end}) b,
+) {
+  if (a.start >= a.end) return b;
+  if (b.start >= b.end) return a;
+  return (
+    start: a.start < b.start ? a.start : b.start,
+    end: a.end > b.end ? a.end : b.end,
+  );
+}
+
 class _RingBufferStream {
   _RingBufferStream(this.bytesPerVertex);
 
@@ -555,10 +649,30 @@ class _RingBufferStream {
   static const int _ringDepth = 4;
 
   final List<gpu.DeviceBuffer> _buffers = [];
+  // Per-buffer span (in vertices) that is stale relative to the current CPU
+  // copy. Because the ring rotates, a buffer last written `_ringDepth`
+  // writes ago is missing every change made since, so a partial write must
+  // refresh that accumulated span, not just the caller's dirty span.
+  final List<({int start, int end})> _stale = [];
   int _capacityVertices = 0;
   int _cursor = 0;
 
-  gpu.BufferView write(Uint8List bytes, int vertexCount) {
+  /// Replaces every vertex (the full-stream write used at construction and
+  /// on rebuild).
+  gpu.BufferView write(Uint8List bytes, int vertexCount) =>
+      writeRange(bytes, vertexCount, 0, vertexCount);
+
+  /// Writes [bytes] (the full attribute array) into the ring's next buffer,
+  /// uploading only the span that buffer is missing. [dirtyStart] and
+  /// [dirtyEnd] mark the half-open vertex range the caller changed since the
+  /// last write; the accumulated stale span of the chosen buffer is unioned
+  /// in so a rotated, several-writes-old buffer is still brought current.
+  gpu.BufferView writeRange(
+    Uint8List bytes,
+    int vertexCount,
+    int dirtyStart,
+    int dirtyEnd,
+  ) {
     if (_buffers.isEmpty || vertexCount > _capacityVertices) {
       _capacityVertices = nextBufferCapacity(vertexCount);
       _buffers
@@ -572,20 +686,40 @@ class _RingBufferStream {
             ),
           ),
         );
+      // Freshly allocated buffers hold no data, so each is fully stale until
+      // it is first written.
+      _stale
+        ..clear()
+        ..addAll(List.filled(_ringDepth, (start: 0, end: vertexCount)));
       _cursor = 0;
     } else {
       _cursor = (_cursor + 1) % _ringDepth;
     }
-    final length = vertexCount * bytesPerVertex;
-    final buffer = _buffers[_cursor];
-    if (length > 0) {
-      buffer.overwrite(
-        ByteData.sublistView(bytes),
-        destinationOffsetInBytes: 0,
-      );
-      buffer.flush(offsetInBytes: 0, lengthInBytes: length);
+
+    // The caller's change makes every buffer stale over that span.
+    final change = (start: dirtyStart, end: dirtyEnd);
+    for (var i = 0; i < _stale.length; i++) {
+      _stale[i] = unionVertexRange(_stale[i], change);
     }
-    return gpu.BufferView(buffer, offsetInBytes: 0, lengthInBytes: length);
+
+    final buffer = _buffers[_cursor];
+    final upload = _stale[_cursor];
+    if (upload.end > upload.start) {
+      final offset = upload.start * bytesPerVertex;
+      final length = (upload.end - upload.start) * bytesPerVertex;
+      buffer.overwrite(
+        ByteData.sublistView(bytes, offset, offset + length),
+        destinationOffsetInBytes: offset,
+      );
+      buffer.flush(offsetInBytes: offset, lengthInBytes: length);
+    }
+    // This buffer now matches the CPU copy.
+    _stale[_cursor] = (start: 0, end: 0);
+    return gpu.BufferView(
+      buffer,
+      offsetInBytes: 0,
+      lengthInBytes: vertexCount * bytesPerVertex,
+    );
   }
 }
 

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -167,9 +167,10 @@ class MeshGeometry extends UnskinnedGeometry {
   bool _packedIndices32Bit = false;
 
   /// The packed interleaved vertex bytes (and packed index bytes with their
-  /// width), retained so the scene serializer can re-emit this geometry as
-  /// payload chunks. Interleaved lazily from the per-attribute CPU streams on
-  /// first access.
+  /// width), in the engine's interleaved unskinned layout. Interleaved lazily
+  /// from the per-attribute CPU streams on first access. The scene serializer
+  /// emits the de-interleaved [soaData] instead; this stays as a convenience
+  /// for callers wanting the interleaved form.
   ({Uint8List vertexBytes, Uint8List? indexBytes, bool indices32Bit})
   get packedData => (
     vertexBytes: _packedVertexBytes ??= InterleavedLayoutAdapter.packUnskinned(

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -6,6 +6,7 @@ import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
+import 'package:flutter_scene/src/geometry/mesh_data.dart';
 
 /// How a [MeshGeometry] manages its GPU buffers over its lifetime.
 /// {@category Geometry}
@@ -134,6 +135,43 @@ class MeshGeometry extends UnskinnedGeometry {
       _uploadAllStreams();
       _recomputeBounds();
     }
+  }
+
+  /// Uploads a mesh from a [MeshData] snapshot built off the render
+  /// isolate.
+  ///
+  /// The snapshot's CPU work (vertex assembly, normal generation) can run
+  /// on a background isolate; this constructor performs only the GPU
+  /// upload. See [MeshData] for the recipe. [storage] selects whether the
+  /// mesh can later be updated in place.
+  factory MeshGeometry.fromMeshData(
+    MeshData data, {
+    GeometryStorage storage = GeometryStorage.fixed,
+  }) {
+    return MeshGeometry.fromArrays(
+      positions: data.positions,
+      normals: data.normals,
+      texCoords: data.texCoords,
+      colors: data.colors,
+      indices: data.indices,
+      primitiveType: data.primitiveType,
+      storage: storage,
+    );
+  }
+
+  /// Replaces this updatable geometry's data from a [MeshData] snapshot.
+  ///
+  /// Equivalent to passing the snapshot's arrays to [rebuild], so the same
+  /// indexed-or-not contract applies. Throws a [StateError] unless this
+  /// geometry is [GeometryStorage.updatable].
+  void applyMeshData(MeshData data) {
+    rebuild(
+      positions: data.positions,
+      normals: data.normals,
+      texCoords: data.texCoords,
+      colors: data.colors,
+      indices: data.indices,
+    );
   }
 
   /// How this geometry's GPU buffers are managed; see [GeometryStorage].

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -117,14 +117,20 @@ class MeshGeometry extends UnskinnedGeometry {
         texCoords,
         colors,
       );
-      _vertexCapacity = nextBufferCapacity(vertexCount);
-      _vertexBuffer = gpu.gpuContext.createDeviceBuffer(
-        gpu.StorageMode.hostVisible,
-        _vertexCapacity * kInterleavedVertexBytes,
+      _positionRing = _RingBufferStream(
+        InterleavedLayoutAdapter.positionStreamBytes,
       );
+      _normalRing = _RingBufferStream(
+        InterleavedLayoutAdapter.normalStreamBytes,
+      );
+      _texCoordRing = _RingBufferStream(
+        InterleavedLayoutAdapter.texCoordStreamBytes,
+      );
+      _colorRing = _RingBufferStream(InterleavedLayoutAdapter.colorStreamBytes);
       _liveVertexCount = vertexCount;
-      _uploadVertexBytes();
+      // Indices first, so the attribute upload can retain them for raycasting.
       if (_indexed) _uploadIndices(indices!);
+      _uploadAllStreams();
       _recomputeBounds();
     }
   }
@@ -132,27 +138,29 @@ class MeshGeometry extends UnskinnedGeometry {
   /// How this geometry's GPU buffers are managed; see [GeometryStorage].
   final GeometryStorage storage;
 
-  /// Bytes per vertex in the interleaved unskinned layout.
-  static const int kInterleavedVertexBytes =
-      InterleavedLayoutAdapter.floatsPerVertex * 4;
-
   // --- Updatable-storage state. Unused while [storage] is fixed. ---
 
   bool _indexed = false;
   int _liveVertexCount = 0;
-  int _vertexCapacity = 0;
   int _indexCapacity = 0;
-  gpu.DeviceBuffer? _vertexBuffer;
   gpu.DeviceBuffer? _indexBuffer;
   gpu.IndexType _indexType = gpu.IndexType.int16;
 
-  // CPU-side copies of every attribute stream, sized to the live vertex
-  // count. Retained so a single-attribute update can re-pack the
-  // interleaved buffer, which holds every attribute together.
+  // One ring of host-visible buffers per attribute, so an in-place update
+  // writes to a buffer the GPU is not currently reading (avoiding the
+  // write-vs-read race). The index buffer stays single-buffered, since
+  // topology-stable updates leave it untouched and only the slow rebuild path
+  // rewrites it. [_streamViews] holds the currently bound view of each ring,
+  // in slot order (position, normal, texcoord, color).
+  late final _RingBufferStream _positionRing;
+  late final _RingBufferStream _normalRing;
+  late final _RingBufferStream _texCoordRing;
+  late final _RingBufferStream _colorRing;
+  List<gpu.BufferView> _streamViews = const [];
+
   // The interleaved vertex bytes, built lazily from the structure-of-arrays
-  // CPU streams only when the scene serializer asks for them (the fixed path
-  // never interleaves otherwise). The updatable path sets it eagerly, since
-  // it interleaves into a single buffer anyway.
+  // CPU streams only when the scene serializer asks for them, and invalidated
+  // on every update. Nothing interleaves on the upload path anymore.
   Uint8List? _packedVertexBytes;
   Uint8List? _packedIndexBytes;
   bool _packedIndices32Bit = false;
@@ -195,7 +203,7 @@ class MeshGeometry extends UnskinnedGeometry {
     _ensureUpdatable('updatePositions');
     _checkAttributeLength('positions', positions.length, 3);
     _cpuPositions = Float32List.fromList(positions);
-    _uploadVertexBytes();
+    _writeStream(0, _positionRing, _cpuPositions);
     _recomputeBounds();
   }
 
@@ -204,7 +212,7 @@ class MeshGeometry extends UnskinnedGeometry {
     _ensureUpdatable('updateNormals');
     _checkAttributeLength('normals', normals.length, 3);
     _cpuNormals = Float32List.fromList(normals);
-    _uploadVertexBytes();
+    _writeStream(1, _normalRing, _cpuNormals);
   }
 
   /// Replaces every texture coordinate, keeping the vertex count
@@ -213,7 +221,7 @@ class MeshGeometry extends UnskinnedGeometry {
     _ensureUpdatable('updateTexCoords');
     _checkAttributeLength('texCoords', texCoords.length, 2);
     _cpuTexCoords = Float32List.fromList(texCoords);
-    _uploadVertexBytes();
+    _writeStream(2, _texCoordRing, _cpuTexCoords);
   }
 
   /// Replaces every vertex color, keeping the vertex count unchanged.
@@ -221,7 +229,7 @@ class MeshGeometry extends UnskinnedGeometry {
     _ensureUpdatable('updateColors');
     _checkAttributeLength('colors', colors.length, 4);
     _cpuColors = Float32List.fromList(colors);
-    _uploadVertexBytes();
+    _writeStream(3, _colorRing, _cpuColors);
   }
 
   /// Replaces all of this geometry's data, allowing the vertex and index
@@ -270,16 +278,10 @@ class MeshGeometry extends UnskinnedGeometry {
             : null);
 
     _setCpuStreams(positions, vertexCount, resolvedNormals, texCoords, colors);
-    if (vertexCount > _vertexCapacity) {
-      _vertexCapacity = nextBufferCapacity(vertexCount);
-      _vertexBuffer = gpu.gpuContext.createDeviceBuffer(
-        gpu.StorageMode.hostVisible,
-        _vertexCapacity * kInterleavedVertexBytes,
-      );
-    }
     _liveVertexCount = vertexCount;
-    _uploadVertexBytes();
+    // The rings reallocate themselves when the count outgrows their capacity.
     if (_indexed) _uploadIndices(indices!);
+    _uploadAllStreams();
     _recomputeBounds();
   }
 
@@ -324,42 +326,51 @@ class MeshGeometry extends UnskinnedGeometry {
     );
   }
 
-  // Re-packs the live CPU streams into the interleaved buffer and binds
-  // it. Reuses the retained DeviceBuffer; no allocation.
-  void _uploadVertexBytes() {
-    final bytes = InterleavedLayoutAdapter.packUnskinned(
+  // Writes all four attribute streams into their rings and binds them.
+  // Used at construction and on rebuild.
+  void _uploadAllStreams() {
+    _streamViews = [
+      _positionRing.write(_bytesOf(_cpuPositions), _liveVertexCount),
+      _normalRing.write(_bytesOf(_cpuNormals), _liveVertexCount),
+      _texCoordRing.write(_bytesOf(_cpuTexCoords), _liveVertexCount),
+      _colorRing.write(_bytesOf(_cpuColors), _liveVertexCount),
+    ];
+    setVertexStreams(_streamViews, _liveVertexCount);
+    _refreshRaycastData();
+    // Invalidate the lazily interleaved serialization bytes.
+    _packedVertexBytes = null;
+  }
+
+  // Writes one changed attribute into its ring's next buffer and rebinds the
+  // streams. The other attributes keep their current ring buffers, so only
+  // the dirty stream's bytes are re-uploaded.
+  void _writeStream(int slot, _RingBufferStream ring, Float32List attribute) {
+    _streamViews = List<gpu.BufferView>.of(_streamViews);
+    _streamViews[slot] = ring.write(_bytesOf(attribute), _liveVertexCount);
+    setVertexStreams(_streamViews, _liveVertexCount);
+    _refreshRaycastData();
+    _packedVertexBytes = null;
+  }
+
+  void _refreshRaycastData() {
+    setRaycastAttributes(
       positions: _cpuPositions,
-      vertexCount: _liveVertexCount,
-      normals: _cpuNormals,
       texCoords: _cpuTexCoords,
-      colors: _cpuColors,
-    );
-    _packedVertexBytes = bytes;
-    retainCpuMeshData(
-      ByteData.sublistView(bytes),
-      _packedIndexBytes == null
+      indices: _packedIndexBytes == null
           ? null
           : ByteData.sublistView(_packedIndexBytes!),
     );
-    final buffer = _vertexBuffer!;
-    if (bytes.isNotEmpty) {
-      buffer.overwrite(ByteData.sublistView(bytes));
-      buffer.flush(offsetInBytes: 0, lengthInBytes: bytes.length);
-    }
-    setVertices(
-      gpu.BufferView(buffer, offsetInBytes: 0, lengthInBytes: bytes.length),
-      _liveVertexCount,
-    );
   }
+
+  static Uint8List _bytesOf(Float32List attribute) => attribute.buffer
+      .asUint8List(attribute.offsetInBytes, attribute.lengthInBytes);
 
   void _uploadIndices(List<int> indices) {
     final packed = InterleavedLayoutAdapter.packIndices(indices);
     _packedIndexBytes = packed.bytes;
     _packedIndices32Bit = packed.is32Bit;
-    retainCpuMeshData(
-      ByteData.sublistView(packedData.vertexBytes),
-      ByteData.sublistView(packed.bytes),
-    );
+    // Raycast index data is retained alongside the attribute streams by
+    // [_refreshRaycastData]; this method only manages the GPU index buffer.
     final indexType = packed.is32Bit
         ? gpu.IndexType.int32
         : gpu.IndexType.int16;
@@ -500,6 +511,60 @@ int nextBufferCapacity(int needed, {int minimum = 16}) {
     capacity <<= 1;
   }
   return capacity;
+}
+
+/// A small ring of host-visible device buffers for one updatable attribute
+/// stream.
+///
+/// Each [write] advances to the next buffer in the ring before overwriting,
+/// so the GPU keeps reading the previously bound buffer while the CPU writes
+/// the next one. The ring depth matches the frame count the engine's
+/// transient `HostBuffer` cycles through, which bounds the GPU's in-flight
+/// reads. The ring reallocates (at a power-of-two capacity) only when the
+/// vertex count outgrows it, so steady-state updates never allocate.
+class _RingBufferStream {
+  _RingBufferStream(this.bytesPerVertex);
+
+  /// Tightly packed bytes for one vertex of this attribute.
+  final int bytesPerVertex;
+
+  // Matches `gpu.HostBuffer`'s frame count, the number of frames the engine
+  // cycles transient buffers through.
+  static const int _ringDepth = 4;
+
+  final List<gpu.DeviceBuffer> _buffers = [];
+  int _capacityVertices = 0;
+  int _cursor = 0;
+
+  gpu.BufferView write(Uint8List bytes, int vertexCount) {
+    if (_buffers.isEmpty || vertexCount > _capacityVertices) {
+      _capacityVertices = nextBufferCapacity(vertexCount);
+      _buffers
+        ..clear()
+        ..addAll(
+          List.generate(
+            _ringDepth,
+            (_) => gpu.gpuContext.createDeviceBuffer(
+              gpu.StorageMode.hostVisible,
+              _capacityVertices * bytesPerVertex,
+            ),
+          ),
+        );
+      _cursor = 0;
+    } else {
+      _cursor = (_cursor + 1) % _ringDepth;
+    }
+    final length = vertexCount * bytesPerVertex;
+    final buffer = _buffers[_cursor];
+    if (length > 0) {
+      buffer.overwrite(
+        ByteData.sublistView(bytes),
+        destinationOffsetInBytes: 0,
+      );
+      buffer.flush(offsetInBytes: 0, lengthInBytes: length);
+    }
+    return gpu.BufferView(buffer, offsetInBytes: 0, lengthInBytes: length);
+  }
 }
 
 /// Assembles a [MeshGeometry] one vertex and triangle at a time.

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -316,7 +316,12 @@ class MeshGeometry extends UnskinnedGeometry {
     );
     // Raycast off this geometry's own attribute arrays instead of the
     // transient upload copies, so no extra position/texcoord copy lingers.
-    setRaycastAttributes(positions: _cpuPositions, texCoords: _cpuTexCoords);
+    // Keep the index bytes so an indexed mesh raycasts as indexed.
+    setRaycastAttributes(
+      positions: _cpuPositions,
+      texCoords: _cpuTexCoords,
+      indices: indexBytes,
+    );
   }
 
   // Re-packs the live CPU streams into the interleaved buffer and binds

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show internal;
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 
@@ -177,6 +178,26 @@ class MeshGeometry extends UnskinnedGeometry {
       normals: _cpuNormals,
       texCoords: _cpuTexCoords,
       colors: _cpuColors,
+    ),
+    indexBytes: _packedIndexBytes,
+    indices32Bit: _packedIndices32Bit,
+  );
+
+  /// The de-interleaved (structure-of-arrays) vertex bytes (the four attribute
+  /// streams concatenated) plus the packed index bytes, for re-emitting this
+  /// geometry as a `.fscene` payload with the
+  /// [InterleavedLayoutAdapter.unskinnedSoaLayout] layout. Built directly from
+  /// the per-attribute CPU streams, no interleave.
+  @internal
+  ({Uint8List vertexBytes, Uint8List? indexBytes, bool indices32Bit})
+  get soaData => (
+    vertexBytes: InterleavedLayoutAdapter.concatUnskinnedStreams(
+      UnskinnedAttributeStreams(
+        position: _bytesOf(_cpuPositions),
+        normal: _bytesOf(_cpuNormals),
+        texCoord: _bytesOf(_cpuTexCoords),
+        color: _bytesOf(_cpuColors),
+      ),
     ),
     indexBytes: _packedIndexBytes,
     indices32Bit: _packedIndices32Bit,

--- a/packages/flutter_scene/lib/src/geometry/primitives.dart
+++ b/packages/flutter_scene/lib/src/geometry/primitives.dart
@@ -724,9 +724,6 @@ PrimitiveArrays buildCylinderArrays({
   // (radial, y) plane the wall runs from (bottomRadius, -h/2) to
   // (topRadius, +h/2), so its outward normal is (height, bottomRadius -
   // topRadius) before normalizing.
-  // TODO(cone-apex): when an end radius is 0 its row collapses to a point,
-  // so half the triangles in the adjacent band are degenerate (zero area,
-  // harmless but wasted). Emit a triangle fan at a collapsed end instead.
   final slopeY = bottomRadius - topRadius;
   final columns = radialSegments + 1;
   for (var r = 0; r <= heightSegments; r++) {
@@ -747,14 +744,18 @@ PrimitiveArrays buildCylinderArrays({
     }
   }
   for (var r = 0; r < heightSegments; r++) {
+    // A zero-radius end collapses its whole row to a point, so the band
+    // next to it is a triangle fan, not quads: the triangle that would use
+    // two coincident apex vertices is degenerate and is skipped.
+    final topApex = r == 0 && topRadius == 0;
+    final bottomApex = r + 1 == heightSegments && bottomRadius == 0;
     for (var s = 0; s < radialSegments; s++) {
       final a = r * columns + s;
       final b = a + 1;
       final c = a + columns;
       final d = c + 1;
-      indices
-        ..addAll([a, c, b])
-        ..addAll([b, c, d]);
+      if (!topApex) indices.addAll([a, c, b]);
+      if (!bottomApex) indices.addAll([b, c, d]);
     }
   }
 

--- a/packages/flutter_scene/lib/src/geometry/primitives.dart
+++ b/packages/flutter_scene/lib/src/geometry/primitives.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
+import 'package:flutter_scene/src/physics/shape.dart';
 
 /// Vertex attribute arrays produced by a primitive generator.
 ///
@@ -30,9 +31,12 @@ class CuboidGeometry extends MeshGeometry {
   ///
   /// When [debugColors] is true each corner carries a distinct vertex color.
   factory CuboidGeometry(Vector3 extents, {bool debugColors = false}) =>
-      CuboidGeometry._(buildCuboidArrays(extents, debugColors: debugColors));
+      CuboidGeometry._(
+        extents,
+        buildCuboidArrays(extents, debugColors: debugColors),
+      );
 
-  CuboidGeometry._(PrimitiveArrays arrays)
+  CuboidGeometry._(this._extents, PrimitiveArrays arrays)
     : super.fromArrays(
         positions: arrays.positions,
         normals: arrays.normals,
@@ -40,6 +44,12 @@ class CuboidGeometry extends MeshGeometry {
         colors: arrays.colors,
         indices: arrays.indices,
       );
+
+  final Vector3 _extents;
+
+  /// The matching physics collision shape, a box of half the cuboid's
+  /// extents centered on the local origin.
+  Shape get collisionShape => cuboidCollisionShape(_extents);
 }
 
 /// A triangular-prism wedge (a ramp), centered on the origin in X and Z
@@ -53,9 +63,9 @@ class CuboidGeometry extends MeshGeometry {
 class WedgeGeometry extends MeshGeometry {
   /// Builds a wedge sized to [size] = `(width, height, run)`.
   factory WedgeGeometry(Vector3 size) =>
-      WedgeGeometry._(buildWedgeArrays(size));
+      WedgeGeometry._(size, buildWedgeArrays(size));
 
-  WedgeGeometry._(PrimitiveArrays arrays)
+  WedgeGeometry._(this._size, PrimitiveArrays arrays)
     : super.fromArrays(
         positions: arrays.positions,
         normals: arrays.normals,
@@ -63,6 +73,12 @@ class WedgeGeometry extends MeshGeometry {
         colors: arrays.colors,
         indices: arrays.indices,
       );
+
+  final Vector3 _size;
+
+  /// The matching physics collision shape, the convex hull of the wedge's
+  /// six corners.
+  Shape get collisionShape => wedgeCollisionShape(_size);
 }
 
 /// A flat rectangular grid in the XZ plane, centered on the origin, with
@@ -114,17 +130,253 @@ class SphereGeometry extends MeshGeometry {
     int rings = 16,
   }) {
     return SphereGeometry._(
+      radius,
       buildSphereArrays(radius: radius, segments: segments, rings: rings),
     );
   }
 
-  SphereGeometry._(PrimitiveArrays arrays)
+  SphereGeometry._(this._radius, PrimitiveArrays arrays)
     : super.fromArrays(
         positions: arrays.positions,
         normals: arrays.normals,
         texCoords: arrays.texCoords,
         indices: arrays.indices,
       );
+
+  final double _radius;
+
+  /// The matching physics collision shape, a sphere of the same radius.
+  Shape get collisionShape => SphereShape(radius: _radius);
+}
+
+/// A cylinder aligned with the Y axis, centered on the origin.
+///
+/// [bottomRadius] and [topRadius] are the radii at `y = -height/2` and
+/// `y = +height/2`. Giving them different values produces a truncated
+/// cone, and setting [topRadius] to `0` produces a cone with its apex at
+/// the top. [radialSegments] divides the circumference and
+/// [heightSegments] divides the side along Y. [bottomCap] and [topCap]
+/// add the end discs (a zero-radius end never emits a cap).
+/// {@category Geometry}
+class CylinderGeometry extends MeshGeometry {
+  /// Builds a cylinder (or cone/truncated cone) of the given dimensions.
+  factory CylinderGeometry({
+    double bottomRadius = 0.5,
+    double topRadius = 0.5,
+    double height = 1.0,
+    int radialSegments = 32,
+    int heightSegments = 1,
+    bool bottomCap = true,
+    bool topCap = true,
+  }) {
+    return CylinderGeometry._(
+      bottomRadius,
+      topRadius,
+      height,
+      radialSegments,
+      buildCylinderArrays(
+        bottomRadius: bottomRadius,
+        topRadius: topRadius,
+        height: height,
+        radialSegments: radialSegments,
+        heightSegments: heightSegments,
+        bottomCap: bottomCap,
+        topCap: topCap,
+      ),
+    );
+  }
+
+  CylinderGeometry._(
+    this._bottomRadius,
+    this._topRadius,
+    this._height,
+    this._radialSegments,
+    PrimitiveArrays arrays,
+  ) : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+      );
+
+  final double _bottomRadius;
+  final double _topRadius;
+  final double _height;
+  final int _radialSegments;
+
+  /// The matching physics collision shape. A straight cylinder (equal
+  /// radii) maps to a [CylinderShape]; a cone or truncated cone maps to the
+  /// convex hull of its two end rings (a zero-radius end collapses to its
+  /// apex point), since there is no analytic cone collision primitive.
+  Shape get collisionShape => cylinderCollisionShape(
+    bottomRadius: _bottomRadius,
+    topRadius: _topRadius,
+    height: _height,
+    radialSegments: _radialSegments,
+  );
+}
+
+/// A capsule (a cylinder capped by two hemispheres) aligned with the Y
+/// axis, centered on the origin.
+///
+/// [radius] is the capsule radius and [height] is the length of the
+/// cylindrical mid-section, excluding the caps, so the total extent along
+/// Y is `height + 2 * radius`. This matches the convention of the physics
+/// `CapsuleShape`. [radialSegments] divides the circumference and
+/// [capRings] divides each hemispherical cap from its equator to its pole.
+/// {@category Geometry}
+class CapsuleGeometry extends MeshGeometry {
+  /// Builds a capsule of the given [radius] and mid-section [height].
+  factory CapsuleGeometry({
+    double radius = 0.5,
+    double height = 1.0,
+    int radialSegments = 32,
+    int capRings = 8,
+  }) {
+    return CapsuleGeometry._(
+      radius,
+      height,
+      buildCapsuleArrays(
+        radius: radius,
+        height: height,
+        radialSegments: radialSegments,
+        capRings: capRings,
+      ),
+    );
+  }
+
+  CapsuleGeometry._(this._radius, this._height, PrimitiveArrays arrays)
+    : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+      );
+
+  final double _radius;
+  final double _height;
+
+  /// The matching physics collision shape, a capsule with the same radius
+  /// and mid-section half-height.
+  Shape get collisionShape =>
+      capsuleCollisionShape(radius: _radius, height: _height);
+}
+
+/// A torus (ring) lying in the XZ plane, centered on the origin.
+///
+/// [radius] is the distance from the center to the center of the tube and
+/// [tubeRadius] is the radius of the tube itself. [radialSegments] divides
+/// the main ring and [tubularSegments] divides the tube's cross-section.
+/// {@category Geometry}
+class TorusGeometry extends MeshGeometry {
+  /// Builds a torus of the given [radius] and [tubeRadius].
+  factory TorusGeometry({
+    double radius = 0.5,
+    double tubeRadius = 0.2,
+    int radialSegments = 32,
+    int tubularSegments = 16,
+  }) {
+    return TorusGeometry._(
+      buildTorusArrays(
+        radius: radius,
+        tubeRadius: tubeRadius,
+        radialSegments: radialSegments,
+        tubularSegments: tubularSegments,
+      ),
+    );
+  }
+
+  TorusGeometry._(PrimitiveArrays arrays)
+    : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+      );
+}
+
+/// A flat filled disc in the XZ plane, centered on the origin, facing
+/// `+Y`.
+///
+/// [radius] is the disc radius and [segments] the number of wedges around
+/// the rim.
+/// {@category Geometry}
+class DiscGeometry extends MeshGeometry {
+  /// Builds a disc of the given [radius].
+  factory DiscGeometry({double radius = 0.5, int segments = 32}) {
+    return DiscGeometry._(buildDiscArrays(radius: radius, segments: segments));
+  }
+
+  DiscGeometry._(PrimitiveArrays arrays)
+    : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+      );
+}
+
+/// A flat annulus (a disc with a concentric hole) in the XZ plane,
+/// centered on the origin, facing `+Y`.
+///
+/// [innerRadius] is the hole radius and [outerRadius] the rim radius.
+/// [segments] is the number of wedges around the ring.
+/// {@category Geometry}
+class RingGeometry extends MeshGeometry {
+  /// Builds an annulus between [innerRadius] and [outerRadius].
+  factory RingGeometry({
+    double innerRadius = 0.25,
+    double outerRadius = 0.5,
+    int segments = 32,
+  }) {
+    return RingGeometry._(
+      buildRingArrays(
+        innerRadius: innerRadius,
+        outerRadius: outerRadius,
+        segments: segments,
+      ),
+    );
+  }
+
+  RingGeometry._(PrimitiveArrays arrays)
+    : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+      );
+}
+
+/// A geodesic sphere built by subdividing an icosahedron, centered on the
+/// origin.
+///
+/// Unlike [SphereGeometry] (a UV sphere with pinched poles), an icosphere
+/// has near-uniform triangle sizes over the whole surface. [subdivisions]
+/// controls the tessellation: each step quadruples the triangle count
+/// (`0` is the bare 20-face icosahedron). Vertex normals point radially
+/// outward.
+/// {@category Geometry}
+class IcosphereGeometry extends MeshGeometry {
+  /// Builds an icosphere of the given [radius] and [subdivisions].
+  factory IcosphereGeometry({double radius = 0.5, int subdivisions = 2}) {
+    return IcosphereGeometry._(
+      radius,
+      buildIcosphereArrays(radius: radius, subdivisions: subdivisions),
+    );
+  }
+
+  IcosphereGeometry._(this._radius, PrimitiveArrays arrays)
+    : super.fromArrays(
+        positions: arrays.positions,
+        normals: arrays.normals,
+        texCoords: arrays.texCoords,
+        indices: arrays.indices,
+      );
+
+  final double _radius;
+
+  /// The matching physics collision shape, a sphere of the same radius.
+  Shape get collisionShape => SphereShape(radius: _radius);
 }
 
 /// Generates the vertex arrays for a [CuboidGeometry] sized to [extents].
@@ -392,4 +644,543 @@ PrimitiveArrays buildSphereArrays({
     colors: null,
     indices: indices,
   );
+}
+
+/// Generates the vertex arrays for a [CylinderGeometry].
+///
+/// The side is a grid of `radialSegments + 1` columns by
+/// `heightSegments + 1` rows whose normals account for the slope when the
+/// radii differ (so a cone shades correctly). End caps are triangle fans
+/// about a center vertex, emitted only when requested and the matching
+/// radius is nonzero. Rows run from the top (`y = +height/2`) down, so the
+/// side winding matches [buildSphereArrays].
+PrimitiveArrays buildCylinderArrays({
+  required double bottomRadius,
+  required double topRadius,
+  required double height,
+  required int radialSegments,
+  required int heightSegments,
+  required bool bottomCap,
+  required bool topCap,
+}) {
+  if (radialSegments < 3) {
+    throw ArgumentError('A cylinder needs at least three radial segments');
+  }
+  if (heightSegments < 1) {
+    throw ArgumentError('A cylinder needs at least one height segment');
+  }
+  if (bottomRadius < 0 || topRadius < 0) {
+    throw ArgumentError('Cylinder radii cannot be negative');
+  }
+  if (bottomRadius == 0 && topRadius == 0) {
+    throw ArgumentError(
+      'A cylinder needs a nonzero radius on at least one end',
+    );
+  }
+
+  final positions = <double>[];
+  final normals = <double>[];
+  final texCoords = <double>[];
+  final indices = <int>[];
+
+  void addVert(Vector3 p, Vector3 n, double u, double v) {
+    positions.addAll([p.x, p.y, p.z]);
+    normals.addAll([n.x, n.y, n.z]);
+    texCoords.addAll([u, v]);
+  }
+
+  // Side surface. The outward normal tilts by the wall slope: in the
+  // (radial, y) plane the wall runs from (bottomRadius, -h/2) to
+  // (topRadius, +h/2), so its outward normal is (height, bottomRadius -
+  // topRadius) before normalizing.
+  // TODO(cone-apex): when an end radius is 0 its row collapses to a point,
+  // so half the triangles in the adjacent band are degenerate (zero area,
+  // harmless but wasted). Emit a triangle fan at a collapsed end instead.
+  final slopeY = bottomRadius - topRadius;
+  final columns = radialSegments + 1;
+  for (var r = 0; r <= heightSegments; r++) {
+    final t = r / heightSegments; // 0 at the top row, 1 at the bottom
+    final y = height / 2 - height * t;
+    final radius = topRadius + (bottomRadius - topRadius) * t;
+    for (var s = 0; s <= radialSegments; s++) {
+      final theta = 2 * math.pi * s / radialSegments;
+      final cos = math.cos(theta);
+      final sin = math.sin(theta);
+      final normal = Vector3(height * cos, slopeY, height * sin).normalized();
+      addVert(
+        Vector3(radius * cos, y, radius * sin),
+        normal,
+        s / radialSegments,
+        t,
+      );
+    }
+  }
+  for (var r = 0; r < heightSegments; r++) {
+    for (var s = 0; s < radialSegments; s++) {
+      final a = r * columns + s;
+      final b = a + 1;
+      final c = a + columns;
+      final d = c + 1;
+      indices
+        ..addAll([a, c, b])
+        ..addAll([b, c, d]);
+    }
+  }
+
+  // End cap as a triangle fan. [flip] selects the winding so the cap's
+  // front face points away along the cap's outward normal (0, ny, 0).
+  void addCap(double y, double radius, double ny, {required bool flip}) {
+    if (radius <= 0) return;
+    final center = positions.length ~/ 3;
+    addVert(Vector3(0, y, 0), Vector3(0, ny, 0), 0.5, 0.5);
+    final rimBase = positions.length ~/ 3;
+    for (var s = 0; s <= radialSegments; s++) {
+      final theta = 2 * math.pi * s / radialSegments;
+      final cos = math.cos(theta);
+      final sin = math.sin(theta);
+      addVert(
+        Vector3(radius * cos, y, radius * sin),
+        Vector3(0, ny, 0),
+        0.5 + 0.5 * cos,
+        0.5 + 0.5 * sin,
+      );
+    }
+    for (var s = 0; s < radialSegments; s++) {
+      final r0 = rimBase + s;
+      final r1 = rimBase + s + 1;
+      indices.addAll(flip ? [center, r1, r0] : [center, r0, r1]);
+    }
+  }
+
+  if (bottomCap) addCap(-height / 2, bottomRadius, -1, flip: true);
+  if (topCap) addCap(height / 2, topRadius, 1, flip: false);
+
+  return (
+    positions: Float32List.fromList(positions),
+    normals: Float32List.fromList(normals),
+    texCoords: Float32List.fromList(texCoords),
+    colors: null,
+    indices: indices,
+  );
+}
+
+/// Generates the vertex arrays for a [CapsuleGeometry].
+///
+/// Built as latitude rings from the top pole down to the bottom pole: the
+/// two hemispheres share their equator rings with the cylindrical
+/// mid-section, whose seam carries horizontal normals. Rows run top to
+/// bottom so the winding matches [buildSphereArrays].
+PrimitiveArrays buildCapsuleArrays({
+  required double radius,
+  required double height,
+  required int radialSegments,
+  required int capRings,
+}) {
+  if (radialSegments < 3) {
+    throw ArgumentError('A capsule needs at least three radial segments');
+  }
+  if (capRings < 1) {
+    throw ArgumentError('A capsule needs at least one cap ring');
+  }
+  if (radius <= 0) {
+    throw ArgumentError('A capsule needs a positive radius');
+  }
+
+  final halfH = height / 2;
+  final rings = <({double posY, double posR, double normY, double normR})>[];
+  // Top hemisphere: phi 0 (pole) to pi/2 (equator at y = +height/2).
+  for (var r = 0; r <= capRings; r++) {
+    final phi = (math.pi / 2) * (r / capRings);
+    rings.add((
+      posY: halfH + radius * math.cos(phi),
+      posR: radius * math.sin(phi),
+      normY: math.cos(phi),
+      normR: math.sin(phi),
+    ));
+  }
+  // Bottom hemisphere: phi pi/2 (equator at y = -height/2) to pi (pole).
+  for (var r = 0; r <= capRings; r++) {
+    final phi = (math.pi / 2) + (math.pi / 2) * (r / capRings);
+    rings.add((
+      posY: -halfH + radius * math.cos(phi),
+      posR: radius * math.sin(phi),
+      normY: math.cos(phi),
+      normR: math.sin(phi),
+    ));
+  }
+
+  final columns = radialSegments + 1;
+  final rowCount = rings.length;
+  final positions = <double>[];
+  final normals = <double>[];
+  final texCoords = <double>[];
+  for (var r = 0; r < rowCount; r++) {
+    final ring = rings[r];
+    for (var s = 0; s <= radialSegments; s++) {
+      final theta = 2 * math.pi * s / radialSegments;
+      final cos = math.cos(theta);
+      final sin = math.sin(theta);
+      positions.addAll([ring.posR * cos, ring.posY, ring.posR * sin]);
+      normals.addAll([ring.normR * cos, ring.normY, ring.normR * sin]);
+      texCoords.addAll([s / radialSegments, r / (rowCount - 1)]);
+    }
+  }
+  final indices = <int>[];
+  for (var r = 0; r < rowCount - 1; r++) {
+    for (var s = 0; s < radialSegments; s++) {
+      final a = r * columns + s;
+      final b = a + 1;
+      final c = a + columns;
+      final d = c + 1;
+      indices
+        ..addAll([a, c, b])
+        ..addAll([b, c, d]);
+    }
+  }
+
+  return (
+    positions: Float32List.fromList(positions),
+    normals: Float32List.fromList(normals),
+    texCoords: Float32List.fromList(texCoords),
+    colors: null,
+    indices: indices,
+  );
+}
+
+/// Generates the vertex arrays for a [TorusGeometry] lying in the XZ
+/// plane.
+PrimitiveArrays buildTorusArrays({
+  required double radius,
+  required double tubeRadius,
+  required int radialSegments,
+  required int tubularSegments,
+}) {
+  if (radialSegments < 3) {
+    throw ArgumentError('A torus needs at least three radial segments');
+  }
+  if (tubularSegments < 3) {
+    throw ArgumentError('A torus needs at least three tubular segments');
+  }
+  if (radius <= 0 || tubeRadius <= 0) {
+    throw ArgumentError('A torus needs positive radii');
+  }
+
+  final columns = tubularSegments + 1;
+  final positions = <double>[];
+  final normals = <double>[];
+  final texCoords = <double>[];
+  for (var i = 0; i <= radialSegments; i++) {
+    final u = 2 * math.pi * i / radialSegments;
+    final cosU = math.cos(u);
+    final sinU = math.sin(u);
+    for (var j = 0; j <= tubularSegments; j++) {
+      final v = 2 * math.pi * j / tubularSegments;
+      final cosV = math.cos(v);
+      final sinV = math.sin(v);
+      final ringRadius = radius + tubeRadius * cosV;
+      positions.addAll([
+        ringRadius * cosU,
+        tubeRadius * sinV,
+        ringRadius * sinU,
+      ]);
+      normals.addAll([cosV * cosU, sinV, cosV * sinU]);
+      texCoords.addAll([j / tubularSegments, i / radialSegments]);
+    }
+  }
+  final indices = <int>[];
+  for (var i = 0; i < radialSegments; i++) {
+    for (var j = 0; j < tubularSegments; j++) {
+      final a = i * columns + j;
+      final b = a + 1;
+      final c = a + columns;
+      final d = c + 1;
+      indices
+        ..addAll([a, c, b])
+        ..addAll([b, c, d]);
+    }
+  }
+
+  return (
+    positions: Float32List.fromList(positions),
+    normals: Float32List.fromList(normals),
+    texCoords: Float32List.fromList(texCoords),
+    colors: null,
+    indices: indices,
+  );
+}
+
+/// Generates the vertex arrays for a [DiscGeometry], a filled disc in the
+/// XZ plane facing +Y.
+PrimitiveArrays buildDiscArrays({
+  required double radius,
+  required int segments,
+}) {
+  if (segments < 3) {
+    throw ArgumentError('A disc needs at least three segments');
+  }
+  if (radius <= 0) {
+    throw ArgumentError('A disc needs a positive radius');
+  }
+
+  final positions = <double>[0, 0, 0];
+  final normals = <double>[0, 1, 0];
+  final texCoords = <double>[0.5, 0.5];
+  for (var s = 0; s <= segments; s++) {
+    final theta = 2 * math.pi * s / segments;
+    final cos = math.cos(theta);
+    final sin = math.sin(theta);
+    positions.addAll([radius * cos, 0, radius * sin]);
+    normals.addAll([0, 1, 0]);
+    texCoords.addAll([0.5 + 0.5 * cos, 0.5 + 0.5 * sin]);
+  }
+  final indices = <int>[];
+  for (var s = 0; s < segments; s++) {
+    // Wound so the lit surface faces +Y (front face opposite +Y normal).
+    indices.addAll([0, 1 + s, 1 + s + 1]);
+  }
+
+  return (
+    positions: Float32List.fromList(positions),
+    normals: Float32List.fromList(normals),
+    texCoords: Float32List.fromList(texCoords),
+    colors: null,
+    indices: indices,
+  );
+}
+
+/// Generates the vertex arrays for a [RingGeometry], a flat annulus in the
+/// XZ plane facing +Y.
+PrimitiveArrays buildRingArrays({
+  required double innerRadius,
+  required double outerRadius,
+  required int segments,
+}) {
+  if (segments < 3) {
+    throw ArgumentError('A ring needs at least three segments');
+  }
+  if (innerRadius < 0 || outerRadius <= 0) {
+    throw ArgumentError('A ring needs a positive outer radius');
+  }
+  if (innerRadius >= outerRadius) {
+    throw ArgumentError('A ring needs innerRadius < outerRadius');
+  }
+
+  final positions = <double>[];
+  final normals = <double>[];
+  final texCoords = <double>[];
+  // Outer rim first (indices 0..segments), then inner rim.
+  for (var s = 0; s <= segments; s++) {
+    final theta = 2 * math.pi * s / segments;
+    positions.addAll([
+      outerRadius * math.cos(theta),
+      0,
+      outerRadius * math.sin(theta),
+    ]);
+    normals.addAll([0, 1, 0]);
+    texCoords.addAll([s / segments, 1]);
+  }
+  final innerBase = segments + 1;
+  for (var s = 0; s <= segments; s++) {
+    final theta = 2 * math.pi * s / segments;
+    positions.addAll([
+      innerRadius * math.cos(theta),
+      0,
+      innerRadius * math.sin(theta),
+    ]);
+    normals.addAll([0, 1, 0]);
+    texCoords.addAll([s / segments, 0]);
+  }
+  final indices = <int>[];
+  for (var s = 0; s < segments; s++) {
+    final o0 = s;
+    final o1 = s + 1;
+    final i0 = innerBase + s;
+    final i1 = innerBase + s + 1;
+    // Wound so the lit surface faces +Y.
+    indices
+      ..addAll([o0, o1, i1])
+      ..addAll([o0, i1, i0]);
+  }
+
+  return (
+    positions: Float32List.fromList(positions),
+    normals: Float32List.fromList(normals),
+    texCoords: Float32List.fromList(texCoords),
+    colors: null,
+    indices: indices,
+  );
+}
+
+/// Generates the vertex arrays for an [IcosphereGeometry] by subdividing
+/// an icosahedron [subdivisions] times and projecting onto the sphere.
+PrimitiveArrays buildIcosphereArrays({
+  required double radius,
+  required int subdivisions,
+}) {
+  if (subdivisions < 0) {
+    throw ArgumentError('Icosphere subdivisions cannot be negative');
+  }
+  if (radius <= 0) {
+    throw ArgumentError('An icosphere needs a positive radius');
+  }
+
+  final t = (1 + math.sqrt(5)) / 2;
+  final verts = <Vector3>[
+    Vector3(-1, t, 0),
+    Vector3(1, t, 0),
+    Vector3(-1, -t, 0),
+    Vector3(1, -t, 0),
+    Vector3(0, -1, t),
+    Vector3(0, 1, t),
+    Vector3(0, -1, -t),
+    Vector3(0, 1, -t),
+    Vector3(t, 0, -1),
+    Vector3(t, 0, 1),
+    Vector3(-t, 0, -1),
+    Vector3(-t, 0, 1),
+  ];
+  // Faces wound so the outward normal opposes the right-hand normal (the
+  // engine's front-face convention), i.e. clockwise seen from outside.
+  var faces = <List<int>>[
+    [0, 5, 11],
+    [0, 1, 5],
+    [0, 7, 1],
+    [0, 10, 7],
+    [0, 11, 10],
+    [1, 9, 5],
+    [5, 4, 11],
+    [11, 2, 10],
+    [10, 6, 7],
+    [7, 8, 1],
+    [3, 4, 9],
+    [3, 2, 4],
+    [3, 6, 2],
+    [3, 8, 6],
+    [3, 9, 8],
+    [4, 5, 9],
+    [2, 11, 4],
+    [6, 10, 2],
+    [8, 7, 6],
+    [9, 1, 8],
+  ];
+
+  // Midpoint cache: each subdivided edge contributes one shared vertex.
+  // The key is the edge's endpoint pair (low, high) so an edge shared by
+  // two faces yields a single welded midpoint.
+  final midpointCache = <({int low, int high}), int>{};
+  int midpoint(int a, int b) {
+    final key = (low: math.min(a, b), high: math.max(a, b));
+    final cached = midpointCache[key];
+    if (cached != null) return cached;
+    final index = verts.length;
+    verts.add((verts[a] + verts[b]) * 0.5);
+    midpointCache[key] = index;
+    return index;
+  }
+
+  for (var i = 0; i < subdivisions; i++) {
+    final next = <List<int>>[];
+    for (final f in faces) {
+      final a = f[0];
+      final b = f[1];
+      final c = f[2];
+      final ab = midpoint(a, b);
+      final bc = midpoint(b, c);
+      final ca = midpoint(c, a);
+      next
+        ..add([a, ab, ca])
+        ..add([b, bc, ab])
+        ..add([c, ca, bc])
+        ..add([ab, bc, ca]);
+    }
+    faces = next;
+  }
+
+  final positions = Float32List(verts.length * 3);
+  final normals = Float32List(verts.length * 3);
+  final texCoords = Float32List(verts.length * 2);
+  for (var i = 0; i < verts.length; i++) {
+    final n = verts[i].normalized();
+    positions[i * 3] = radius * n.x;
+    positions[i * 3 + 1] = radius * n.y;
+    positions[i * 3 + 2] = radius * n.z;
+    normals[i * 3] = n.x;
+    normals[i * 3 + 1] = n.y;
+    normals[i * 3 + 2] = n.z;
+    // TODO(icosphere-uv): spherical mapping leaves a seam where longitude
+    // wraps and distorts near the poles; emit per-face UVs to remove it.
+    texCoords[i * 2] = 0.5 + math.atan2(n.z, n.x) / (2 * math.pi);
+    texCoords[i * 2 + 1] = 0.5 - math.asin(n.y) / math.pi;
+  }
+  final indices = <int>[];
+  for (final f in faces) {
+    indices.addAll(f);
+  }
+
+  return (
+    positions: positions,
+    normals: normals,
+    texCoords: texCoords,
+    colors: null,
+    indices: indices,
+  );
+}
+
+/// The collision [Shape] for a [CuboidGeometry] of full [extents]: a box of
+/// half those extents, since [BoxShape] is specified by half-extents.
+Shape cuboidCollisionShape(Vector3 extents) =>
+    BoxShape(halfExtents: extents * 0.5);
+
+/// The collision [Shape] for a [WedgeGeometry] of `(width, height, run)`
+/// [size]: the convex hull of its six corners.
+Shape wedgeCollisionShape(Vector3 size) {
+  final hx = size.x / 2;
+  final hz = size.z / 2;
+  final y = size.y;
+  return ConvexHullShape(
+    points: Float32List.fromList(<double>[
+      -hx, 0, -hz, // low edge, -Z
+      hx, 0, -hz,
+      -hx, 0, hz, // back-bottom, +Z
+      hx, 0, hz,
+      -hx, y, hz, // back-top, +Z
+      hx, y, hz,
+    ]),
+  );
+}
+
+/// The collision [Shape] for a [CapsuleGeometry]: a capsule whose
+/// [CapsuleShape.halfHeight] is half the cylindrical mid-section [height]
+/// (excluding the caps), matching the geometry's height convention.
+Shape capsuleCollisionShape({required double radius, required double height}) =>
+    CapsuleShape(radius: radius, halfHeight: height / 2);
+
+/// The collision [Shape] for a [CylinderGeometry]. Equal radii map to a
+/// [CylinderShape]; a cone or truncated cone maps to the convex hull of its
+/// two end rings sampled with [radialSegments] points (a zero-radius end
+/// collapses to its apex point), since there is no analytic cone shape.
+Shape cylinderCollisionShape({
+  required double bottomRadius,
+  required double topRadius,
+  required double height,
+  required int radialSegments,
+}) {
+  if (bottomRadius == topRadius) {
+    return CylinderShape(radius: bottomRadius, halfHeight: height / 2);
+  }
+  final points = <double>[];
+  void ring(double radius, double y) {
+    if (radius <= 0) {
+      points.addAll([0, y, 0]);
+      return;
+    }
+    for (var s = 0; s < radialSegments; s++) {
+      final theta = 2 * math.pi * s / radialSegments;
+      points.addAll([radius * math.cos(theta), y, radius * math.sin(theta)]);
+    }
+  }
+
+  ring(bottomRadius, -height / 2);
+  ring(topRadius, height / 2);
+  return ConvexHullShape(points: Float32List.fromList(points));
 }

--- a/packages/flutter_scene/lib/src/geometry/primitives.dart
+++ b/packages/flutter_scene/lib/src/geometry/primitives.dart
@@ -277,6 +277,8 @@ class TorusGeometry extends MeshGeometry {
     int tubularSegments = 16,
   }) {
     return TorusGeometry._(
+      radius,
+      tubeRadius,
       buildTorusArrays(
         radius: radius,
         tubeRadius: tubeRadius,
@@ -286,13 +288,22 @@ class TorusGeometry extends MeshGeometry {
     );
   }
 
-  TorusGeometry._(PrimitiveArrays arrays)
+  TorusGeometry._(this._radius, this._tubeRadius, PrimitiveArrays arrays)
     : super.fromArrays(
         positions: arrays.positions,
         normals: arrays.normals,
         texCoords: arrays.texCoords,
         indices: arrays.indices,
       );
+
+  final double _radius;
+  final double _tubeRadius;
+
+  /// The matching physics collision shape. A torus is not convex, so this
+  /// is a [CompoundShape] of convex chunks swept around the ring, which
+  /// preserves the central hole. See [torusCollisionShape].
+  Shape get collisionShape =>
+      torusCollisionShape(radius: _radius, tubeRadius: _tubeRadius);
 }
 
 /// A flat filled disc in the XZ plane, centered on the origin, facing
@@ -304,16 +315,25 @@ class TorusGeometry extends MeshGeometry {
 class DiscGeometry extends MeshGeometry {
   /// Builds a disc of the given [radius].
   factory DiscGeometry({double radius = 0.5, int segments = 32}) {
-    return DiscGeometry._(buildDiscArrays(radius: radius, segments: segments));
+    return DiscGeometry._(
+      radius,
+      buildDiscArrays(radius: radius, segments: segments),
+    );
   }
 
-  DiscGeometry._(PrimitiveArrays arrays)
+  DiscGeometry._(this._radius, PrimitiveArrays arrays)
     : super.fromArrays(
         positions: arrays.positions,
         normals: arrays.normals,
         texCoords: arrays.texCoords,
         indices: arrays.indices,
       );
+
+  final double _radius;
+
+  /// The matching physics collision shape. A flat disc has no volume, so
+  /// this is a thin [CylinderShape] (a coin). See [discCollisionShape].
+  Shape get collisionShape => discCollisionShape(radius: _radius);
 }
 
 /// A flat annulus (a disc with a concentric hole) in the XZ plane,
@@ -330,6 +350,8 @@ class RingGeometry extends MeshGeometry {
     int segments = 32,
   }) {
     return RingGeometry._(
+      innerRadius,
+      outerRadius,
       buildRingArrays(
         innerRadius: innerRadius,
         outerRadius: outerRadius,
@@ -338,13 +360,22 @@ class RingGeometry extends MeshGeometry {
     );
   }
 
-  RingGeometry._(PrimitiveArrays arrays)
+  RingGeometry._(this._innerRadius, this._outerRadius, PrimitiveArrays arrays)
     : super.fromArrays(
         positions: arrays.positions,
         normals: arrays.normals,
         texCoords: arrays.texCoords,
         indices: arrays.indices,
       );
+
+  final double _innerRadius;
+  final double _outerRadius;
+
+  /// The matching physics collision shape. An annulus is not convex, so
+  /// this is a [CompoundShape] of thin convex segments around the ring,
+  /// which preserves the hole. See [ringCollisionShape].
+  Shape get collisionShape =>
+      ringCollisionShape(innerRadius: _innerRadius, outerRadius: _outerRadius);
 }
 
 /// A geodesic sphere built by subdividing an icosahedron, centered on the
@@ -1183,4 +1214,94 @@ Shape cylinderCollisionShape({
   ring(bottomRadius, -height / 2);
   ring(topRadius, height / 2);
   return ConvexHullShape(points: Float32List.fromList(points));
+}
+
+// A flat shape (disc, ring) has no real thickness, so its collision hull is
+// extruded to this fraction of its radius along Y, both to give a convex
+// hull a valid (non-degenerate) volume and so a dropped disc behaves like a
+// thin coin rather than an infinitely thin sheet.
+const double _kFlatCollisionHalfThickness = 0.05;
+
+/// The collision [Shape] for a [TorusGeometry]: a [CompoundShape] of
+/// [segments] convex chunks swept around the ring, each the convex hull of
+/// two adjacent tube cross-sections sampled with [tubularSegments] points.
+/// The chunks leave the central hole open, which a single convex hull would
+/// fill. The collision tessellation is intentionally coarser than a render
+/// mesh.
+Shape torusCollisionShape({
+  required double radius,
+  required double tubeRadius,
+  int segments = 16,
+  int tubularSegments = 8,
+}) {
+  final children = <CompoundChild>[];
+  for (var i = 0; i < segments; i++) {
+    final points = <double>[];
+    for (final u in [
+      2 * math.pi * i / segments,
+      2 * math.pi * (i + 1) / segments,
+    ]) {
+      final cosU = math.cos(u);
+      final sinU = math.sin(u);
+      for (var j = 0; j < tubularSegments; j++) {
+        final v = 2 * math.pi * j / tubularSegments;
+        final ringRadius = radius + tubeRadius * math.cos(v);
+        points.addAll([
+          ringRadius * cosU,
+          tubeRadius * math.sin(v),
+          ringRadius * sinU,
+        ]);
+      }
+    }
+    children.add(
+      CompoundChild(
+        shape: ConvexHullShape(points: Float32List.fromList(points)),
+        localPose: Matrix4.identity(),
+      ),
+    );
+  }
+  return CompoundShape(children: children);
+}
+
+/// The collision [Shape] for a [DiscGeometry]: a thin [CylinderShape] (a
+/// coin), since a flat disc has no volume. The thickness is a small
+/// fraction of the [radius].
+Shape discCollisionShape({required double radius}) => CylinderShape(
+  radius: radius,
+  halfHeight: radius * _kFlatCollisionHalfThickness,
+);
+
+/// The collision [Shape] for a [RingGeometry]: a [CompoundShape] of
+/// [segments] thin convex segments around the annulus, leaving the hole
+/// open. Each segment is extruded to a small thickness so it forms a valid
+/// (non-degenerate) 3D hull.
+Shape ringCollisionShape({
+  required double innerRadius,
+  required double outerRadius,
+  int segments = 16,
+}) {
+  final halfThickness = outerRadius * _kFlatCollisionHalfThickness;
+  final children = <CompoundChild>[];
+  for (var i = 0; i < segments; i++) {
+    final points = <double>[];
+    for (final a in [
+      2 * math.pi * i / segments,
+      2 * math.pi * (i + 1) / segments,
+    ]) {
+      final cosA = math.cos(a);
+      final sinA = math.sin(a);
+      for (final r in [innerRadius, outerRadius]) {
+        points
+          ..addAll([r * cosA, halfThickness, r * sinA])
+          ..addAll([r * cosA, -halfThickness, r * sinA]);
+      }
+    }
+    children.add(
+      CompoundChild(
+        shape: ConvexHullShape(points: Float32List.fromList(points)),
+        localPose: Matrix4.identity(),
+      ),
+    );
+  }
+  return CompoundShape(children: children);
 }

--- a/packages/flutter_scene/lib/src/geometry/vertex_layout.dart
+++ b/packages/flutter_scene/lib/src/geometry/vertex_layout.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+
+/// A described vertex attribute: the shader input it feeds (by [name]), its
+/// element [format], and its byte [offsetInBytes] within the owning buffer's
+/// per-element stride.
+///
+/// This is the engine-side, value-equal description of a single attribute.
+/// It lowers to a [gpu.VertexAttribute] (the flutter_gpu pipeline type) but,
+/// unlike that type, compares by value so two structurally identical layouts
+/// can be interned to one identity (see [vertexLayoutId]).
+@immutable
+class VertexAttributeDescriptor {
+  const VertexAttributeDescriptor({
+    required this.name,
+    required this.format,
+    this.offsetInBytes = 0,
+  });
+
+  /// Name of the shader-side input this attribute feeds (e.g. `position`).
+  /// flutter_gpu binds vertex attributes by name, so this must match the
+  /// vertex shader's `in` declaration.
+  final String name;
+
+  /// Format of each element of this attribute.
+  final gpu.VertexFormat format;
+
+  /// Byte offset of this attribute from the start of each element of the
+  /// owning [VertexBufferDescriptor].
+  final int offsetInBytes;
+
+  gpu.VertexAttribute _toGpu() => gpu.VertexAttribute(
+    name: name,
+    format: format,
+    offsetInBytes: offsetInBytes,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      other is VertexAttributeDescriptor &&
+      other.name == name &&
+      other.format == format &&
+      other.offsetInBytes == offsetInBytes;
+
+  @override
+  int get hashCode => Object.hash(name, format, offsetInBytes);
+}
+
+/// One vertex buffer slot: its per-element [strideInBytes], how it advances
+/// while drawing ([stepMode]), and the [attributes] read from it. The
+/// buffer's position in [VertexLayoutDescriptor.buffers] is its binding slot.
+///
+/// Lowers to a [gpu.VertexBuffer]; compares by value.
+@immutable
+class VertexBufferDescriptor {
+  const VertexBufferDescriptor({
+    required this.strideInBytes,
+    required this.attributes,
+    this.stepMode = gpu.VertexStepMode.vertex,
+  });
+
+  /// Byte distance from the start of one element to the start of the next.
+  final int strideInBytes;
+
+  /// Attributes read from this slot by the vertex shader.
+  final List<VertexAttributeDescriptor> attributes;
+
+  /// Whether this slot advances per vertex or per instance.
+  final gpu.VertexStepMode stepMode;
+
+  gpu.VertexBuffer _toGpu() => gpu.VertexBuffer(
+    strideInBytes: strideInBytes,
+    stepMode: stepMode,
+    attributes: [for (final attribute in attributes) attribute._toGpu()],
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      other is VertexBufferDescriptor &&
+      other.strideInBytes == strideInBytes &&
+      other.stepMode == stepMode &&
+      listEquals(other.attributes, attributes);
+
+  @override
+  int get hashCode =>
+      Object.hash(strideInBytes, stepMode, Object.hashAll(attributes));
+}
+
+/// A complete, described vertex input layout: the buffer slots a pipeline
+/// reads from and the attributes each one feeds.
+///
+/// This is the engine-side description that replaces the two magic
+/// per-vertex byte counts with an explicit attribute set. It lowers to a
+/// [gpu.VertexLayout] via [toGpuLayout] (the flutter_gpu pipeline type, kept
+/// as the dumb lowering target), but adds value equality so identical
+/// layouts share one pipeline-cache identity. The canonical instance is
+/// `kUnskinnedInstancedLayout`.
+@immutable
+class VertexLayoutDescriptor {
+  const VertexLayoutDescriptor({required this.buffers});
+
+  /// Vertex buffer slots; list position is the binding slot.
+  final List<VertexBufferDescriptor> buffers;
+
+  /// Lowers this description to the flutter_gpu pipeline layout, validating
+  /// it first.
+  ///
+  /// Called at pipeline-creation time (once per interned layout). Throws an
+  /// [ArgumentError] when an attribute would read past its slot's stride or
+  /// when an attribute name is reused, so a malformed layout fails loudly
+  /// here instead of producing silently wrong rendering.
+  gpu.VertexLayout toGpuLayout() {
+    _validate();
+    return gpu.VertexLayout(
+      buffers: [for (final buffer in buffers) buffer._toGpu()],
+    );
+  }
+
+  void _validate() {
+    final seenNames = <String>{};
+    for (final buffer in buffers) {
+      for (final attribute in buffer.attributes) {
+        if (!seenNames.add(attribute.name)) {
+          throw ArgumentError(
+            'Vertex attribute "${attribute.name}" is declared more than once '
+            'in the layout; attribute names must be unique because '
+            'flutter_gpu binds them by name.',
+          );
+        }
+        final end = attribute.offsetInBytes + attribute.format.bytesPerElement;
+        if (end > buffer.strideInBytes) {
+          throw ArgumentError(
+            'Vertex attribute "${attribute.name}" ends at byte $end, past its '
+            'buffer stride of ${buffer.strideInBytes}.',
+          );
+        }
+      }
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is VertexLayoutDescriptor && listEquals(other.buffers, buffers);
+
+  @override
+  int get hashCode => Object.hashAll(buffers);
+}
+
+// Interned identities for layout descriptors. A pipeline depends on its
+// vertex layout as well as its shaders, so a cache keyed on the shader pair
+// alone serves the wrong pipeline once one shader has more than one layout.
+// Interning collapses every structurally identical layout to one small
+// integer the pipeline-cache key can carry. (Mirrors interned vertex-layout
+// ids used by other engines.) The map is never pruned: layouts are a small,
+// process-stable set, so ids stay stable for the process lifetime.
+final Map<VertexLayoutDescriptor, int> _layoutIds = {};
+
+/// A stable, process-wide integer identity for [layout], shared by every
+/// structurally equal layout.
+///
+/// The default reflection-derived layout (a `null` layout, used by skinned
+/// geometry) is id `0`; described layouts are numbered from `1`. Pipeline
+/// caches include this in their key so two layouts on one vertex shader do
+/// not collide.
+@internal
+int vertexLayoutId(VertexLayoutDescriptor? layout) =>
+    layout == null ? 0 : (_layoutIds[layout] ??= _layoutIds.length + 1);

--- a/packages/flutter_scene/lib/src/gpu/render_pass_compat.dart
+++ b/packages/flutter_scene/lib/src/gpu/render_pass_compat.dart
@@ -3,10 +3,11 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 void bindVertexBufferCompat(
   gpu.RenderPass pass,
   gpu.BufferView bufferView,
-  int vertexCount,
-) {
+  int vertexCount, {
+  int slot = 0,
+}) {
   try {
-    (pass as dynamic).bindVertexBuffer(bufferView);
+    (pass as dynamic).bindVertexBuffer(bufferView, slot: slot);
   } on NoSuchMethodError {
     (pass as dynamic).bindVertexBuffer(bufferView, vertexCount);
   }

--- a/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
+++ b/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
@@ -29,6 +29,7 @@ import '../../../fscene/binary/fsceneb.dart';
 import '../../../fscene/property_value.dart';
 import '../../../fscene/scene_document.dart';
 import '../../../fscene/specs.dart';
+import '../../../geometry/interleaved_layout.dart';
 import '../../../texture/ktx2_image.dart';
 import '../gltf/accessor.dart';
 import '../gltf/bounds_baker.dart';
@@ -396,13 +397,30 @@ LocalId _buildGeometry(
     bufferViews: doc.bufferViews,
     bufferData: bufferData,
   );
+  // Unskinned geometry is stored de-interleaved (structure of arrays) so the
+  // realizer uploads each attribute straight to its own GPU buffer with no
+  // load-time reshuffle. Skinned geometry stays interleaved.
+  final Uint8List vertexBytes;
+  final String vertexLayout;
+  if (packed.isSkinned) {
+    vertexBytes = packed.vertexBytes;
+    vertexLayout = 'skinned';
+  } else {
+    vertexBytes = InterleavedLayoutAdapter.concatUnskinnedStreams(
+      InterleavedLayoutAdapter.splitUnskinnedAttributes(
+        ByteData.sublistView(packed.vertexBytes),
+        packed.vertexCount,
+      ),
+    );
+    vertexLayout = InterleavedLayoutAdapter.unskinnedSoaLayout;
+  }
   final vertices = document.addPayload(
     PayloadSpec(
       document.newId(),
       encoding: PayloadEncoding.vertexBuffer,
-      layout: packed.isSkinned ? 'skinned' : 'unskinned',
-      length: packed.vertexBytes.length,
-      bytes: packed.vertexBytes,
+      layout: vertexLayout,
+      length: vertexBytes.length,
+      bytes: vertexBytes,
     ),
   );
   final indices = document.addPayload(

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -22,6 +22,10 @@ class EngineLightingUniforms {
   /// 160..163). See the layout map in the implementation.
   static const fragInfoFloatCount = 164;
 
+  /// Index of the LOD cross-fade `fade` field in `FragInfo`, occupying std140
+  /// padding before `environment_transform` (so the block size is unchanged).
+  static const fadeIndex = 137;
+
   /// Writes the engine lighting / IBL / shadow fields of `FragInfo` into
   /// [fragInfo] from [lighting] and [env]. Leaves the material-specific fields
   /// (color, factors, alpha mode) untouched for the caller to fill.
@@ -30,6 +34,10 @@ class EngineLightingUniforms {
     Lighting lighting,
     EnvironmentMap env,
   ) {
+    // Default to fully drawn; a material with an active LOD cross-fade
+    // overwrites this. Without it the zero-initialized slot would discard
+    // every fragment.
+    fragInfo[fadeIndex] = 1.0;
     final light = lighting.directionalLight;
     final cascades = lighting.shadowMap == null
         ? const <ShadowCascade>[]

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -185,6 +185,14 @@ abstract class Material {
   /// material.
   bool doubleSided = false;
 
+  /// Per-draw level-of-detail cross-fade coverage, set by the encoder right
+  /// before [bind] and written into the material's `FragInfo.fade`. 1 draws
+  /// every fragment; a value in (0, 1) keeps that dithered fraction and a
+  /// negative value keeps the complement (see lod_fade.glsl). Only the
+  /// built-in lit and unlit materials honor it.
+  @internal
+  double lodFade = 1.0;
+
   gpu.Shader? _fragmentShader;
 
   /// The fragment shader used when rendering geometry with this material.

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -216,6 +216,7 @@ class PhysicallyBasedMaterial extends Material {
     fragInfo[125] = occlusionStrength;
     fragInfo[132] = alphaMode.index.toDouble();
     fragInfo[133] = alphaCutoff;
+    fragInfo[EngineLightingUniforms.fadeIndex] = lodFade;
     pass.bindUniform(
       fragmentShader.getUniformSlot("FragInfo"),
       transientsBuffer.emplace(ByteData.sublistView(fragInfo)),

--- a/packages/flutter_scene/lib/src/material/unlit_material.dart
+++ b/packages/flutter_scene/lib/src/material/unlit_material.dart
@@ -77,6 +77,7 @@ class UnlitMaterial extends Material {
       baseColorFactor.r, baseColorFactor.g,
       baseColorFactor.b, baseColorFactor.a, // color
       vertexColorWeight, // vertex_color_weight
+      lodFade, // fade
     ]);
     pass.bindUniform(
       fragmentShader.getUniformSlot("FragInfo"),

--- a/packages/flutter_scene/lib/src/raycast.dart
+++ b/packages/flutter_scene/lib/src/raycast.dart
@@ -177,12 +177,21 @@ void _testNodeMesh(
     final geometry = primitives[p].geometry;
     if (geometry.primitiveType != gpu.PrimitiveType.triangle) continue;
     final data = geometry.cpuMeshData;
-    final vertices = data.vertices;
-    if (vertices == null || data.vertexCount == 0) continue;
+    if (data.vertexCount == 0) continue;
 
-    final stride = vertices.lengthInBytes ~/ data.vertexCount;
-    if (stride != kUnskinnedPerVertexSize && stride != kSkinnedPerVertexSize) {
-      continue; // custom layout; not raycastable
+    // De-interleaved geometry exposes structure-of-arrays attributes;
+    // interleaved geometry exposes a single packed buffer. Either is
+    // raycastable; a custom interleaved layout (unexpected stride) is not.
+    final positions = data.positions;
+    final vertices = data.vertices;
+    int? stride;
+    if (positions == null) {
+      if (vertices == null) continue;
+      stride = vertices.lengthInBytes ~/ data.vertexCount;
+      if (stride != kUnskinnedPerVertexSize &&
+          stride != kSkinnedPerVertexSize) {
+        continue; // custom layout; not raycastable
+      }
     }
 
     // Node-local bounds early-out.
@@ -196,6 +205,8 @@ void _testNodeMesh(
       primitiveIndex: p,
       vertices: vertices,
       stride: stride,
+      positions: positions,
+      texCoords: data.texCoords,
       indices: data.indices,
       indexType: data.indexType,
       indexCount: data.indexCount,
@@ -225,13 +236,78 @@ typedef PackedTriangleHit = ({
   Vector3 localNormal,
 });
 
-/// Intersects [localRay] with the triangles of an engine-layout packed
+/// Intersects [localRay] with the triangles of an engine-layout interleaved
 /// vertex buffer (and optional index buffer), emitting one record per hit
 /// (both faces). Pure math over the packed bytes; exposed for testing.
 @visibleForTesting
 void intersectPackedTriangles({
   required ByteData vertices,
   required int stride,
+  required ByteData? indices,
+  required gpu.IndexType indexType,
+  required int indexCount,
+  required int vertexCount,
+  required Ray localRay,
+  required double maxDistance,
+  required void Function(PackedTriangleHit) emit,
+}) {
+  _intersectTriangles(
+    getPosition: (v) => Vector3(
+      vertices.getFloat32(v * stride + _positionOffset, Endian.little),
+      vertices.getFloat32(v * stride + _positionOffset + 4, Endian.little),
+      vertices.getFloat32(v * stride + _positionOffset + 8, Endian.little),
+    ),
+    getTexCoord: (v) => Vector2(
+      vertices.getFloat32(v * stride + _texCoordOffset, Endian.little),
+      vertices.getFloat32(v * stride + _texCoordOffset + 4, Endian.little),
+    ),
+    indices: indices,
+    indexType: indexType,
+    indexCount: indexCount,
+    vertexCount: vertexCount,
+    localRay: localRay,
+    maxDistance: maxDistance,
+    emit: emit,
+  );
+}
+
+/// Structure-of-arrays variant: position (3 floats/vertex) and optional
+/// texture coordinates (2 floats/vertex) come from separate lists. Exposed
+/// for testing.
+@visibleForTesting
+void intersectSoATriangles({
+  required Float32List positions,
+  Float32List? texCoords,
+  required ByteData? indices,
+  required gpu.IndexType indexType,
+  required int indexCount,
+  required int vertexCount,
+  required Ray localRay,
+  required double maxDistance,
+  required void Function(PackedTriangleHit) emit,
+}) {
+  _intersectTriangles(
+    getPosition: (v) =>
+        Vector3(positions[v * 3], positions[v * 3 + 1], positions[v * 3 + 2]),
+    getTexCoord: texCoords == null
+        ? null
+        : (v) => Vector2(texCoords[v * 2], texCoords[v * 2 + 1]),
+    indices: indices,
+    indexType: indexType,
+    indexCount: indexCount,
+    vertexCount: vertexCount,
+    localRay: localRay,
+    maxDistance: maxDistance,
+    emit: emit,
+  );
+}
+
+/// The layout-agnostic triangle intersection core. Reads position (and
+/// optional texcoord) through accessors so it serves both the interleaved
+/// and structure-of-arrays vertex layouts.
+void _intersectTriangles({
+  required Vector3 Function(int) getPosition,
+  Vector2 Function(int)? getTexCoord,
   required ByteData? indices,
   required gpu.IndexType indexType,
   required int indexCount,
@@ -248,12 +324,6 @@ void intersectPackedTriangles({
         : indices.getUint32(i * 4, Endian.little);
   }
 
-  Vector3 position(int v) => Vector3(
-    vertices.getFloat32(v * stride + _positionOffset, Endian.little),
-    vertices.getFloat32(v * stride + _positionOffset + 4, Endian.little),
-    vertices.getFloat32(v * stride + _positionOffset + 8, Endian.little),
-  );
-
   final origin = localRay.origin;
   final direction = localRay.direction;
 
@@ -261,9 +331,9 @@ void intersectPackedTriangles({
     final i0 = vertexIndex(t * 3);
     final i1 = vertexIndex(t * 3 + 1);
     final i2 = vertexIndex(t * 3 + 2);
-    final a = position(i0);
-    final b = position(i1);
-    final c = position(i2);
+    final a = getPosition(i0);
+    final b = getPosition(i1);
+    final c = getPosition(i2);
 
     // Moller-Trumbore, both faces.
     final edge1 = b - a;
@@ -281,20 +351,18 @@ void intersectPackedTriangles({
     final rayT = edge2.dot(qvec) * invDet;
     if (rayT <= 0.0 || rayT > maxDistance) continue;
 
-    // The engine's fixed vertex layouts always carry tex_coords, so uv is
-    // non-null for every standard-layout hit (the hit field stays nullable
-    // for future custom layouts).
     final w = 1.0 - u - v;
-    Vector2 texCoord(int vtx) => Vector2(
-      vertices.getFloat32(vtx * stride + _texCoordOffset, Endian.little),
-      vertices.getFloat32(vtx * stride + _texCoordOffset + 4, Endian.little),
-    );
+    // The engine's fixed vertex layouts always carry tex_coords; uv is zero
+    // only for a custom layout that omits them.
+    final uv = getTexCoord == null
+        ? Vector2.zero()
+        : getTexCoord(i0) * w + getTexCoord(i1) * u + getTexCoord(i2) * v;
 
     emit((
       t: rayT,
       barycentrics: Vector3(w, u, v),
       triangleIndex: t,
-      uv: texCoord(i0) * w + texCoord(i1) * u + texCoord(i2) * v,
+      uv: uv,
       localNormal: edge1.cross(edge2)..normalize(),
     ));
   }
@@ -303,8 +371,10 @@ void intersectPackedTriangles({
 void _testTriangles({
   required Node node,
   required int primitiveIndex,
-  required ByteData vertices,
-  required int stride,
+  ByteData? vertices,
+  int? stride,
+  Float32List? positions,
+  Float32List? texCoords,
   required ByteData? indices,
   required gpu.IndexType indexType,
   required int indexCount,
@@ -316,35 +386,51 @@ void _testTriangles({
   required double maxDistance,
   required void Function(SceneRaycastHit) emit,
 }) {
-  intersectPackedTriangles(
-    vertices: vertices,
-    stride: stride,
-    indices: indices,
-    indexType: indexType,
-    indexCount: indexCount,
-    vertexCount: vertexCount,
-    localRay: localRay,
-    maxDistance: maxDistance,
-    emit: (hit) {
-      // hit.t is in world units because the local direction is the
-      // transformed (unnormalized) world unit direction.
-      final worldPoint = worldOrigin + worldDirection * hit.t;
-      final worldNormal = _transformNormal(worldTransform, hit.localNormal);
-      if (worldNormal.dot(worldDirection) > 0) worldNormal.negate();
-      emit(
-        SceneRaycastHit(
-          node: node,
-          distance: hit.t,
-          worldPoint: worldPoint,
-          worldNormal: worldNormal,
-          uv: hit.uv,
-          barycentrics: hit.barycentrics,
-          triangleIndex: hit.triangleIndex,
-          primitiveIndex: primitiveIndex,
-        ),
-      );
-    },
-  );
+  void onHit(PackedTriangleHit hit) {
+    // hit.t is in world units because the local direction is the
+    // transformed (unnormalized) world unit direction.
+    final worldPoint = worldOrigin + worldDirection * hit.t;
+    final worldNormal = _transformNormal(worldTransform, hit.localNormal);
+    if (worldNormal.dot(worldDirection) > 0) worldNormal.negate();
+    emit(
+      SceneRaycastHit(
+        node: node,
+        distance: hit.t,
+        worldPoint: worldPoint,
+        worldNormal: worldNormal,
+        uv: hit.uv,
+        barycentrics: hit.barycentrics,
+        triangleIndex: hit.triangleIndex,
+        primitiveIndex: primitiveIndex,
+      ),
+    );
+  }
+
+  if (positions != null) {
+    intersectSoATriangles(
+      positions: positions,
+      texCoords: texCoords,
+      indices: indices,
+      indexType: indexType,
+      indexCount: indexCount,
+      vertexCount: vertexCount,
+      localRay: localRay,
+      maxDistance: maxDistance,
+      emit: onHit,
+    );
+  } else {
+    intersectPackedTriangles(
+      vertices: vertices!,
+      stride: stride!,
+      indices: indices,
+      indexType: indexType,
+      indexCount: indexCount,
+      vertexCount: vertexCount,
+      localRay: localRay,
+      maxDistance: maxDistance,
+      emit: onHit,
+    );
+  }
 }
 
 /// Applies the linear part of [transform]'s inverse transpose to [normal],

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -9,19 +9,13 @@ import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/render/render_layers.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
+import 'package:flutter_scene/src/scene_encoder.dart' show resolvePipeline;
 import 'package:flutter_scene/src/shaders.dart';
 
 /// Render-graph blackboard key under which [DepthPrepass] publishes the
 /// camera linear-depth texture: planar view-space depth (world units) in
 /// the red channel, with the far value where no geometry was drawn.
 const String kLinearDepthBlackboardKey = 'linear_depth';
-
-/// Process-lifetime cache of depth-prepass render pipelines, keyed by
-/// vertex shader. The fragment shader is constant, so only the (skinned /
-/// unskinned) vertex shader varies; the engine loads each shader once, so
-/// the prepass only ever needs two pipelines. Caching them avoids
-/// rebuilding a pipeline per draw, every frame.
-final Map<gpu.Shader, gpu.RenderPipeline> _depthPipelineCache = {};
 
 /// Renders the opaque scene's depth from the camera into a linear-depth
 /// color target and publishes it on the render-graph blackboard.
@@ -186,13 +180,11 @@ class _DepthPrepassEncoder {
       }
     }
     _renderPass.clearBindings();
-    final pipeline = _depthPipelineCache[item.geometry.vertexShader] ??= gpu
-        .gpuContext
-        .createRenderPipeline(
-          item.geometry.vertexShader,
-          _depthShader,
-          vertexLayout: item.geometry.instancedVertexLayout,
-        );
+    final pipeline = resolvePipeline(
+      item.geometry.vertexShader,
+      _depthShader,
+      vertexLayout: item.geometry.instancedVertexLayout,
+    );
     if (!identical(_boundPipeline, pipeline)) {
       _renderPass.bindPipeline(pipeline);
       _boundPipeline = pipeline;

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -208,7 +208,7 @@ class _DepthPrepassEncoder {
     // transform passed here, since skinned uses joint matrices).
     void bindDraw(Matrix4 worldTransform) {
       if (depthVertex != null) {
-        geometry.bindGeometryBuffers(_renderPass);
+        geometry.bindPositionStream(_renderPass);
         bindUnskinnedFrameInfo(
           _renderPass,
           _transientsBuffer,

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -6,6 +6,8 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/geometry/geometry.dart'
+    show bindUnskinnedFrameInfo;
 import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/render/render_layers.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
@@ -180,33 +182,57 @@ class _DepthPrepassEncoder {
       }
     }
     _renderPass.clearBindings();
+    final geometry = item.geometry;
+    // Unskinned geometry draws depth through a position-only shader and layout
+    // (fetching only position); skinned geometry has no such variant, so it
+    // falls back to its full vertex shader and bind.
+    final depthVertex = geometry.depthOnlyVertex;
     final pipeline = resolvePipeline(
-      item.geometry.vertexShader,
+      depthVertex?.shader ?? geometry.vertexShader,
       _depthShader,
-      vertexLayout: item.geometry.instancedVertexLayout,
+      vertexLayout: depthVertex?.layout ?? geometry.instancedVertexLayout,
     );
     if (!identical(_boundPipeline, pipeline)) {
       _renderPass.bindPipeline(pipeline);
       _boundPipeline = pipeline;
     }
-    _renderPass.setPrimitiveType(item.geometry.primitiveType);
+    _renderPass.setPrimitiveType(geometry.primitiveType);
     _renderPass.bindUniform(
       _depthShader.getUniformSlot('DepthInfo'),
       _transientsBuffer.emplace(ByteData.sublistView(_depthInfo)),
     );
 
+    // Binds the vertex/index buffers and the per-frame uniform for one draw.
+    // The position-only path resolves FrameInfo against the depth shader; the
+    // skinned fallback uses the geometry's own bind (which ignores the model
+    // transform passed here, since skinned uses joint matrices).
+    void bindDraw(Matrix4 worldTransform) {
+      if (depthVertex != null) {
+        geometry.bindGeometryBuffers(_renderPass);
+        bindUnskinnedFrameInfo(
+          _renderPass,
+          _transientsBuffer,
+          depthVertex.shader,
+          _cameraTransform,
+          _cameraPosition,
+        );
+      } else {
+        geometry.bind(
+          _renderPass,
+          _transientsBuffer,
+          worldTransform,
+          _cameraTransform,
+          _cameraPosition,
+        );
+      }
+    }
+
     final instances = item.instanceTransforms;
     if (instances != null) {
-      if (item.geometry.instancedVertexLayout == null) {
+      if (geometry.instancedVertexLayout == null) {
         // Skinned geometry has no instance-attribute path; loop.
         for (final instanceTransform in instances) {
-          item.geometry.bind(
-            _renderPass,
-            _transientsBuffer,
-            item.worldTransform * instanceTransform,
-            _cameraTransform,
-            _cameraPosition,
-          );
+          bindDraw(item.worldTransform * instanceTransform);
           final flip =
               item.windingFlipped != (instanceTransform.determinant() < 0);
           _renderPass.setWindingOrder(
@@ -214,17 +240,11 @@ class _DepthPrepassEncoder {
                 ? gpu.WindingOrder.clockwise
                 : gpu.WindingOrder.counterClockwise,
           );
-          item.geometry.draw(_renderPass);
+          geometry.draw(_renderPass);
         }
         return;
       }
-      item.geometry.bind(
-        _renderPass,
-        _transientsBuffer,
-        item.worldTransform,
-        _cameraTransform,
-        _cameraPosition,
-      );
+      bindDraw(item.worldTransform);
       final packed = packInstanceTransforms(
         item.worldTransform,
         instances,
@@ -233,24 +253,18 @@ class _DepthPrepassEncoder {
       if (packed.ccwCount > 0) {
         bindInstanceTransforms(_renderPass, packed.ccw);
         _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
-        item.geometry.draw(_renderPass, instanceCount: packed.ccwCount);
+        geometry.draw(_renderPass, instanceCount: packed.ccwCount);
       }
       if (packed.cwCount > 0) {
         bindInstanceTransforms(_renderPass, packed.cw);
         _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
-        item.geometry.draw(_renderPass, instanceCount: packed.cwCount);
+        geometry.draw(_renderPass, instanceCount: packed.cwCount);
       }
       return;
     }
 
-    item.geometry.bind(
-      _renderPass,
-      _transientsBuffer,
-      item.worldTransform,
-      _cameraTransform,
-      _cameraPosition,
-    );
-    if (item.geometry.instancedVertexLayout != null) {
+    bindDraw(item.worldTransform);
+    if (geometry.instancedVertexLayout != null) {
       bindSingleInstanceTransform(_renderPass, item.worldTransform);
     }
     _renderPass.setWindingOrder(
@@ -258,6 +272,6 @@ class _DepthPrepassEncoder {
           ? gpu.WindingOrder.clockwise
           : gpu.WindingOrder.counterClockwise,
     );
-    item.geometry.draw(_renderPass);
+    geometry.draw(_renderPass);
   }
 }

--- a/packages/flutter_scene/lib/src/render/instance_packing.dart
+++ b/packages/flutter_scene/lib/src/render/instance_packing.dart
@@ -64,8 +64,16 @@ PackedInstanceTransforms packInstanceTransforms(
 /// Every draw through the unskinned vertex shader needs this: the model
 /// matrix arrives via instance attributes whether or not the draw is
 /// instanced.
-void bindSingleInstanceTransform(gpu.RenderPass pass, Matrix4 worldTransform) {
-  bindInstanceTransforms(pass, Float32List.fromList(worldTransform.storage));
+void bindSingleInstanceTransform(
+  gpu.RenderPass pass,
+  Matrix4 worldTransform, {
+  int slot = 1,
+}) {
+  bindInstanceTransforms(
+    pass,
+    Float32List.fromList(worldTransform.storage),
+    slot: slot,
+  );
 }
 
 /// Uploads [packed] transforms and binds them to the instance-rate slot.
@@ -77,13 +85,17 @@ void bindSingleInstanceTransform(gpu.RenderPass pass, Matrix4 worldTransform) {
 /// (flutter/flutter#187931, buffer writes racing the GL upload) that a
 /// dedicated buffer does not actually avoid. Kept for now since it is
 /// harmless and the engine fix has not shipped in the SDK yet.
-void bindInstanceTransforms(gpu.RenderPass pass, Float32List packed) {
+void bindInstanceTransforms(
+  gpu.RenderPass pass,
+  Float32List packed, {
+  int slot = 1,
+}) {
   // TODO(gles-dirty-range): fold instance transforms back into the shared
   // transients HostBuffer once flutter/flutter#187931 is fixed in the SDK.
   if (packed.isEmpty) return;
   pass.bindVertexBuffer(
     instanceTransformBuffers.emplace(ByteData.sublistView(packed)),
-    slot: 1,
+    slot: slot,
   );
 }
 

--- a/packages/flutter_scene/lib/src/render/lod.dart
+++ b/packages/flutter_scene/lib/src/render/lod.dart
@@ -85,6 +85,44 @@ int selectLodLevel(
   return naive;
 }
 
+/// The level(s) to draw for a projected [screenSize] when cross-fading, each
+/// with a fade weight in `(0, 1]`. Returns one entry away from a boundary,
+/// two complementary entries (fades summing to 1) inside a boundary's blend
+/// band so the encoder can dither-blend them, the last level alone fading out
+/// across the cull band, or an empty list to cull.
+///
+/// [thresholds] are the same descending list as [selectLodLevel]. [blendRange]
+/// is the half-width of each band as a fraction of the threshold; `0` reduces
+/// to a hard switch (one level or cull). Bands must not overlap, so keep
+/// [blendRange] smaller than the relative gap between adjacent thresholds.
+List<({int level, double fade})> blendLodLevels(
+  double screenSize,
+  List<double> thresholds, {
+  double blendRange = 0.1,
+}) {
+  final count = thresholds.length;
+  if (blendRange > 0) {
+    for (var k = 0; k < count; k++) {
+      final lo = thresholds[k] * (1 - blendRange);
+      final hi = thresholds[k] * (1 + blendRange);
+      if (screenSize >= lo && screenSize < hi) {
+        // Boundary k sits between level k (above) and level k+1 or, for the
+        // last threshold, the cull floor (below). Fade from the lower to the
+        // upper level across the band.
+        final t = (screenSize - lo) / (hi - lo);
+        return [
+          (level: k, fade: t),
+          if (k + 1 < count) (level: k + 1, fade: 1 - t),
+        ];
+      }
+    }
+  }
+  for (var i = 0; i < count; i++) {
+    if (screenSize >= thresholds[i]) return [(level: i, fade: 1.0)];
+  }
+  return const [];
+}
+
 /// One level of detail for an [LodComponent]: a drawable variant shown while
 /// the object's projected on-screen size (see [lodScreenSize]) is at least
 /// [screenSize], a fraction of the viewport height.

--- a/packages/flutter_scene/lib/src/render/lod.dart
+++ b/packages/flutter_scene/lib/src/render/lod.dart
@@ -160,13 +160,17 @@ class LodLevel {
 /// the hysteresis memory is shared (acceptable for V1; per-view selection is
 /// a later refinement).
 class LodSelection {
-  LodSelection(this.levels, {this.lodBias = 1.0, this.hysteresis = 0.1})
-    : assert(levels.isNotEmpty, 'LOD needs at least one level'),
-      assert(
-        _strictlyDescending(levels),
-        'LOD level screenSize thresholds must strictly descend',
-      ),
-      _thresholds = [for (final level in levels) level.screenSize];
+  LodSelection(
+    this.levels, {
+    this.lodBias = 1.0,
+    this.hysteresis = 0.1,
+    this.blendRange = 0.0,
+  }) : assert(levels.isNotEmpty, 'LOD needs at least one level'),
+       assert(
+         _strictlyDescending(levels),
+         'LOD level screenSize thresholds must strictly descend',
+       ),
+       _thresholds = [for (final level in levels) level.screenSize];
 
   static bool _strictlyDescending(List<LodLevel> levels) {
     for (var i = 1; i < levels.length; i++) {
@@ -179,25 +183,44 @@ class LodSelection {
   final List<LodLevel> levels;
 
   /// Multiplies the projected size before selection. Above `1` keeps higher
-  /// detail at a greater distance; below `1` drops detail sooner.
-  final double lodBias;
+  /// detail at a greater distance; below `1` drops detail sooner. Mutable so
+  /// the detail bias can be tuned at runtime (a quality setting).
+  double lodBias;
 
-  /// Fractional dead-band around each threshold; see [selectLodLevel].
+  /// Fractional dead-band around each threshold; see [selectLodLevel]. Used
+  /// only by the hard-switch path ([blendRange] of `0`).
   final double hysteresis;
+
+  /// Half-width of the cross-fade band as a fraction of each threshold. `0`
+  /// hard-switches; a positive value dither-blends adjacent levels across the
+  /// band. Mutable so cross-fade can be toggled at runtime. See
+  /// [blendLodLevels].
+  double blendRange;
 
   final List<double> _thresholds;
   int _currentLevel = -1;
 
-  /// Selects the level index for a projected [screenSize], or `-1` to cull,
-  /// applying [lodBias] and the [hysteresis] dead-band, and remembering the
-  /// result for next frame.
-  int select(double screenSize) {
+  /// The level(s) to draw for a projected [screenSize], each with a fade
+  /// coverage for [Material.lodFade], or an empty list to cull. Applies
+  /// [lodBias]. With [blendRange] greater than `0` a boundary crossing returns
+  /// two entries (the coarser carrying a negative complement coverage) to
+  /// dither-blend; otherwise one level chosen with the [hysteresis] dead-band.
+  List<({int level, double fade})> resolve(double screenSize) {
+    final size = screenSize * lodBias;
+    if (blendRange > 0) {
+      final blended = blendLodLevels(size, _thresholds, blendRange: blendRange);
+      if (blended.length == 2) {
+        // Draw the coarser level through the complementary dither pattern.
+        return [blended[0], (level: blended[1].level, fade: -blended[1].fade)];
+      }
+      return blended;
+    }
     _currentLevel = selectLodLevel(
-      screenSize * lodBias,
+      size,
       _thresholds,
       hysteresis: hysteresis,
       currentLevel: _currentLevel,
     );
-    return _currentLevel;
+    return _currentLevel < 0 ? const [] : [(level: _currentLevel, fade: 1.0)];
   }
 }

--- a/packages/flutter_scene/lib/src/render/lod.dart
+++ b/packages/flutter_scene/lib/src/render/lod.dart
@@ -1,0 +1,83 @@
+import 'dart:math' as math;
+
+import 'package:vector_math/vector_math.dart';
+
+/// The projected on-screen size of a world-space bounding sphere, as a
+/// fraction of the viewport height.
+///
+/// A value of `1.0` means the sphere's diameter spans the full viewport
+/// height; `0.5` means half. This is the level-of-detail selection metric:
+/// unlike raw camera distance it is field-of-view aware (a wider lens makes
+/// everything smaller) and resolution independent (it is a fraction, not a
+/// pixel count), matching how the major engines drive LOD.
+///
+/// [center] and [radius] are the sphere in world space, [cameraPosition] is
+/// the eye, and [fovRadiansY] is the camera's vertical field of view. The
+/// camera sitting inside the sphere yields [double.infinity] (treat as the
+/// highest detail).
+double lodScreenSize({
+  required Vector3 center,
+  required double radius,
+  required Vector3 cameraPosition,
+  required double fovRadiansY,
+}) {
+  final distance = center.distanceTo(cameraPosition);
+  if (distance <= radius) return double.infinity;
+  // The viewport spans 2 * distance * tan(fovY / 2) world units at the
+  // sphere's depth, so the sphere's diameter (2 * radius) covers
+  // radius / (distance * tan(fovY / 2)) of the height.
+  return radius / (distance * math.tan(fovRadiansY / 2));
+}
+
+/// Selects the level-of-detail index for a projected [screenSize] against a
+/// list of [thresholds], or `-1` to cull (draw nothing).
+///
+/// [thresholds] are ordered highest detail first with descending values:
+/// `thresholds[i]` is the smallest [screenSize] at which level `i` is used.
+/// The last (smallest) threshold doubles as the cull floor, so a size below
+/// it culls the object; set the last threshold to `0` to never cull.
+///
+/// [currentLevel] is the level selected last frame (or `-1` if culled), and
+/// [hysteresis] is a fractional dead-band around each boundary. With a
+/// nonzero margin an adjacent level change only happens once the size moves
+/// clearly past the boundary, so a size hovering on a threshold does not
+/// flip-flop. Larger jumps (a fast camera move) switch immediately.
+int selectLodLevel(
+  double screenSize,
+  List<double> thresholds, {
+  double hysteresis = 0.0,
+  int currentLevel = -1,
+}) {
+  assert(thresholds.isNotEmpty, 'LOD needs at least one level');
+  var naive = -1;
+  for (var i = 0; i < thresholds.length; i++) {
+    if (screenSize >= thresholds[i]) {
+      naive = i;
+      break;
+    }
+  }
+  if (naive == currentLevel || hysteresis <= 0) return naive;
+
+  final last = thresholds.length - 1;
+  // Switch to finer detail only once clearly past the upper boundary.
+  if (currentLevel >= 1 && naive == currentLevel - 1) {
+    return screenSize >= thresholds[currentLevel - 1] * (1 + hysteresis)
+        ? naive
+        : currentLevel;
+  }
+  // Switch to coarser detail only once clearly below the lower boundary.
+  if (currentLevel >= 0 && naive == currentLevel + 1) {
+    return screenSize < thresholds[currentLevel] * (1 - hysteresis)
+        ? naive
+        : currentLevel;
+  }
+  // The cull floor is just the boundary below the last level.
+  if (currentLevel == last && naive == -1) {
+    return screenSize < thresholds[last] * (1 - hysteresis) ? -1 : currentLevel;
+  }
+  if (currentLevel == -1 && naive == last) {
+    return screenSize >= thresholds[last] * (1 + hysteresis) ? naive : -1;
+  }
+  // A multi-level jump (or any non-adjacent change) switches immediately.
+  return naive;
+}

--- a/packages/flutter_scene/lib/src/render/lod.dart
+++ b/packages/flutter_scene/lib/src/render/lod.dart
@@ -2,6 +2,9 @@ import 'dart:math' as math;
 
 import 'package:vector_math/vector_math.dart';
 
+import 'package:flutter_scene/src/geometry/geometry.dart';
+import 'package:flutter_scene/src/material/material.dart';
+
 /// The projected on-screen size of a world-space bounding sphere, as a
 /// fraction of the viewport height.
 ///
@@ -80,4 +83,83 @@ int selectLodLevel(
   }
   // A multi-level jump (or any non-adjacent change) switches immediately.
   return naive;
+}
+
+/// One level of detail for an [LodComponent]: a drawable variant shown while
+/// the object's projected on-screen size (see [lodScreenSize]) is at least
+/// [screenSize], a fraction of the viewport height.
+///
+/// Levels are listed highest detail first, with strictly descending
+/// [screenSize] thresholds. The smallest threshold is the cull floor: below
+/// it the object is not drawn. Set the last level's [screenSize] to `0` to
+/// never cull.
+/// {@category Scene graph}
+class LodLevel {
+  /// A level drawing [geometry] with [material] down to a [screenSize]
+  /// fraction of the viewport height.
+  const LodLevel({
+    required this.geometry,
+    required this.material,
+    required this.screenSize,
+  });
+
+  /// The geometry drawn at this level.
+  final Geometry geometry;
+
+  /// The material drawn at this level.
+  final Material material;
+
+  /// The smallest projected size (fraction of viewport height) at which this
+  /// level is used.
+  final double screenSize;
+}
+
+/// The per-item level-of-detail state the encoder consults each frame: the
+/// ordered [levels], the policy ([lodBias], [hysteresis]), and the level
+/// selected last frame so the hysteresis dead-band has memory.
+///
+/// One instance is shared by the item across views, so in a multi-view frame
+/// the hysteresis memory is shared (acceptable for V1; per-view selection is
+/// a later refinement).
+class LodSelection {
+  LodSelection(this.levels, {this.lodBias = 1.0, this.hysteresis = 0.1})
+    : assert(levels.isNotEmpty, 'LOD needs at least one level'),
+      assert(
+        _strictlyDescending(levels),
+        'LOD level screenSize thresholds must strictly descend',
+      ),
+      _thresholds = [for (final level in levels) level.screenSize];
+
+  static bool _strictlyDescending(List<LodLevel> levels) {
+    for (var i = 1; i < levels.length; i++) {
+      if (levels[i].screenSize >= levels[i - 1].screenSize) return false;
+    }
+    return true;
+  }
+
+  /// The drawable variants, highest detail first.
+  final List<LodLevel> levels;
+
+  /// Multiplies the projected size before selection. Above `1` keeps higher
+  /// detail at a greater distance; below `1` drops detail sooner.
+  final double lodBias;
+
+  /// Fractional dead-band around each threshold; see [selectLodLevel].
+  final double hysteresis;
+
+  final List<double> _thresholds;
+  int _currentLevel = -1;
+
+  /// Selects the level index for a projected [screenSize], or `-1` to cull,
+  /// applying [lodBias] and the [hysteresis] dead-band, and remembering the
+  /// result for next frame.
+  int select(double screenSize) {
+    _currentLevel = selectLodLevel(
+      screenSize * lodBias,
+      _thresholds,
+      hysteresis: hysteresis,
+      currentLevel: _currentLevel,
+    );
+    return _currentLevel;
+  }
 }

--- a/packages/flutter_scene/lib/src/render/object_filter.dart
+++ b/packages/flutter_scene/lib/src/render/object_filter.dart
@@ -167,7 +167,7 @@ class _ObjectMaskEncoder {
     // Binds the vertex/index buffers and the per-frame uniform for one draw.
     void bindDraw(Matrix4 worldTransform) {
       if (depthVertex != null) {
-        geometry.bindGeometryBuffers(_renderPass);
+        geometry.bindPositionStream(_renderPass);
         bindUnskinnedFrameInfo(
           _renderPass,
           _transientsBuffer,

--- a/packages/flutter_scene/lib/src/render/object_filter.dart
+++ b/packages/flutter_scene/lib/src/render/object_filter.dart
@@ -5,6 +5,7 @@ import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/render/instance_packing.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
+import 'package:flutter_scene/src/scene_encoder.dart' show resolvePipeline;
 import 'package:flutter_scene/src/shaders.dart';
 
 /// Selects which scene nodes an object-filtered draw includes.
@@ -44,11 +45,6 @@ class NodeFilter {
     return true;
   }
 }
-
-/// Process-lifetime cache of flat-fill pipelines, keyed by vertex shader
-/// (skinned vs unskinned). The fragment shader is constant, so at most two
-/// pipelines exist.
-final Map<gpu.Shader, gpu.RenderPipeline> _maskPipelineCache = {};
 
 /// Draws a filtered set of the scene's geometry flat into [target], each
 /// item filled with a solid color (coverage in alpha), with its own cleared
@@ -141,13 +137,11 @@ class _ObjectMaskEncoder {
       }
     }
     _renderPass.clearBindings();
-    final pipeline = _maskPipelineCache[item.geometry.vertexShader] ??= gpu
-        .gpuContext
-        .createRenderPipeline(
-          item.geometry.vertexShader,
-          _maskShader,
-          vertexLayout: item.geometry.instancedVertexLayout,
-        );
+    final pipeline = resolvePipeline(
+      item.geometry.vertexShader,
+      _maskShader,
+      vertexLayout: item.geometry.instancedVertexLayout,
+    );
     if (!identical(_boundPipeline, pipeline)) {
       _renderPass.bindPipeline(pipeline);
       _boundPipeline = pipeline;

--- a/packages/flutter_scene/lib/src/render/object_filter.dart
+++ b/packages/flutter_scene/lib/src/render/object_filter.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 
+import 'package:flutter_scene/src/geometry/geometry.dart'
+    show bindUnskinnedFrameInfo;
 import 'package:flutter_scene/src/render/instance_packing.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/scene_encoder.dart' show resolvePipeline;
@@ -137,16 +139,20 @@ class _ObjectMaskEncoder {
       }
     }
     _renderPass.clearBindings();
+    final geometry = item.geometry;
+    // Unskinned geometry fills the mask through a position-only shader and
+    // layout; skinned geometry falls back to its full vertex shader and bind.
+    final depthVertex = geometry.depthOnlyVertex;
     final pipeline = resolvePipeline(
-      item.geometry.vertexShader,
+      depthVertex?.shader ?? geometry.vertexShader,
       _maskShader,
-      vertexLayout: item.geometry.instancedVertexLayout,
+      vertexLayout: depthVertex?.layout ?? geometry.instancedVertexLayout,
     );
     if (!identical(_boundPipeline, pipeline)) {
       _renderPass.bindPipeline(pipeline);
       _boundPipeline = pipeline;
     }
-    _renderPass.setPrimitiveType(item.geometry.primitiveType);
+    _renderPass.setPrimitiveType(geometry.primitiveType);
     final highlight = _colorOf(item);
     final color = Float32List(4)
       ..[0] = highlight.x
@@ -158,17 +164,33 @@ class _ObjectMaskEncoder {
       _transientsBuffer.emplace(ByteData.sublistView(color)),
     );
 
+    // Binds the vertex/index buffers and the per-frame uniform for one draw.
+    void bindDraw(Matrix4 worldTransform) {
+      if (depthVertex != null) {
+        geometry.bindGeometryBuffers(_renderPass);
+        bindUnskinnedFrameInfo(
+          _renderPass,
+          _transientsBuffer,
+          depthVertex.shader,
+          _cameraTransform,
+          _cameraPosition,
+        );
+      } else {
+        geometry.bind(
+          _renderPass,
+          _transientsBuffer,
+          worldTransform,
+          _cameraTransform,
+          _cameraPosition,
+        );
+      }
+    }
+
     final instances = item.instanceTransforms;
     if (instances != null) {
-      if (item.geometry.instancedVertexLayout == null) {
+      if (geometry.instancedVertexLayout == null) {
         for (final instanceTransform in instances) {
-          item.geometry.bind(
-            _renderPass,
-            _transientsBuffer,
-            item.worldTransform * instanceTransform,
-            _cameraTransform,
-            _cameraPosition,
-          );
+          bindDraw(item.worldTransform * instanceTransform);
           final flip =
               item.windingFlipped != (instanceTransform.determinant() < 0);
           _renderPass.setWindingOrder(
@@ -176,17 +198,11 @@ class _ObjectMaskEncoder {
                 ? gpu.WindingOrder.clockwise
                 : gpu.WindingOrder.counterClockwise,
           );
-          item.geometry.draw(_renderPass);
+          geometry.draw(_renderPass);
         }
         return;
       }
-      item.geometry.bind(
-        _renderPass,
-        _transientsBuffer,
-        item.worldTransform,
-        _cameraTransform,
-        _cameraPosition,
-      );
+      bindDraw(item.worldTransform);
       final packed = packInstanceTransforms(
         item.worldTransform,
         instances,
@@ -195,24 +211,18 @@ class _ObjectMaskEncoder {
       if (packed.ccwCount > 0) {
         bindInstanceTransforms(_renderPass, packed.ccw);
         _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
-        item.geometry.draw(_renderPass, instanceCount: packed.ccwCount);
+        geometry.draw(_renderPass, instanceCount: packed.ccwCount);
       }
       if (packed.cwCount > 0) {
         bindInstanceTransforms(_renderPass, packed.cw);
         _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
-        item.geometry.draw(_renderPass, instanceCount: packed.cwCount);
+        geometry.draw(_renderPass, instanceCount: packed.cwCount);
       }
       return;
     }
 
-    item.geometry.bind(
-      _renderPass,
-      _transientsBuffer,
-      item.worldTransform,
-      _cameraTransform,
-      _cameraPosition,
-    );
-    if (item.geometry.instancedVertexLayout != null) {
+    bindDraw(item.worldTransform);
+    if (geometry.instancedVertexLayout != null) {
       bindSingleInstanceTransform(_renderPass, item.worldTransform);
     }
     _renderPass.setWindingOrder(
@@ -220,6 +230,6 @@ class _ObjectMaskEncoder {
           ? gpu.WindingOrder.clockwise
           : gpu.WindingOrder.counterClockwise,
     );
-    item.geometry.draw(_renderPass);
+    geometry.draw(_renderPass);
   }
 }

--- a/packages/flutter_scene/lib/src/render/render_scene.dart
+++ b/packages/flutter_scene/lib/src/render/render_scene.dart
@@ -6,6 +6,7 @@ import 'package:flutter_scene/src/components/environment_volume_component.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/render/bvh.dart';
+import 'package:flutter_scene/src/render/lod.dart';
 import 'package:flutter_scene/src/render/render_layers.dart';
 
 /// One drawable primitive in the flat render layer.
@@ -23,6 +24,13 @@ class RenderItem {
 
   /// Shader and per-material parameters.
   final Material material;
+
+  /// Level-of-detail state, set by an [LodComponent] when the item is
+  /// registered. When non-null the encoder picks one of its levels per view
+  /// (or culls) from the item's projected screen size, instead of drawing
+  /// [geometry] and [material]. Those serve as the highest-detail fallback
+  /// and the source of [cullBounds].
+  LodSelection? lod;
 
   /// The `Node` that owns this item, set once when the item is registered.
   ///

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_scene/src/geometry/geometry.dart'
+    show bindUnskinnedFrameInfo;
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/render/instance_packing.dart';
 import 'package:vector_math/vector_math.dart';
@@ -65,29 +67,51 @@ class ShadowEncoder {
       }
     }
     _renderPass.clearBindings();
+    final geometry = item.geometry;
+    // Unskinned casters draw depth through a position-only shader and layout;
+    // skinned geometry falls back to its full vertex shader and bind.
+    final depthVertex = geometry.depthOnlyVertex;
     final pipeline = resolvePipeline(
-      item.geometry.vertexShader,
+      depthVertex?.shader ?? geometry.vertexShader,
       _depthShader,
-      vertexLayout: item.geometry.instancedVertexLayout,
+      vertexLayout: depthVertex?.layout ?? geometry.instancedVertexLayout,
     );
     if (!identical(_boundPipeline, pipeline)) {
       _renderPass.bindPipeline(pipeline);
       _boundPipeline = pipeline;
     }
-    _renderPass.setPrimitiveType(item.geometry.primitiveType);
+    _renderPass.setPrimitiveType(geometry.primitiveType);
+
+    // Binds the vertex/index buffers and the per-frame uniform for one draw.
+    // The light-space matrix takes the place of the camera transform; the
+    // camera position is unused by the shadow fragment shader.
+    void bindDraw(Matrix4 worldTransform) {
+      if (depthVertex != null) {
+        geometry.bindGeometryBuffers(_renderPass);
+        bindUnskinnedFrameInfo(
+          _renderPass,
+          _transientsBuffer,
+          depthVertex.shader,
+          _lightSpaceMatrix,
+          _cameraPositionPlaceholder,
+        );
+      } else {
+        geometry.bind(
+          _renderPass,
+          _transientsBuffer,
+          worldTransform,
+          _lightSpaceMatrix,
+          _cameraPositionPlaceholder,
+        );
+      }
+    }
 
     final instances = item.instanceTransforms;
     if (instances != null) {
-      if (item.geometry.instancedVertexLayout == null) {
+      if (geometry.instancedVertexLayout == null) {
         // Skinned geometry has no instance-attribute path; loop.
         for (final instanceTransform in instances) {
-          item.geometry.bind(
-            _renderPass,
-            _transientsBuffer,
-            item.worldTransform * instanceTransform,
-            _lightSpaceMatrix,
-            _cameraPositionPlaceholder,
-          );
+          bindDraw(item.worldTransform * instanceTransform);
           final flip =
               item.windingFlipped != (instanceTransform.determinant() < 0);
           _renderPass.setWindingOrder(
@@ -95,17 +119,11 @@ class ShadowEncoder {
                 ? gpu.WindingOrder.clockwise
                 : gpu.WindingOrder.counterClockwise,
           );
-          item.geometry.draw(_renderPass);
+          geometry.draw(_renderPass);
         }
         return;
       }
-      item.geometry.bind(
-        _renderPass,
-        _transientsBuffer,
-        item.worldTransform,
-        _lightSpaceMatrix,
-        _cameraPositionPlaceholder,
-      );
+      bindDraw(item.worldTransform);
       final packed = packInstanceTransforms(
         item.worldTransform,
         instances,
@@ -114,24 +132,18 @@ class ShadowEncoder {
       if (packed.ccwCount > 0) {
         bindInstanceTransforms(_renderPass, packed.ccw);
         _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
-        item.geometry.draw(_renderPass, instanceCount: packed.ccwCount);
+        geometry.draw(_renderPass, instanceCount: packed.ccwCount);
       }
       if (packed.cwCount > 0) {
         bindInstanceTransforms(_renderPass, packed.cw);
         _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
-        item.geometry.draw(_renderPass, instanceCount: packed.cwCount);
+        geometry.draw(_renderPass, instanceCount: packed.cwCount);
       }
       return;
     }
 
-    item.geometry.bind(
-      _renderPass,
-      _transientsBuffer,
-      item.worldTransform,
-      _lightSpaceMatrix,
-      _cameraPositionPlaceholder,
-    );
-    if (item.geometry.instancedVertexLayout != null) {
+    bindDraw(item.worldTransform);
+    if (geometry.instancedVertexLayout != null) {
       bindSingleInstanceTransform(_renderPass, item.worldTransform);
     }
     // Mirrored casters reverse winding; flip the cull order so the same faces
@@ -141,6 +153,6 @@ class ShadowEncoder {
           ? gpu.WindingOrder.clockwise
           : gpu.WindingOrder.counterClockwise,
     );
-    item.geometry.draw(_renderPass);
+    geometry.draw(_renderPass);
   }
 }

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -3,15 +3,8 @@ import 'package:flutter_scene/src/render/instance_packing.dart';
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/render/render_scene.dart';
+import 'package:flutter_scene/src/scene_encoder.dart' show resolvePipeline;
 import 'package:flutter_scene/src/shaders.dart';
-
-/// Process-lifetime cache of depth-pass render pipelines, keyed by vertex
-/// shader. The depth fragment shader is constant, so only the (skinned /
-/// unskinned) vertex shader varies; the engine loads each shader once, so
-/// the depth pass only ever needs two pipelines. Caching them keeps the
-/// shadow pass from rebuilding a pipeline for every caster, every cascade,
-/// every frame.
-final Map<gpu.Shader, gpu.RenderPipeline> _depthPipelineCache = {};
 
 /// Records each opaque shadow caster's depth into a shadow-map render
 /// pass, from a directional light's point of view.
@@ -72,13 +65,11 @@ class ShadowEncoder {
       }
     }
     _renderPass.clearBindings();
-    final pipeline = _depthPipelineCache[item.geometry.vertexShader] ??= gpu
-        .gpuContext
-        .createRenderPipeline(
-          item.geometry.vertexShader,
-          _depthShader,
-          vertexLayout: item.geometry.instancedVertexLayout,
-        );
+    final pipeline = resolvePipeline(
+      item.geometry.vertexShader,
+      _depthShader,
+      vertexLayout: item.geometry.instancedVertexLayout,
+    );
     if (!identical(_boundPipeline, pipeline)) {
       _renderPass.bindPipeline(pipeline);
       _boundPipeline = pipeline;

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -87,7 +87,7 @@ class ShadowEncoder {
     // camera position is unused by the shadow fragment shader.
     void bindDraw(Matrix4 worldTransform) {
       if (depthVertex != null) {
-        geometry.bindGeometryBuffers(_renderPass);
+        geometry.bindPositionStream(_renderPass);
         bindUnskinnedFrameInfo(
           _renderPass,
           _transientsBuffer,

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -256,8 +256,13 @@ base class SceneEncoder {
       _camera.position,
     );
     if (geometry.instancedVertexLayout != null) {
-      // The model matrix arrives through the instance-rate vertex buffer.
-      bindSingleInstanceTransform(_renderPass, worldTransform);
+      // The model matrix arrives through the instance-rate vertex buffer,
+      // bound to the slot after the geometry's vertex streams.
+      bindSingleInstanceTransform(
+        _renderPass,
+        worldTransform,
+        slot: geometry.vertexStreamCount,
+      );
     }
     material.bind(_renderPass, _transientsBuffer, _lighting);
     if (windingFlipped) {
@@ -322,13 +327,14 @@ base class SceneEncoder {
       instances,
       nodeWindingFlipped: windingFlipped,
     );
+    final instanceSlot = geometry.vertexStreamCount;
     if (packed.ccwCount > 0) {
-      bindInstanceTransforms(_renderPass, packed.ccw);
+      bindInstanceTransforms(_renderPass, packed.ccw, slot: instanceSlot);
       _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
       geometry.draw(_renderPass, instanceCount: packed.ccwCount);
     }
     if (packed.cwCount > 0) {
-      bindInstanceTransforms(_renderPass, packed.cw);
+      bindInstanceTransforms(_renderPass, packed.cw, slot: instanceSlot);
       _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
       geometry.draw(_renderPass, instanceCount: packed.cwCount);
     }

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -20,6 +20,7 @@ base class _OpaqueRecord {
     this.item,
     this.geometry,
     this.material,
+    this.fade,
     this.pipeline,
     this.pipelineKey,
     this.depth,
@@ -29,6 +30,9 @@ base class _OpaqueRecord {
   // a level of detail was selected.
   final Geometry geometry;
   final Material material;
+  // LOD cross-fade coverage for this draw (1 when not fading); see
+  // [Material.lodFade].
+  final double fade;
   final gpu.RenderPipeline pipeline;
   final int pipelineKey;
   final double depth;
@@ -41,6 +45,7 @@ base class _TranslucentRecord {
     this.worldTransform,
     this.geometry,
     this.material,
+    this.fade,
     this.pipeline,
     this.depth,
     this.windingFlipped,
@@ -48,6 +53,7 @@ base class _TranslucentRecord {
   final Matrix4 worldTransform;
   final Geometry geometry;
   final Material material;
+  final double fade;
   final gpu.RenderPipeline pipeline;
   final double depth;
   final bool windingFlipped;
@@ -205,17 +211,26 @@ base class SceneEncoder {
       return;
     }
 
-    // Resolve the level of detail (or cull) before choosing a pipeline, so a
-    // distant object draws its cheaper variant or nothing at all.
-    var geometry = item.geometry;
-    var material = item.material;
+    // Queue the level(s) of detail to draw (or cull). A cross-fading node
+    // returns its two adjacent levels with complementary dither coverage.
     if (lod != null) {
-      final level = _selectLod(lod, worldBounds);
-      if (level == null) return;
-      geometry = level.geometry;
-      material = level.material;
+      for (final selection in _resolveLod(lod, worldBounds)) {
+        final level = lod.levels[selection.level];
+        _record(item, level.geometry, level.material, selection.fade);
+      }
+      return;
     }
+    _record(item, item.geometry, item.material, 1.0);
+  }
 
+  // Queues a single draw for [item] using the already-LOD-resolved [geometry]
+  // and [material] at cross-fade coverage [fade].
+  void _record(
+    RenderItem item,
+    Geometry geometry,
+    Material material,
+    double fade,
+  ) {
     final pipeline = resolvePipeline(
       geometry.vertexShader,
       material.fragmentShader,
@@ -228,6 +243,7 @@ base class SceneEncoder {
           item,
           geometry,
           material,
+          fade,
           pipeline,
           identityHashCode(pipeline),
           _depthOf(item.worldTransform),
@@ -247,6 +263,7 @@ base class SceneEncoder {
             worldTransform,
             geometry,
             material,
+            fade,
             pipeline,
             _depthOf(worldTransform),
             item.windingFlipped != (instanceTransform.determinant() < 0),
@@ -259,6 +276,7 @@ base class SceneEncoder {
           item.worldTransform,
           geometry,
           material,
+          fade,
           pipeline,
           _depthOf(item.worldTransform),
           item.windingFlipped,
@@ -267,24 +285,28 @@ base class SceneEncoder {
     }
   }
 
-  // Picks the level of detail for [lod] from the item's [worldBounds], or
-  // null to cull. Falls back to the highest detail when no screen-size metric
-  // is available (no bounds, or a non-perspective camera).
-  LodLevel? _selectLod(LodSelection lod, Aabb3? worldBounds) {
+  // The level(s) of detail to draw for [lod] from the item's [worldBounds],
+  // each with a fade coverage; empty to cull. Falls back to the highest detail
+  // when no screen-size metric is available (no bounds, or a non-perspective
+  // camera).
+  List<({int level, double fade})> _resolveLod(
+    LodSelection lod,
+    Aabb3? worldBounds,
+  ) {
     final fovRadiansY = _lodFovRadiansY;
-    if (worldBounds == null || fovRadiansY == null) return lod.levels.first;
-    final center = worldBounds.center;
+    if (worldBounds == null || fovRadiansY == null) {
+      return const [(level: 0, fade: 1.0)];
+    }
     // The circumscribed sphere of the world AABB (conservative, so detail is
     // kept slightly longer than a tight sphere would).
     final radius = worldBounds.max.distanceTo(worldBounds.min) * 0.5;
     final size = lodScreenSize(
-      center: center,
+      center: worldBounds.center,
       radius: radius,
       cameraPosition: _camera.position,
       fovRadiansY: fovRadiansY,
     );
-    final level = lod.select(size);
-    return level < 0 ? null : lod.levels[level];
+    return lod.resolve(size);
   }
 
   double _depthOf(Matrix4 worldTransform) =>
@@ -305,9 +327,14 @@ base class SceneEncoder {
     Geometry geometry,
     Material material,
     bool windingFlipped,
+    double fade,
   ) {
     _renderPass.clearBindings();
     _bindPipeline(pipeline);
+    // The material reads its cross-fade coverage from this transient field as
+    // it binds; reset for every draw so a shared material does not leak a
+    // previous draw's fade.
+    material.lodFade = fade;
     geometry.bind(
       _renderPass,
       _transientsBuffer,
@@ -350,9 +377,11 @@ base class SceneEncoder {
     Material material,
     List<Matrix4> instances,
     bool windingFlipped,
+    double fade,
   ) {
     _renderPass.clearBindings();
     _bindPipeline(pipeline);
+    material.lodFade = fade;
     material.bind(_renderPass, _transientsBuffer, _lighting);
     _renderPass.setPrimitiveType(geometry.primitiveType);
 
@@ -425,6 +454,7 @@ base class SceneEncoder {
           record.material,
           instances,
           item.windingFlipped,
+          record.fade,
         );
       } else {
         _encode(
@@ -433,6 +463,7 @@ base class SceneEncoder {
           record.geometry,
           record.material,
           item.windingFlipped,
+          record.fade,
         );
       }
     }
@@ -460,6 +491,7 @@ base class SceneEncoder {
         record.geometry,
         record.material,
         record.windingFlipped,
+        record.fade,
       );
     }
     _translucentRecords.clear();

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -9,14 +9,26 @@ import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/render/instance_packing.dart';
+import 'package:flutter_scene/src/render/lod.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 
 /// A deferred opaque draw. Holds the [RenderItem] (instanced or not), its
 /// resolved pipeline, a per-pipeline grouping key, and the camera
 /// distance, all captured when [SceneEncoder.submit] is called.
 base class _OpaqueRecord {
-  _OpaqueRecord(this.item, this.pipeline, this.pipelineKey, this.depth);
+  _OpaqueRecord(
+    this.item,
+    this.geometry,
+    this.material,
+    this.pipeline,
+    this.pipelineKey,
+    this.depth,
+  );
   final RenderItem item;
+  // The geometry and material to draw, which differ from the item's own when
+  // a level of detail was selected.
+  final Geometry geometry;
+  final Material material;
   final gpu.RenderPipeline pipeline;
   final int pipelineKey;
   final double depth;
@@ -128,6 +140,10 @@ base class SceneEncoder {
       _transientsBuffer = transientsBuffer {
     _cameraTransform = _camera.getViewTransform(dimensions);
     frustum = Frustum.matrix(_cameraTransform);
+    // The screen-size LOD metric is perspective-specific; with any other
+    // projection LOD nodes draw their highest-detail level.
+    final camera = _camera;
+    _lodFovRadiansY = camera is PerspectiveCamera ? camera.fovRadiansY : null;
 
     // Begin the opaque phase.
     _renderPass.setDepthWriteEnable(true);
@@ -141,6 +157,9 @@ base class SceneEncoder {
   final gpu.RenderPass _renderPass;
   final gpu.HostBuffer _transientsBuffer;
   late final Matrix4 _cameraTransform;
+  // The camera's vertical field of view in radians, or null for a
+  // non-perspective camera (which disables screen-size LOD).
+  late final double? _lodFovRadiansY;
   final List<_OpaqueRecord> _opaqueRecords = [];
   final List<_TranslucentRecord> _translucentRecords = [];
 
@@ -168,26 +187,47 @@ base class SceneEncoder {
   void submit(RenderItem item) {
     if (!item.visible) return;
     if ((item.layers & _layerMask) == 0) return;
-    if (item.frustumCulled) {
-      final bounds = item.cullBounds;
-      if (bounds != null) {
-        cullScratchAabb
-          ..copyFrom(bounds)
-          ..transform(item.worldTransform);
-        if (!frustum.intersectsWithAabb3(cullScratchAabb)) return;
-      }
+
+    // The world-space AABB is needed for frustum culling and, when the item
+    // has levels of detail, for the screen-size metric; compute it once.
+    final lod = item.lod;
+    Aabb3? worldBounds;
+    final localBounds = item.cullBounds;
+    if ((item.frustumCulled || lod != null) && localBounds != null) {
+      cullScratchAabb
+        ..copyFrom(localBounds)
+        ..transform(item.worldTransform);
+      worldBounds = cullScratchAabb;
+    }
+    if (item.frustumCulled &&
+        worldBounds != null &&
+        !frustum.intersectsWithAabb3(worldBounds)) {
+      return;
+    }
+
+    // Resolve the level of detail (or cull) before choosing a pipeline, so a
+    // distant object draws its cheaper variant or nothing at all.
+    var geometry = item.geometry;
+    var material = item.material;
+    if (lod != null) {
+      final level = _selectLod(lod, worldBounds);
+      if (level == null) return;
+      geometry = level.geometry;
+      material = level.material;
     }
 
     final pipeline = resolvePipeline(
-      item.geometry.vertexShader,
-      item.material.fragmentShader,
-      vertexLayout: item.geometry.instancedVertexLayout,
+      geometry.vertexShader,
+      material.fragmentShader,
+      vertexLayout: geometry.instancedVertexLayout,
     );
 
-    if (item.material.isOpaque()) {
+    if (material.isOpaque()) {
       _opaqueRecords.add(
         _OpaqueRecord(
           item,
+          geometry,
+          material,
           pipeline,
           identityHashCode(pipeline),
           _depthOf(item.worldTransform),
@@ -205,8 +245,8 @@ base class SceneEncoder {
         _translucentRecords.add(
           _TranslucentRecord(
             worldTransform,
-            item.geometry,
-            item.material,
+            geometry,
+            material,
             pipeline,
             _depthOf(worldTransform),
             item.windingFlipped != (instanceTransform.determinant() < 0),
@@ -217,14 +257,34 @@ base class SceneEncoder {
       _translucentRecords.add(
         _TranslucentRecord(
           item.worldTransform,
-          item.geometry,
-          item.material,
+          geometry,
+          material,
           pipeline,
           _depthOf(item.worldTransform),
           item.windingFlipped,
         ),
       );
     }
+  }
+
+  // Picks the level of detail for [lod] from the item's [worldBounds], or
+  // null to cull. Falls back to the highest detail when no screen-size metric
+  // is available (no bounds, or a non-perspective camera).
+  LodLevel? _selectLod(LodSelection lod, Aabb3? worldBounds) {
+    final fovRadiansY = _lodFovRadiansY;
+    if (worldBounds == null || fovRadiansY == null) return lod.levels.first;
+    final center = worldBounds.center;
+    // The circumscribed sphere of the world AABB (conservative, so detail is
+    // kept slightly longer than a tight sphere would).
+    final radius = worldBounds.max.distanceTo(worldBounds.min) * 0.5;
+    final size = lodScreenSize(
+      center: center,
+      radius: radius,
+      cameraPosition: _camera.position,
+      fovRadiansY: fovRadiansY,
+    );
+    final level = lod.select(size);
+    return level < 0 ? null : lod.levels[level];
   }
 
   double _depthOf(Matrix4 worldTransform) =>
@@ -361,8 +421,8 @@ base class SceneEncoder {
         _encodeInstanced(
           record.pipeline,
           item.worldTransform,
-          item.geometry,
-          item.material,
+          record.geometry,
+          record.material,
           instances,
           item.windingFlipped,
         );
@@ -370,8 +430,8 @@ base class SceneEncoder {
         _encode(
           record.pipeline,
           item.worldTransform,
-          item.geometry,
-          item.material,
+          record.geometry,
+          record.material,
           item.windingFlipped,
         );
       }

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -5,6 +5,7 @@ import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
+import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/render/instance_packing.dart';
@@ -40,27 +41,37 @@ base class _TranslucentRecord {
   final bool windingFlipped;
 }
 
-/// Render pipelines keyed by their (vertex, fragment) shader pair.
+/// Render pipelines keyed by their (vertex shader, fragment shader, vertex
+/// layout) triple.
 ///
-/// A pipeline depends only on its two shaders (blend, depth, and cull
-/// state are set on the render pass, not baked into the pipeline), and
-/// shaders are loaded once and reused, so pipelines are cached for the
-/// process lifetime instead of being rebuilt per draw call.
-final Map<(gpu.Shader, gpu.Shader), gpu.RenderPipeline> _pipelineCache = {};
+/// A pipeline depends on its two shaders and its vertex layout (blend,
+/// depth, and cull state are set on the render pass, not baked into the
+/// pipeline). Shaders are loaded once and reused and layouts are interned to
+/// a small stable id, so pipelines are cached for the process lifetime
+/// instead of being rebuilt per draw call. The layout is part of the key
+/// because one vertex shader can be drawn with more than one layout (for
+/// example the same shader fed a single-buffer or a position-split layout);
+/// keying on the shader pair alone would serve the wrong pipeline.
+final Map<(gpu.Shader, gpu.Shader, int), gpu.RenderPipeline> _pipelineCache =
+    {};
 
+/// Returns the cached render pipeline for ([vertexShader], [fragmentShader],
+/// [vertexLayout]), building and caching it on first use.
+///
+/// A `null` [vertexLayout] uses the shader bundle's reflection-derived
+/// default layout (the skinned path); a described layout is lowered to the
+/// flutter_gpu layout once, on the cache miss.
 gpu.RenderPipeline resolvePipeline(
   gpu.Shader vertexShader,
   gpu.Shader fragmentShader, {
-  gpu.VertexLayout? vertexLayout,
+  VertexLayoutDescriptor? vertexLayout,
 }) {
-  // The layout is a pure function of the vertex shader (each shader has one
-  // expected layout), so the cache key stays the shader pair.
-  return _pipelineCache[(vertexShader, fragmentShader)] ??= gpu.gpuContext
-      .createRenderPipeline(
-        vertexShader,
-        fragmentShader,
-        vertexLayout: vertexLayout,
-      );
+  final key = (vertexShader, fragmentShader, vertexLayoutId(vertexLayout));
+  return _pipelineCache[key] ??= gpu.gpuContext.createRenderPipeline(
+    vertexShader,
+    fragmentShader,
+    vertexLayout: vertexLayout?.toGpuLayout(),
+  );
 }
 
 /// Drops cached pipelines that use any of [shaders] (as vertex or fragment) so

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -1,8 +1,14 @@
 name: flutter_scene
-description: A powerful and flexible realtime 3D rendering engine for Flutter.
+description: A flexible realtime 3D engine for Flutter games and apps, with glTF models, physics, skeletal animation, and PBR lighting.
 version: 0.18.1
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
+topics:
+  - graphics
+  - gltf
+  - game
+  - physics
+  - animation
 screenshots:
   - description: The Flutter Scene logo.
     path: screenshots/flutter_scene_logo.png

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -7,6 +7,10 @@
         "type": "vertex",
         "file": "shaders/flutter_scene_skinned.vert"
     },
+    "UnskinnedDepthVertex": {
+        "type": "vertex",
+        "file": "shaders/flutter_scene_unskinned_depth.vert"
+    },
     "UnlitFragment": {
         "type": "fragment",
         "file": "shaders/flutter_scene_unlit.frag"

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -5,6 +5,7 @@
 #include <material_engine_lighting.glsl>
 #include <material_inputs.glsl>
 #include <material_lighting.glsl>
+#include <lod_fade.glsl>
 
 uniform sampler2D base_color_texture;
 uniform sampler2D emissive_texture;
@@ -61,6 +62,7 @@ void Surface(inout MaterialInputs material) {
 }
 
 void main() {
+  ApplyLodFade(frag_info.fade);
   MaterialInputs material = InitMaterialInputs();
   Surface(material);
   frag_color = EvaluateLighting(material);

--- a/packages/flutter_scene/shaders/flutter_scene_unlit.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_unlit.frag
@@ -1,8 +1,12 @@
 uniform FragInfo {
   vec4 color;
   float vertex_color_weight;
+  // LOD cross-fade coverage; see lod_fade.glsl.
+  float fade;
 }
 frag_info;
+
+#include <lod_fade.glsl>
 
 uniform sampler2D base_color_texture;
 
@@ -18,6 +22,7 @@ const float kGamma = 2.2;
 vec3 SRGBToLinear(vec3 color) { return pow(color, vec3(kGamma)); }
 
 void main() {
+  ApplyLodFade(frag_info.fade);
   vec4 vertex_color = mix(vec4(1), v_color, frag_info.vertex_color_weight);
   vec4 base = texture(base_color_texture, v_texture_coords);
   // Linearize the sRGB-encoded base color so what we write to the

--- a/packages/flutter_scene/shaders/flutter_scene_unskinned_depth.vert
+++ b/packages/flutter_scene/shaders/flutter_scene_unskinned_depth.vert
@@ -1,0 +1,49 @@
+// Position-only vertex shader for the depth-style passes (directional-light
+// shadow map, camera depth prepass, and the object-selection mask).
+//
+// It reads only the position attribute and the instance-rate model transform,
+// so a pipeline built with it can bind a layout that omits normal, texture
+// coordinates, and color, and the input assembler fetches only position per
+// vertex. The full UnskinnedVertex shader reads all four attributes, so it
+// could not be paired with such a trimmed layout.
+//
+// The paired fragment shaders (DepthOnlyFragment, LinearDepthFragment,
+// MaskFragment) include material_varyings.glsl, which declares the full set of
+// per-vertex inputs. To keep the vertex/fragment varying interface matched,
+// this shader writes every one of those varyings, but only v_position and
+// v_viewvector carry real data (the prepass needs v_viewvector for view-space
+// depth); the rest are zero because no consumer reads them.
+
+uniform FrameInfo {
+  mat4 camera_transform;
+  vec3 camera_position;
+}
+frame_info;
+
+in vec3 position;
+
+// Instance-rate model matrix columns (vertex buffer slot 1, advanced once per
+// instance). Non-instanced draws bind a single-element buffer holding the
+// node's world transform, matching UnskinnedVertex.
+in vec4 model_transform_0;
+in vec4 model_transform_1;
+in vec4 model_transform_2;
+in vec4 model_transform_3;
+
+out vec3 v_position;
+out vec3 v_normal;
+out vec3 v_viewvector; // camera_position - vertex_position
+out vec2 v_texture_coords;
+out vec4 v_color;
+
+void main() {
+  mat4 model_transform = mat4(model_transform_0, model_transform_1,
+                              model_transform_2, model_transform_3);
+  vec4 model_position = model_transform * vec4(position, 1.0);
+  v_position = model_position.xyz;
+  gl_Position = frame_info.camera_transform * model_position;
+  v_viewvector = frame_info.camera_position - v_position;
+  v_normal = vec3(0.0);
+  v_texture_coords = vec2(0.0);
+  v_color = vec4(0.0);
+}

--- a/packages/flutter_scene/shaders/lod_fade.glsl
+++ b/packages/flutter_scene/shaders/lod_fade.glsl
@@ -1,0 +1,26 @@
+// Screen-door dither for level-of-detail cross-fades.
+//
+// [coverage] of 1 keeps every fragment. A value in (0, 1) keeps that fraction
+// of fragments in a stable screen-space dither pattern and discards the rest;
+// a negative value keeps the complementary pattern of |coverage|. Drawing two
+// adjacent LOD levels whose fades sum to 1, one with the positive coverage and
+// one with the negative, tiles the screen between them with no overdraw, so
+// the levels blend without translucency.
+//
+// The hash is the Weyl pattern used elsewhere in the engine (resolve grain,
+// shadow PCF rotation), and gl_FragCoord behaves the same on Impeller and the
+// WebGL2 backend.
+void ApplyLodFade(float coverage) {
+  if (coverage >= 1.0) {
+    return;
+  }
+  float dither = fract(
+      52.9829189 * fract(dot(gl_FragCoord.xy, vec2(0.06711056, 0.00583715))));
+  if (coverage < 0.0) {
+    dither = 1.0 - dither;
+    coverage = -coverage;
+  }
+  if (dither >= coverage) {
+    discard;
+  }
+}

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -57,6 +57,13 @@ uniform FragInfo {
   float shadow_softness;
   // Number of valid cascades in light_space_matrix (1 to 4).
   float shadow_cascade_count;
+  // Level-of-detail cross-fade coverage. 1 draws every fragment. A value in
+  // (0, 1) keeps that fraction of fragments in a screen-space dither pattern
+  // (the rest discard); a negative value keeps the complementary pattern of
+  // |value|, so two adjacent LOD levels with fades summing to 1 tile the
+  // screen between them. Occupies std140 padding before the mat4, so the
+  // block size is unchanged. See lod_fade.glsl.
+  float fade;
   // Rotates the image-based-lighting environment: the diffuse-SH and
   // prefiltered-radiance lookup directions are transformed by this before
   // sampling. Identity leaves the environment unrotated. A mat4 (not mat3)

--- a/packages/flutter_scene/test/fscene/importer_test.dart
+++ b/packages/flutter_scene/test/fscene/importer_test.dart
@@ -1,8 +1,11 @@
-// Covers the glTF -> .fscene importer. The load-bearing check is byte parity:
-// a primitive's packed vertex/index payload must equal packGltfPrimitive's
-// output, the same packer the runtime GLB importer uses. This is the
-// project's proven import-verification method (compare bytes against the
-// known-good packer rather than eyeballing renders).
+// Covers the glTF -> .fscene importer. The load-bearing check is byte parity
+// against packGltfPrimitive (the same packer the runtime GLB importer uses).
+// Skinned geometry is stored interleaved, so its payload equals the packer's
+// bytes directly; unskinned geometry is stored de-interleaved (structure of
+// arrays), so its payload equals the packer's interleaved bytes split into the
+// four attribute streams and concatenated. This is the project's proven
+// import-verification method (compare bytes against the known-good packer
+// rather than eyeballing renders).
 //
 // Runs only when the source GLB corpus is present (CI without it skips).
 
@@ -11,6 +14,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/importer/gltf.dart';
 import 'package:flutter_scene/src/importer/in_memory_import.dart';
 import 'package:flutter_scene/src/importer/src/gltf/bounds_baker.dart';
@@ -68,19 +72,36 @@ void main() {
           final geometry = geometries[i];
           final vertexPayload = document.payload(geometry.vertices!)!;
           final indexPayload = document.payload(geometry.indices!)!;
-          expect(
-            vertexPayload.bytes,
-            equals(packed.vertexBytes),
-            reason: '$name geometry $i vertex bytes',
-          );
+          if (packed.isSkinned) {
+            expect(vertexPayload.layout, 'skinned');
+            expect(
+              vertexPayload.bytes,
+              equals(packed.vertexBytes),
+              reason: '$name geometry $i skinned vertex bytes',
+            );
+          } else {
+            // Unskinned is de-interleaved: the packer's interleaved bytes,
+            // split into per-attribute streams and concatenated.
+            expect(
+              vertexPayload.layout,
+              InterleavedLayoutAdapter.unskinnedSoaLayout,
+            );
+            final expectedSoa = InterleavedLayoutAdapter.concatUnskinnedStreams(
+              InterleavedLayoutAdapter.splitUnskinnedAttributes(
+                ByteData.sublistView(packed.vertexBytes),
+                packed.vertexCount,
+              ),
+            );
+            expect(
+              vertexPayload.bytes,
+              equals(expectedSoa),
+              reason: '$name geometry $i unskinned SoA vertex bytes',
+            );
+          }
           expect(
             indexPayload.bytes,
             equals(packed.indexBytes),
             reason: '$name geometry $i index bytes',
-          );
-          expect(
-            vertexPayload.layout,
-            packed.isSkinned ? 'skinned' : 'unskinned',
           );
           expect(
             indexPayload.format,

--- a/packages/flutter_scene/test/interleaved_layout_test.dart
+++ b/packages/flutter_scene/test/interleaved_layout_test.dart
@@ -65,8 +65,8 @@ void main() {
     });
   });
 
-  group('splitUnskinnedStreams', () {
-    test('separates position from the remaining attributes', () {
+  group('splitUnskinnedAttributes', () {
+    test('separates the interleaved buffer into four per-attribute streams', () {
       // Two vertices, all attributes distinct and exactly float-representable.
       final interleaved = InterleavedLayoutAdapter.packUnskinned(
         positions: Float32List.fromList([1, 2, 3, 4, 5, 6]),
@@ -75,32 +75,77 @@ void main() {
         texCoords: Float32List.fromList([13, 14, 15, 16]),
         colors: Float32List.fromList([17, 18, 19, 20, 21, 22, 23, 24]),
       );
-      final split = InterleavedLayoutAdapter.splitUnskinnedStreams(
+      final streams = InterleavedLayoutAdapter.splitUnskinnedAttributes(
         ByteData.sublistView(interleaved),
         2,
       );
 
-      // Position stream: 12 bytes (3 floats) per vertex.
-      expect(split.position, hasLength(2 * 12));
-      expect(Float32List.sublistView(split.position), [1, 2, 3, 4, 5, 6]);
-
-      // Attribute stream: 36 bytes (9 floats) per vertex, normal then
-      // texcoord then color, matching the de-interleaved layout's offsets.
-      expect(split.rest, hasLength(2 * 36));
-      expect(Float32List.sublistView(split.rest), [
-        7, 8, 9, 13, 14, 17, 18, 19, 20, // vertex 0
-        10, 11, 12, 15, 16, 21, 22, 23, 24, // vertex 1
+      expect(Float32List.sublistView(streams.position), [1, 2, 3, 4, 5, 6]);
+      expect(Float32List.sublistView(streams.normal), [7, 8, 9, 10, 11, 12]);
+      expect(Float32List.sublistView(streams.texCoord), [13, 14, 15, 16]);
+      expect(Float32List.sublistView(streams.color), [
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
       ]);
     });
 
     test('throws when the interleaved buffer is too short', () {
       expect(
-        () => InterleavedLayoutAdapter.splitUnskinnedStreams(
+        () => InterleavedLayoutAdapter.splitUnskinnedAttributes(
           ByteData(48),
           2, // needs 96 bytes
         ),
         throwsArgumentError,
       );
+    });
+  });
+
+  group('unskinnedAttributeStreams', () {
+    test('packs structure-of-arrays attributes with defaults', () {
+      final streams = InterleavedLayoutAdapter.unskinnedAttributeStreams(
+        positions: Float32List.fromList([1, 2, 3]),
+        vertexCount: 1,
+      );
+      expect(Float32List.sublistView(streams.position), [1, 2, 3]);
+      // Defaults: normal (0,0,1), texcoord (0,0), color opaque white.
+      expect(Float32List.sublistView(streams.normal), [0, 0, 1]);
+      expect(Float32List.sublistView(streams.texCoord), [0, 0]);
+      expect(Float32List.sublistView(streams.color), [1, 1, 1, 1]);
+    });
+
+    test('round-trips through split back to the same per-attribute bytes', () {
+      final positions = Float32List.fromList([1, 2, 3, 4, 5, 6]);
+      final normals = Float32List.fromList([7, 8, 9, 10, 11, 12]);
+      final texCoords = Float32List.fromList([13, 14, 15, 16]);
+      final colors = Float32List.fromList([17, 18, 19, 20, 21, 22, 23, 24]);
+      final direct = InterleavedLayoutAdapter.unskinnedAttributeStreams(
+        positions: positions,
+        vertexCount: 2,
+        normals: normals,
+        texCoords: texCoords,
+        colors: colors,
+      );
+      final interleaved = InterleavedLayoutAdapter.packUnskinned(
+        positions: positions,
+        vertexCount: 2,
+        normals: normals,
+        texCoords: texCoords,
+        colors: colors,
+      );
+      final viaSplit = InterleavedLayoutAdapter.splitUnskinnedAttributes(
+        ByteData.sublistView(interleaved),
+        2,
+      );
+      expect(direct.position, viaSplit.position);
+      expect(direct.normal, viaSplit.normal);
+      expect(direct.texCoord, viaSplit.texCoord);
+      expect(direct.color, viaSplit.color);
     });
   });
 

--- a/packages/flutter_scene/test/interleaved_layout_test.dart
+++ b/packages/flutter_scene/test/interleaved_layout_test.dart
@@ -149,6 +149,57 @@ void main() {
     });
   });
 
+  group('concat/slice structure-of-arrays payload', () {
+    test('concat then slice round-trips the four streams', () {
+      final streams = InterleavedLayoutAdapter.unskinnedAttributeStreams(
+        positions: Float32List.fromList([1, 2, 3, 4, 5, 6]),
+        vertexCount: 2,
+        normals: Float32List.fromList([7, 8, 9, 10, 11, 12]),
+        texCoords: Float32List.fromList([13, 14, 15, 16]),
+        colors: Float32List.fromList([17, 18, 19, 20, 21, 22, 23, 24]),
+      );
+      final payload = InterleavedLayoutAdapter.concatUnskinnedStreams(streams);
+      // Same total size as the interleaved buffer (48 bytes per vertex).
+      expect(payload, hasLength(2 * 48));
+
+      final sliced = InterleavedLayoutAdapter.sliceUnskinnedStreams(payload, 2);
+      expect(sliced.position, streams.position);
+      expect(sliced.normal, streams.normal);
+      expect(sliced.texCoord, streams.texCoord);
+      expect(sliced.color, streams.color);
+    });
+
+    test('the SoA payload equals the split of the interleaved buffer', () {
+      final positions = Float32List.fromList([1, 2, 3, 4, 5, 6]);
+      final normals = Float32List.fromList([7, 8, 9, 10, 11, 12]);
+      final texCoords = Float32List.fromList([13, 14, 15, 16]);
+      final colors = Float32List.fromList([17, 18, 19, 20, 21, 22, 23, 24]);
+      final interleaved = InterleavedLayoutAdapter.packUnskinned(
+        positions: positions,
+        vertexCount: 2,
+        normals: normals,
+        texCoords: texCoords,
+        colors: colors,
+      );
+      final fromInterleaved = InterleavedLayoutAdapter.concatUnskinnedStreams(
+        InterleavedLayoutAdapter.splitUnskinnedAttributes(
+          ByteData.sublistView(interleaved),
+          2,
+        ),
+      );
+      final fromArrays = InterleavedLayoutAdapter.concatUnskinnedStreams(
+        InterleavedLayoutAdapter.unskinnedAttributeStreams(
+          positions: positions,
+          vertexCount: 2,
+          normals: normals,
+          texCoords: texCoords,
+          colors: colors,
+        ),
+      );
+      expect(fromInterleaved, fromArrays);
+    });
+  });
+
   group('packIndices', () {
     test('uses a 16-bit buffer when every index fits', () {
       final packed = InterleavedLayoutAdapter.packIndices([0, 1, 2, 0xFFFF]);

--- a/packages/flutter_scene/test/interleaved_layout_test.dart
+++ b/packages/flutter_scene/test/interleaved_layout_test.dart
@@ -65,6 +65,45 @@ void main() {
     });
   });
 
+  group('splitUnskinnedStreams', () {
+    test('separates position from the remaining attributes', () {
+      // Two vertices, all attributes distinct and exactly float-representable.
+      final interleaved = InterleavedLayoutAdapter.packUnskinned(
+        positions: Float32List.fromList([1, 2, 3, 4, 5, 6]),
+        vertexCount: 2,
+        normals: Float32List.fromList([7, 8, 9, 10, 11, 12]),
+        texCoords: Float32List.fromList([13, 14, 15, 16]),
+        colors: Float32List.fromList([17, 18, 19, 20, 21, 22, 23, 24]),
+      );
+      final split = InterleavedLayoutAdapter.splitUnskinnedStreams(
+        ByteData.sublistView(interleaved),
+        2,
+      );
+
+      // Position stream: 12 bytes (3 floats) per vertex.
+      expect(split.position, hasLength(2 * 12));
+      expect(Float32List.sublistView(split.position), [1, 2, 3, 4, 5, 6]);
+
+      // Attribute stream: 36 bytes (9 floats) per vertex, normal then
+      // texcoord then color, matching the de-interleaved layout's offsets.
+      expect(split.rest, hasLength(2 * 36));
+      expect(Float32List.sublistView(split.rest), [
+        7, 8, 9, 13, 14, 17, 18, 19, 20, // vertex 0
+        10, 11, 12, 15, 16, 21, 22, 23, 24, // vertex 1
+      ]);
+    });
+
+    test('throws when the interleaved buffer is too short', () {
+      expect(
+        () => InterleavedLayoutAdapter.splitUnskinnedStreams(
+          ByteData(48),
+          2, // needs 96 bytes
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
   group('packIndices', () {
     test('uses a 16-bit buffer when every index fits', () {
       final packed = InterleavedLayoutAdapter.packIndices([0, 1, 2, 0xFFFF]);

--- a/packages/flutter_scene/test/lod_test.dart
+++ b/packages/flutter_scene/test/lod_test.dart
@@ -1,0 +1,120 @@
+// The level-of-detail selection core: the projected-screen-size metric and
+// the threshold selection with its cull floor and hysteresis dead-band.
+// Pure logic, so these run without a Flutter GPU context.
+
+import 'dart:math' as math;
+
+import 'package:flutter_scene/src/render/lod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  group('lodScreenSize', () {
+    const fov = math.pi / 2; // 90 degrees, tan(fov/2) == 1
+
+    test('halves as the object moves twice as far', () {
+      double sizeAt(double distance) => lodScreenSize(
+        center: Vector3(0, 0, -distance),
+        radius: 1,
+        cameraPosition: Vector3.zero(),
+        fovRadiansY: fov,
+      );
+      // With tan(fov/2) == 1, size == radius / distance.
+      expect(sizeAt(2), closeTo(0.5, 1e-9));
+      expect(sizeAt(4), closeTo(0.25, 1e-9));
+    });
+
+    test('a wider field of view shrinks the projected size', () {
+      double sizeAt(double f) => lodScreenSize(
+        center: Vector3(0, 0, -4),
+        radius: 1,
+        cameraPosition: Vector3.zero(),
+        fovRadiansY: f,
+      );
+      expect(sizeAt(math.pi / 3), greaterThan(sizeAt(math.pi / 2)));
+    });
+
+    test('the camera inside the sphere yields infinity', () {
+      expect(
+        lodScreenSize(
+          center: Vector3.zero(),
+          radius: 2,
+          cameraPosition: Vector3(0, 0, 1),
+          fovRadiansY: fov,
+        ),
+        double.infinity,
+      );
+    });
+  });
+
+  group('selectLodLevel', () {
+    final thresholds = [0.5, 0.25, 0.1]; // three levels, cull below 0.1
+
+    test('picks the highest detail whose threshold is met', () {
+      expect(selectLodLevel(0.8, thresholds), 0);
+      expect(selectLodLevel(0.5, thresholds), 0);
+      expect(selectLodLevel(0.3, thresholds), 1);
+      expect(selectLodLevel(0.1, thresholds), 2);
+    });
+
+    test('culls below the smallest threshold', () {
+      expect(selectLodLevel(0.05, thresholds), -1);
+    });
+
+    test('a zero last threshold never culls', () {
+      expect(selectLodLevel(0.0, [0.5, 0.0]), 1);
+    });
+
+    test('hysteresis holds the current level inside the dead-band', () {
+      // The 1<->2 boundary is 0.25; with a 20% margin level 1 holds down to
+      // 0.20 and level 2 holds up to 0.30.
+      expect(
+        selectLodLevel(0.22, thresholds, hysteresis: 0.2, currentLevel: 1),
+        1, // would be 2 without hysteresis, but stays 1
+      );
+      expect(
+        selectLodLevel(0.28, thresholds, hysteresis: 0.2, currentLevel: 2),
+        2, // would be 1 without hysteresis, but stays 2
+      );
+    });
+
+    test('hysteresis still switches once clearly past the boundary', () {
+      expect(
+        selectLodLevel(0.18, thresholds, hysteresis: 0.2, currentLevel: 1),
+        2, // below 0.25 * 0.8, so it drops
+      );
+      expect(
+        selectLodLevel(0.32, thresholds, hysteresis: 0.2, currentLevel: 2),
+        1, // above 0.25 * 1.2, so it rises
+      );
+    });
+
+    test('hysteresis brackets the cull floor too', () {
+      // Holding level 2 just under the floor, and staying culled just over it.
+      expect(
+        selectLodLevel(0.095, thresholds, hysteresis: 0.2, currentLevel: 2),
+        2,
+      );
+      expect(
+        selectLodLevel(0.105, thresholds, hysteresis: 0.2, currentLevel: -1),
+        -1,
+      );
+      // Clearly past in each direction.
+      expect(
+        selectLodLevel(0.07, thresholds, hysteresis: 0.2, currentLevel: 2),
+        -1,
+      );
+      expect(
+        selectLodLevel(0.13, thresholds, hysteresis: 0.2, currentLevel: -1),
+        2,
+      );
+    });
+
+    test('a non-adjacent jump switches immediately despite hysteresis', () {
+      expect(
+        selectLodLevel(0.9, thresholds, hysteresis: 0.5, currentLevel: 2),
+        0,
+      );
+    });
+  });
+}

--- a/packages/flutter_scene/test/lod_test.dart
+++ b/packages/flutter_scene/test/lod_test.dart
@@ -117,4 +117,50 @@ void main() {
       );
     });
   });
+
+  group('blendLodLevels', () {
+    final thresholds = [0.5, 0.25, 0.1];
+
+    test('draws a single level at full fade away from any boundary', () {
+      final r = blendLodLevels(0.35, thresholds, blendRange: 0.1);
+      expect(r, hasLength(1));
+      expect(r.single.level, 1);
+      expect(r.single.fade, 1.0);
+    });
+
+    test('blends both adjacent levels inside a band', () {
+      // The 1<->2 boundary is 0.25; a +-10% band is [0.225, 0.275]. At the
+      // midpoint the two levels split evenly.
+      final mid = blendLodLevels(0.25, thresholds, blendRange: 0.1);
+      expect(mid.map((e) => e.level), [1, 2]);
+      expect(mid[0].fade, closeTo(0.5, 1e-9));
+      expect(mid[1].fade, closeTo(0.5, 1e-9));
+      // Fades always complement to 1.
+      expect(mid[0].fade + mid[1].fade, closeTo(1.0, 1e-9));
+      // Near the top of the band the finer level dominates.
+      final high = blendLodLevels(0.27, thresholds, blendRange: 0.1);
+      expect(high[0].level, 1);
+      expect(high[0].fade, greaterThan(0.5));
+    });
+
+    test('the last level fades out alone across the cull band', () {
+      // Cull boundary is 0.1; band [0.09, 0.11]. Inside it only level 2 draws,
+      // dissolving as the size drops.
+      final r = blendLodLevels(0.095, thresholds, blendRange: 0.1);
+      expect(r, hasLength(1));
+      expect(r.single.level, 2);
+      expect(r.single.fade, lessThan(0.5));
+    });
+
+    test('culls below the cull band', () {
+      expect(blendLodLevels(0.05, thresholds, blendRange: 0.1), isEmpty);
+    });
+
+    test('a zero blend range reduces to a hard switch', () {
+      final r = blendLodLevels(0.25, thresholds, blendRange: 0);
+      expect(r, hasLength(1));
+      expect(r.single.level, 1);
+      expect(r.single.fade, 1.0);
+    });
+  });
 }

--- a/packages/flutter_scene/test/mesh_data_test.dart
+++ b/packages/flutter_scene/test/mesh_data_test.dart
@@ -1,0 +1,64 @@
+// Covers the MeshData snapshot: pure construction (normal generation,
+// validation) and that it survives an isolate round-trip, the property
+// that lets meshing run off the render isolate. Turning a MeshData into a
+// live MeshGeometry uploads to the GPU and is exercised by the example app.
+
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart' show compute;
+import 'package:flutter_scene/src/geometry/mesh_data.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_test/flutter_test.dart';
+
+// Top-level so it can run on a background isolate via compute.
+MeshData buildTriangleData(Float32List positions) =>
+    MeshData.build(positions: positions, indices: <int>[0, 1, 2]);
+
+void main() {
+  // A triangle wound per the engine front-face convention (clockwise in
+  // model space), whose generated face normal points at +Z.
+  final triangle = Float32List.fromList(<double>[0, 0, 0, 0, 1, 0, 1, 0, 0]);
+
+  group('MeshData.build', () {
+    test('generates face normals when normals are absent', () {
+      final data = MeshData.build(positions: triangle, indices: <int>[0, 1, 2]);
+      expect(data.vertexCount, 3);
+      expect(data.normals, isNotNull);
+      expect(data.normals!, hasLength(3 * 3));
+      // Vertex 0's generated normal is +Z.
+      expect(data.normals![0], closeTo(0, 1e-6));
+      expect(data.normals![1], closeTo(0, 1e-6));
+      expect(data.normals![2], closeTo(1, 1e-6));
+    });
+
+    test('preserves authored normals', () {
+      final normals = Float32List.fromList(<double>[0, 1, 0, 0, 1, 0, 0, 1, 0]);
+      final data = MeshData.build(positions: triangle, normals: normals);
+      expect(data.normals, same(normals));
+    });
+
+    test('leaves normals null for a point primitive', () {
+      final data = MeshData.build(
+        positions: triangle,
+        primitiveType: gpu.PrimitiveType.point,
+      );
+      expect(data.normals, isNull);
+    });
+
+    test('rejects a position array that is not whole vertices', () {
+      expect(
+        () => MeshData.build(positions: Float32List(4)),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  test('a MeshData survives an isolate round-trip', () async {
+    final data = await compute(buildTriangleData, triangle);
+    expect(data.vertexCount, 3);
+    expect(data.positions, triangle);
+    expect(data.indices, <int>[0, 1, 2]);
+    // The off-isolate build generated the same +Z normal.
+    expect(data.normals![2], closeTo(1, 1e-6));
+  });
+}

--- a/packages/flutter_scene/test/mesh_geometry_test.dart
+++ b/packages/flutter_scene/test/mesh_geometry_test.dart
@@ -119,4 +119,43 @@ void main() {
       expect(nextBufferCapacity(9, minimum: 8), 16);
     });
   });
+
+  group('unionVertexRange', () {
+    test('an empty range contributes nothing', () {
+      expect(unionVertexRange((start: 0, end: 0), (start: 3, end: 7)), (
+        start: 3,
+        end: 7,
+      ));
+      expect(unionVertexRange((start: 3, end: 7), (start: 5, end: 5)), (
+        start: 3,
+        end: 7,
+      ));
+      // Two empty ranges stay empty.
+      final empty = unionVertexRange((start: 0, end: 0), (start: 2, end: 2));
+      expect(empty.end <= empty.start, isTrue);
+    });
+
+    test('overlapping and disjoint ranges return the bounding span', () {
+      expect(unionVertexRange((start: 2, end: 5), (start: 4, end: 9)), (
+        start: 2,
+        end: 9,
+      ));
+      // Disjoint spans are bridged (the buffer must refresh the whole span).
+      expect(unionVertexRange((start: 0, end: 2), (start: 8, end: 10)), (
+        start: 0,
+        end: 10,
+      ));
+    });
+
+    test('unioning a stable dirty span is idempotent', () {
+      // A buffer repeatedly dirtied over the same span converges to exactly
+      // that span, which is what lets a steady partial update stay cheap.
+      const span = (start: 4, end: 6);
+      var stale = (start: 0, end: 0);
+      for (var i = 0; i < 5; i++) {
+        stale = unionVertexRange(stale, span);
+      }
+      expect(stale, span);
+    });
+  });
 }

--- a/packages/flutter_scene/test/primitives_test.dart
+++ b/packages/flutter_scene/test/primitives_test.dart
@@ -499,5 +499,59 @@ void main() {
       expect(shape, isA<ConvexHullShape>());
       expect((shape as ConvexHullShape).points, hasLength(6 * 3));
     });
+
+    test('a torus maps to a compound of convex chunks around the ring', () {
+      final shape = torusCollisionShape(
+        radius: 1,
+        tubeRadius: 0.25,
+        segments: 12,
+        tubularSegments: 6,
+      );
+      expect(shape, isA<CompoundShape>());
+      final children = (shape as CompoundShape).children;
+      expect(children, hasLength(12));
+      // Each chunk is the convex hull of two tube cross-sections.
+      final first = children.first.shape;
+      expect(first, isA<ConvexHullShape>());
+      expect((first as ConvexHullShape).points, hasLength(2 * 6 * 3));
+      // The chunks leave the hole open: no point sits at the center.
+      for (final child in children) {
+        final pts = (child.shape as ConvexHullShape).points;
+        for (var i = 0; i < pts.length; i += 3) {
+          final r = math.sqrt(pts[i] * pts[i] + pts[i + 2] * pts[i + 2]);
+          expect(r, greaterThan(0.7)); // radius - tubeRadius
+        }
+      }
+    });
+
+    test('a disc maps to a thin cylinder', () {
+      final shape = discCollisionShape(radius: 1.5);
+      expect(shape, isA<CylinderShape>());
+      final cylinder = shape as CylinderShape;
+      expect(cylinder.radius, 1.5);
+      expect(cylinder.halfHeight, lessThan(0.2)); // thin coin
+    });
+
+    test('a ring maps to a compound of thin segments around the hole', () {
+      final shape = ringCollisionShape(
+        innerRadius: 0.5,
+        outerRadius: 1,
+        segments: 10,
+      );
+      expect(shape, isA<CompoundShape>());
+      final children = (shape as CompoundShape).children;
+      expect(children, hasLength(10));
+      // Each segment is an 8-point extruded convex hull, and none reach the
+      // hole (radius below innerRadius).
+      for (final child in children) {
+        expect(child.shape, isA<ConvexHullShape>());
+        final pts = (child.shape as ConvexHullShape).points;
+        expect(pts, hasLength(8 * 3));
+        for (var i = 0; i < pts.length; i += 3) {
+          final r = math.sqrt(pts[i] * pts[i] + pts[i + 2] * pts[i + 2]);
+          expect(r, greaterThanOrEqualTo(0.5 - 1e-9));
+        }
+      }
+    });
   });
 }

--- a/packages/flutter_scene/test/primitives_test.dart
+++ b/packages/flutter_scene/test/primitives_test.dart
@@ -239,6 +239,18 @@ void main() {
       expectOutwardWinding(cylinder(bottomRadius: 0.5, topRadius: 2));
     });
 
+    test('a collapsed end produces a fan with no degenerate triangles', () {
+      for (final arrays in [
+        cylinder(topRadius: 0, radialSegments: 12),
+        cylinder(bottomRadius: 0, radialSegments: 12),
+      ]) {
+        for (var t = 0; t < arrays.indices.length ~/ 3; t++) {
+          final area = triangleNormal(arrays.positions, arrays.indices, t);
+          expect(area.length, greaterThan(1e-9), reason: 'triangle $t is flat');
+        }
+      }
+    });
+
     test('rejects degenerate parameters', () {
       expect(() => cylinder(radialSegments: 2), throwsArgumentError);
       expect(() => cylinder(heightSegments: 0), throwsArgumentError);

--- a/packages/flutter_scene/test/primitives_test.dart
+++ b/packages/flutter_scene/test/primitives_test.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter_scene/src/geometry/primitives.dart';
+import 'package:flutter_scene/src/physics/shape.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart';
 
@@ -19,6 +20,35 @@ Vector3 triangleNormal(Float32List positions, List<int> indices, int triangle) {
   final b = at(indices[triangle * 3 + 1]);
   final c = at(indices[triangle * 3 + 2]);
   return (b - a).cross(c - a);
+}
+
+// Asserts every (non-degenerate) triangle is wound so its front face points
+// outward, i.e. the right-hand-rule geometric normal opposes the stored
+// per-vertex shading normals (the engine's front-face convention).
+void expectOutwardWinding(PrimitiveArrays arrays) {
+  final positions = arrays.positions;
+  final normals = arrays.normals!;
+  final indices = arrays.indices;
+  Vector3 shadingAt(int v) =>
+      Vector3(normals[v * 3], normals[v * 3 + 1], normals[v * 3 + 2]);
+  for (var tri = 0; tri < indices.length ~/ 3; tri++) {
+    final geo = triangleNormal(positions, indices, tri);
+    // Skip degenerate triangles (zero area, e.g. at a cone apex or pole).
+    if (geo.length < 1e-9) continue;
+    final avg =
+        shadingAt(indices[tri * 3]) +
+        shadingAt(indices[tri * 3 + 1]) +
+        shadingAt(indices[tri * 3 + 2]);
+    expect(geo.dot(avg), lessThan(0), reason: 'triangle $tri is inside-out');
+  }
+}
+
+void expectUnitNormals(PrimitiveArrays arrays) {
+  final normals = arrays.normals!;
+  for (var v = 0; v < normals.length ~/ 3; v++) {
+    final n = Vector3(normals[v * 3], normals[v * 3 + 1], normals[v * 3 + 2]);
+    expect(n.length, closeTo(1, 1e-5));
+  }
 }
 
 void main() {
@@ -153,6 +183,321 @@ void main() {
         () => buildSphereArrays(radius: 1, segments: 8, rings: 1),
         throwsArgumentError,
       );
+    });
+  });
+
+  group('buildCylinderArrays', () {
+    PrimitiveArrays cylinder({
+      double bottomRadius = 1,
+      double topRadius = 1,
+      double height = 2,
+      int radialSegments = 8,
+      int heightSegments = 1,
+      bool bottomCap = true,
+      bool topCap = true,
+    }) => buildCylinderArrays(
+      bottomRadius: bottomRadius,
+      topRadius: topRadius,
+      height: height,
+      radialSegments: radialSegments,
+      heightSegments: heightSegments,
+      bottomCap: bottomCap,
+      topCap: topCap,
+    );
+
+    test('side spans the requested height and radius', () {
+      final arrays = cylinder(bottomRadius: 2, topRadius: 2, height: 4);
+      var minY = double.infinity;
+      var maxY = -double.infinity;
+      for (var v = 0; v < arrays.positions.length ~/ 3; v++) {
+        final y = arrays.positions[v * 3 + 1];
+        minY = math.min(minY, y);
+        maxY = math.max(maxY, y);
+      }
+      expect(minY, closeTo(-2, 1e-6));
+      expect(maxY, closeTo(2, 1e-6));
+      // A side vertex sits at the radius from the Y axis.
+      final px = arrays.positions[0];
+      final pz = arrays.positions[2];
+      expect(math.sqrt(px * px + pz * pz), closeTo(2, 1e-6));
+    });
+
+    test('caps can be omitted and a zero top radius makes a cone', () {
+      final capped = cylinder();
+      final open = cylinder(bottomCap: false, topCap: false);
+      expect(open.indices.length, lessThan(capped.indices.length));
+      // A cone has no top cap even when topCap is requested.
+      final cone = cylinder(topRadius: 0);
+      final coneCapped = cylinder(topRadius: 0, topCap: false);
+      expect(cone.indices.length, coneCapped.indices.length);
+    });
+
+    test('normals are unit length and wound outward (cylinder and cone)', () {
+      expectUnitNormals(cylinder());
+      expectOutwardWinding(cylinder());
+      expectOutwardWinding(cylinder(topRadius: 0));
+      expectOutwardWinding(cylinder(bottomRadius: 0.5, topRadius: 2));
+    });
+
+    test('rejects degenerate parameters', () {
+      expect(() => cylinder(radialSegments: 2), throwsArgumentError);
+      expect(() => cylinder(heightSegments: 0), throwsArgumentError);
+      expect(
+        () => cylinder(bottomRadius: 0, topRadius: 0),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('buildCapsuleArrays', () {
+    test('total extent is height plus two radii', () {
+      final arrays = buildCapsuleArrays(
+        radius: 0.5,
+        height: 2,
+        radialSegments: 12,
+        capRings: 4,
+      );
+      var minY = double.infinity;
+      var maxY = -double.infinity;
+      for (var v = 0; v < arrays.positions.length ~/ 3; v++) {
+        final y = arrays.positions[v * 3 + 1];
+        minY = math.min(minY, y);
+        maxY = math.max(maxY, y);
+      }
+      expect(maxY, closeTo(1.5, 1e-6));
+      expect(minY, closeTo(-1.5, 1e-6));
+    });
+
+    test('every surface point is within the capsule radius of its axis', () {
+      const radius = 0.75;
+      const height = 2.0;
+      final arrays = buildCapsuleArrays(
+        radius: radius,
+        height: height,
+        radialSegments: 16,
+        capRings: 6,
+      );
+      for (var v = 0; v < arrays.positions.length ~/ 3; v++) {
+        final x = arrays.positions[v * 3];
+        final y = arrays.positions[v * 3 + 1];
+        final z = arrays.positions[v * 3 + 2];
+        // Distance to the capsule's segment (the Y axis clamped to the
+        // cylinder section) equals the radius on the surface.
+        final clampedY = y.clamp(-height / 2, height / 2);
+        final dy = y - clampedY;
+        expect(math.sqrt(x * x + z * z + dy * dy), closeTo(radius, 1e-4));
+      }
+    });
+
+    test('normals are unit length and wound outward', () {
+      final arrays = buildCapsuleArrays(
+        radius: 0.5,
+        height: 1.5,
+        radialSegments: 12,
+        capRings: 4,
+      );
+      expectUnitNormals(arrays);
+      expectOutwardWinding(arrays);
+    });
+
+    test('rejects degenerate parameters', () {
+      expect(
+        () => buildCapsuleArrays(
+          radius: 0,
+          height: 1,
+          radialSegments: 8,
+          capRings: 2,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => buildCapsuleArrays(
+          radius: 1,
+          height: 1,
+          radialSegments: 2,
+          capRings: 2,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('buildTorusArrays', () {
+    test('points lie on the tube and counts follow the tessellation', () {
+      const radius = 1.0;
+      const tube = 0.25;
+      const radial = 10;
+      const tubular = 6;
+      final arrays = buildTorusArrays(
+        radius: radius,
+        tubeRadius: tube,
+        radialSegments: radial,
+        tubularSegments: tubular,
+      );
+      expect(arrays.positions, hasLength((radial + 1) * (tubular + 1) * 3));
+      expect(arrays.indices, hasLength(radial * tubular * 6));
+      for (var v = 0; v < arrays.positions.length ~/ 3; v++) {
+        final x = arrays.positions[v * 3];
+        final y = arrays.positions[v * 3 + 1];
+        final z = arrays.positions[v * 3 + 2];
+        // Distance from the tube centerline circle equals the tube radius.
+        final ringDist = math.sqrt(x * x + z * z) - radius;
+        expect(math.sqrt(ringDist * ringDist + y * y), closeTo(tube, 1e-5));
+      }
+    });
+
+    test('normals are unit length and wound outward', () {
+      final arrays = buildTorusArrays(
+        radius: 1,
+        tubeRadius: 0.3,
+        radialSegments: 12,
+        tubularSegments: 8,
+      );
+      expectUnitNormals(arrays);
+      expectOutwardWinding(arrays);
+    });
+
+    test('rejects degenerate parameters', () {
+      expect(
+        () => buildTorusArrays(
+          radius: 1,
+          tubeRadius: 0.2,
+          radialSegments: 2,
+          tubularSegments: 8,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('buildDiscArrays and buildRingArrays', () {
+    test('a disc is a +Y-facing fan within its radius', () {
+      final arrays = buildDiscArrays(radius: 2, segments: 8);
+      expect(arrays.indices, hasLength(8 * 3));
+      for (var v = 0; v < arrays.positions.length ~/ 3; v++) {
+        expect(arrays.positions[v * 3 + 1], 0);
+        expect(arrays.normals!.sublist(v * 3, v * 3 + 3), [0, 1, 0]);
+      }
+      // Front face points +Y, so the geometric normal points -Y.
+      expect(
+        triangleNormal(arrays.positions, arrays.indices, 0).y,
+        lessThan(0),
+      );
+    });
+
+    test('a ring spans inner to outer radius and faces +Y', () {
+      const inner = 0.5;
+      const outer = 1.5;
+      final arrays = buildRingArrays(
+        innerRadius: inner,
+        outerRadius: outer,
+        segments: 12,
+      );
+      var minR = double.infinity;
+      var maxR = -double.infinity;
+      for (var v = 0; v < arrays.positions.length ~/ 3; v++) {
+        final x = arrays.positions[v * 3];
+        final z = arrays.positions[v * 3 + 2];
+        final r = math.sqrt(x * x + z * z);
+        minR = math.min(minR, r);
+        maxR = math.max(maxR, r);
+      }
+      expect(minR, closeTo(inner, 1e-6));
+      expect(maxR, closeTo(outer, 1e-6));
+      expectOutwardWinding(arrays);
+    });
+
+    test('reject degenerate parameters', () {
+      expect(
+        () => buildDiscArrays(radius: 1, segments: 2),
+        throwsArgumentError,
+      );
+      expect(
+        () => buildRingArrays(innerRadius: 1, outerRadius: 0.5, segments: 8),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('buildIcosphereArrays', () {
+    test('subdivision quadruples the face count from 20', () {
+      expect(
+        buildIcosphereArrays(radius: 1, subdivisions: 0).indices,
+        hasLength(20 * 3),
+      );
+      expect(
+        buildIcosphereArrays(radius: 1, subdivisions: 1).indices,
+        hasLength(80 * 3),
+      );
+      expect(
+        buildIcosphereArrays(radius: 1, subdivisions: 2).indices,
+        hasLength(320 * 3),
+      );
+    });
+
+    test('all points lie on the sphere and faces wind outward', () {
+      final arrays = buildIcosphereArrays(radius: 2, subdivisions: 2);
+      for (var v = 0; v < arrays.positions.length ~/ 3; v++) {
+        final x = arrays.positions[v * 3];
+        final y = arrays.positions[v * 3 + 1];
+        final z = arrays.positions[v * 3 + 2];
+        expect(math.sqrt(x * x + y * y + z * z), closeTo(2, 1e-5));
+      }
+      expectUnitNormals(arrays);
+      expectOutwardWinding(arrays);
+    });
+
+    test('rejects negative subdivisions', () {
+      expect(
+        () => buildIcosphereArrays(radius: 1, subdivisions: -1),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('collision shape bridge', () {
+    test('a cuboid maps to a box of half its extents', () {
+      final shape = cuboidCollisionShape(Vector3(2, 4, 6));
+      expect(shape, isA<BoxShape>());
+      expect((shape as BoxShape).halfExtents, Vector3(1, 2, 3));
+    });
+
+    test('a capsule keeps its radius and half mid-section height', () {
+      final shape = capsuleCollisionShape(radius: 0.5, height: 2);
+      expect(shape, isA<CapsuleShape>());
+      expect((shape as CapsuleShape).radius, 0.5);
+      // halfHeight is half the mid-section, excluding the caps.
+      expect(shape.halfHeight, 1.0);
+    });
+
+    test('an equal-radius cylinder maps to a cylinder shape', () {
+      final shape = cylinderCollisionShape(
+        bottomRadius: 1,
+        topRadius: 1,
+        height: 3,
+        radialSegments: 8,
+      );
+      expect(shape, isA<CylinderShape>());
+      expect((shape as CylinderShape).radius, 1);
+      expect(shape.halfHeight, 1.5);
+    });
+
+    test('a cone maps to a convex hull of its base ring plus the apex', () {
+      final shape = cylinderCollisionShape(
+        bottomRadius: 1,
+        topRadius: 0,
+        height: 2,
+        radialSegments: 8,
+      );
+      expect(shape, isA<ConvexHullShape>());
+      // 8 base-ring points plus a single apex point, xyz each.
+      expect((shape as ConvexHullShape).points, hasLength((8 + 1) * 3));
+    });
+
+    test('a wedge maps to the convex hull of its six corners', () {
+      final shape = wedgeCollisionShape(Vector3(2, 1, 2));
+      expect(shape, isA<ConvexHullShape>());
+      expect((shape as ConvexHullShape).points, hasLength(6 * 3));
     });
   });
 }

--- a/packages/flutter_scene/test/raycast_test.dart
+++ b/packages/flutter_scene/test/raycast_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_scene/scene.dart' hide Material;
 // The packed-triangle intersector is test-only surface; reach it directly.
 // ignore: implementation_imports
 import 'package:flutter_scene/src/raycast.dart'
-    show PackedTriangleHit, intersectPackedTriangles;
+    show PackedTriangleHit, intersectPackedTriangles, intersectSoATriangles;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu show IndexType;
 import 'package:vector_math/vector_math.dart';
@@ -161,6 +161,71 @@ void main() {
         Ray.originDirection(Vector3(0.3, -0.2, 5), Vector3(0, 0, -1)),
       ).single;
       expect(hit.localNormal.dot(Vector3(0, 0, 1)).abs(), closeTo(1.0, 1e-6));
+    });
+  });
+
+  group('structure-of-arrays triangle intersection (GPU-free)', () {
+    // The same quad as the interleaved test, but position and texcoord come
+    // from separate tightly packed lists.
+    final positions = Float32List.fromList([
+      -0.5, -0.5, 0, //
+      0.5, -0.5, 0, //
+      0.5, 0.5, 0, //
+      -0.5, 0.5, 0, //
+    ]);
+    final texCoords = Float32List.fromList([0, 1, 1, 1, 1, 0, 0, 0]);
+    final indices = _packIndices16([0, 1, 2, 0, 2, 3]);
+
+    List<PackedTriangleHit> cast(Ray ray) {
+      final hits = <PackedTriangleHit>[];
+      intersectSoATriangles(
+        positions: positions,
+        texCoords: texCoords,
+        indices: indices,
+        indexType: gpu.IndexType.int16,
+        indexCount: 6,
+        vertexCount: 4,
+        localRay: ray,
+        maxDistance: 1e9,
+        emit: hits.add,
+      );
+      return hits;
+    }
+
+    test('matches the interleaved intersector on a center hit', () {
+      final hits = cast(
+        Ray.originDirection(Vector3(0, 0, 5), Vector3(0, 0, -1)),
+      );
+      expect(hits, isNotEmpty);
+      expect(hits.first.t, closeTo(5.0, 1e-6));
+      expect(hits.first.uv.x, closeTo(0.5, 1e-6));
+      expect(hits.first.uv.y, closeTo(0.5, 1e-6));
+    });
+
+    test('interpolates uv toward a corner like the interleaved path', () {
+      final hits = cast(
+        Ray.originDirection(Vector3(0.4, -0.1, 5), Vector3(0, 0, -1)),
+      );
+      expect(hits, hasLength(1));
+      expect(hits.first.uv.x, closeTo(0.9, 1e-5));
+      expect(hits.first.uv.y, closeTo(0.6, 1e-5));
+    });
+
+    test('reports a zero uv when texcoords are absent', () {
+      final hits = <PackedTriangleHit>[];
+      intersectSoATriangles(
+        positions: positions,
+        texCoords: null,
+        indices: indices,
+        indexType: gpu.IndexType.int16,
+        indexCount: 6,
+        vertexCount: 4,
+        localRay: Ray.originDirection(Vector3(0, 0, 5), Vector3(0, 0, -1)),
+        maxDistance: 1e9,
+        emit: hits.add,
+      );
+      expect(hits, isNotEmpty);
+      expect(hits.first.uv, Vector2.zero());
     });
   });
 

--- a/packages/flutter_scene/test/raycast_test.dart
+++ b/packages/flutter_scene/test/raycast_test.dart
@@ -15,8 +15,23 @@ import 'package:flutter_scene/scene.dart' hide Material;
 import 'package:flutter_scene/src/raycast.dart'
     show PackedTriangleHit, intersectPackedTriangles, intersectSoATriangles;
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_scene/src/gpu/gpu.dart' as gpu show IndexType;
+import 'package:flutter_scene/src/gpu/gpu.dart'
+    as gpu
+    show IndexType, RenderPass, HostBuffer;
 import 'package:vector_math/vector_math.dart';
+
+/// A bare [Geometry] whose only purpose is to exercise the CPU-side raycast
+/// data contract without a GPU upload.
+class _RaycastDataGeometry extends Geometry {
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Matrix4 modelTransform,
+    Matrix4 cameraTransform,
+    Vector3 cameraPosition,
+  ) {}
+}
 
 bool _gpuAvailable() {
   try {
@@ -226,6 +241,27 @@ void main() {
       );
       expect(hits, isNotEmpty);
       expect(hits.first.uv, Vector2.zero());
+    });
+  });
+
+  group('structure-of-arrays raycast data wiring (GPU-free)', () {
+    test('setRaycastAttributes retains the index data', () {
+      // Regression: the SoA upload path uploaded the index buffer to the GPU
+      // but did not retain it for the CPU raycast, so an indexed mesh was
+      // raycast as a non-indexed triangle list (picking missed the surface).
+      final geometry = _RaycastDataGeometry();
+      final indices = ByteData(6);
+      geometry.setRaycastAttributes(
+        positions: Float32List(9),
+        texCoords: Float32List(6),
+        indices: indices,
+      );
+      final data = geometry.cpuMeshData;
+      expect(data.positions, isNotNull);
+      expect(data.texCoords, isNotNull);
+      expect(data.indices, same(indices));
+      // SoA geometry does not expose the interleaved buffer.
+      expect(data.vertices, isNull);
     });
   });
 

--- a/packages/flutter_scene/test/vertex_layout_test.dart
+++ b/packages/flutter_scene/test/vertex_layout_test.dart
@@ -8,8 +8,8 @@ import 'package:flutter_scene/src/geometry/geometry.dart'
     show
         kUnskinnedInstancedLayout,
         kUnskinnedPositionOnlyLayout,
-        kUnskinnedSplitColorLayout,
-        kUnskinnedSplitDepthLayout;
+        kUnskinnedSoAColorLayout,
+        kUnskinnedSoADepthLayout;
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
@@ -114,32 +114,25 @@ void main() {
     });
   });
 
-  group('de-interleaved split layouts', () {
-    test('color layout has tight position, attribute, and instance slots', () {
-      final layout = kUnskinnedSplitColorLayout.toGpuLayout();
-      expect(layout.buffers, hasLength(3));
-
-      // Slot 0: tight 12-byte position.
-      expect(layout.buffers[0].strideInBytes, 12);
-      expect(layout.buffers[0].attributes.map((a) => a.name), ['position']);
-
-      // Slot 1: the 36-byte attribute stream, offsets matching the split
-      // (normal at 0, texcoord at 12, color at 20).
-      final rest = layout.buffers[1];
-      expect(rest.strideInBytes, 36);
-      expect(rest.attributes.map((a) => (a.name, a.offsetInBytes)), [
-        ('normal', 0),
-        ('texture_coords', 12),
-        ('color', 20),
-      ]);
-
-      // Slot 2: the instance-rate model matrix.
-      expect(layout.buffers[2].strideInBytes, 64);
-      expect(layout.buffers[2].stepMode, gpu.VertexStepMode.instance);
+  group('structure-of-arrays layouts', () {
+    test('color layout is one tight buffer per attribute plus instance', () {
+      final layout = kUnskinnedSoAColorLayout.toGpuLayout();
+      expect(layout.buffers, hasLength(5));
+      expect(
+        layout.buffers.map((b) => (b.strideInBytes, b.attributes.first.name)),
+        [
+          (12, 'position'),
+          (12, 'normal'),
+          (8, 'texture_coords'),
+          (16, 'color'),
+          (64, 'model_transform_0'),
+        ],
+      );
+      expect(layout.buffers.last.stepMode, gpu.VertexStepMode.instance);
     });
 
     test('depth layout binds only tight position plus the instance slot', () {
-      final layout = kUnskinnedSplitDepthLayout.toGpuLayout();
+      final layout = kUnskinnedSoADepthLayout.toGpuLayout();
       expect(layout.buffers, hasLength(2));
       expect(layout.buffers[0].strideInBytes, 12);
       expect(layout.buffers[0].attributes.map((a) => a.name), ['position']);
@@ -150,8 +143,8 @@ void main() {
       final ids = {
         vertexLayoutId(kUnskinnedInstancedLayout),
         vertexLayoutId(kUnskinnedPositionOnlyLayout),
-        vertexLayoutId(kUnskinnedSplitColorLayout),
-        vertexLayoutId(kUnskinnedSplitDepthLayout),
+        vertexLayoutId(kUnskinnedSoAColorLayout),
+        vertexLayoutId(kUnskinnedSoADepthLayout),
       };
       expect(ids, hasLength(4));
     });

--- a/packages/flutter_scene/test/vertex_layout_test.dart
+++ b/packages/flutter_scene/test/vertex_layout_test.dart
@@ -5,7 +5,11 @@
 // without a Flutter GPU context.
 
 import 'package:flutter_scene/src/geometry/geometry.dart'
-    show kUnskinnedInstancedLayout, kUnskinnedPositionOnlyLayout;
+    show
+        kUnskinnedInstancedLayout,
+        kUnskinnedPositionOnlyLayout,
+        kUnskinnedSplitColorLayout,
+        kUnskinnedSplitDepthLayout;
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
@@ -107,6 +111,49 @@ void main() {
         vertexLayoutId(kUnskinnedPositionOnlyLayout),
         isNot(vertexLayoutId(kUnskinnedInstancedLayout)),
       );
+    });
+  });
+
+  group('de-interleaved split layouts', () {
+    test('color layout has tight position, attribute, and instance slots', () {
+      final layout = kUnskinnedSplitColorLayout.toGpuLayout();
+      expect(layout.buffers, hasLength(3));
+
+      // Slot 0: tight 12-byte position.
+      expect(layout.buffers[0].strideInBytes, 12);
+      expect(layout.buffers[0].attributes.map((a) => a.name), ['position']);
+
+      // Slot 1: the 36-byte attribute stream, offsets matching the split
+      // (normal at 0, texcoord at 12, color at 20).
+      final rest = layout.buffers[1];
+      expect(rest.strideInBytes, 36);
+      expect(rest.attributes.map((a) => (a.name, a.offsetInBytes)), [
+        ('normal', 0),
+        ('texture_coords', 12),
+        ('color', 20),
+      ]);
+
+      // Slot 2: the instance-rate model matrix.
+      expect(layout.buffers[2].strideInBytes, 64);
+      expect(layout.buffers[2].stepMode, gpu.VertexStepMode.instance);
+    });
+
+    test('depth layout binds only tight position plus the instance slot', () {
+      final layout = kUnskinnedSplitDepthLayout.toGpuLayout();
+      expect(layout.buffers, hasLength(2));
+      expect(layout.buffers[0].strideInBytes, 12);
+      expect(layout.buffers[0].attributes.map((a) => a.name), ['position']);
+      expect(layout.buffers[1].stepMode, gpu.VertexStepMode.instance);
+    });
+
+    test('the four unskinned layouts are all distinct identities', () {
+      final ids = {
+        vertexLayoutId(kUnskinnedInstancedLayout),
+        vertexLayoutId(kUnskinnedPositionOnlyLayout),
+        vertexLayoutId(kUnskinnedSplitColorLayout),
+        vertexLayoutId(kUnskinnedSplitDepthLayout),
+      };
+      expect(ids, hasLength(4));
     });
   });
 

--- a/packages/flutter_scene/test/vertex_layout_test.dart
+++ b/packages/flutter_scene/test/vertex_layout_test.dart
@@ -5,7 +5,7 @@
 // without a Flutter GPU context.
 
 import 'package:flutter_scene/src/geometry/geometry.dart'
-    show kUnskinnedInstancedLayout;
+    show kUnskinnedInstancedLayout, kUnskinnedPositionOnlyLayout;
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
@@ -65,6 +65,48 @@ void main() {
       expect(cursor, kUnskinnedPerVertexSize);
       // Sanity-check that the packer agrees on the per-vertex size.
       expect(InterleavedLayoutAdapter.floatsPerVertex * 4, cursor);
+    });
+  });
+
+  group('position-only depth layout', () {
+    test('reads only position from slot 0, plus the instance slot', () {
+      final layout = kUnskinnedPositionOnlyLayout.toGpuLayout();
+      expect(layout.buffers, hasLength(2));
+
+      // Slot 0: still the 48-byte interleaved stride, but only position is
+      // declared, so the input assembler fetches only position per vertex.
+      final vertex = layout.buffers[0];
+      expect(vertex.strideInBytes, kUnskinnedPerVertexSize);
+      expect(vertex.stepMode, gpu.VertexStepMode.vertex);
+      expect(
+        vertex.attributes.map((a) => (a.name, a.format, a.offsetInBytes)),
+        [('position', gpu.VertexFormat.float32x3, 0)],
+      );
+
+      // Slot 1: the same instance-rate model matrix as the color layout, so
+      // the bound instance buffer is identical across the two passes.
+      final instance = layout.buffers[1];
+      expect(instance.strideInBytes, 64);
+      expect(instance.stepMode, gpu.VertexStepMode.instance);
+      expect(instance.attributes.map((a) => a.name), [
+        'model_transform_0',
+        'model_transform_1',
+        'model_transform_2',
+        'model_transform_3',
+      ]);
+    });
+
+    test('is a distinct layout from the color layout', () {
+      // The two layouts drive the same vertex buffer but different pipelines,
+      // so they must not share a pipeline-cache identity.
+      expect(
+        kUnskinnedPositionOnlyLayout,
+        isNot(equals(kUnskinnedInstancedLayout)),
+      );
+      expect(
+        vertexLayoutId(kUnskinnedPositionOnlyLayout),
+        isNot(vertexLayoutId(kUnskinnedInstancedLayout)),
+      );
     });
   });
 

--- a/packages/flutter_scene/test/vertex_layout_test.dart
+++ b/packages/flutter_scene/test/vertex_layout_test.dart
@@ -1,0 +1,159 @@
+// Covers the described vertex-layout type: the canonical unskinned layout's
+// structure and byte parity with the interleaved packer, value equality and
+// interning (so two layouts on one shader cannot share a pipeline-cache
+// identity), and the lowering-time validation. Pure logic, so these run
+// without a Flutter GPU context.
+
+import 'package:flutter_scene/src/geometry/geometry.dart'
+    show kUnskinnedInstancedLayout;
+import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
+import 'package:flutter_scene/src/geometry/vertex_layout.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/importer/constants.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('canonical unskinned layout', () {
+    test('lowers to the expected two-buffer gpu layout', () {
+      final layout = kUnskinnedInstancedLayout.toGpuLayout();
+      expect(layout.buffers, hasLength(2));
+
+      // Slot 0: the interleaved 48-byte vertex stream.
+      final vertex = layout.buffers[0];
+      expect(vertex.strideInBytes, kUnskinnedPerVertexSize);
+      expect(vertex.stepMode, gpu.VertexStepMode.vertex);
+      expect(
+        vertex.attributes.map((a) => (a.name, a.format, a.offsetInBytes)),
+        [
+          ('position', gpu.VertexFormat.float32x3, 0),
+          ('normal', gpu.VertexFormat.float32x3, 12),
+          ('texture_coords', gpu.VertexFormat.float32x2, 24),
+          ('color', gpu.VertexFormat.float32x4, 32),
+        ],
+      );
+
+      // Slot 1: the instance-rate model matrix, four vec4 columns.
+      final instance = layout.buffers[1];
+      expect(instance.strideInBytes, 64);
+      expect(instance.stepMode, gpu.VertexStepMode.instance);
+      expect(
+        instance.attributes.map((a) => (a.name, a.format, a.offsetInBytes)),
+        [
+          ('model_transform_0', gpu.VertexFormat.float32x4, 0),
+          ('model_transform_1', gpu.VertexFormat.float32x4, 16),
+          ('model_transform_2', gpu.VertexFormat.float32x4, 32),
+          ('model_transform_3', gpu.VertexFormat.float32x4, 48),
+        ],
+      );
+    });
+
+    test('vertex attributes match the interleaved packer byte for byte', () {
+      // The packer writes position at floats 0-2, normal 3-5, texcoord 6-7,
+      // and color 8-11 of each 12-float vertex; the canonical layout's slot-0
+      // attribute byte offsets and formats must describe exactly that, or the
+      // declared layout and the packed bytes would disagree.
+      final vertex = kUnskinnedInstancedLayout.toGpuLayout().buffers[0];
+      var cursor = 0;
+      for (final attribute in vertex.attributes) {
+        expect(
+          attribute.offsetInBytes,
+          cursor,
+          reason: '${attribute.name} is not tightly packed',
+        );
+        cursor += attribute.format.bytesPerElement;
+      }
+      expect(cursor, kUnskinnedPerVertexSize);
+      // Sanity-check that the packer agrees on the per-vertex size.
+      expect(InterleavedLayoutAdapter.floatsPerVertex * 4, cursor);
+    });
+  });
+
+  group('value equality and interning', () {
+    VertexLayoutDescriptor singleBuffer(int stride) => VertexLayoutDescriptor(
+      buffers: [
+        VertexBufferDescriptor(
+          strideInBytes: stride,
+          attributes: const [
+            VertexAttributeDescriptor(
+              name: 'position',
+              format: gpu.VertexFormat.float32x3,
+            ),
+          ],
+        ),
+      ],
+    );
+
+    test('structurally identical layouts are equal and share an id', () {
+      final a = singleBuffer(12);
+      final b = singleBuffer(12);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(vertexLayoutId(a), vertexLayoutId(b));
+    });
+
+    test('different layouts get different non-zero ids', () {
+      // The pipeline-cache key carries this id, so two layouts on one shader
+      // must not collapse to the same id (the latent cache bug this fixes).
+      final a = singleBuffer(12);
+      final c = singleBuffer(16);
+      expect(a, isNot(equals(c)));
+      expect(vertexLayoutId(a), isNot(vertexLayoutId(c)));
+      expect(vertexLayoutId(a), isNot(0));
+      expect(vertexLayoutId(c), isNot(0));
+    });
+
+    test('the default reflected layout (null) is id 0', () {
+      expect(vertexLayoutId(null), 0);
+    });
+
+    test('an id is stable across repeated lookups', () {
+      final a = singleBuffer(24);
+      expect(vertexLayoutId(a), vertexLayoutId(singleBuffer(24)));
+    });
+  });
+
+  group('lowering-time validation', () {
+    test('rejects an attribute that overruns its buffer stride', () {
+      final layout = VertexLayoutDescriptor(
+        buffers: const [
+          VertexBufferDescriptor(
+            strideInBytes: 8,
+            attributes: [
+              VertexAttributeDescriptor(
+                name: 'position',
+                format: gpu.VertexFormat.float32x3, // 12 bytes > 8 stride
+              ),
+            ],
+          ),
+        ],
+      );
+      expect(layout.toGpuLayout, throwsArgumentError);
+    });
+
+    test('rejects a duplicated attribute name', () {
+      final layout = VertexLayoutDescriptor(
+        buffers: const [
+          VertexBufferDescriptor(
+            strideInBytes: 24,
+            attributes: [
+              VertexAttributeDescriptor(
+                name: 'position',
+                format: gpu.VertexFormat.float32x3,
+              ),
+              VertexAttributeDescriptor(
+                name: 'position',
+                format: gpu.VertexFormat.float32x3,
+                offsetInBytes: 12,
+              ),
+            ],
+          ),
+        ],
+      );
+      expect(layout.toGpuLayout, throwsArgumentError);
+    });
+
+    test('accepts the canonical layout', () {
+      expect(kUnskinnedInstancedLayout.toGpuLayout, returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
Foundational geometry and vertex-layout work, plus a memory-model overhaul to a structure-of-arrays vertex pipeline. Landed in stages; tested end to end (example app plus the smoke-render matrix) as it went.

Phase A makes vertex layouts describable and fixes a latent pipeline-cache bug. Geometry carries a described, value-equal `VertexLayoutDescriptor` (attributes by name, format, slot, offset, with per-buffer stride and step mode) that lowers to the flutter_gpu layout, and the render-pipeline cache keys on (vertex shader, fragment shader, layout id) rather than the shader pair alone, so two layouts on one shader no longer collide. The depth-prepass, shadow, and object-filter passes resolve through the shared layout-aware cache. A described layout is validated at lowering time.

Phase B fetches only position in the depth, shadow, and mask passes, via a new position-only `UnskinnedDepthVertex` shader.

Structure-of-arrays overhaul (motivated by avoiding redundant copies and exploiting unified memory; a cross-engine survey and the constraints are in the design notes). flutter_gpu exposes no buffer read-back, so a CPU copy is unavoidable for raycast and serialization, and host-visible is the only practical storage mode (it is the shared UMA region). Given that, unskinned geometry now stores each attribute (position, normal, texcoord, color) in its own tightly packed buffer end to end:

- A structure-of-arrays source (MeshGeometry.fromArrays, the generators) writes each attribute straight to its stream with no interleave and no de-interleave round trip; the color pass binds five slots, the depth/shadow/mask passes bind only the 12-byte position stream.
- Updatable geometry stores each attribute in a ring of host-visible buffers and an update rewrites only the dirty stream into the next ring buffer, so a position update touches 12 bytes per vertex and does not race the GPU read.
- The `.fscene` format stores unskinned vertices de-interleaved (a new `unskinned_soa` payload layout); the realizer uploads each stream directly with no load-time reshuffle. Backward compatible: old interleaved `.fsceneb` files still load. Skinned geometry stays interleaved throughout.
- Raycasting reads whichever CPU form a geometry kept (structure-of-arrays attributes, or the interleaved buffer for skinned and pre-SoA documents).

Tests cover the described layouts, the four unskinned layout variants, byte parity with the packer, the de-interleave split, the concat/slice round trip, the interning/collision behavior, validation, and the structure-of-arrays raycast path. `dart analyze` is clean and the full unit suite passes. The smoke-render matrix passed for the layout change; the CRT widget-texture picking, skybox, and dynamic-geometry paths were checked in the running example app.

Two pre-existing engine issues surfaced during verification and are tracked separately, not addressed here: #185 (HDR skybox star-bursting) and #186 (roughness 0 reflection brightness drop).


Convenience geometry utilities. A procedural shape library (cylinder with separate top/bottom radii so it also covers cone and truncated cone, capsule, torus, disc, ring, and a geodesic icosphere) alongside the existing cuboid/plane/sphere/wedge, each an indexed mesh with generated outward normals and UVs. A backend-free physics-`Shape` bridge gives the analytic primitives a `collisionShape` getter (box, sphere, capsule, cylinder, convex hull for cones and the wedge, and compound shapes for the torus and ring that preserve the hole). `MeshData` is an isolate-transferable snapshot so meshing can run off the render isolate and upload via `MeshGeometry.fromMeshData`. `update*` gain an optional dirty vertex range that uploads only the changed span. A new Shapes example drops these primitives into a physics playground.

Geometry level of detail. An `LodComponent` draws one of several `LodLevel` variants chosen per view from the object's projected on-screen size (field-of-view aware, resolution independent), with a per-instance bias, a hysteresis dead-band, and a cull floor; selection runs in the encoder next to frustum culling. An optional dithered (screen-door) cross-fade blends adjacent levels across a screen-size band so the switch does not pop, honored by the built-in lit and unlit materials via a fade coverage carried in existing uniform padding. A Geometry LOD example shows a field of icospheres switching detail with distance.

Also widens the published package description and adds pub.dev topics.
