### PR TITLE
Add shadow-ambient darkening, grazing-angle cascade reach, and caster faces

### DIFF
--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -90,7 +90,8 @@ export 'src/components/mesh_component.dart' show MeshComponent;
 export 'src/render/lod.dart' show LodLevel;
 export 'src/components/widget_component.dart' show WidgetComponent, WidgetInput;
 export 'src/instanced_mesh.dart' show InstancedMesh;
-export 'src/light.dart' show DirectionalLight, Lighting, ShadowCascade;
+export 'src/light.dart'
+    show DirectionalLight, Lighting, ShadowCascade, ShadowCasterFaces;
 export 'src/render/custom_render_pass.dart'
     show CustomRenderPass, RenderPassContext, RenderStage;
 export 'src/render/object_filter.dart' show NodeFilter;

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -7,6 +7,29 @@ import 'package:vector_math/vector_math.dart';
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 
+/// Which faces of a shadow caster are rendered into the shadow map (the
+/// others are culled). Trades the two shadow-map failure modes (self-shadow
+/// acne vs peter-panning) against each other.
+/// {@category Lighting and environment}
+enum ShadowCasterFaces {
+  /// Render the light-facing (front) faces; cull back faces. The
+  /// general-purpose default. Self-shadow acne on lit surfaces is held off by
+  /// the depth and normal bias, which is hard to tune at grazing light angles.
+  front,
+
+  /// Render the faces pointing away from the light (back faces); cull front
+  /// faces ("second-depth" shadow mapping). For solid, watertight geometry
+  /// this removes self-shadow acne on lit surfaces, since the recorded depth
+  /// is the far side of the body. The tradeoff is peter-panning (a shadow can
+  /// detach from a thin caster); on thick bodies the offset hides inside the
+  /// solid, so this is a good fit for blocky/voxel worlds.
+  back,
+
+  /// Render both faces (no culling). Records the nearest face, like [front]
+  /// for closed geometry, but also captures one-sided or open meshes.
+  both,
+}
+
 /// An infinitely-distant light source (e.g. the sun) that illuminates
 /// the whole scene from a single direction.
 ///
@@ -43,6 +66,8 @@ class DirectionalLight {
     this.shadowMapResolution = 1024,
     this.shadowDepthBias = 0.02,
     this.shadowNormalBias = 0.02,
+    this.shadowAmbientStrength = 0.0,
+    this.shadowCasterFaces = ShadowCasterFaces.front,
   }) : direction = direction ?? Vector3(-0.3, -1.0, -0.2),
        color = color ?? Vector3(1.0, 1.0, 1.0);
 
