### PR TITLE
Resolve built-in shaders lazily so scene content can be built before warm-up

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.19.0
+
+* Built-in materials and geometries can now be constructed before
+  `Scene.initializeStaticResources()` finishes loading the base shader bundle.
+  Each resolves its shader from the base library lazily on first render (which
+  the engine already defers until resources are ready) and caches it, so
+  `SceneView` handles the warm-up with no `await` or `FutureBuilder` in app
+  code. The built-in gradient and physical sky sources work the same way. To
+  show placeholder content during warm-up, await
+  `Scene.initializeStaticResources()` yourself. Custom `ShaderMaterial` and
+  `ShaderSkySource` shaders are unaffected (you still supply a loaded shader).
+  `Material` and `Geometry` gain `setFragmentShaderName` and
+  `setVertexShaderName` for custom subclasses that pull from the base library,
+  and `ShaderSkySource` gains a `fragmentShaderName` constructor argument.
+
 ## 0.18.1
 
 * No code changes. Reworded the package description, added the Flutter Scene

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -53,6 +53,7 @@ abstract class Geometry {
   Float32List? _cpuTexCoords;
 
   gpu.Shader? _vertexShader;
+  String? _vertexShaderName;
 
   /// How the vertex/index data is assembled into primitives when drawn.
   ///
@@ -98,13 +99,20 @@ abstract class Geometry {
 
   /// The vertex shader used when rendering this geometry.
   ///
-  /// Set by subclasses (or via [setVertexShader]) before the first frame.
-  /// Throws if accessed before a shader has been assigned.
+  /// Set by subclasses, either directly with [setVertexShader] or, for a
+  /// shader from [baseShaderLibrary], by name with [setVertexShaderName]. A
+  /// name is resolved on first access and cached, so the lookup happens once
+  /// (at render time) rather than per draw. Throws if accessed before a
+  /// shader has been assigned, or before the base shader bundle has loaded
+  /// for a named shader.
   gpu.Shader get vertexShader {
-    if (_vertexShader == null) {
+    final resolved = _vertexShader ??= _vertexShaderName == null
+        ? null
+        : baseShaderLibrary[_vertexShaderName!];
+    if (resolved == null) {
       throw Exception('Vertex shader has not been set');
     }
-    return _vertexShader!;
+    return resolved;
   }
 
   /// Binds an already-uploaded vertex buffer view as this geometry's
@@ -370,6 +378,18 @@ abstract class Geometry {
   /// from [baseShaderLibrary] or another shader bundle.
   void setVertexShader(gpu.Shader shader) {
     _vertexShader = shader;
+    _vertexShaderName = null;
+  }
+
+  /// Assigns the vertex shader by [name] from [baseShaderLibrary].
+  ///
+  /// The shader is resolved lazily on first use and then cached, so a
+  /// geometry can be constructed before [Scene.initializeStaticResources]
+  /// has loaded the base shader bundle. The shader is only needed at render
+  /// time, which the engine already defers until the bundle is ready.
+  void setVertexShaderName(String name) {
+    _vertexShaderName = name;
+    _vertexShader = null;
   }
 
   /// Hook for skinned geometries to receive the joints texture computed
@@ -480,7 +500,7 @@ class UnskinnedGeometry extends Geometry {
   /// Creates an [UnskinnedGeometry] preconfigured with the
   /// `UnskinnedVertex` shader from [baseShaderLibrary].
   UnskinnedGeometry() {
-    setVertexShader(baseShaderLibrary['UnskinnedVertex']!);
+    setVertexShaderName('UnskinnedVertex');
   }
 
   // Whether this geometry stores its attributes de-interleaved into separate
@@ -645,7 +665,7 @@ class SkinnedGeometry extends Geometry {
   /// Creates a [SkinnedGeometry] preconfigured with the `SkinnedVertex`
   /// shader from [baseShaderLibrary].
   SkinnedGeometry() {
-    setVertexShader(baseShaderLibrary['SkinnedVertex']!);
+    setVertexShaderName('SkinnedVertex');
   }
 
   @override

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/physically_based_material.dart';
 import 'package:flutter_scene/src/material/unlit_material.dart';
 import 'package:flutter_scene/src/render_texture.dart';
+import 'package:flutter_scene/src/shaders.dart';
 
 /// Validates a value assigned to a material texture slot.
 ///
@@ -194,22 +195,41 @@ abstract class Material {
   double lodFade = 1.0;
 
   gpu.Shader? _fragmentShader;
+  String? _fragmentShaderName;
 
   /// The fragment shader used when rendering geometry with this material.
   ///
-  /// Subclasses set this in their constructor (typically via
-  /// [setFragmentShader]). Throws if accessed before a shader has been
-  /// assigned.
+  /// Subclasses assign this in their constructor, either directly with
+  /// [setFragmentShader] or, for a shader from [baseShaderLibrary], by name
+  /// with [setFragmentShaderName]. A name is resolved on first access and
+  /// cached, so the lookup happens once (at render time) rather than per
+  /// draw. Throws if accessed before a shader has been assigned, or before
+  /// the base shader bundle has loaded for a named shader.
   gpu.Shader get fragmentShader {
-    if (_fragmentShader == null) {
+    final resolved = _fragmentShader ??= _fragmentShaderName == null
+        ? null
+        : baseShaderLibrary[_fragmentShaderName!];
+    if (resolved == null) {
       throw Exception('Fragment shader has not been set');
     }
-    return _fragmentShader!;
+    return resolved;
   }
 
   /// Assigns the fragment [shader] used when this material is drawn.
   void setFragmentShader(gpu.Shader shader) {
     _fragmentShader = shader;
+    _fragmentShaderName = null;
+  }
+
+  /// Assigns the fragment shader by [name] from [baseShaderLibrary].
+  ///
+  /// The shader is resolved lazily on first use and then cached, so a
+  /// material can be constructed before [Scene.initializeStaticResources]
+  /// has loaded the base shader bundle. The shader is only needed at render
+  /// time, which the engine already defers until the bundle is ready.
+  void setFragmentShaderName(String name) {
+    _fragmentShaderName = name;
+    _fragmentShader = null;
   }
 
   /// Binds this material's render-pass state, uniforms, and textures.

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -4,7 +4,6 @@ import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material.dart';
-import 'package:flutter_scene/src/shaders.dart';
 
 import 'package:vector_math/vector_math.dart';
 
@@ -63,7 +62,7 @@ class PhysicallyBasedMaterial extends Material {
        _normalSource = normalTexture,
        _emissiveSource = emissiveTexture,
        _occlusionSource = occlusionTexture {
-    setFragmentShader(baseShaderLibrary['StandardFragment']!);
+    setFragmentShaderName('StandardFragment');
   }
 
   // Texture slots hold either a gpu.Texture or a live RenderTexture; the

--- a/packages/flutter_scene/lib/src/material/unlit_material.dart
+++ b/packages/flutter_scene/lib/src/material/unlit_material.dart
@@ -4,7 +4,6 @@ import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/material/physically_based_material.dart'
     show AlphaMode;
-import 'package:flutter_scene/src/shaders.dart';
 
 import 'package:vector_math/vector_math.dart';
 
@@ -15,7 +14,7 @@ import 'package:vector_math/vector_math.dart';
 /// The final color is `baseColorFactor * baseColorTexture`, optionally
 /// blended with the per-vertex color via [vertexColorWeight].
 ///
-/// Wraps the `UnlitFragment` shader from [baseShaderLibrary].
+/// Wraps the `UnlitFragment` shader from the base shader library.
 /// {@category Materials}
 class UnlitMaterial extends Material {
   /// Creates an [UnlitMaterial], optionally textured.
@@ -23,7 +22,7 @@ class UnlitMaterial extends Material {
   /// When [colorTexture] is null a 1×1 white placeholder is used so the
   /// final color reduces to [baseColorFactor].
   UnlitMaterial({gpu.Texture? colorTexture}) : _baseColorSource = colorTexture {
-    setFragmentShader(baseShaderLibrary['UnlitFragment']!);
+    setFragmentShaderName('UnlitFragment');
   }
 
   Object? _baseColorSource;

--- a/packages/flutter_scene/lib/src/sky_sources.dart
+++ b/packages/flutter_scene/lib/src/sky_sources.dart
@@ -5,7 +5,6 @@ import 'dart:math' as math;
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/material/environment.dart';
-import 'package:flutter_scene/src/shaders.dart';
 import 'package:flutter_scene/src/skybox.dart';
 import 'package:vector_math/vector_math.dart';
 
@@ -35,7 +34,7 @@ class GradientSkySource extends ShaderSkySource implements SunSky {
        groundColor = groundColor ?? Vector3(0.16, 0.14, 0.12),
        sunDirection = sunDirection ?? Vector3(0.4, 0.5, 0.6),
        sunColor = sunColor ?? Vector3(3.0, 2.7, 2.2),
-       super(fragmentShader: baseShaderLibrary['SkyGradientFragment']!);
+       super(fragmentShaderName: 'SkyGradientFragment');
 
   /// The sky color straight up.
   Vector3 zenithColor;
@@ -122,7 +121,7 @@ class PhysicalSkySource extends ShaderSkySource implements SunSky {
        rayleighColor = rayleighColor ?? Vector3(0.26, 0.41, 0.58),
        mieColor = mieColor ?? Vector3(0.69, 0.73, 0.81),
        groundColor = groundColor ?? Vector3(0.12, 0.12, 0.13),
-       super(fragmentShader: baseShaderLibrary['SkyPhysicalFragment']!);
+       super(fragmentShaderName: 'SkyPhysicalFragment');
 
   /// Direction toward the sun (world space; normalized when used).
   @override

--- a/packages/flutter_scene/lib/src/skybox.dart
+++ b/packages/flutter_scene/lib/src/skybox.dart
@@ -10,6 +10,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/shaders.dart';
 
 /// A sky that exposes a directional sun, so the engine can drive a matching
 /// shadow-casting directional light from it.
@@ -74,11 +75,32 @@ class EnvironmentSkySource extends SkySource {
 /// the shader controls its own output brightness.
 /// {@category Lighting and environment}
 class ShaderSkySource extends SkySource {
-  ShaderSkySource({required this.fragmentShader, this.useEnvironment = false});
+  /// Creates a sky source from a fragment shader.
+  ///
+  /// Provide exactly one of [fragmentShader] (an already-loaded shader, for
+  /// custom skies) or [fragmentShaderName] (a shader from the base library,
+  /// resolved lazily so the source can be constructed before
+  /// [Scene.initializeStaticResources] completes).
+  ShaderSkySource({
+    gpu.Shader? fragmentShader,
+    String? fragmentShaderName,
+    this.useEnvironment = false,
+  }) : assert(
+         (fragmentShader == null) != (fragmentShaderName == null),
+         'Provide exactly one of fragmentShader or fragmentShaderName.',
+       ),
+       _fragmentShader = fragmentShader,
+       _fragmentShaderName = fragmentShaderName;
+
+  gpu.Shader? _fragmentShader;
+  final String? _fragmentShaderName;
 
   /// The full-screen sky fragment shader, typically loaded from a
-  /// `.shaderbundle`.
-  gpu.Shader fragmentShader;
+  /// `.shaderbundle`. When the source was constructed by name, the shader is
+  /// resolved from the base library on first access and then cached.
+  gpu.Shader get fragmentShader =>
+      _fragmentShader ??= baseShaderLibrary[_fragmentShaderName!]!;
+  set fragmentShader(gpu.Shader shader) => _fragmentShader = shader;
 
   /// Whether the engine binds the active environment's IBL textures
   /// (`prefiltered_radiance`, `brdf_lut`) when the shader declares them.


### PR DESCRIPTION
Built-in materials and geometries read their shader from the base shader bundle, which loads asynchronously, so constructing one before `Scene.initializeStaticResources()` finished threw with "The base shader bundle has not been loaded yet". That forced apps to await initialization (or wrap construction in a `FutureBuilder`) before building any `Mesh`, which is easy to get wrong.

This stores the shader name at construction and resolves it from the base library on first access, caching the result so the lookup happens once at render time rather than per draw (the same pattern already used for the depth vertex shader). Rendering is already gated on resources being ready, so the shader is always available by the time it is needed.

Apps can now construct scene content immediately and hand it to `SceneView`, which handles the warm-up. Awaiting `Scene.initializeStaticResources()` is still available for showing placeholder content during the load.

Covers `UnlitMaterial`, `PhysicallyBasedMaterial`, `UnskinnedGeometry`, `SkinnedGeometry`, and the gradient and physical sky sources. `Material` and `Geometry` gain `setFragmentShaderName` and `setVertexShaderName` for custom subclasses that pull from the base library, and `ShaderSkySource` gains a `fragmentShaderName` constructor argument. Custom `ShaderMaterial` and `ShaderSkySource` shaders that supply an already-loaded shader are unaffected.

`flutter analyze` is clean and the full test suite passes.
