### PR TITLE
Add a scene-tracked primary camera and a default fallback

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -13,6 +13,17 @@
   `setVertexShaderName` for custom subclasses that pull from the base library,
   and `ShaderSkySource` gains a `fragmentShaderName` constructor argument.
 
+* Added a scene-tracked primary camera. `Scene.camera` is the camera a
+  `SceneView` uses when it is given no `camera`, `cameraBuilder`, or
+  `viewsBuilder`. It resolves to an explicit override (assign any `Camera`),
+  else the first `CameraComponent` mounted in the scene (auto-promotion), else
+  null. `CameraComponent` gains `makeActive` (select it as the primary,
+  deferred until mount if needed) and `active`. When nothing resolves a
+  camera, `SceneView` now renders through a default camera instead of
+  asserting, so a bare `SceneView(scene)` always renders. The `SceneView`
+  constraint relaxes from exactly one to at most one of `camera`,
+  `cameraBuilder`, or `viewsBuilder`.
+
 ## 0.18.1
 
 * No code changes. Reworded the package description, added the Flutter Scene

--- a/packages/flutter_scene/lib/src/components/camera_component.dart
+++ b/packages/flutter_scene/lib/src/components/camera_component.dart
@@ -16,22 +16,83 @@ import 'package:flutter_scene/src/node.dart';
 /// `Scene.render` or a persistent `RenderView`. (The node should not be
 /// scaled; a camera node is expected to carry only rotation and
 /// translation.)
+///
+/// When the owning node is mounted in a scene, the component registers as a
+/// candidate for the scene's primary camera (`Scene.camera`). The first
+/// camera mounted becomes the primary automatically; call [makeActive] to
+/// select this one explicitly.
 /// {@category Scene graph}
 class CameraComponent extends Component {
   /// Creates a camera component with the given [projection] (a
   /// [PerspectiveProjection] by default).
   CameraComponent({CameraProjection? projection})
-    : projection = projection ?? PerspectiveProjection();
+    : _projection = projection ?? PerspectiveProjection();
+
+  CameraProjection _projection;
 
   /// The lens projection for this camera.
-  CameraProjection projection;
+  CameraProjection get projection => _projection;
+  set projection(CameraProjection value) {
+    _projection = value;
+    // Keep the cached camera (held by RenderViews or as the scene primary) in
+    // sync so a projection change takes effect without re-fetching.
+    _camera?.projection = value;
+  }
+
+  // Memoized so repeated resolution does not allocate and so the camera has a
+  // stable identity (used by [active] and the scene primary). Invalidated when
+  // the component is detached, since a new attachment may use a new node.
+  NodeCamera? _camera;
+
+  bool _activateOnMount = false;
 
   /// Returns a [NodeCamera] backed by the owning node.
   ///
   /// The returned camera tracks the node: moving or rotating the node
   /// moves the view on the next frame, so it is safe to hold in a
-  /// persistent `RenderView`.
-  NodeCamera toCamera() => NodeCamera(node, projection);
+  /// persistent `RenderView`. The same instance is returned across calls
+  /// while the component stays attached.
+  NodeCamera toCamera() => _camera ??= NodeCamera(node, _projection);
+
+  /// Makes this the scene's primary camera, overriding auto-promotion.
+  ///
+  /// If the owning node is not yet mounted, the selection is deferred and
+  /// applied when it mounts.
+  void makeActive() {
+    final renderScene = isAttached ? node.internalRenderScene : null;
+    if (renderScene != null) {
+      renderScene.cameraOverride = toCamera();
+    } else {
+      _activateOnMount = true;
+    }
+  }
+
+  /// Whether the scene's primary camera currently resolves to this component.
+  bool get active {
+    final renderScene = isAttached ? node.internalRenderScene : null;
+    return renderScene != null &&
+        identical(renderScene.primaryCamera, toCamera());
+  }
+
+  @override
+  void onMount() {
+    node.internalRenderScene?.addCamera(this);
+    if (_activateOnMount) {
+      _activateOnMount = false;
+      node.internalRenderScene?.cameraOverride = toCamera();
+    }
+  }
+
+  @override
+  void onUnmount() {
+    node.internalRenderScene?.removeCamera(this);
+  }
+
+  @override
+  void onDetach() {
+    // A reattachment may bind a different node, so drop the cached camera.
+    _camera = null;
+  }
 }
 
 /// A [Camera] whose view comes from a [node]'s world transform: the `+Z`