@@ -98,6 +123,26 @@ class DirectionalLight {
   /// no slope-scaled depth-bias rasterizer state, so this carries the
   /// load of acne removal on grazing surfaces.
   double shadowNormalBias;
+
+  /// How much the cast shadow also darkens the image-based-lighting ambient,
+  /// from `0.0` to `1.0`.
+  ///
+  /// Physically the analytic light is additive over the IBL ambient, so a
+  /// shadow only removes the direct sun and leaves the ambient (sky) fully
+  /// lighting the shadowed area. That is correct when the IBL excludes the
+  /// sun, but a sky-baked environment already contains the sun's energy, so
+  /// the ambient alone reads as fully lit. This control multiplies the ambient
+  /// by `mix(1.0, shadow, shadowAmbientStrength)`, so `0.0` leaves the ambient
+  /// untouched (the physical default) and `1.0` lets the shadow darken the
+  /// ambient as much as the direct light. A non-physical artistic control for
+  /// sky-lit scenes that want shadows to read as shadows.
+  double shadowAmbientStrength;
+
+  /// Which faces are rendered into the shadow map. Defaults to
+  /// [ShadowCasterFaces.front]; use [ShadowCasterFaces.back] for solid,
+  /// watertight geometry (e.g. voxel terrain) to remove grazing-angle
+  /// self-shadow acne.
+  ShadowCasterFaces shadowCasterFaces;
 
   /// Builds the [shadowCascadeCount] shadow cascades that cover
   /// [camera]'s view out to [shadowMaxDistance], for a render target of
@@ -185,10 +230,23 @@ class DirectionalLight {
     return cascades;
   }
 
+  // How far toward the sun (in sphere radii) a cascade's light-space box
+  // reaches, plus a small forward margin past the slice. The reach must be
+  // generous because at grazing sun angles the occluder that shadows a receiver
+  // can be far toward the sun (long shadows); too short a reach drops those
+  // occluders from the map and the shadow goes missing (lit bands, one per
+  // cascade). The depth range is decoupled from the perpendicular box, so reach
+  // costs no shadow-map resolution; the fp32 atlas keeps depth precise over the
+  // wide range. Their sum over 2 is the depthRange / boxSize ratio that
+  // material_lighting.glsl's depth-bias normalization (`... / (7.0 * box)`)
+  // must match: (12 + 2) / 2 = 7.
+  static const double _casterReachRadii = 12.0;
+  static const double _forwardMarginRadii = 2.0;
+
   // The world -> light-clip matrix for a cascade whose frustum slice is
-  // bounded by a sphere ([sphereCenter], [sphereRadius]). The
-  // orthographic box is the sphere's bounding square, extended along
-  // the light axis so casters behind the slice still reach it, and
+  // bounded by a sphere ([sphereCenter], [sphereRadius]). The orthographic box
+  // is the sphere's bounding square in the perpendicular plane, with a depth
+  // range extended far toward the sun (see [_casterReachRadii]), and
   // texel-snapped against the world origin.
   Matrix4 _cascadeLightSpaceMatrix(
     Vector3 lightDir,
@@ -198,13 +256,13 @@ class DirectionalLight {
     final up = lightDir.y.abs() > 0.99
         ? Vector3(0.0, 0.0, 1.0)
         : Vector3(0.0, 1.0, 0.0);
-    // The eye sits well behind the sphere so casters between it and the
-    // slice are captured.
-    final eye = sphereCenter - lightDir * (sphereRadius * 3.0);
+    // The eye sits far toward the sun so occluders casting long shadows still
+    // render into this cascade (see [_casterReachRadii]).
+    final eye = sphereCenter - lightDir * (sphereRadius * _casterReachRadii);
     final view = _lookAt(eye, sphereCenter, up);
 
     const near = 0.0;
-    final far = sphereRadius * 6.0;
+    final far = sphereRadius * (_casterReachRadii + _forwardMarginRadii);
     final s = sphereRadius * 2.0;
     final ortho = Matrix4(
       2.0 / s,

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -94,11 +94,14 @@ class EngineLightingUniforms {
     final viewport = lighting.viewportSize;
     fragInfo[158] = viewport.width > 0 ? 1.0 / viewport.width : 0.0;
     fragInfo[159] = viewport.height > 0 ? 1.0 / viewport.height : 0.0;
-    // radiance_blend at [160..163]: the IBL cross-fade factor toward the
-    // secondary environment, 0 (and ignored) when there is no secondary.
+    // radiance_blend at [160..163]: x is the IBL cross-fade factor toward the
+    // secondary environment (0 and ignored when there is no secondary); y is
+    // the shadow-ambient strength (how much the cast shadow darkens the IBL
+    // ambient, 0 leaves it physical); zw reserved.
     fragInfo[160] = lighting.environmentMapB != null
         ? lighting.environmentBlend.clamp(0.0, 1.0)
         : 0.0;
+    fragInfo[161] = light?.shadowAmbientStrength.clamp(0.0, 1.0) ?? 0.0;
   }
 
   // Tiny constant uniform blocks (std140, 16 bytes) selecting the bound

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_scene/src/geometry/geometry.dart'
     show bindUnskinnedFrameInfo;
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/light.dart' show ShadowCasterFaces;
 import 'package:flutter_scene/src/render/instance_packing.dart';
 import 'package:vector_math/vector_math.dart';
 
@@ -20,15 +21,22 @@ class ShadowEncoder {
     this._renderPass,
     this._transientsBuffer,
     this._lightSpaceMatrix,
+    ShadowCasterFaces casterFaces,
   ) {
     frustum = Frustum.matrix(_lightSpaceMatrix);
     _renderPass.setDepthWriteEnable(true);
     _renderPass.setColorBlendEnable(false);
     _renderPass.setDepthCompareOperation(gpu.CompareFunction.lessEqual);
-    // Match the standard materials' winding / culling so the same faces
-    // that are visible cast shadows; a depth bias on the receiver handles
-    // self-shadow acne.
-    _renderPass.setCullMode(gpu.CullMode.backFace);
+    // Cull the complement of the faces that should cast: rendering front faces
+    // (the default) means culling back faces, and vice versa. With base CCW
+    // winding (flipped per-item for mirrored casters below), back-face culling
+    // keeps the light-facing faces. [ShadowCasterFaces.back] (second-depth)
+    // suits solid geometry, recording the far face to avoid self-shadow acne.
+    _renderPass.setCullMode(switch (casterFaces) {
+      ShadowCasterFaces.front => gpu.CullMode.backFace,
+      ShadowCasterFaces.back => gpu.CullMode.frontFace,
+      ShadowCasterFaces.both => gpu.CullMode.none,
+    });
     _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
   }
 

--- a/packages/flutter_scene/lib/src/render/shadow_pass.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_pass.dart
@@ -24,13 +24,16 @@ class ShadowPass extends RenderGraphPass {
     required RenderScene renderScene,
     required List<ShadowCascade> cascades,
     required int tileResolution,
+    required ShadowCasterFaces casterFaces,
   }) : _renderScene = renderScene,
        _cascades = cascades,
-       _tileResolution = tileResolution;
+       _tileResolution = tileResolution,
+       _casterFaces = casterFaces;
 
   final RenderScene _renderScene;
   final List<ShadowCascade> _cascades;
   final int _tileResolution;
+  final ShadowCasterFaces _casterFaces;
 
   @override
   String get name => 'ShadowPass';
@@ -91,6 +94,7 @@ class ShadowPass extends RenderGraphPass {
         renderPass,
         context.transientsBuffer,
         _cascades[c].lightSpaceMatrix,
+        _casterFaces,
       );
       _renderScene.cull(encoder.frustum, encoder.submit);
     }

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -992,6 +992,7 @@ base class Scene implements SceneGraph {
           renderScene: renderScene,
           cascades: cascades,
           tileResolution: light!.shadowMapResolution,
+          casterFaces: light.shadowCasterFaces,
         ),
       );
     }

--- a/packages/flutter_scene/lib/src/sun_light.dart
+++ b/packages/flutter_scene/lib/src/sun_light.dart
@@ -47,6 +47,8 @@ class SunLight {
     this.shadowNormalBias = 0.02,
     this.shadowFadeRange = 2.0,
     this.shadowCascadeSplitLambda = 0.6,
+    this.shadowAmbientStrength = 0.0,
+    this.shadowCasterFaces = ShadowCasterFaces.front,
   });
 
   /// The sky whose sun aims the light.
@@ -89,6 +91,16 @@ class SunLight {
   /// Cascade split blend; see [DirectionalLight.shadowCascadeSplitLambda].
   double shadowCascadeSplitLambda;
 
+  /// How much the shadow also darkens the IBL ambient; see
+  /// [DirectionalLight.shadowAmbientStrength]. Useful here because a
+  /// [SkyEnvironment] bakes the sun into the ambient, so a plain shadow leaves
+  /// shadowed areas reading as fully lit.
+  double shadowAmbientStrength;
+
+  /// Which faces are rendered into the shadow map; see
+  /// [DirectionalLight.shadowCasterFaces].
+  ShadowCasterFaces shadowCasterFaces;
+
   /// The managed light. Mutated in place by [resolve] each frame so the scene
   /// graph need not re-register a new light when the sun moves.
   final DirectionalLight light = DirectionalLight();
@@ -111,6 +123,8 @@ class SunLight {
     light.shadowNormalBias = shadowNormalBias;
     light.shadowFadeRange = shadowFadeRange;
     light.shadowCascadeSplitLambda = shadowCascadeSplitLambda;
+    light.shadowAmbientStrength = shadowAmbientStrength;
+    light.shadowCasterFaces = shadowCasterFaces;
     return light;
   }
 }

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -76,10 +76,12 @@ uniform FragInfo {
   // reciprocal of the render-target size, to turn gl_FragCoord into the
   // occlusion-texture UV.
   vec4 ssao_params;
-  // Image-based-lighting cross-fade. x: blend toward the secondary environment
-  // (the *_b samplers), 0 samples only the primary. yzw reserved. Both
-  // environments share RadianceLayoutInfo (the layout is a per-backend choice,
-  // not per-environment).
+  // Image-based-lighting cross-fade and shadow-ambient control. x: blend
+  // toward the secondary environment (the *_b samplers), 0 samples only the
+  // primary. y: shadow-ambient strength, how much the cast shadow also darkens
+  // the IBL ambient (0 leaves the ambient physical, 1 darkens it as much as the
+  // direct light). zw reserved. Both environments share RadianceLayoutInfo (the
+  // layout is a per-backend choice, not per-environment).
   vec4 radiance_blend;
 }
 frag_info;

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -78,11 +78,12 @@ float SampleCascade(int cascade, vec3 world_pos, vec3 n, int count) {
       frag_info.light_space_matrix[cascade] * vec4(biased, 1.0);
   vec3 proj = light_clip.xyz / light_clip.w;
   vec2 uv = proj.xy * 0.5 + 0.5;
-  // The depth bias is world-space; convert it to this cascade's clip-z
-  // (its orthographic depth range is 3 * box) so a caster crosses the
-  // shadow threshold at the same world height in every cascade, with
-  // no discontinuity where cascades meet.
-  float receiver_depth = proj.z - frag_info.shadow_bias / (3.0 * box);
+  // The depth bias is world-space; convert it to this cascade's clip-z (its
+  // orthographic depth range is 7 * box: the toward-sun reach + forward margin
+  // in light.dart, _casterReachRadii + _forwardMarginRadii, over the half-width
+  // that makes box) so a caster crosses the shadow threshold at the same world
+  // height in every cascade, with no discontinuity where cascades meet.
+  float receiver_depth = proj.z - frag_info.shadow_bias / (7.0 * box);
 
   // World-space penumbra -> this cascade's UV space, floored at a texel.
   float radius =
@@ -276,33 +277,56 @@ vec4 EvaluateLighting(MaterialInputs material) {
   float specular_occlusion = frag_info.ssao_params.y > 0.5
       ? ComputeSpecularOcclusion(n_dot_v, occlusion, roughness)
       : occlusion;
+  // Sun direction and how squarely this surface faces it. `facing` ramps from
+  // 0 (at or past the terminator) to 1 (sun-facing) over a small band, so the
+  // sun's influence falls off smoothly rather than at a hard line.
+  float n_dot_l = 0.0;
+  vec3 light_vector = vec3(0.0);
+  if (frag_info.has_directional_light > 0.5) {
+    light_vector = -normalize(frag_info.directional_light_direction.xyz);
+    n_dot_l = dot(normal, light_vector);
+  }
+  float facing = clamp(n_dot_l / 0.15, 0.0, 1.0);
+
+  // Sun-shadow visibility (1 lit .. 0 shadowed). The shadow map is only
+  // meaningful for sun-facing surfaces; a back face receives no sun by
+  // definition, so it is treated as fully shadowed (facing = 0) without a
+  // shadow-map lookup, whose normal-offset bias assumes a sun-facing receiver
+  // and would otherwise stripe the back face with acne.
+  float shadow =
+      (frag_info.has_directional_light > 0.5 && frag_info.casts_shadow > 0.5 &&
+       facing > 0.0)
+          ? SampleShadow(v_position, normal)
+          : 1.0;
+  float sun_visibility = facing * shadow;
+
+  // When shadow_ambient_strength (radiance_blend.y) is non-zero, the sun's
+  // occlusion also darkens the IBL ambient: a sky-baked environment already
+  // contains the sun's energy, so the ambient alone otherwise reads as fully
+  // lit inside shadows.
+  float ambient_shadow = mix(1.0, sun_visibility, frag_info.radiance_blend.y);
+
   vec3 ambient =
-      indirect_diffuse * occlusion + indirect_specular * specular_occlusion;
+      (indirect_diffuse * occlusion + indirect_specular * specular_occlusion) *
+      ambient_shadow;
 
   // Analytic directional light (Cook-Torrance, layered on top of the IBL
   // ambient term).
   vec3 direct = vec3(0.0);
-  if (frag_info.has_directional_light > 0.5) {
-    // surface -> light.
-    vec3 light_vector = -normalize(frag_info.directional_light_direction.xyz);
-    float n_dot_l = max(dot(normal, light_vector), 0.0);
-    if (n_dot_l > 0.0) {
-      vec3 half_vector = normalize(light_vector + camera_normal);
-      float n_dot_v_safe = max(n_dot_v, 1e-4);
-      float distribution = DistributionGGX(normal, half_vector, roughness);
-      float visibility =
-          VisibilitySmithGGXCorrelated(n_dot_v_safe, n_dot_l, roughness);
-      vec3 specular_fresnel =
-          FresnelSchlick(max(dot(half_vector, camera_normal), 0.0), reflectance);
-      // `visibility` already folds in 1 / (4 * NoL * NoV).
-      vec3 specular = distribution * visibility * specular_fresnel;
-      vec3 diffuse = (vec3(1.0) - specular_fresnel) * (1.0 - metallic) *
-                     albedo * (1.0 / kPi);
-      float shadow =
-          frag_info.casts_shadow > 0.5 ? SampleShadow(v_position, normal) : 1.0;
-      direct = (diffuse + specular) * frag_info.directional_light_color.rgb *
-               n_dot_l * shadow;
-    }
+  if (frag_info.has_directional_light > 0.5 && n_dot_l > 0.0) {
+    vec3 half_vector = normalize(light_vector + camera_normal);
+    float n_dot_v_safe = max(n_dot_v, 1e-4);
+    float distribution = DistributionGGX(normal, half_vector, roughness);
+    float visibility =
+        VisibilitySmithGGXCorrelated(n_dot_v_safe, n_dot_l, roughness);
+    vec3 specular_fresnel =
+        FresnelSchlick(max(dot(half_vector, camera_normal), 0.0), reflectance);
+    // `visibility` already folds in 1 / (4 * NoL * NoV).
+    vec3 specular = distribution * visibility * specular_fresnel;
+    vec3 diffuse = (vec3(1.0) - specular_fresnel) * (1.0 - metallic) *
+                   albedo * (1.0 / kPi);
+    direct = (diffuse + specular) * frag_info.directional_light_color.rgb *
+             n_dot_l * shadow;
   }
 
   vec3 emissive = material.emissive;


### PR DESCRIPTION
Three directional-shadow controls and fixes, each defaulting to the current behavior so existing scenes are unaffected.

**shadowAmbientStrength** (new on `DirectionalLight` and `SunLight`) lets the cast shadow also darken the image-based-lighting ambient, via `ambient *= mix(1.0, shadow, strength)`. The analytic light is additive over the IBL, so by default a shadow removes only the direct sun and the IBL still fully lights a shadowed area. That is correct when the IBL excludes the sun, but a sky-baked environment (`SkyEnvironment`) already contains the sun, so a shadow reads as a no-op on the ambient and shadowed areas look fully lit. This control darkens the ambient inside shadows. It is gated on the sun-facing term, so back faces are uniformly occluded without a bias-fragile shadow-map lookup. Default `0.0` keeps the ambient physical.

**Grazing-angle cascade reach.** Each cascade's light-space box now extends far toward the sun, decoupled from the perpendicular box so the toward-sun reach costs no shadow-map resolution. At low sun angles, long shadows are cast by occluders that previously fell outside the cascade box and were dropped from the map, which showed up as lit bands, one per cascade. The depth-bias normalization tracks the wider depth range.

**shadowCasterFaces** (new on `DirectionalLight` and `SunLight`) selects which faces render into the shadow map. `front` is the default and renders light-facing faces as before. `back` is second-depth and records the far face, which removes self-shadow acne on solid watertight geometry such as voxel terrain, at the cost of possible peter-panning. `both` renders all faces.

All shadow parameters keep their existing defaults, so this is purely additive. Verified locally on macOS Metal.