@@ -51,7 +112,7 @@ class NodeCamera extends Camera {
   final Node node;
 
   @override
-  final CameraProjection projection;
+  CameraProjection projection;
 
   Matrix4 get _worldTransform => node.globalTransform;
 

--- a/packages/flutter_scene/lib/src/render/render_scene.dart
+++ b/packages/flutter_scene/lib/src/render/render_scene.dart
@@ -1,6 +1,8 @@
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter/foundation.dart' show ValueNotifier;
+import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/components/camera_component.dart';
 import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/components/environment_volume_component.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
@@ -191,6 +193,31 @@ class RenderScene {
   void removeEnvironmentVolumeComponent(EnvironmentVolumeComponent volume) {
     environmentVolumeComponents.remove(volume);
   }
+
+  /// The mounted [CameraComponent]s, in mount order. The first is the
+  /// auto-promoted primary when no [cameraOverride] is set.
+  final List<CameraComponent> cameras = [];
+
+  /// An explicit primary-camera override, set through `Scene.camera`. When
+  /// non-null it wins over auto-promotion; when null the primary resolves to
+  /// the first mounted [CameraComponent], or null when there are none.
+  Camera? cameraOverride;
+
+  /// Registers [camera] as a mounted camera. Called by a [CameraComponent]
+  /// when its owning node mounts.
+  void addCamera(CameraComponent camera) {
+    cameras.add(camera);
+  }
+
+  /// Unregisters [camera]. Called when its owning node unmounts.
+  void removeCamera(CameraComponent camera) {
+    cameras.remove(camera);
+  }
+
+  /// The scene's primary camera: the explicit [cameraOverride] if set, else
+  /// the first mounted [CameraComponent]'s camera, else null.
+  Camera? get primaryCamera =>
+      cameraOverride ?? (cameras.isEmpty ? null : cameras.first.toCamera());
 
   Bvh _bvh = Bvh.build([]);
   final List<RenderItem> _alwaysVisible = [];

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart' show Matrix3, Ray;
 import 'ambient_occlusion.dart';
 import 'camera.dart';
+import 'components/camera_component.dart';
 import 'components/directional_light_component.dart';
 import 'light.dart';
 import 'material/environment.dart';
@@ -339,6 +340,21 @@ base class Scene implements SceneGraph {
   /// Kept in sync by the node graph as mesh-bearing nodes are added and
   /// removed. Engine-internal; not part of the stable public API.
   final RenderScene renderScene = RenderScene();
+
+  /// The scene's primary camera.
+  ///
+  /// A `SceneView` with no `camera`, `cameraBuilder`, or `viewsBuilder`
+  /// renders through this. It resolves to an explicit override (assign any
+  /// [Camera] here) if set, otherwise to the first [CameraComponent] mounted
+  /// in the scene (auto-promotion), otherwise null. When it is null, a
+  /// `SceneView` falls back to a default camera so a scene with no camera set
+  /// up still renders.
+  ///
+  /// Assigning a value sets the override; assign null to clear it and revert
+  /// to auto-promotion. See also [CameraComponent.makeActive].
+  /// {@category Rendering}
+  Camera? get camera => renderScene.primaryCamera;
+  set camera(Camera? value) => renderScene.cameraOverride = value;
 
   /// Handles the creation and management of render targets for this [Scene].
   final Surface surface = Surface();

--- a/packages/flutter_scene/lib/src/widgets/scene_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view.dart
@@ -70,8 +70,10 @@ typedef SceneTickCallback =
 class SceneView extends StatefulWidget {
   /// Renders [scene], driving a repaint each frame.
   ///
-  /// Exactly one of [camera], [cameraBuilder], or [viewsBuilder] must be
-  /// provided.
+  /// At most one of [camera], [cameraBuilder], or [viewsBuilder] may be
+  /// provided. When none is, the view renders through the scene's primary
+  /// camera (`Scene.camera`), falling back to a default camera when the scene
+  /// has none, so `SceneView(scene)` always renders something.
   const SceneView(
     this.scene, {
     super.key,
@@ -85,9 +87,9 @@ class SceneView extends StatefulWidget {
   }) : assert(
          (camera != null ? 1 : 0) +
                  (cameraBuilder != null ? 1 : 0) +
-                 (viewsBuilder != null ? 1 : 0) ==
+                 (viewsBuilder != null ? 1 : 0) <=
              1,
-         'Provide exactly one of camera, cameraBuilder, or viewsBuilder.',
+         'Provide at most one of camera, cameraBuilder, or viewsBuilder.',
        );
 
   /// The scene to render. Owned and mutated by the application.
@@ -125,9 +127,29 @@ class SceneView extends StatefulWidget {
   /// Called once per frame while ticking. See [SceneTickCallback].
   final SceneTickCallback? onTick;
 
+  /// Resolves the camera for a single-view frame.
+  ///
+  /// Precedence: the explicit [camera], then [cameraBuilder] evaluated at
+  /// [elapsed], then [sceneCamera] (the scene's primary), then a default
+  /// camera so a scene with no camera still renders. Pure given its inputs.
+  @visibleForTesting
+  static Camera resolveCamera(
+    Duration elapsed, {
+    Camera? camera,
+    SceneCameraBuilder? cameraBuilder,
+    Camera? sceneCamera,
+  }) => camera ?? cameraBuilder?.call(elapsed) ?? sceneCamera ?? _defaultCamera;
+
   @override
   State<SceneView> createState() => _SceneViewState();
 }
+
+// Used when a scene has no camera set up at all, so a bare SceneView(scene)
+// still renders. Frames the front of content placed near the origin.
+// TODO(camera): verify this placement frames the front for both
+// runtime-imported glTF (after the scene-root Z flip) and procedurally added
+// content, and adjust the sign if they disagree.
+final Camera _defaultCamera = PerspectiveCamera();
 
 /// A [Listenable] that repaints the scene; its [notify] is called each frame so
 /// only the painting layer repaints (not the whole widget subtree).
@@ -174,8 +196,12 @@ class _SceneViewState extends State<SceneView>
 
   Camera? _lastBuiltCamera;
 
-  Camera _cameraForFrame() =>
-      _lastBuiltCamera = widget.camera ?? widget.cameraBuilder!(_elapsed.value);
+  Camera _cameraForFrame() => _lastBuiltCamera = SceneView.resolveCamera(
+    _elapsed.value,
+    camera: widget.camera,
+    cameraBuilder: widget.cameraBuilder,
+    sceneCamera: widget.scene.camera,
+  );
 
   List<RenderView> _viewsForFrame() => widget.viewsBuilder!(_elapsed.value);
 

--- a/packages/flutter_scene/lib/src/widgets/scene_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view.dart
@@ -145,10 +145,9 @@ class SceneView extends StatefulWidget {
 }
 
 // Used when a scene has no camera set up at all, so a bare SceneView(scene)
-// still renders. Frames the front of content placed near the origin.
-// TODO(camera): verify this placement frames the front for both
-// runtime-imported glTF (after the scene-root Z flip) and procedurally added
-// content, and adjust the sign if they disagree.
+// still renders. The PerspectiveCamera default sits on -Z looking toward the
+// origin, which frames the front of imported glTF content (whose front faces
+// -Z after the scene-root flip) and centers content placed near the origin.
 final Camera _defaultCamera = PerspectiveCamera();
 
 /// A [Listenable] that repaints the scene; its [notify] is called each frame so

--- a/packages/flutter_scene/test/camera_component_test.dart
+++ b/packages/flutter_scene/test/camera_component_test.dart
@@ -4,6 +4,7 @@
 import 'dart:ui' show Size;
 
 import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart';
 
@@ -58,6 +59,176 @@ void main() {
       expect(camera.position.x, closeTo(1.0, 1e-6));
       expect(camera.position.y, closeTo(2.0, 1e-6));
       expect(camera.position.z, closeTo(3.0, 1e-6));
+    });
+  });
+
+  group('primary camera', () {
+    test('no cameras mounted resolves to null', () {
+      expect(RenderScene().primaryCamera, isNull);
+    });
+
+    test('the first mounted camera auto-promotes to primary', () {
+      final rs = RenderScene();
+      final root = Node();
+      final cam = CameraComponent();
+      root.add(Node()..addComponent(cam));
+      root.debugMountInto(rs);
+
+      expect(rs.cameras, hasLength(1));
+      expect(rs.primaryCamera, same(cam.toCamera()));
+      expect(cam.active, isTrue);
+    });
+
+    test('later cameras do not steal the primary', () {
+      final rs = RenderScene();
+      final root = Node();
+      final a = CameraComponent();
+      final b = CameraComponent();
+      root.add(Node()..addComponent(a));
+      root.add(Node()..addComponent(b));
+      root.debugMountInto(rs);
+
+      expect(rs.primaryCamera, same(a.toCamera()));
+      expect(a.active, isTrue);
+      expect(b.active, isFalse);
+    });
+
+    test('makeActive overrides auto-promotion', () {
+      final rs = RenderScene();
+      final root = Node();
+      final a = CameraComponent();
+      final b = CameraComponent();
+      root.add(Node()..addComponent(a));
+      root.add(Node()..addComponent(b));
+      root.debugMountInto(rs);
+
+      b.makeActive();
+      expect(rs.primaryCamera, same(b.toCamera()));
+      expect(a.active, isFalse);
+      expect(b.active, isTrue);
+    });
+
+    test('clearing the override reverts to the first mounted camera', () {
+      final rs = RenderScene();
+      final root = Node();
+      final a = CameraComponent();
+      final b = CameraComponent();
+      root.add(Node()..addComponent(a));
+      root.add(Node()..addComponent(b));
+      root.debugMountInto(rs);
+
+      b.makeActive();
+      rs.cameraOverride = null;
+      expect(rs.primaryCamera, same(a.toCamera()));
+      expect(a.active, isTrue);
+    });
+
+    test('unmounting the active camera promotes the next', () {
+      final rs = RenderScene();
+      final root = Node();
+      final a = CameraComponent();
+      final b = CameraComponent();
+      final aNode = Node()..addComponent(a);
+      root.add(aNode);
+      root.add(Node()..addComponent(b));
+      root.debugMountInto(rs);
+      expect(rs.primaryCamera, same(a.toCamera()));
+
+      root.remove(aNode);
+      expect(rs.cameras, hasLength(1));
+      expect(rs.primaryCamera, same(b.toCamera()));
+    });
+
+    test('an explicit override persists when its component unmounts', () {
+      final rs = RenderScene();
+      final root = Node();
+      final a = CameraComponent();
+      final b = CameraComponent();
+      root.add(Node()..addComponent(a));
+      final bNode = Node()..addComponent(b);
+      root.add(bNode);
+      root.debugMountInto(rs);
+
+      final bCamera = b.toCamera();
+      b.makeActive();
+      root.remove(bNode);
+
+      // The override is independent of the mounted-camera registry.
+      expect(rs.cameras, hasLength(1));
+      expect(rs.primaryCamera, same(bCamera));
+    });
+
+    test('makeActive before mount is deferred and applied on mount', () {
+      final rs = RenderScene();
+      final root = Node();
+      final a = CameraComponent();
+      final b = CameraComponent();
+      root.add(Node()..addComponent(a));
+      root.add(Node()..addComponent(b));
+
+      // Nothing is mounted yet, so this defers until onMount.
+      b.makeActive();
+      root.debugMountInto(rs);
+
+      expect(rs.primaryCamera, same(b.toCamera()));
+      expect(b.active, isTrue);
+    });
+
+    test('changing the projection updates the cached camera in place', () {
+      final rs = RenderScene();
+      final node = Node()..addComponent(CameraComponent());
+      node.debugMountInto(rs);
+      final component = node.getComponents<CameraComponent>().first;
+
+      final camera = component.toCamera();
+      final newProjection = PerspectiveProjection(fovRadiansY: 1.0);
+      component.projection = newProjection;
+
+      expect(camera.projection, same(newProjection));
+      expect(component.toCamera(), same(camera));
+    });
+  });
+
+  group('SceneView.resolveCamera precedence', () {
+    final explicit = PerspectiveCamera();
+    final built = PerspectiveCamera();
+    final primary = PerspectiveCamera();
+
+    test('an explicit camera wins over everything', () {
+      expect(
+        SceneView.resolveCamera(
+          Duration.zero,
+          camera: explicit,
+          cameraBuilder: (_) => built,
+          sceneCamera: primary,
+        ),
+        same(explicit),
+      );
+    });
+
+    test('cameraBuilder is used when there is no explicit camera', () {
+      expect(
+        SceneView.resolveCamera(
+          Duration.zero,
+          cameraBuilder: (_) => built,
+          sceneCamera: primary,
+        ),
+        same(built),
+      );
+    });
+
+    test('the scene primary is used when no argument is given', () {
+      expect(
+        SceneView.resolveCamera(Duration.zero, sceneCamera: primary),
+        same(primary),
+      );
+    });
+
+    test('a shared default is used when nothing resolves a camera', () {
+      final a = SceneView.resolveCamera(Duration.zero);
+      final b = SceneView.resolveCamera(Duration.zero);
+      expect(a, isA<PerspectiveCamera>());
+      expect(a, same(b));
     });
   });
 }


### PR DESCRIPTION
A `SceneView` given no `camera`, `cameraBuilder`, or `viewsBuilder` now renders through the scene's primary camera, and falls back to a default camera when the scene has none, so a bare `SceneView(scene)` always renders something instead of asserting.

`Scene.camera` is the primary. It resolves to an explicit override (assign any `Camera`), otherwise the first `CameraComponent` mounted in the scene (auto-promotion), otherwise null. `CameraComponent` gains `makeActive` to select it as the primary (deferred until mount when its node is not mounted yet) and `active` to query it, and it keeps its `NodeCamera` memoized so changing the projection updates the live camera in place. The mounted-camera registry and the override live on the render scene, registered through the component mount hooks like the existing light and environment-volume registries.

The `SceneView` constraint relaxes from exactly one to at most one of `camera`, `cameraBuilder`, or `viewsBuilder`. This is non-breaking, since code passing one option is unaffected and code passing none previously hit the assert. The per-frame camera resolution is exposed as a pure, testable `SceneView.resolveCamera`.

Multi-view is unchanged and stays explicit (multiple `SceneView` widgets, `viewsBuilder`, or `Scene.views`). The viewport and target stay on `RenderView` rather than the camera, so a camera is reusable across views.

The default-camera placement was verified to frame the front of imported glTF content (its front faces `-Z` after the scene-root flip, which the default eye on `-Z` looks toward).

Tests cover auto-promotion, override via `makeActive`, promotion on unmount, deferred activation, projection sync, and the `resolveCamera` precedence. `flutter analyze` is clean and the full test suite passes.
