### PR TITLE
Add screen-space reflections

### DIFF
--- a/examples/flutter_app/lib/example_ssr.dart
+++ b/examples/flutter_app/lib/example_ssr.dart
@@ -5,10 +5,12 @@ import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_settings.dart';
+import 'quake_camera.dart';
 
 /// Demonstrates screen-space reflections: a dark floor reflects a ring of
-/// lit objects standing on it. The camera orbits at a low, grazing angle
-/// where the reflections read most strongly.
+/// lit objects standing on it. A tuning panel exposes the SSR settings, and
+/// the camera can be detached into a free first-person fly mode to inspect
+/// trouble spots.
 class ExampleSsr extends StatefulWidget {
   const ExampleSsr({super.key});
 
@@ -17,7 +19,22 @@ class ExampleSsr extends StatefulWidget {
 }
 
 class ExampleSsrState extends State<ExampleSsr> {
-  Scene scene = Scene();
+  final Scene scene = Scene();
+
+  bool _panelOpen = true;
+
+  // The free "inspection" camera and whether it is active. While inactive it
+  // is kept synced to the orbiting camera so toggling on does not jump.
+  bool _freeCamera = false;
+  final QuakeCamera _freeCam = QuakeCamera(position: vm.Vector3(0, 2.2, 9))
+    ..speed = 8.0
+    ..enabled = false;
+
+  double _elapsed = 0;
+  Camera _camera = PerspectiveCamera(
+    position: vm.Vector3(0, 2.2, 9),
+    target: vm.Vector3(0, 1, 0),
+  );
 
   @override
   void initState() {
@@ -34,18 +51,18 @@ class ExampleSsrState extends State<ExampleSsr> {
       ),
     );
 
-    // A large, dark, smooth floor at y = 0. Screen-space reflections compose
-    // over the lit image, so the surrounding objects appear mirrored in it.
-    final floor = Node(
-      mesh: Mesh(
-        PlaneGeometry(width: 40, depth: 40),
-        PhysicallyBasedMaterial()
-          ..baseColorFactor = vm.Vector4(0.02, 0.02, 0.025, 1.0)
-          ..roughnessFactor = 0.1
-          ..metallicFactor = 0.0,
+    // A large, dark, smooth floor at y = 0.
+    scene.add(
+      Node(
+        mesh: Mesh(
+          PlaneGeometry(width: 40, depth: 40),
+          PhysicallyBasedMaterial()
+            ..baseColorFactor = vm.Vector4(0.02, 0.02, 0.025, 1.0)
+            ..roughnessFactor = 0.1
+            ..metallicFactor = 0.0,
+        ),
       ),
     );
-    scene.add(floor);
 
     // A ring of brightly colored objects sitting on the floor.
     final palette = <vm.Vector4>[
@@ -88,21 +105,338 @@ class ExampleSsrState extends State<ExampleSsr> {
     scene.screenSpaceReflections.enabled = true;
   }
 
+  void _toggleFreeCamera() {
+    setState(() {
+      _freeCamera = !_freeCamera;
+      _freeCam
+        ..enabled = _freeCamera
+        ..releaseKeys()
+        ..move(_elapsed);
+    });
+  }
+
+  PerspectiveCamera _orbitCamera() {
+    return PerspectiveCamera(
+      position: vm.Vector3(
+        sin(_elapsed * 0.3) * 9,
+        2.2,
+        cos(_elapsed * 0.3) * 9,
+      ),
+      target: vm.Vector3(0, 1.0, 0),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return SceneView(
-      scene,
-      cameraBuilder: (elapsed) {
-        final t = elapsed.inMicroseconds / 1e6;
-        // Orbit slowly at a low height for a grazing view of the floor, where
-        // the reflections are strongest.
-        return PerspectiveCamera(
-          position: vm.Vector3(sin(t * 0.3) * 9, 2.2, cos(t * 0.3) * 9),
-          target: vm.Vector3(0, 1.0, 0),
-          fovFar: 50,
-        );
-      },
-      onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+    return Focus(
+      autofocus: true,
+      onKeyEvent: _freeCam.onKeyEvent,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: GestureDetector(
+              onPanUpdate: _freeCamera
+                  ? (details) => setState(() => _freeCam.look(details.delta))
+                  : null,
+              child: SceneView(
+                scene,
+                cameraBuilder: (elapsed) => _camera,
+                onTick: (elapsed, deltaSeconds) {
+                  _elapsed = elapsed.inMicroseconds / 1e6;
+                  if (_freeCamera) {
+                    _freeCam.move(_elapsed);
+                    _camera = _freeCam.camera;
+                  } else {
+                    final orbit = _orbitCamera();
+                    _freeCam.syncTo(orbit);
+                    _camera = orbit;
+                  }
+                  exampleSettings.applyTo(scene);
+                },
+              ),
+            ),
+          ),
+          Positioned(
+            top: 56,
+            right: 8,
+            child: _SsrPanel(
+              open: _panelOpen,
+              settings: scene.screenSpaceReflections,
+              onToggle: () => setState(() => _panelOpen = !_panelOpen),
+              onChanged: () => setState(() {}),
+            ),
+          ),
+          Positioned(
+            left: 8,
+            bottom: 8,
+            child: _CameraToggle(
+              freeCamera: _freeCamera,
+              onToggle: _toggleFreeCamera,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// The SSR tuning panel: a collapsible card of sliders and a debug-view
+// dropdown that mutate the scene's ScreenSpaceReflectionsSettings live.
+class _SsrPanel extends StatelessWidget {
+  const _SsrPanel({
+    required this.open,
+    required this.settings,
+    required this.onToggle,
+    required this.onChanged,
+  });
+
+  final bool open;
+  final ScreenSpaceReflectionsSettings settings;
+  final VoidCallback onToggle;
+  final VoidCallback onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Colors.black54,
+      child: SizedBox(
+        width: 340,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            InkWell(
+              onTap: onToggle,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(12, 10, 8, 10),
+                child: Row(
+                  children: [
+                    const Icon(Icons.tune, color: Colors.white, size: 20),
+                    const SizedBox(width: 8),
+                    const Expanded(
+                      child: Text(
+                        'SSR Settings',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    Icon(
+                      open ? Icons.expand_less : Icons.expand_more,
+                      color: Colors.white,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (open) ...[
+              const Divider(height: 1, color: Colors.white24),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        const Expanded(
+                          child: Text(
+                            'Enabled',
+                            style: TextStyle(color: Colors.white),
+                          ),
+                        ),
+                        Switch(
+                          value: settings.enabled,
+                          onChanged: (v) {
+                            settings.enabled = v;
+                            onChanged();
+                          },
+                        ),
+                      ],
+                    ),
+                    _SliderRow(
+                      label: 'Intensity',
+                      value: settings.intensity,
+                      min: 0,
+                      max: 2,
+                      onChanged: (v) {
+                        settings.intensity = v;
+                        onChanged();
+                      },
+                    ),
+                    _SliderRow(
+                      label: 'Max dist',
+                      value: settings.maxDistance,
+                      min: 1,
+                      max: 60,
+                      onChanged: (v) {
+                        settings.maxDistance = v;
+                        onChanged();
+                      },
+                    ),
+                    _SliderRow(
+                      label: 'Thickness',
+                      value: settings.thickness,
+                      min: 0.01,
+                      max: 3,
+                      onChanged: (v) {
+                        settings.thickness = v;
+                        onChanged();
+                      },
+                    ),
+                    _SliderRow(
+                      label: 'Max steps',
+                      value: settings.maxSteps.toDouble(),
+                      min: 8,
+                      max: 96,
+                      onChanged: (v) {
+                        settings.maxSteps = v.round();
+                        onChanged();
+                      },
+                    ),
+                    _SliderRow(
+                      label: 'Blur',
+                      value: settings.blur,
+                      min: 0,
+                      max: 1,
+                      onChanged: (v) {
+                        settings.blur = v;
+                        onChanged();
+                      },
+                    ),
+                    Row(
+                      children: [
+                        const SizedBox(
+                          width: 110,
+                          child: Text(
+                            'Debug',
+                            style: TextStyle(color: Colors.white),
+                          ),
+                        ),
+                        Expanded(
+                          child: DropdownButton<SsrDebugView>(
+                            isExpanded: true,
+                            dropdownColor: Colors.black87,
+                            value: settings.debugView,
+                            onChanged: (v) {
+                              if (v != null) {
+                                settings.debugView = v;
+                                onChanged();
+                              }
+                            },
+                            items: [
+                              for (final view in SsrDebugView.values)
+                                DropdownMenuItem(
+                                  value: view,
+                                  child: Text(
+                                    view.name,
+                                    style: const TextStyle(color: Colors.white),
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SliderRow extends StatelessWidget {
+  const _SliderRow({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 110,
+          child: Text(
+            '$label: ${value.toStringAsFixed(2)}',
+            style: const TextStyle(color: Colors.white),
+          ),
+        ),
+        Expanded(
+          child: Slider(value: value, min: min, max: max, onChanged: onChanged),
+        ),
+      ],
+    );
+  }
+}
+
+// A toggle for the free "inspection" camera, with a usage hint while active.
+class _CameraToggle extends StatelessWidget {
+  const _CameraToggle({required this.freeCamera, required this.onToggle});
+
+  final bool freeCamera;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (freeCamera)
+          Card(
+            color: Colors.black54,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              child: Text(
+                'WASD to move, Q and E for down and up, Shift to boost, drag to look',
+                style: TextStyle(color: Colors.white.withValues(alpha: 0.85)),
+              ),
+            ),
+          ),
+        Card(
+          color: Colors.black54,
+          child: InkWell(
+            onTap: onToggle,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    freeCamera ? Icons.videocam : Icons.videocam_outlined,
+                    color: Colors.white,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    freeCamera ? 'Free camera' : 'Orbit camera',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/examples/flutter_app/lib/example_ssr.dart
+++ b/examples/flutter_app/lib/example_ssr.dart
@@ -1,0 +1,108 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+
+/// Demonstrates screen-space reflections: a dark floor reflects a ring of
+/// lit objects standing on it. The camera orbits at a low, grazing angle
+/// where the reflections read most strongly.
+class ExampleSsr extends StatefulWidget {
+  const ExampleSsr({super.key});
+
+  @override
+  ExampleSsrState createState() => ExampleSsrState();
+}
+
+class ExampleSsrState extends State<ExampleSsr> {
+  Scene scene = Scene();
+
+  @override
+  void initState() {
+    super.initState();
+
+    scene.root.addComponent(
+      DirectionalLightComponent(
+        DirectionalLight(
+          direction: vm.Vector3(-0.5, -1.0, -0.4),
+          intensity: 3.0,
+          castsShadow: true,
+          shadowMaxDistance: 30.0,
+        ),
+      ),
+    );
+
+    // A large, dark, smooth floor at y = 0. Screen-space reflections compose
+    // over the lit image, so the surrounding objects appear mirrored in it.
+    final floor = Node(
+      mesh: Mesh(
+        PlaneGeometry(width: 40, depth: 40),
+        PhysicallyBasedMaterial()
+          ..baseColorFactor = vm.Vector4(0.02, 0.02, 0.025, 1.0)
+          ..roughnessFactor = 0.1
+          ..metallicFactor = 0.0,
+      ),
+    );
+    scene.add(floor);
+
+    // A ring of brightly colored objects sitting on the floor.
+    final palette = <vm.Vector4>[
+      vm.Vector4(0.90, 0.25, 0.25, 1.0),
+      vm.Vector4(0.95, 0.65, 0.20, 1.0),
+      vm.Vector4(0.25, 0.80, 0.40, 1.0),
+      vm.Vector4(0.25, 0.55, 0.95, 1.0),
+      vm.Vector4(0.70, 0.35, 0.90, 1.0),
+      vm.Vector4(0.95, 0.85, 0.30, 1.0),
+    ];
+    const count = 6;
+    const ringRadius = 4.0;
+    for (var i = 0; i < count; i++) {
+      final angle = (i / count) * 2 * pi;
+      final geometry = i.isEven
+          ? SphereGeometry(radius: 0.9)
+          : CuboidGeometry(vm.Vector3(1.4, 1.6, 1.4));
+      final height = i.isEven ? 0.9 : 0.8;
+      final node =
+          Node(
+              mesh: Mesh(
+                geometry,
+                PhysicallyBasedMaterial()
+                  ..baseColorFactor = palette[i]
+                  ..roughnessFactor = 0.4
+                  ..metallicFactor = 0.0,
+              ),
+            )
+            ..localTransform = vm.Matrix4.translation(
+              vm.Vector3(
+                cos(angle) * ringRadius,
+                height,
+                sin(angle) * ringRadius,
+              ),
+            );
+      scene.add(node);
+    }
+
+    scene.environmentIntensity = 0.5;
+    scene.screenSpaceReflections.enabled = true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SceneView(
+      scene,
+      cameraBuilder: (elapsed) {
+        final t = elapsed.inMicroseconds / 1e6;
+        // Orbit slowly at a low height for a grazing view of the floor, where
+        // the reflections are strongest.
+        return PerspectiveCamera(
+          position: vm.Vector3(sin(t * 0.3) * 9, 2.2, cos(t * 0.3) * 9),
+          target: vm.Vector3(0, 1.0, 0),
+          fovFar: 50,
+        );
+      },
+      onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+    );
+  }
+}

--- a/examples/flutter_app/lib/example_ssr.dart
+++ b/examples/flutter_app/lib/example_ssr.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
+import 'environment_menu.dart';
 import 'example_settings.dart';
+import 'lighting_panel.dart';
 import 'quake_camera.dart';
 
 /// Demonstrates screen-space reflections: a dark floor reflects a ring of
@@ -22,6 +24,11 @@ class ExampleSsrState extends State<ExampleSsr> {
   final Scene scene = Scene();
 
   bool _panelOpen = true;
+
+  // Drives the image-based-lighting environment / skybox menu (the same one
+  // the stress-tests example uses). The environment is what a reflection
+  // falls back to on a miss, so it is worth exploring against SSR.
+  final EnvironmentSelector _environmentSelector = EnvironmentSelector();
 
   // The free "inspection" camera and whether it is active. While inactive it
   // is kept synced to the orbiting camera so toggling on does not jump.
@@ -51,18 +58,9 @@ class ExampleSsrState extends State<ExampleSsr> {
       ),
     );
 
-    // A physical sky, both as the visible background and as the environment
-    // the floor reflects. Screen-space reflections cannot reflect the sky (it
-    // has no on-screen geometry to hit), so where a reflected ray points at
-    // the sky the trace misses and the pixel falls back to this environment;
-    // without a sky it would fall back to nothing and leave dark voids.
-    final sky = PhysicalSkySource()
-      ..sunDirection = vm.Vector3(0.5, 0.8, 0.4).normalized();
-    scene.skybox = Skybox(sky);
-    scene.skyEnvironment = SkyEnvironment(
-      sky,
-      refresh: SkyEnvironmentRefresh.manual,
-    );
+    // The environment and skybox are configured live through the lighting
+    // panel below. The skybox samples the selected environment, so the floor
+    // reflects (via SSR and the miss fallback) the same backdrop it shows.
 
     // A large, dark, smooth floor at y = 0.
     scene.add(
@@ -114,7 +112,6 @@ class ExampleSsrState extends State<ExampleSsr> {
       scene.add(node);
     }
 
-    scene.environmentIntensity = 1.0;
     scene.screenSpaceReflections.enabled = true;
   }
 
@@ -181,6 +178,11 @@ class ExampleSsrState extends State<ExampleSsr> {
           ),
           Positioned(
             left: 8,
+            bottom: 8,
+            child: LightingPanel(scene: scene, selector: _environmentSelector),
+          ),
+          Positioned(
+            right: 8,
             bottom: 8,
             child: _CameraToggle(
               freeCamera: _freeCamera,

--- a/examples/flutter_app/lib/example_ssr.dart
+++ b/examples/flutter_app/lib/example_ssr.dart
@@ -51,6 +51,19 @@ class ExampleSsrState extends State<ExampleSsr> {
       ),
     );
 
+    // A physical sky, both as the visible background and as the environment
+    // the floor reflects. Screen-space reflections cannot reflect the sky (it
+    // has no on-screen geometry to hit), so where a reflected ray points at
+    // the sky the trace misses and the pixel falls back to this environment;
+    // without a sky it would fall back to nothing and leave dark voids.
+    final sky = PhysicalSkySource()
+      ..sunDirection = vm.Vector3(0.5, 0.8, 0.4).normalized();
+    scene.skybox = Skybox(sky);
+    scene.skyEnvironment = SkyEnvironment(
+      sky,
+      refresh: SkyEnvironmentRefresh.manual,
+    );
+
     // A large, dark, smooth floor at y = 0.
     scene.add(
       Node(
@@ -101,7 +114,7 @@ class ExampleSsrState extends State<ExampleSsr> {
       scene.add(node);
     }
 
-    scene.environmentIntensity = 0.5;
+    scene.environmentIntensity = 1.0;
     scene.screenSpaceReflections.enabled = true;
   }
 
@@ -287,10 +300,20 @@ class _SsrPanel extends StatelessWidget {
                       },
                     ),
                     _SliderRow(
+                      label: 'Stride',
+                      value: settings.stride,
+                      min: 1,
+                      max: 12,
+                      onChanged: (v) {
+                        settings.stride = v;
+                        onChanged();
+                      },
+                    ),
+                    _SliderRow(
                       label: 'Max steps',
                       value: settings.maxSteps.toDouble(),
-                      min: 8,
-                      max: 96,
+                      min: 16,
+                      max: 256,
                       onChanged: (v) {
                         settings.maxSteps = v.round();
                         onChanged();
@@ -303,6 +326,26 @@ class _SsrPanel extends StatelessWidget {
                       max: 1,
                       onChanged: (v) {
                         settings.blur = v;
+                        onChanged();
+                      },
+                    ),
+                    _SliderRow(
+                      label: 'Fade start',
+                      value: settings.distanceFadeStart,
+                      min: 0,
+                      max: 1,
+                      onChanged: (v) {
+                        settings.distanceFadeStart = v;
+                        onChanged();
+                      },
+                    ),
+                    _SliderRow(
+                      label: 'Resolution',
+                      value: settings.resolutionScale,
+                      min: 0.25,
+                      max: 1,
+                      onChanged: (v) {
+                        settings.resolutionScale = v;
                         onChanged();
                       },
                     ),

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -23,6 +23,7 @@ import 'example_shapes.dart';
 import 'example_particles.dart';
 import 'example_skybox.dart';
 import 'example_sprites.dart';
+import 'example_ssr.dart';
 import 'example_widget_texture.dart';
 import 'example_split_screen.dart';
 import 'example_stress_tests.dart';
@@ -63,6 +64,7 @@ class _MyAppState extends State<MyApp> {
       'Particles': (context) => const ExampleParticles(),
       'Instancing': (context) => const ExampleInstancing(),
       'Geometry LOD': (context) => const ExampleLod(),
+      'Screen-space Reflections': (context) => const ExampleSsr(),
       'Navigation Route': (context) => const ExampleNavRoute(),
       'Toon': (context) => const ExampleToon(),
       'Toon (.fmat)': (context) => const ExampleToonFmat(),

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -72,7 +72,8 @@ export 'src/importer/scene_registry.dart'
 
 export 'src/ambient_occlusion.dart'
     show AmbientOcclusionSettings, SpecularAmbientOcclusionMode;
-export 'src/screen_space_reflections.dart' show ScreenSpaceReflectionsSettings;
+export 'src/screen_space_reflections.dart'
+    show ScreenSpaceReflectionsSettings, SsrDebugView;
 export 'src/asset_helpers.dart'
     show
         gpuTextureFromAsset,

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -72,6 +72,7 @@ export 'src/importer/scene_registry.dart'
 
 export 'src/ambient_occlusion.dart'
     show AmbientOcclusionSettings, SpecularAmbientOcclusionMode;
+export 'src/screen_space_reflections.dart' show ScreenSpaceReflectionsSettings;
 export 'src/asset_helpers.dart'
     show
         gpuTextureFromAsset,

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -39,12 +39,18 @@ class DepthPrepass extends RenderGraphPass {
     required Vector3 cameraForward,
     required double farDepth,
     int layerMask = kRenderLayerAll,
+    bool writeNormals = false,
+    Vector3? cameraRight,
+    Vector3? cameraUp,
   }) : _camera = camera,
        _renderScene = renderScene,
        _dimensions = dimensions,
        _cameraForward = cameraForward,
        _farDepth = farDepth,
-       _layerMask = layerMask;
+       _layerMask = layerMask,
+       _writeNormals = writeNormals,
+       _cameraRight = cameraRight ?? Vector3.zero(),
+       _cameraUp = cameraUp ?? Vector3.zero();
 
   final Camera _camera;
   final RenderScene _renderScene;
@@ -52,6 +58,15 @@ class DepthPrepass extends RenderGraphPass {
   final Vector3 _cameraForward;
   final double _farDepth;
   final int _layerMask;
+
+  // When set, the prepass also writes the interpolated view-space normal
+  // into the linear-depth target's green/blue/alpha channels (the depth uses
+  // only red), for screen-space reflections. This forces the full vertex
+  // shader (the depth-only position path carries no normal), so it is left
+  // off when only ambient occlusion needs the prepass.
+  final bool _writeNormals;
+  final Vector3 _cameraRight;
+  final Vector3 _cameraUp;
 
   @override
   String get name => 'DepthPrepass';
@@ -105,6 +120,9 @@ class DepthPrepass extends RenderGraphPass {
       _camera.position,
       _cameraForward,
       _layerMask,
+      writeNormals: _writeNormals,
+      cameraRight: _cameraRight,
+      cameraUp: _cameraUp,
     );
     _renderScene.cull(encoder.frustum, encoder.submit);
     commandBuffer.submit();
@@ -127,8 +145,11 @@ class _DepthPrepassEncoder {
     this._cameraTransform,
     this._cameraPosition,
     Vector3 cameraForward,
-    this._layerMask,
-  ) {
+    this._layerMask, {
+    required bool writeNormals,
+    required Vector3 cameraRight,
+    required Vector3 cameraUp,
+  }) : _writeNormals = writeNormals {
     frustum = Frustum.matrix(_cameraTransform);
     _renderPass.setDepthWriteEnable(true);
     _renderPass.setColorBlendEnable(false);
@@ -137,12 +158,27 @@ class _DepthPrepassEncoder {
     // that are visible contribute depth.
     _renderPass.setCullMode(gpu.CullMode.backFace);
     _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
-    // The camera forward axis is constant across the pass. Pack it once and
-    // rebind it per draw (clearBindings drops it between draws).
-    _depthInfo = Float32List(4)
-      ..[0] = cameraForward.x
-      ..[1] = cameraForward.y
-      ..[2] = cameraForward.z;
+    // The camera axes are constant across the pass. Pack them once and
+    // rebind per draw (clearBindings drops the binding between draws). The
+    // normal-writing path also needs the right/up axes to rotate the world
+    // normal into view space; the depth-only path uses just forward.
+    if (writeNormals) {
+      _depthInfo = Float32List(12)
+        ..[0] = cameraForward.x
+        ..[1] = cameraForward.y
+        ..[2] = cameraForward.z
+        ..[4] = cameraRight.x
+        ..[5] = cameraRight.y
+        ..[6] = cameraRight.z
+        ..[8] = cameraUp.x
+        ..[9] = cameraUp.y
+        ..[10] = cameraUp.z;
+    } else {
+      _depthInfo = Float32List(4)
+        ..[0] = cameraForward.x
+        ..[1] = cameraForward.y
+        ..[2] = cameraForward.z;
+    }
   }
 
   final gpu.RenderPass _renderPass;
@@ -150,10 +186,18 @@ class _DepthPrepassEncoder {
   final Matrix4 _cameraTransform;
   final Vector3 _cameraPosition;
   final int _layerMask;
+  final bool _writeNormals;
   late final Float32List _depthInfo;
 
   static final gpu.Shader _depthShader =
       baseShaderLibrary['LinearDepthFragment']!;
+  static final gpu.Shader _depthNormalShader =
+      baseShaderLibrary['LinearDepthNormalFragment']!;
+
+  // The fragment shader and its uniform-block name for this pass.
+  gpu.Shader get _fragmentShader =>
+      _writeNormals ? _depthNormalShader : _depthShader;
+  String get _infoBlockName => _writeNormals ? 'DepthNormalInfo' : 'DepthInfo';
 
   /// Frustum of the camera view-projection, used for per-item culling.
   late final Frustum frustum;
@@ -185,11 +229,13 @@ class _DepthPrepassEncoder {
     final geometry = item.geometry;
     // Unskinned geometry draws depth through a position-only shader and layout
     // (fetching only position); skinned geometry has no such variant, so it
-    // falls back to its full vertex shader and bind.
-    final depthVertex = geometry.depthOnlyVertex;
+    // falls back to its full vertex shader and bind. The normal-writing path
+    // always uses the full vertex shader, since the position-only path
+    // carries no normal.
+    final depthVertex = _writeNormals ? null : geometry.depthOnlyVertex;
     final pipeline = resolvePipeline(
       depthVertex?.shader ?? geometry.vertexShader,
-      _depthShader,
+      _fragmentShader,
       vertexLayout: depthVertex?.layout ?? geometry.instancedVertexLayout,
     );
     if (!identical(_boundPipeline, pipeline)) {
@@ -198,7 +244,7 @@ class _DepthPrepassEncoder {
     }
     _renderPass.setPrimitiveType(geometry.primitiveType);
     _renderPass.bindUniform(
-      _depthShader.getUniformSlot('DepthInfo'),
+      _fragmentShader.getUniformSlot(_infoBlockName),
       _transientsBuffer.emplace(ByteData.sublistView(_depthInfo)),
     );
 

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -273,6 +273,13 @@ class _DepthPrepassEncoder {
       }
     }
 
+    // The instance-rate model transform sits in the slot after the bound
+    // vertex streams. The depth-only path binds just the position stream
+    // (slot 0), so its instance is slot 1; the normal-writing path binds the
+    // full stream set, so the instance follows them (slot
+    // [vertexStreamCount]), matching the color encoder.
+    final instanceSlot = depthVertex != null ? 1 : geometry.vertexStreamCount;
+
     final instances = item.instanceTransforms;
     if (instances != null) {
       if (geometry.instancedVertexLayout == null) {
@@ -297,12 +304,12 @@ class _DepthPrepassEncoder {
         nodeWindingFlipped: item.windingFlipped,
       );
       if (packed.ccwCount > 0) {
-        bindInstanceTransforms(_renderPass, packed.ccw);
+        bindInstanceTransforms(_renderPass, packed.ccw, slot: instanceSlot);
         _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
         geometry.draw(_renderPass, instanceCount: packed.ccwCount);
       }
       if (packed.cwCount > 0) {
-        bindInstanceTransforms(_renderPass, packed.cw);
+        bindInstanceTransforms(_renderPass, packed.cw, slot: instanceSlot);
         _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
         geometry.draw(_renderPass, instanceCount: packed.cwCount);
       }
@@ -311,10 +318,15 @@ class _DepthPrepassEncoder {
 
     bindDraw(item.worldTransform);
     // Skip the model-transform instance buffer for geometry that supplies its
-    // own per-instance buffer (see the color encoder), or it clobbers slot 1.
+    // own per-instance buffer (see the color encoder), or it clobbers the
+    // stream slot.
     if (geometry.instancedVertexLayout != null &&
         geometry.bindsModelTransformInstance) {
-      bindSingleInstanceTransform(_renderPass, item.worldTransform);
+      bindSingleInstanceTransform(
+        _renderPass,
+        item.worldTransform,
+        slot: instanceSlot,
+      );
     }
     _renderPass.setWindingOrder(
       item.windingFlipped

--- a/packages/flutter_scene/lib/src/render/ssr_pass.dart
+++ b/packages/flutter_scene/lib/src/render/ssr_pass.dart
@@ -46,12 +46,14 @@ final gpu.SamplerOptions _nearestClamp = gpu.SamplerOptions(
   heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
 );
 
-/// Traces the camera linear-depth target to composite screen-space
-/// reflections onto the linear HDR scene color, then republishes the result
-/// under [kSceneColorBlackboardKey] for the rest of the pipeline.
+/// Adds screen-space reflections to the linear HDR scene color and
+/// republishes the result under [kSceneColorBlackboardKey].
 ///
-/// A single full-screen fragment pass, no compute. See
-/// `flutter_scene_ssr.frag` for the algorithm.
+/// Two full-screen fragment draws, no compute: a trace at the (possibly
+/// reduced) reflection resolution that writes a reflection buffer
+/// (`flutter_scene_ssr.frag`), then a full-resolution composite that
+/// bilinear-upscales and blends it over the scene color
+/// (`flutter_scene_ssr_composite.frag`).
 class SsrPass extends RenderGraphPass {
   SsrPass({
     required ui.Size dimensions,
@@ -72,11 +74,13 @@ class SsrPass extends RenderGraphPass {
   final double _far;
 
   // The shader's constant march-loop bound; user step counts clamp to this.
-  static const int _maxStepCeiling = 96;
+  static const int _maxStepCeiling = 256;
 
   static final gpu.Shader _vertexShader =
       baseShaderLibrary['FullscreenVertex']!;
   static final gpu.Shader _fragmentShader = baseShaderLibrary['SsrFragment']!;
+  static final gpu.Shader _compositeShader =
+      baseShaderLibrary['SsrCompositeFragment']!;
 
   @override
   String get name => 'SsrPass';
@@ -92,6 +96,85 @@ class SsrPass extends RenderGraphPass {
 
     final width = _dimensions.width.toInt();
     final height = _dimensions.height.toInt();
+
+    // The reflection is traced at a (possibly reduced) resolution and
+    // bilinear-upscaled by the composite, so the reflection layer scales
+    // cheaply while the scene image stays full resolution.
+    final scale = _settings.resolutionScale.clamp(0.1, 1.0);
+    final traceWidth = math.max(1, (width * scale).round());
+    final traceHeight = math.max(1, (height * scale).round());
+    final reflection = context.texturePool.acquire(
+      TransientTextureDescriptor.color(
+        width: traceWidth,
+        height: traceHeight,
+        format: gpu.PixelFormat.r16g16b16a16Float,
+        debugName: 'ssr_reflection',
+      ),
+    );
+
+    final tanHalfFovY = math.tan(_fovRadiansY * 0.5);
+    final aspect = _dimensions.width / _dimensions.height;
+    final tanHalfFovX = tanHalfFovY * aspect;
+
+    final maxSteps = _settings.maxSteps.clamp(1, _maxStepCeiling);
+    final maxDistance = _settings.maxDistance;
+    final thickness = _settings.thickness;
+    // A small offset off the surface to avoid self-intersection at the first
+    // sample. Kept independent of thickness (a scale-relative fraction of the
+    // march distance) so thickness only controls hit acceptance and does not
+    // shift the reflection geometry.
+    final startBias = maxDistance * 0.003;
+    final debugView = _settings.debugView.index.toDouble();
+
+    // Trace: the viewport is the reduced trace resolution, so the pixel-space
+    // march (stride, step budget) is measured in trace pixels.
+    final info = Float32List(20)
+      ..[0] = traceWidth.toDouble()
+      ..[1] = traceHeight.toDouble()
+      ..[2] = 1.0 / traceWidth
+      ..[3] = 1.0 / traceHeight
+      ..[4] = tanHalfFovX
+      ..[5] = tanHalfFovY
+      ..[6] = _near
+      ..[7] = _far
+      ..[8] = maxDistance
+      ..[9] = thickness
+      ..[10] = startBias
+      ..[11] = maxSteps.toDouble()
+      ..[12] = _settings.intensity
+      ..[13] = debugView
+      ..[14] = _settings.blur
+      ..[15] = _settings.stride
+      ..[16] = _settings.distanceFadeStart;
+
+    final traceCmd = gpu.gpuContext.createCommandBuffer();
+    final tracePass = traceCmd.createRenderPass(
+      gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: reflection)),
+    );
+    tracePass.bindPipeline(
+      gpu.gpuContext.createRenderPipeline(_vertexShader, _fragmentShader),
+    );
+    tracePass.setColorBlendEnable(false);
+    bindVertexBufferCompat(tracePass, _fullscreenQuad(), 6);
+    tracePass.bindUniform(
+      _fragmentShader.getUniformSlot('SsrInfo'),
+      context.transientsBuffer.emplace(ByteData.sublistView(info)),
+    );
+    tracePass.bindTexture(
+      _fragmentShader.getUniformSlot('input_color'),
+      sceneColor,
+      sampler: _linearClamp,
+    );
+    tracePass.bindTexture(
+      _fragmentShader.getUniformSlot('linear_depth'),
+      linearDepth,
+      sampler: _nearestClamp,
+    );
+    drawCompat(tracePass, 6);
+    traceCmd.submit();
+
+    // Composite: bilinear-upscale the reflection and blend it over the
+    // full-resolution scene color.
     final output = context.texturePool.acquire(
       TransientTextureDescriptor.color(
         width: width,
@@ -100,61 +183,32 @@ class SsrPass extends RenderGraphPass {
         debugName: 'ssr_scene_color',
       ),
     );
-
-    final tanHalfFovY = math.tan(_fovRadiansY * 0.5);
-    final aspect = _dimensions.width / _dimensions.height;
-    final tanHalfFovX = tanHalfFovY * aspect;
-
-    final stepCount = _settings.maxSteps.clamp(1, _maxStepCeiling);
-    final maxDistance = _settings.maxDistance;
-    final thickness = _settings.thickness;
-    // Start the ray off the surface by a fraction of a step to avoid
-    // self-intersection.
-    final startBias = (maxDistance / stepCount) * 0.5;
-
-    final info = Float32List(16)
-      ..[0] = width.toDouble()
-      ..[1] = height.toDouble()
-      ..[2] = 1.0 / width
-      ..[3] = 1.0 / height
-      ..[4] = tanHalfFovX
-      ..[5] = tanHalfFovY
-      ..[6] = _near
-      ..[7] = _far
-      ..[8] = maxDistance
-      ..[9] = thickness
-      ..[10] = startBias
-      ..[11] = stepCount.toDouble()
-      ..[12] = _settings.intensity
-      ..[13] = _settings.debugView.index.toDouble()
-      ..[14] = _settings.blur;
-
-    final commandBuffer = gpu.gpuContext.createCommandBuffer();
-    final renderPass = commandBuffer.createRenderPass(
+    final compositeInfo = Float32List(4)..[0] = debugView;
+    final compositeCmd = gpu.gpuContext.createCommandBuffer();
+    final compositePass = compositeCmd.createRenderPass(
       gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: output)),
     );
-    renderPass.bindPipeline(
-      gpu.gpuContext.createRenderPipeline(_vertexShader, _fragmentShader),
+    compositePass.bindPipeline(
+      gpu.gpuContext.createRenderPipeline(_vertexShader, _compositeShader),
     );
-    renderPass.setColorBlendEnable(false);
-    bindVertexBufferCompat(renderPass, _fullscreenQuad(), 6);
-
-    renderPass.bindUniform(
-      _fragmentShader.getUniformSlot('SsrInfo'),
-      context.transientsBuffer.emplace(ByteData.sublistView(info)),
+    compositePass.setColorBlendEnable(false);
+    bindVertexBufferCompat(compositePass, _fullscreenQuad(), 6);
+    compositePass.bindUniform(
+      _compositeShader.getUniformSlot('CompositeInfo'),
+      context.transientsBuffer.emplace(ByteData.sublistView(compositeInfo)),
     );
-    renderPass.bindTexture(
-      _fragmentShader.getUniformSlot('input_color'),
+    compositePass.bindTexture(
+      _compositeShader.getUniformSlot('input_color'),
       sceneColor,
       sampler: _linearClamp,
     );
-    renderPass.bindTexture(
-      _fragmentShader.getUniformSlot('linear_depth'),
-      linearDepth,
-      sampler: _nearestClamp,
+    compositePass.bindTexture(
+      _compositeShader.getUniformSlot('ssr_reflection'),
+      reflection,
+      sampler: _linearClamp,
     );
-    drawCompat(renderPass, 6);
-    commandBuffer.submit();
+    drawCompat(compositePass, 6);
+    compositeCmd.submit();
 
     context.blackboard.set(kSceneColorBlackboardKey, output);
   }

--- a/packages/flutter_scene/lib/src/render/ssr_pass.dart
+++ b/packages/flutter_scene/lib/src/render/ssr_pass.dart
@@ -80,7 +80,8 @@ class SsrPass extends RenderGraphPass {
   // presets.
   static const int _stepCount = 48;
   static const double _intensity = 1.0;
-  // 0 = composite, 1 = reflected UV, 2 = hit mask, 3 = normal, 4 = confidence.
+  // 0 = composite, 1 = reflected UV, 2 = hit mask, 3 = normal, 4 = confidence,
+  // 5 = raw depth.
   static const double _debugView = 0.0;
 
   static final gpu.Shader _vertexShader =

--- a/packages/flutter_scene/lib/src/render/ssr_pass.dart
+++ b/packages/flutter_scene/lib/src/render/ssr_pass.dart
@@ -66,23 +66,13 @@ class SsrPass extends RenderGraphPass {
        _far = far;
 
   final ui.Size _dimensions;
-  // ignore: unused_field
   final ScreenSpaceReflectionsSettings _settings;
   final double _fovRadiansY;
   final double _near;
   final double _far;
 
-  // March defaults until the settings expose them. The reflected ray is
-  // marched out to half the view depth in a fixed number of view-space
-  // steps, accepting a hit within roughly one step's depth of a surface.
-  // TODO(ssr): expose these (max distance, thickness, bias, step count,
-  // intensity) on ScreenSpaceReflectionsSettings with mobile/desktop
-  // presets.
-  static const int _stepCount = 48;
-  static const double _intensity = 1.0;
-  // 0 = composite, 1 = reflected UV, 2 = hit mask, 3 = normal, 4 = confidence,
-  // 5 = raw depth.
-  static const double _debugView = 0.0;
+  // The shader's constant march-loop bound; user step counts clamp to this.
+  static const int _maxStepCeiling = 96;
 
   static final gpu.Shader _vertexShader =
       baseShaderLibrary['FullscreenVertex']!;
@@ -115,13 +105,12 @@ class SsrPass extends RenderGraphPass {
     final aspect = _dimensions.width / _dimensions.height;
     final tanHalfFovX = tanHalfFovY * aspect;
 
-    final maxDistance = _far * 0.5;
-    final stepLength = maxDistance / _stepCount;
-    // Accept a hit within roughly two steps' depth (the coarse fixed step
-    // would otherwise tunnel through thin surfaces), and start the ray off
-    // the surface by a fraction of a step to avoid self-intersection.
-    final thickness = stepLength * 2.0;
-    final startBias = stepLength * 0.5;
+    final stepCount = _settings.maxSteps.clamp(1, _maxStepCeiling);
+    final maxDistance = _settings.maxDistance;
+    final thickness = _settings.thickness;
+    // Start the ray off the surface by a fraction of a step to avoid
+    // self-intersection.
+    final startBias = (maxDistance / stepCount) * 0.5;
 
     final info = Float32List(16)
       ..[0] = width.toDouble()
@@ -135,9 +124,10 @@ class SsrPass extends RenderGraphPass {
       ..[8] = maxDistance
       ..[9] = thickness
       ..[10] = startBias
-      ..[11] = _stepCount.toDouble()
-      ..[12] = _intensity
-      ..[13] = _debugView;
+      ..[11] = stepCount.toDouble()
+      ..[12] = _settings.intensity
+      ..[13] = _settings.debugView.index.toDouble()
+      ..[14] = _settings.blur;
 
     final commandBuffer = gpu.gpuContext.createCommandBuffer();
     final renderPass = commandBuffer.createRenderPass(

--- a/packages/flutter_scene/lib/src/render/ssr_pass.dart
+++ b/packages/flutter_scene/lib/src/render/ssr_pass.dart
@@ -1,0 +1,170 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
+
+import 'package:flutter_scene/src/render/depth_prepass.dart';
+import 'package:flutter_scene/src/render/render_graph.dart';
+import 'package:flutter_scene/src/render/scene_pass.dart';
+import 'package:flutter_scene/src/screen_space_reflections.dart';
+import 'package:flutter_scene/src/shaders.dart';
+
+// Two triangles of NDC positions covering the screen (6 vec2s).
+gpu.BufferView _fullscreenQuad() {
+  return _quadView ??= () {
+    final buffer = gpu.gpuContext.createDeviceBufferWithCopy(
+      ByteData.sublistView(
+        Float32List.fromList(<double>[
+          -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, //
+          -1.0, 1.0, 1.0, -1.0, 1.0, 1.0, //
+        ]),
+      ),
+    );
+    return gpu.BufferView(buffer, offsetInBytes: 0, lengthInBytes: 6 * 2 * 4);
+  }();
+}
+
+gpu.BufferView? _quadView;
+
+final gpu.SamplerOptions _linearClamp = gpu.SamplerOptions(
+  minFilter: gpu.MinMagFilter.linear,
+  magFilter: gpu.MinMagFilter.linear,
+  widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+);
+
+// Linear depth is fp32. GLES / WebGL2 devices may not filter float textures
+// (no OES_texture_float_linear), and depth must not be interpolated across
+// edges anyway, so it is always sampled with nearest filtering. Mirrors the
+// occlusion pass.
+final gpu.SamplerOptions _nearestClamp = gpu.SamplerOptions(
+  minFilter: gpu.MinMagFilter.nearest,
+  magFilter: gpu.MinMagFilter.nearest,
+  widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+);
+
+/// Traces the camera linear-depth target to composite screen-space
+/// reflections onto the linear HDR scene color, then republishes the result
+/// under [kSceneColorBlackboardKey] for the rest of the pipeline.
+///
+/// A single full-screen fragment pass, no compute. See
+/// `flutter_scene_ssr.frag` for the algorithm.
+class SsrPass extends RenderGraphPass {
+  SsrPass({
+    required ui.Size dimensions,
+    required ScreenSpaceReflectionsSettings settings,
+    required double fovRadiansY,
+    required double near,
+    required double far,
+  }) : _dimensions = dimensions,
+       _settings = settings,
+       _fovRadiansY = fovRadiansY,
+       _near = near,
+       _far = far;
+
+  final ui.Size _dimensions;
+  // ignore: unused_field
+  final ScreenSpaceReflectionsSettings _settings;
+  final double _fovRadiansY;
+  final double _near;
+  final double _far;
+
+  // March defaults until the settings expose them. The reflected ray is
+  // marched out to half the view depth in a fixed number of view-space
+  // steps, accepting a hit within roughly one step's depth of a surface.
+  // TODO(ssr): expose these (max distance, thickness, bias, step count,
+  // intensity) on ScreenSpaceReflectionsSettings with mobile/desktop
+  // presets.
+  static const int _stepCount = 48;
+  static const double _intensity = 1.0;
+  // 0 = composite, 1 = reflected UV, 2 = hit mask, 3 = normal, 4 = confidence.
+  static const double _debugView = 0.0;
+
+  static final gpu.Shader _vertexShader =
+      baseShaderLibrary['FullscreenVertex']!;
+  static final gpu.Shader _fragmentShader = baseShaderLibrary['SsrFragment']!;
+
+  @override
+  String get name => 'SsrPass';
+
+  @override
+  void execute(RenderGraphContext context) {
+    final sceneColor = context.blackboard.require<gpu.Texture>(
+      kSceneColorBlackboardKey,
+    );
+    final linearDepth = context.blackboard.require<gpu.Texture>(
+      kLinearDepthBlackboardKey,
+    );
+
+    final width = _dimensions.width.toInt();
+    final height = _dimensions.height.toInt();
+    final output = context.texturePool.acquire(
+      TransientTextureDescriptor.color(
+        width: width,
+        height: height,
+        format: gpu.PixelFormat.r16g16b16a16Float,
+        debugName: 'ssr_scene_color',
+      ),
+    );
+
+    final tanHalfFovY = math.tan(_fovRadiansY * 0.5);
+    final aspect = _dimensions.width / _dimensions.height;
+    final tanHalfFovX = tanHalfFovY * aspect;
+
+    final maxDistance = _far * 0.5;
+    final stepLength = maxDistance / _stepCount;
+    // Accept a hit within roughly two steps' depth (the coarse fixed step
+    // would otherwise tunnel through thin surfaces), and start the ray off
+    // the surface by a fraction of a step to avoid self-intersection.
+    final thickness = stepLength * 2.0;
+    final startBias = stepLength * 0.5;
+
+    final info = Float32List(16)
+      ..[0] = width.toDouble()
+      ..[1] = height.toDouble()
+      ..[2] = 1.0 / width
+      ..[3] = 1.0 / height
+      ..[4] = tanHalfFovX
+      ..[5] = tanHalfFovY
+      ..[6] = _near
+      ..[7] = _far
+      ..[8] = maxDistance
+      ..[9] = thickness
+      ..[10] = startBias
+      ..[11] = _stepCount.toDouble()
+      ..[12] = _intensity
+      ..[13] = _debugView;
+
+    final commandBuffer = gpu.gpuContext.createCommandBuffer();
+    final renderPass = commandBuffer.createRenderPass(
+      gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: output)),
+    );
+    renderPass.bindPipeline(
+      gpu.gpuContext.createRenderPipeline(_vertexShader, _fragmentShader),
+    );
+    renderPass.setColorBlendEnable(false);
+    bindVertexBufferCompat(renderPass, _fullscreenQuad(), 6);
+
+    renderPass.bindUniform(
+      _fragmentShader.getUniformSlot('SsrInfo'),
+      context.transientsBuffer.emplace(ByteData.sublistView(info)),
+    );
+    renderPass.bindTexture(
+      _fragmentShader.getUniformSlot('input_color'),
+      sceneColor,
+      sampler: _linearClamp,
+    );
+    renderPass.bindTexture(
+      _fragmentShader.getUniformSlot('linear_depth'),
+      linearDepth,
+      sampler: _nearestClamp,
+    );
+    drawCompat(renderPass, 6);
+    commandBuffer.submit();
+
+    context.blackboard.set(kSceneColorBlackboardKey, output);
+  }
+}

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -28,6 +28,7 @@ import 'render/render_graph.dart';
 import 'render/render_scene.dart';
 import 'render/instance_packing.dart';
 import 'render/scene_pass.dart';
+import 'render/ssr_pass.dart';
 import 'screen_space_reflections.dart';
 import 'render/selection_outline_pass.dart';
 import 'render/shadow_pass.dart';
@@ -1008,9 +1009,14 @@ base class Scene implements SceneGraph {
     // from a camera depth prepass, so they need a perspective projection
     // (others render without them) and share the one prepass.
     final perspective = camera.projection;
-    if (perspective is PerspectiveProjection) {
+    final perspectiveCamera = perspective is PerspectiveProjection
+        ? perspective
+        : null;
+    // Reflections run after the scene is drawn (they sample the lit color),
+    // so capture whether they apply here and add the pass below.
+    final wantSsr = perspectiveCamera != null && screenSpaceReflections.enabled;
+    if (perspectiveCamera != null) {
       final wantAo = ambientOcclusion.enabled;
-      final wantSsr = screenSpaceReflections.enabled;
       if (wantAo || wantSsr) {
         // Ambient occlusion evaluates its chain (depth prepass, occlusion,
         // blur) at one resolution so depth is sampled 1:1 (a half-resolution
@@ -1028,7 +1034,7 @@ base class Scene implements SceneGraph {
             renderScene: renderScene,
             dimensions: depthDimensions,
             cameraForward: camera.forward,
-            farDepth: perspective.far,
+            farDepth: perspectiveCamera.far,
             layerMask: view.layerMask,
           ),
         );
@@ -1038,9 +1044,9 @@ base class Scene implements SceneGraph {
           SsaoPass(
             dimensions: pixelSize,
             settings: ambientOcclusion,
-            fovRadiansY: perspective.fovRadiansY,
-            near: perspective.near,
-            far: perspective.far,
+            fovRadiansY: perspectiveCamera.fovRadiansY,
+            near: perspectiveCamera.near,
+            far: perspectiveCamera.far,
           ),
         );
         graph.addPass(
@@ -1067,6 +1073,20 @@ base class Scene implements SceneGraph {
         layerMask: view.layerMask,
       ),
     );
+    // Screen-space reflections refine the lit HDR color in place, before
+    // bloom and tone mapping, so reflected highlights bloom and tone-map
+    // with the rest of the image.
+    if (wantSsr) {
+      graph.addPass(
+        SsrPass(
+          dimensions: pixelSize,
+          settings: screenSpaceReflections,
+          fovRadiansY: perspectiveCamera.fovRadiansY,
+          near: perspectiveCamera.near,
+          far: perspectiveCamera.far,
+        ),
+      );
+    }
     // Split custom effects by where they run in the chain.
     final beforeTonemap = <PostEffect>[];
     final afterTonemap = <PostEffect>[];

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -1028,14 +1028,23 @@ base class Scene implements SceneGraph {
         final depthDimensions = wantAo
             ? ambientOcclusionTargetSize(pixelSize, ambientOcclusion)
             : pixelSize;
+        // Reflections need the interpolated view-space normal, so the prepass
+        // writes it alongside depth (it carries the camera basis to rotate
+        // world normals into view space). Occlusion needs only depth.
+        final cameraForward = camera.forward;
+        final cameraRight = camera.up.cross(cameraForward)..normalize();
+        final cameraUp = cameraForward.cross(cameraRight)..normalize();
         graph.addPass(
           DepthPrepass(
             camera: camera,
             renderScene: renderScene,
             dimensions: depthDimensions,
-            cameraForward: camera.forward,
+            cameraForward: cameraForward,
             farDepth: perspectiveCamera.far,
             layerMask: view.layerMask,
+            writeNormals: wantSsr,
+            cameraRight: cameraRight,
+            cameraUp: cameraUp,
           ),
         );
       }

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -28,6 +28,7 @@ import 'render/render_graph.dart';
 import 'render/render_scene.dart';
 import 'render/instance_packing.dart';
 import 'render/scene_pass.dart';
+import 'screen_space_reflections.dart';
 import 'render/selection_outline_pass.dart';
 import 'render/shadow_pass.dart';
 import 'render/ssao_pass.dart';
@@ -556,6 +557,13 @@ base class Scene implements SceneGraph {
   /// perspective depth); it is skipped for other camera types.
   final AmbientOcclusionSettings ambientOcclusion = AmbientOcclusionSettings();
 
+  /// Screen-space reflection settings. Off by default; set
+  /// [ScreenSpaceReflectionsSettings.enabled] to turn it on. Requires a
+  /// [PerspectiveCamera] (the reflection trace is reconstructed from the
+  /// camera's perspective depth); it is skipped for other camera types.
+  final ScreenSpaceReflectionsSettings screenSpaceReflections =
+      ScreenSpaceReflectionsSettings();
+
   @override
   void add(Node child) {
     root.add(child);
@@ -996,39 +1004,49 @@ base class Scene implements SceneGraph {
         ),
       );
     }
-    // Ambient occlusion is reconstructed from a camera depth prepass, so it
-    // needs a perspective projection (others render without it).
+    // Ambient occlusion and screen-space reflections are both reconstructed
+    // from a camera depth prepass, so they need a perspective projection
+    // (others render without them) and share the one prepass.
     final perspective = camera.projection;
-    if (ambientOcclusion.enabled && perspective is PerspectiveProjection) {
-      // The whole occlusion chain (depth prepass, occlusion, blur) runs at one
-      // resolution so depth is sampled 1:1; sampling a full-resolution depth
-      // from the half-resolution occlusion pass would alias on fine geometry.
-      final aoDimensions = ambientOcclusionTargetSize(
-        pixelSize,
-        ambientOcclusion,
-      );
-      graph.addPass(
-        DepthPrepass(
-          camera: camera,
-          renderScene: renderScene,
-          dimensions: aoDimensions,
-          cameraForward: camera.forward,
-          farDepth: perspective.far,
-          layerMask: view.layerMask,
-        ),
-      );
-      graph.addPass(
-        SsaoPass(
-          dimensions: pixelSize,
-          settings: ambientOcclusion,
-          fovRadiansY: perspective.fovRadiansY,
-          near: perspective.near,
-          far: perspective.far,
-        ),
-      );
-      graph.addPass(
-        SsaoBlurPass(dimensions: pixelSize, settings: ambientOcclusion),
-      );
+    if (perspective is PerspectiveProjection) {
+      final wantAo = ambientOcclusion.enabled;
+      final wantSsr = screenSpaceReflections.enabled;
+      if (wantAo || wantSsr) {
+        // Ambient occlusion evaluates its chain (depth prepass, occlusion,
+        // blur) at one resolution so depth is sampled 1:1 (a half-resolution
+        // occlusion pass reading a full-resolution depth would alias on fine
+        // geometry). Size the prepass to occlusion's target whenever it is on
+        // so its behavior is unchanged; reflections sample whatever
+        // resolution is published. With only reflections on, use full
+        // resolution.
+        final depthDimensions = wantAo
+            ? ambientOcclusionTargetSize(pixelSize, ambientOcclusion)
+            : pixelSize;
+        graph.addPass(
+          DepthPrepass(
+            camera: camera,
+            renderScene: renderScene,
+            dimensions: depthDimensions,
+            cameraForward: camera.forward,
+            farDepth: perspective.far,
+            layerMask: view.layerMask,
+          ),
+        );
+      }
+      if (wantAo) {
+        graph.addPass(
+          SsaoPass(
+            dimensions: pixelSize,
+            settings: ambientOcclusion,
+            fovRadiansY: perspective.fovRadiansY,
+            near: perspective.near,
+            far: perspective.far,
+          ),
+        );
+        graph.addPass(
+          SsaoBlurPass(dimensions: pixelSize, settings: ambientOcclusion),
+        );
+      }
     }
     graph.addPass(
       ScenePass(

--- a/packages/flutter_scene/lib/src/screen_space_reflections.dart
+++ b/packages/flutter_scene/lib/src/screen_space_reflections.dart
@@ -1,3 +1,28 @@
+/// A diagnostic visualization for [ScreenSpaceReflectionsSettings.debugView].
+///
+/// Replaces the composited image with an intermediate of the reflection
+/// trace, for tuning and debugging. [composite] is the normal output.
+/// {@category Rendering}
+enum SsrDebugView {
+  /// The normal reflection-composited image.
+  composite,
+
+  /// The screen UV the reflected ray hit (red/green), scaled by confidence.
+  reflectedUv,
+
+  /// White where a reflection hit was accepted, black otherwise.
+  hitMask,
+
+  /// The per-pixel view-space normal read from the depth prepass.
+  normal,
+
+  /// The accepted hit's confidence (the reflection blend weight).
+  confidence,
+
+  /// The raw linear depth the trace marches against.
+  depth,
+}
+
 /// Screen-space reflection settings for a [Scene].
 ///
 /// Reachable through `Scene.screenSpaceReflections`. Screen-space
@@ -23,4 +48,33 @@ class ScreenSpaceReflectionsSettings {
   /// Enabling this schedules the shared camera depth prepass (also used by
   /// ambient occlusion); the reflection trace reads it.
   bool enabled = false;
+
+  /// Overall strength of the reflections, multiplying the per-pixel blend
+  /// weight. `1.0` is the physical estimate; lower values fade reflections
+  /// out, higher values exaggerate them.
+  double intensity = 1.0;
+
+  /// How far, in world units, a reflected ray is marched before it is
+  /// considered to have missed. Larger values let reflections reach more
+  /// distant geometry at a higher trace cost.
+  double maxDistance = 25.0;
+
+  /// The assumed world-space thickness of surfaces, used to accept a ray
+  /// crossing as a hit. Too small misses thin or grazing geometry; too large
+  /// lets a ray passing behind an object falsely reflect it.
+  double thickness = 0.5;
+
+  /// Number of screen-space steps the reflected ray is marched in. More
+  /// steps give smoother, longer reflections at a higher cost. Clamped to the
+  /// shader's maximum (currently 96).
+  int maxSteps = 96;
+
+  /// Glossy blur applied to the reflected color, `0` for a sharp mirror.
+  /// Higher values soften the reflection (and hide trace noise), widening
+  /// with the hit distance.
+  double blur = 0.3;
+
+  /// A diagnostic visualization to render instead of the composited image.
+  /// Defaults to [SsrDebugView.composite] (the normal output).
+  SsrDebugView debugView = SsrDebugView.composite;
 }

--- a/packages/flutter_scene/lib/src/screen_space_reflections.dart
+++ b/packages/flutter_scene/lib/src/screen_space_reflections.dart
@@ -57,22 +57,43 @@ class ScreenSpaceReflectionsSettings {
   /// How far, in world units, a reflected ray is marched before it is
   /// considered to have missed. Larger values let reflections reach more
   /// distant geometry at a higher trace cost.
-  double maxDistance = 25.0;
+  double maxDistance = 24.4;
 
   /// The assumed world-space thickness of surfaces, used to accept a ray
   /// crossing as a hit. Too small misses thin or grazing geometry; too large
   /// lets a ray passing behind an object falsely reflect it.
-  double thickness = 0.5;
+  double thickness = 0.46;
 
-  /// Number of screen-space steps the reflected ray is marched in. More
-  /// steps give smoother, longer reflections at a higher cost. Clamped to the
-  /// shader's maximum (currently 96).
-  int maxSteps = 96;
+  /// Pixels advanced along the screen per march step. `1` samples every
+  /// pixel the reflection crosses (highest quality, most costly); larger
+  /// values sample more sparsely and cheaply, but can step over thin or
+  /// grazing surfaces. This sets the reflection quality; [maxSteps] bounds
+  /// its cost.
+  double stride = 9.0;
+
+  /// The maximum number of march steps, a hard cost ceiling. Clamped to the
+  /// shader's maximum (currently 256). A reflection that reaches this budget
+  /// fades out (see [distanceFadeStart]) rather than cutting off.
+  int maxSteps = 90;
 
   /// Glossy blur applied to the reflected color, `0` for a sharp mirror.
   /// Higher values soften the reflection (and hide trace noise), widening
   /// with the hit distance.
   double blur = 0.3;
+
+  /// Where the reflection begins fading out, as a fraction (0..1) of its
+  /// reachable range (the closer of [maxDistance] and the [stride]/[maxSteps]
+  /// budget). Reflections ramp to zero from here to the range limit, so they
+  /// taper smoothly instead of hard-cutting. `1.0` disables the fade; `0.0`
+  /// fades gradually across the whole range.
+  double distanceFadeStart = 0.0;
+
+  /// The resolution the reflections are traced at, as a fraction (0..1) of
+  /// the render size. `1.0` traces at full resolution; lower values trace
+  /// (and blur) the reflection layer more cheaply and bilinear-upscale it,
+  /// leaving the rest of the image full resolution. The single biggest
+  /// performance lever, and the main one to lower on mobile.
+  double resolutionScale = 1.0;
 
   /// A diagnostic visualization to render instead of the composited image.
   /// Defaults to [SsrDebugView.composite] (the normal output).

--- a/packages/flutter_scene/lib/src/screen_space_reflections.dart
+++ b/packages/flutter_scene/lib/src/screen_space_reflections.dart
@@ -1,0 +1,26 @@
+/// Screen-space reflection settings for a [Scene].
+///
+/// Reachable through `Scene.screenSpaceReflections`. Screen-space
+/// reflections (SSR) trace the rendered image to add sharp, view-dependent
+/// reflections on top of the smooth image-based reflections every surface
+/// already receives from the scene environment. A surface the trace cannot
+/// resolve (a ray that leaves the screen, finds no hit, or lands on too
+/// rough a surface) falls back to that environment reflection, so SSR is a
+/// refinement layer and never removes reflection detail.
+///
+/// Disabled by default: a fresh scene does no reflection tracing and adds no
+/// render passes. Set [enabled] to turn it on.
+///
+/// The trace reconstructs view-space positions and normals from a camera
+/// depth prepass, so it needs only a depth buffer (no normal buffer) and
+/// fits a forward renderer. It requires a [PerspectiveCamera]; other camera
+/// types render without it.
+/// {@category Rendering}
+class ScreenSpaceReflectionsSettings {
+  /// Whether screen-space reflections run. Off by default. When false the
+  /// scene adds no reflection passes and the image is unaffected.
+  ///
+  /// Enabling this schedules the shared camera depth prepass (also used by
+  /// ambient occlusion); the reflection trace reads it.
+  bool enabled = false;
+}

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -55,6 +55,10 @@
         "type": "fragment",
         "file": "shaders/flutter_scene_ssr.frag"
     },
+    "LinearDepthNormalFragment": {
+        "type": "fragment",
+        "file": "shaders/flutter_scene_linear_depth_normal.frag"
+    },
     "FullscreenVertex": {
         "type": "vertex",
         "file": "shaders/flutter_scene_fullscreen.vert"

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -55,6 +55,10 @@
         "type": "fragment",
         "file": "shaders/flutter_scene_ssr.frag"
     },
+    "SsrCompositeFragment": {
+        "type": "fragment",
+        "file": "shaders/flutter_scene_ssr_composite.frag"
+    },
     "LinearDepthNormalFragment": {
         "type": "fragment",
         "file": "shaders/flutter_scene_linear_depth_normal.frag"

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -51,6 +51,10 @@
         "type": "fragment",
         "file": "shaders/flutter_scene_ssao_blur.frag"
     },
+    "SsrFragment": {
+        "type": "fragment",
+        "file": "shaders/flutter_scene_ssr.frag"
+    },
     "FullscreenVertex": {
         "type": "vertex",
         "file": "shaders/flutter_scene_fullscreen.vert"

--- a/packages/flutter_scene/shaders/flutter_scene_linear_depth_normal.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_linear_depth_normal.frag
@@ -1,0 +1,42 @@
+// Fragment shader for the camera depth prepass when a consumer also needs
+// per-pixel normals (screen-space reflections).
+//
+// Like LinearDepthFragment it writes planar view-space depth into the red
+// channel, but it also writes the smooth, interpolated view-space normal
+// into the green/blue/alpha channels of the same floating-point target (the
+// depth uses only red, so the normal rides along at no extra attachment
+// cost). Reflections need the shaded vertex normal, not a face normal
+// reconstructed from depth, so that curved surfaces reflect smoothly rather
+// than per-triangle.
+//
+// Pairs with the engine's full vertex shaders (UnskinnedVertex /
+// SkinnedVertex), which provide the world-space v_normal and v_viewvector.
+// The world normal is rotated into view space with the camera basis passed
+// in, matching the lookAt view matrix (+X right, +Y up, +Z forward).
+
+#include <material_varyings.glsl>
+
+uniform DepthNormalInfo {
+  // xyz: normalized world-space camera forward (eye into the scene).
+  vec4 camera_forward;
+  // xyz: world-space camera right axis.
+  vec4 camera_right;
+  // xyz: world-space camera up axis.
+  vec4 camera_up;
+}
+info;
+
+void main() {
+  // v_viewvector is (camera_position - world_position); negating it and
+  // projecting onto the forward axis gives planar view-space depth.
+  float view_depth = -dot(v_viewvector, info.camera_forward.xyz);
+
+  // Rotate the interpolated world normal into view space (eye looking down
+  // +Z), the space the reflection trace works in.
+  vec3 n = normalize(v_normal);
+  vec3 view_normal = normalize(vec3(dot(n, info.camera_right.xyz),
+                                    dot(n, info.camera_up.xyz),
+                                    dot(n, info.camera_forward.xyz)));
+
+  frag_color = vec4(view_depth, view_normal);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_ssr.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssr.frag
@@ -1,0 +1,183 @@
+// Screen-space reflections, composited over the linear HDR scene color.
+//
+// Reconstructs each pixel's view-space position and a face normal from the
+// camera linear-depth prepass (no normal buffer, so it fits a forward
+// renderer), reflects the view ray about that normal, and marches the
+// reflected ray through the depth buffer looking for the surface it hits.
+// On a hit it samples the already-lit scene color at the hit point and
+// blends it in, weighted by a Fresnel term and a confidence that fades at
+// screen edges. A ray that leaves the screen or finds no hit contributes
+// nothing, so the surface keeps the image-based reflection it was lit with.
+//
+// The scene color is premultiplied linear HDR; the output follows the same
+// contract. This pass stays entirely in render-to-texture space (it samples
+// the scene color and depth, both render targets, and writes another), so
+// like the occlusion pass it needs no Y flip; the resolve pass handles the
+// final upright orientation.
+
+uniform sampler2D input_color;
+uniform sampler2D linear_depth;
+
+uniform SsrInfo {
+  // x, y: viewport size in pixels. z, w: its reciprocal.
+  vec4 viewport;
+  // x: tan(fovX / 2). y: tan(fovY / 2). z: near plane. w: far plane.
+  vec4 proj;
+  // x: max march distance (world units). y: thickness for hit acceptance
+  // (world units). z: starting bias off the surface (world units). w: step
+  // count.
+  vec4 march;
+  // x: reflection intensity. y: debug view (0 = composite, 1 = reflected
+  // UV, 2 = hit mask, 3 = reconstructed normal, 4 = confidence).
+  vec4 params;
+}
+ssr;
+
+in vec2 v_uv;
+out vec4 frag_color;
+
+// Constant loop bound so the march is statically bounded for the GLES 1.00
+// shader output (a uniform-bounded loop is rejected by conformant ES
+// drivers); the dynamic step count breaks out early. Matches the occlusion
+// pass's constant-loop pattern.
+#define MAX_SSR_STEPS 64
+
+const float kEpsilon = 0.0001;
+// Screen-edge fade width, as a fraction of the viewport: reflections ramp
+// out over this band as the hit approaches a screen border.
+const float kEdgeFade = 0.08;
+
+// Reconstructs a view-space position from a depth-buffer UV. Camera space
+// places the eye at the origin looking down +Z (the convention the depth
+// prepass writes), so the stored planar depth is the view-space Z and the
+// X/Y follow from the projection tangents. Mirrors the occlusion pass.
+vec3 ViewPositionAt(vec2 uv) {
+  float z = texture(linear_depth, uv).r;
+  vec2 ndc = vec2(2.0 * uv.x - 1.0, 1.0 - 2.0 * uv.y);
+  return vec3(ndc.x * z * ssr.proj.x, ndc.y * z * ssr.proj.y, z);
+}
+
+// Projects a view-space position back to a depth-buffer UV (the inverse of
+// the X/Y mapping in ViewPositionAt). Valid for positions in front of the
+// eye (z > 0).
+vec2 UvFromView(vec3 p) {
+  vec2 ndc = vec2(p.x / (p.z * ssr.proj.x), p.y / (p.z * ssr.proj.y));
+  return vec2(ndc.x * 0.5 + 0.5, 0.5 - ndc.y * 0.5);
+}
+
+// Un-premultiplies a sampled premultiplied-alpha color.
+vec3 Unpremultiply(vec4 c) { return c.a > 0.0 ? c.rgb / c.a : vec3(0.0); }
+
+void main() {
+  float near = ssr.proj.z;
+  float far = ssr.proj.w;
+  float max_distance = ssr.march.x;
+  float thickness = ssr.march.y;
+  float start_bias = ssr.march.z;
+  int step_count = int(ssr.march.w);
+  float intensity = ssr.params.x;
+  int debug_view = int(ssr.params.y + 0.5);
+
+  vec4 base = texture(input_color, v_uv);
+  vec3 origin = ViewPositionAt(v_uv);
+
+  // Background texels (no geometry) reflect nothing.
+  if (origin.z >= far) {
+    frag_color = base;
+    return;
+  }
+
+  // Face normal from the screen-space gradient of the reconstructed
+  // position, oriented toward the camera (the eye is at the origin, so the
+  // view direction is -origin). Single-pixel silhouette errors are
+  // acceptable for reflections, which the Fresnel and edge fades soften.
+  vec3 normal = normalize(cross(dFdx(origin), dFdy(origin)));
+  if (dot(normal, origin) > 0.0) {
+    normal = -normal;
+  }
+
+  if (debug_view == 3) {
+    frag_color = vec4(normal * 0.5 + 0.5, 1.0);
+    return;
+  }
+
+  // View-space reflection of the eye-to-pixel ray about the surface normal.
+  vec3 incident = normalize(origin);
+  vec3 reflection = reflect(incident, normal);
+
+  // March the reflected ray in view space, projecting each step to a UV and
+  // testing it against the stored depth.
+  // TODO(ssr): this fixed view-space step over-samples near the camera and
+  // under-samples far away; replace with a perspective-correct screen-space
+  // DDA (McGuire & Mara) so samples are evenly spaced in pixels.
+  float step_length = max_distance / float(step_count);
+  vec3 march_pos = origin + normal * start_bias;
+  float confidence = 0.0;
+  vec2 hit_uv = vec2(0.0);
+
+  for (int i = 0; i < MAX_SSR_STEPS; i++) {
+    if (i >= step_count) {
+      break;
+    }
+    march_pos += reflection * step_length;
+    // Stop if the ray passes behind the near plane (nothing to sample).
+    if (march_pos.z <= near) {
+      break;
+    }
+    vec2 uv = UvFromView(march_pos);
+    // Stop when the ray leaves the screen.
+    if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+      break;
+    }
+    float scene_z = texture(linear_depth, uv).r;
+    // Skip background (sky) texels: no geometry to reflect there.
+    if (scene_z >= far) {
+      continue;
+    }
+    float delta = march_pos.z - scene_z;
+    // A hit: the ray has crossed behind the sampled surface, within the
+    // surface's assumed thickness.
+    if (delta > 0.0 && delta < thickness) {
+      hit_uv = uv;
+      // Edge fade: ramp confidence to zero in a thin band at the screen
+      // border so a hit near the edge does not pop.
+      vec2 edge = clamp(min(uv, 1.0 - uv) / kEdgeFade, 0.0, 1.0);
+      float edge_fade = smoothstep(0.0, 1.0, edge.x) *
+                        smoothstep(0.0, 1.0, edge.y);
+      confidence = edge_fade;
+      break;
+    }
+  }
+
+  if (debug_view == 1) {
+    frag_color = vec4(hit_uv * confidence, 0.0, 1.0);
+    return;
+  }
+  if (debug_view == 2) {
+    frag_color = vec4(vec3(confidence > 0.0 ? 1.0 : 0.0), 1.0);
+    return;
+  }
+  if (debug_view == 4) {
+    frag_color = vec4(vec3(confidence), 1.0);
+    return;
+  }
+
+  if (confidence <= 0.0) {
+    frag_color = base;
+    return;
+  }
+
+  // Fresnel weight (Schlick): reflections strengthen at grazing angles. The
+  // base reflectance stands in for a per-pixel value until a reflectivity
+  // source is available.
+  // TODO(ssr): drive the reflection strength from per-pixel reflectivity and
+  // roughness (a thin reflectivity prepass) instead of a global intensity.
+  float facing = clamp(dot(normal, -incident), 0.0, 1.0);
+  float fresnel = 0.04 + 0.96 * pow(1.0 - facing, 5.0);
+  float strength = clamp(confidence * intensity * fresnel, 0.0, 1.0);
+
+  vec3 base_rgb = Unpremultiply(base);
+  vec3 reflected_rgb = Unpremultiply(texture(input_color, hit_uv));
+  vec3 out_rgb = mix(base_rgb, reflected_rgb, strength);
+  frag_color = vec4(out_rgb * base.a, base.a);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_ssr.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssr.frag
@@ -80,7 +80,21 @@ void main() {
   int debug_view = int(ssr.params.y + 0.5);
 
   vec4 base = texture(input_color, v_uv);
+  vec4 depth_sample = texture(linear_depth, v_uv);
   vec3 origin = ViewPositionAt(v_uv);
+
+  // Debug views, evaluated before any early-out so they show what the trace
+  // actually reads.
+  if (debug_view == 5) {
+    float g = depth_sample.r / far;
+    frag_color = vec4(vec3(g), 1.0);
+    return;
+  }
+  if (debug_view == 3) {
+    vec3 dn = normalize(depth_sample.gba);
+    frag_color = vec4(dn * 0.5 + 0.5, 1.0);
+    return;
+  }
 
   // Background texels (no geometry) reflect nothing.
   if (origin.z >= far) {
@@ -92,12 +106,7 @@ void main() {
   // (in green/blue/alpha). Using the shaded vertex normal rather than one
   // reconstructed from depth keeps reflections smooth across curved
   // surfaces instead of faceted per triangle.
-  vec3 normal = normalize(texture(linear_depth, v_uv).gba);
-
-  if (debug_view == 3) {
-    frag_color = vec4(normal * 0.5 + 0.5, 1.0);
-    return;
-  }
+  vec3 normal = normalize(depth_sample.gba);
 
   // View-space reflection of the eye-to-pixel ray about the surface normal.
   vec3 incident = normalize(origin);

--- a/packages/flutter_scene/shaders/flutter_scene_ssr.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssr.frag
@@ -1,20 +1,22 @@
-// Screen-space reflections, composited over the linear HDR scene color.
+// Screen-space reflection trace. Produces a reflection buffer that the
+// separate composite pass (flutter_scene_ssr_composite.frag) upscales and
+// blends over the full-resolution scene color.
 //
 // Reads each pixel's view-space position and smooth view-space normal from
 // the camera depth prepass (depth in red, the interpolated normal packed
 // into green/blue/alpha), reflects the view ray about that normal, and
 // marches the reflected ray through the depth buffer looking for the surface
-// it hits. On a hit it samples the already-lit scene color at the hit point
-// and blends it in, weighted by a Fresnel term and a confidence that fades at
-// screen edges and with distance. A ray that leaves the screen or finds no
-// hit contributes nothing, so the surface keeps the image-based reflection it
-// was lit with.
+// it hits. On a hit it samples the already-lit scene color at the hit point,
+// weighted by a Fresnel term and a confidence that fades at screen edges and
+// with distance. A ray that leaves the screen or finds no hit contributes
+// nothing.
 //
-// The scene color is premultiplied linear HDR; the output follows the same
-// contract. This pass stays entirely in render-to-texture space (it samples
-// the scene color and depth, both render targets, and writes another), so
-// like the occlusion pass it needs no Y flip; the resolve pass handles the
-// final upright orientation.
+// The output is the reflected color premultiplied by its blend strength
+// (rgb = color * strength, a = strength), so the composite can bilinear-
+// upscale it correctly (straight color would bleed from no-hit texels). This
+// pass can run at a reduced resolution; the scene color it samples is
+// full-resolution. It stays entirely in render-to-texture space, so like the
+// occlusion pass it needs no Y flip.
 
 uniform sampler2D input_color;
 uniform sampler2D linear_depth;
@@ -25,13 +27,17 @@ uniform SsrInfo {
   // x: tan(fovX / 2). y: tan(fovY / 2). z: near plane. w: far plane.
   vec4 proj;
   // x: max march distance (world units). y: thickness for hit acceptance
-  // (world units). z: starting bias off the surface (world units). w: step
-  // count.
+  // (world units). z: starting bias off the surface (world units). w: max
+  // step count (a cost ceiling).
   vec4 march;
   // x: reflection intensity. y: debug view (0 = composite, 1 = reflected
   // UV, 2 = hit mask, 3 = normal, 4 = confidence, 5 = raw depth). z: glossy
-  // blur strength (0 = sharp mirror).
+  // blur strength (0 = sharp mirror). w: march stride (pixels per step).
   vec4 params;
+  // x: distance fade start, as a fraction (0..1) of the reflection's
+  // reachable range. The reflection ramps to zero from here to the range
+  // limit, so it tapers out instead of hard-cutting.
+  vec4 fade;
 }
 ssr;
 
@@ -42,7 +48,7 @@ out vec4 frag_color;
 // shader output (a uniform-bounded loop is rejected by conformant ES
 // drivers); the dynamic step count breaks out early. Matches the occlusion
 // pass's constant-loop pattern.
-#define MAX_SSR_STEPS 96
+#define MAX_SSR_STEPS 256
 
 // Binary-search iterations used to refine a hit once the coarse march
 // brackets the surface crossing. Constant-bounded for the same reason as the
@@ -87,12 +93,13 @@ void main() {
   float max_distance = ssr.march.x;
   float thickness = ssr.march.y;
   float start_bias = ssr.march.z;
-  int step_count = int(ssr.march.w);
+  int max_steps = int(ssr.march.w);
   float intensity = ssr.params.x;
   int debug_view = int(ssr.params.y + 0.5);
   float blur = ssr.params.z;
+  float stride = max(ssr.params.w, 1.0);
+  float fade_start = clamp(ssr.fade.x, 0.0, 0.999);
 
-  vec4 base = texture(input_color, v_uv);
   vec4 depth_sample = texture(linear_depth, v_uv);
   vec3 origin = ViewPositionAt(v_uv);
 
@@ -111,7 +118,7 @@ void main() {
 
   // Background texels (no geometry) reflect nothing.
   if (origin.z >= far) {
-    frag_color = base;
+    frag_color = vec4(0.0);
     return;
   }
 
@@ -143,6 +150,19 @@ void main() {
   float inv_z_start = 1.0 / ray_start.z;
   float inv_z_end = 1.0 / ray_end.z;
 
+  // The ray's screen-space length in pixels. Steps advance a fixed pixel
+  // [stride] along it, so sampling density is set by the stride (not by the
+  // ray's length, which would spread a fixed step count thin on long rays
+  // and skip surfaces). The march stops at the ray's end, the screen border,
+  // or the [max_steps] ceiling, whichever comes first; a ray longer than
+  // stride * max_steps is truncated and fades out by distance.
+  vec2 res = ssr.viewport.xy;
+  float total_px = length((uv_end - uv_start) * res);
+  if (total_px < 1.0) {
+    frag_color = vec4(0.0);
+    return;
+  }
+
   float confidence = 0.0;
   vec2 hit_uv = vec2(0.0);
   // Parameter [0,1] of the accepted hit along the ray, used to widen the
@@ -152,10 +172,15 @@ void main() {
   float prev_t = 0.0;
 
   for (int i = 1; i <= MAX_SSR_STEPS; i++) {
-    if (i > step_count) {
+    if (i > max_steps) {
       break;
     }
-    float t = float(i) / float(step_count);
+    float traveled = float(i) * stride;
+    // Stop at the ray's end (the max-distance point).
+    if (traveled >= total_px) {
+      break;
+    }
+    float t = traveled / total_px;
     vec2 uv = mix(uv_start, uv_end, t);
     // Stop when the ray leaves the screen.
     if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
@@ -206,13 +231,19 @@ void main() {
         hit_uv = candidate_uv;
         // Confidence fades the reflection where it is least reliable: a thin
         // band at the screen border (a hit there has no off-screen data
-        // behind it), toward the end of the march so reflections taper off
-        // with distance instead of ending in a hard line, and at grazing
-        // hits where the ray skims the surface.
+        // behind it), toward the end of the reachable range so reflections
+        // taper off instead of ending in a hard line, and at grazing hits
+        // where the ray skims the surface.
         vec2 edge = clamp(min(hit_uv, 1.0 - hit_uv) / kEdgeFade, 0.0, 1.0);
         float edge_fade = smoothstep(0.0, 1.0, edge.x) *
                           smoothstep(0.0, 1.0, edge.y);
-        float distance_fade = 1.0 - smoothstep(0.7, 1.0, hit_t);
+        // The reflection is limited by whichever binds first: the world max
+        // distance (hit_t, the fraction of the ray traveled) or the step
+        // budget (i / max_steps). Fade toward whichever is nearer its limit,
+        // so lowering max steps just fades reflections sooner rather than
+        // hard-cutting them.
+        float range_fraction = max(hit_t, float(i) / float(max_steps));
+        float distance_fade = 1.0 - smoothstep(fade_start, 1.0, range_fraction);
         float face_fade = smoothstep(0.0, 0.25, facing_hit);
         confidence = edge_fade * distance_fade * face_fade;
         break;
@@ -235,7 +266,7 @@ void main() {
   }
 
   if (confidence <= 0.0) {
-    frag_color = base;
+    frag_color = vec4(0.0);
     return;
   }
 
@@ -266,7 +297,7 @@ void main() {
     reflected_rgb = sum / float(SSR_BLUR_TAPS);
   }
 
-  vec3 base_rgb = Unpremultiply(base);
-  vec3 out_rgb = mix(base_rgb, reflected_rgb, strength);
-  frag_color = vec4(out_rgb * base.a, base.a);
+  // Output premultiplied by strength so the composite pass can bilinear-
+  // upscale and blend it over the full-resolution scene color.
+  frag_color = vec4(reflected_rgb * strength, strength);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_ssr.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssr.frag
@@ -1,8 +1,9 @@
 // Screen-space reflections, composited over the linear HDR scene color.
 //
-// Reconstructs each pixel's view-space position and a face normal from the
-// camera linear-depth prepass (no normal buffer, so it fits a forward
-// renderer), reflects the view ray about that normal, and marches the
+// Reads each pixel's view-space position and smooth view-space normal from
+// the camera depth prepass (depth in red, the interpolated normal packed
+// into green/blue/alpha), reflects the view ray about that normal, and
+// marches the
 // reflected ray through the depth buffer looking for the surface it hits.
 // On a hit it samples the already-lit scene color at the hit point and
 // blends it in, weighted by a Fresnel term and a confidence that fades at
@@ -87,14 +88,11 @@ void main() {
     return;
   }
 
-  // Face normal from the screen-space gradient of the reconstructed
-  // position, oriented toward the camera (the eye is at the origin, so the
-  // view direction is -origin). Single-pixel silhouette errors are
-  // acceptable for reflections, which the Fresnel and edge fades soften.
-  vec3 normal = normalize(cross(dFdx(origin), dFdy(origin)));
-  if (dot(normal, origin) > 0.0) {
-    normal = -normal;
-  }
+  // The smooth, interpolated view-space normal written by the depth prepass
+  // (in green/blue/alpha). Using the shaded vertex normal rather than one
+  // reconstructed from depth keeps reflections smooth across curved
+  // surfaces instead of faceted per triangle.
+  vec3 normal = normalize(texture(linear_depth, v_uv).gba);
 
   if (debug_view == 3) {
     frag_color = vec4(normal * 0.5 + 0.5, 1.0);

--- a/packages/flutter_scene/shaders/flutter_scene_ssr.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssr.frag
@@ -3,12 +3,12 @@
 // Reads each pixel's view-space position and smooth view-space normal from
 // the camera depth prepass (depth in red, the interpolated normal packed
 // into green/blue/alpha), reflects the view ray about that normal, and
-// marches the
-// reflected ray through the depth buffer looking for the surface it hits.
-// On a hit it samples the already-lit scene color at the hit point and
-// blends it in, weighted by a Fresnel term and a confidence that fades at
-// screen edges. A ray that leaves the screen or finds no hit contributes
-// nothing, so the surface keeps the image-based reflection it was lit with.
+// marches the reflected ray through the depth buffer looking for the surface
+// it hits. On a hit it samples the already-lit scene color at the hit point
+// and blends it in, weighted by a Fresnel term and a confidence that fades at
+// screen edges and with distance. A ray that leaves the screen or finds no
+// hit contributes nothing, so the surface keeps the image-based reflection it
+// was lit with.
 //
 // The scene color is premultiplied linear HDR; the output follows the same
 // contract. This pass stays entirely in render-to-texture space (it samples
@@ -29,7 +29,8 @@ uniform SsrInfo {
   // count.
   vec4 march;
   // x: reflection intensity. y: debug view (0 = composite, 1 = reflected
-  // UV, 2 = hit mask, 3 = reconstructed normal, 4 = confidence).
+  // UV, 2 = hit mask, 3 = normal, 4 = confidence, 5 = raw depth). z: glossy
+  // blur strength (0 = sharp mirror).
   vec4 params;
 }
 ssr;
@@ -41,7 +42,7 @@ out vec4 frag_color;
 // shader output (a uniform-bounded loop is rejected by conformant ES
 // drivers); the dynamic step count breaks out early. Matches the occlusion
 // pass's constant-loop pattern.
-#define MAX_SSR_STEPS 64
+#define MAX_SSR_STEPS 96
 
 // Binary-search iterations used to refine a hit once the coarse march
 // brackets the surface crossing. Constant-bounded for the same reason as the
@@ -52,6 +53,12 @@ const float kEpsilon = 0.0001;
 // Screen-edge fade width, as a fraction of the viewport: reflections ramp
 // out over this band as the hit approaches a screen border.
 const float kEdgeFade = 0.08;
+
+// Glossy reflection blur: a small Vogel disk of taps around the hit, with a
+// radius that grows with the blur strength and the march distance (a rougher
+// surface, or a more distant hit, spreads the reflected cone wider).
+#define SSR_BLUR_TAPS 12
+const float kGoldenAngle = 2.39996323;
 
 // Reconstructs a view-space position from a depth-buffer UV. Camera space
 // places the eye at the origin looking down +Z (the convention the depth
@@ -83,6 +90,7 @@ void main() {
   int step_count = int(ssr.march.w);
   float intensity = ssr.params.x;
   int debug_view = int(ssr.params.y + 0.5);
+  float blur = ssr.params.z;
 
   vec4 base = texture(input_color, v_uv);
   vec4 depth_sample = texture(linear_depth, v_uv);
@@ -117,17 +125,14 @@ void main() {
   vec3 incident = normalize(origin);
   vec3 reflection = reflect(incident, normal);
 
-  // March the reflected ray in screen space (McGuire & Mara): project the
-  // ray's start and end to UVs and walk the screen-space segment in equal
-  // steps, so samples are evenly spaced in pixels regardless of distance
-  // (a fixed view-space step would clump near the camera and skip far
-  // geometry). View-space depth is recovered per step from a
-  // perspective-correct interpolation of 1/z, which is linear across the
-  // screen.
+  // March the reflected ray in screen space: project the ray's start and end
+  // to UVs and walk the screen-space segment in equal steps. View-space
+  // depth is recovered per step from a perspective-correct interpolation of
+  // 1/z, which is linear across the screen.
   vec3 ray_start = origin + normal * start_bias;
   vec3 ray_end = ray_start + reflection * max_distance;
   // Clip the segment to the near plane so the projection stays in front of
-  // the eye (z > 0).
+  // the eye (z > near).
   if (ray_end.z < near) {
     float t = (near - ray_start.z) / (ray_end.z - ray_start.z);
     ray_end = mix(ray_start, ray_end, clamp(t, 0.0, 1.0));
@@ -140,8 +145,10 @@ void main() {
 
   float confidence = 0.0;
   vec2 hit_uv = vec2(0.0);
-  // Parameter of the last coarse sample that was still in front of the
-  // surface, the near end of the bracket for the binary search.
+  // Parameter [0,1] of the accepted hit along the ray, used to widen the
+  // glossy blur with distance.
+  float hit_t = 0.0;
+  // Parameter of the previous sample, the near end of the refine bracket.
   float prev_t = 0.0;
 
   for (int i = 1; i <= MAX_SSR_STEPS; i++) {
@@ -163,39 +170,53 @@ void main() {
       continue;
     }
     float delta = ray_z - scene_z;
-    if (delta > 0.0) {
-      // The ray crossed behind the sampled surface. Reject the crossing if
-      // it sits beyond the surface's assumed thickness (the ray likely
-      // passed behind a foreground occluder into open space), and stop.
-      if (delta < thickness) {
-        // Binary-search the exact crossing between the last in-front sample
-        // and this one, so the hit is pinned far more precisely than the
-        // coarse step, removing most of the per-step banding.
-        float lo = prev_t;
-        float hi = t;
-        for (int j = 0; j < MAX_SSR_REFINE_STEPS; j++) {
-          float mid = 0.5 * (lo + hi);
-          vec2 muv = mix(uv_start, uv_end, mid);
-          float mz = 1.0 / mix(inv_z_start, inv_z_end, mid);
-          if (mz - texture(linear_depth, muv).r > 0.0) {
-            hi = mid;
-          } else {
-            lo = mid;
-          }
+    // Accept only a crossing within the surface's assumed thickness. A
+    // crossing beyond it means the ray passed behind a nearer occluder into
+    // open space, so keep marching: that is what lets a reflection reach an
+    // object standing behind a closer one (rather than stopping at the
+    // first surface the ray goes behind).
+    if (delta > 0.0 && delta < thickness) {
+      // Binary-search the exact crossing between the last sample and this
+      // one, so the hit is pinned far more precisely than the coarse step,
+      // removing most of the per-step banding.
+      float lo = prev_t;
+      float hi = t;
+      for (int j = 0; j < MAX_SSR_REFINE_STEPS; j++) {
+        float mid = 0.5 * (lo + hi);
+        vec2 muv = mix(uv_start, uv_end, mid);
+        float mz = 1.0 / mix(inv_z_start, inv_z_end, mid);
+        if (mz - texture(linear_depth, muv).r > 0.0) {
+          hi = mid;
+        } else {
+          lo = mid;
         }
-        float hit_t = hi;
-        hit_uv = mix(uv_start, uv_end, hit_t);
+      }
+      vec2 candidate_uv = mix(uv_start, uv_end, hi);
+
+      // Backface rejection. A real reflection lands on a surface that faces
+      // the incoming ray. When the surface at the hit faces away, the ray
+      // passed behind a nearer object in screen space, so the color here is
+      // that occluder's, not the reflected surface's. Reject it and keep
+      // marching (so a valid surface further along can still be found, and
+      // if none is, the pixel falls back to its image-based reflection).
+      vec3 hit_normal = normalize(texture(linear_depth, candidate_uv).gba);
+      float facing_hit = -dot(reflection, hit_normal);
+      if (facing_hit > 0.0) {
+        hit_t = hi;
+        hit_uv = candidate_uv;
         // Confidence fades the reflection where it is least reliable: a thin
         // band at the screen border (a hit there has no off-screen data
-        // behind it), and toward the end of the march so reflections taper
-        // off with distance instead of ending in a hard line.
+        // behind it), toward the end of the march so reflections taper off
+        // with distance instead of ending in a hard line, and at grazing
+        // hits where the ray skims the surface.
         vec2 edge = clamp(min(hit_uv, 1.0 - hit_uv) / kEdgeFade, 0.0, 1.0);
         float edge_fade = smoothstep(0.0, 1.0, edge.x) *
                           smoothstep(0.0, 1.0, edge.y);
         float distance_fade = 1.0 - smoothstep(0.7, 1.0, hit_t);
-        confidence = edge_fade * distance_fade;
+        float face_fade = smoothstep(0.0, 0.25, facing_hit);
+        confidence = edge_fade * distance_fade * face_fade;
+        break;
       }
-      break;
     }
     prev_t = t;
   }
@@ -218,17 +239,34 @@ void main() {
     return;
   }
 
-  // Fresnel weight (Schlick): reflections strengthen at grazing angles. The
-  // base reflectance stands in for a per-pixel value until a reflectivity
-  // source is available.
+  // Fresnel weight (Schlick): reflections strengthen at grazing angles.
   // TODO(ssr): drive the reflection strength from per-pixel reflectivity and
   // roughness (a thin reflectivity prepass) instead of a global intensity.
   float facing = clamp(dot(normal, -incident), 0.0, 1.0);
   float fresnel = 0.04 + 0.96 * pow(1.0 - facing, 5.0);
   float strength = clamp(confidence * intensity * fresnel, 0.0, 1.0);
 
+  // Glossy blur of the reflected color. The radius grows with the blur
+  // strength and the hit distance, so a rougher surface (or a more distant
+  // reflection) softens, which also hides the noise the trace produces at
+  // grazing contact points. A zero strength keeps a single sharp tap.
+  vec3 reflected_rgb;
+  if (blur <= 0.0) {
+    reflected_rgb = Unpremultiply(texture(input_color, hit_uv));
+  } else {
+    float radius = blur * (0.004 + 0.03 * hit_t);
+    vec3 sum = vec3(0.0);
+    for (int k = 0; k < SSR_BLUR_TAPS; k++) {
+      float tap_radius =
+          sqrt((float(k) + 0.5) / float(SSR_BLUR_TAPS)) * radius;
+      float theta = float(k) * kGoldenAngle;
+      vec2 offset = vec2(cos(theta), sin(theta)) * tap_radius;
+      sum += Unpremultiply(texture(input_color, hit_uv + offset));
+    }
+    reflected_rgb = sum / float(SSR_BLUR_TAPS);
+  }
+
   vec3 base_rgb = Unpremultiply(base);
-  vec3 reflected_rgb = Unpremultiply(texture(input_color, hit_uv));
   vec3 out_rgb = mix(base_rgb, reflected_rgb, strength);
   frag_color = vec4(out_rgb * base.a, base.a);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_ssr.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssr.frag
@@ -43,6 +43,11 @@ out vec4 frag_color;
 // pass's constant-loop pattern.
 #define MAX_SSR_STEPS 64
 
+// Binary-search iterations used to refine a hit once the coarse march
+// brackets the surface crossing. Constant-bounded for the same reason as the
+// march loop.
+#define MAX_SSR_REFINE_STEPS 5
+
 const float kEpsilon = 0.0001;
 // Screen-edge fade width, as a fraction of the viewport: reflections ramp
 // out over this band as the hit approaches a screen border.
@@ -135,6 +140,9 @@ void main() {
 
   float confidence = 0.0;
   vec2 hit_uv = vec2(0.0);
+  // Parameter of the last coarse sample that was still in front of the
+  // surface, the near end of the bracket for the binary search.
+  float prev_t = 0.0;
 
   for (int i = 1; i <= MAX_SSR_STEPS; i++) {
     if (i > step_count) {
@@ -151,21 +159,45 @@ void main() {
     float scene_z = texture(linear_depth, uv).r;
     // Skip background (sky) texels: no geometry to reflect there.
     if (scene_z >= far) {
+      prev_t = t;
       continue;
     }
     float delta = ray_z - scene_z;
-    // A hit: the ray has crossed behind the sampled surface, within the
-    // surface's assumed thickness.
-    if (delta > 0.0 && delta < thickness) {
-      hit_uv = uv;
-      // Edge fade: ramp confidence to zero in a thin band at the screen
-      // border so a hit near the edge does not pop.
-      vec2 edge = clamp(min(uv, 1.0 - uv) / kEdgeFade, 0.0, 1.0);
-      float edge_fade = smoothstep(0.0, 1.0, edge.x) *
-                        smoothstep(0.0, 1.0, edge.y);
-      confidence = edge_fade;
+    if (delta > 0.0) {
+      // The ray crossed behind the sampled surface. Reject the crossing if
+      // it sits beyond the surface's assumed thickness (the ray likely
+      // passed behind a foreground occluder into open space), and stop.
+      if (delta < thickness) {
+        // Binary-search the exact crossing between the last in-front sample
+        // and this one, so the hit is pinned far more precisely than the
+        // coarse step, removing most of the per-step banding.
+        float lo = prev_t;
+        float hi = t;
+        for (int j = 0; j < MAX_SSR_REFINE_STEPS; j++) {
+          float mid = 0.5 * (lo + hi);
+          vec2 muv = mix(uv_start, uv_end, mid);
+          float mz = 1.0 / mix(inv_z_start, inv_z_end, mid);
+          if (mz - texture(linear_depth, muv).r > 0.0) {
+            hi = mid;
+          } else {
+            lo = mid;
+          }
+        }
+        float hit_t = hi;
+        hit_uv = mix(uv_start, uv_end, hit_t);
+        // Confidence fades the reflection where it is least reliable: a thin
+        // band at the screen border (a hit there has no off-screen data
+        // behind it), and toward the end of the march so reflections taper
+        // off with distance instead of ending in a hard line.
+        vec2 edge = clamp(min(hit_uv, 1.0 - hit_uv) / kEdgeFade, 0.0, 1.0);
+        float edge_fade = smoothstep(0.0, 1.0, edge.x) *
+                          smoothstep(0.0, 1.0, edge.y);
+        float distance_fade = 1.0 - smoothstep(0.7, 1.0, hit_t);
+        confidence = edge_fade * distance_fade;
+      }
       break;
     }
+    prev_t = t;
   }
 
   if (debug_view == 1) {

--- a/packages/flutter_scene/shaders/flutter_scene_ssr.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssr.frag
@@ -105,36 +105,48 @@ void main() {
   vec3 incident = normalize(origin);
   vec3 reflection = reflect(incident, normal);
 
-  // March the reflected ray in view space, projecting each step to a UV and
-  // testing it against the stored depth.
-  // TODO(ssr): this fixed view-space step over-samples near the camera and
-  // under-samples far away; replace with a perspective-correct screen-space
-  // DDA (McGuire & Mara) so samples are evenly spaced in pixels.
-  float step_length = max_distance / float(step_count);
-  vec3 march_pos = origin + normal * start_bias;
+  // March the reflected ray in screen space (McGuire & Mara): project the
+  // ray's start and end to UVs and walk the screen-space segment in equal
+  // steps, so samples are evenly spaced in pixels regardless of distance
+  // (a fixed view-space step would clump near the camera and skip far
+  // geometry). View-space depth is recovered per step from a
+  // perspective-correct interpolation of 1/z, which is linear across the
+  // screen.
+  vec3 ray_start = origin + normal * start_bias;
+  vec3 ray_end = ray_start + reflection * max_distance;
+  // Clip the segment to the near plane so the projection stays in front of
+  // the eye (z > 0).
+  if (ray_end.z < near) {
+    float t = (near - ray_start.z) / (ray_end.z - ray_start.z);
+    ray_end = mix(ray_start, ray_end, clamp(t, 0.0, 1.0));
+  }
+
+  vec2 uv_start = UvFromView(ray_start);
+  vec2 uv_end = UvFromView(ray_end);
+  float inv_z_start = 1.0 / ray_start.z;
+  float inv_z_end = 1.0 / ray_end.z;
+
   float confidence = 0.0;
   vec2 hit_uv = vec2(0.0);
 
-  for (int i = 0; i < MAX_SSR_STEPS; i++) {
-    if (i >= step_count) {
+  for (int i = 1; i <= MAX_SSR_STEPS; i++) {
+    if (i > step_count) {
       break;
     }
-    march_pos += reflection * step_length;
-    // Stop if the ray passes behind the near plane (nothing to sample).
-    if (march_pos.z <= near) {
-      break;
-    }
-    vec2 uv = UvFromView(march_pos);
+    float t = float(i) / float(step_count);
+    vec2 uv = mix(uv_start, uv_end, t);
     // Stop when the ray leaves the screen.
     if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
       break;
     }
+    // Perspective-correct view-space depth of the ray at this screen point.
+    float ray_z = 1.0 / mix(inv_z_start, inv_z_end, t);
     float scene_z = texture(linear_depth, uv).r;
     // Skip background (sky) texels: no geometry to reflect there.
     if (scene_z >= far) {
       continue;
     }
-    float delta = march_pos.z - scene_z;
+    float delta = ray_z - scene_z;
     // A hit: the ray has crossed behind the sampled surface, within the
     // surface's assumed thickness.
     if (delta > 0.0 && delta < thickness) {

--- a/packages/flutter_scene/shaders/flutter_scene_ssr_composite.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssr_composite.frag
@@ -1,0 +1,42 @@
+// Composites the screen-space reflection buffer (produced by
+// flutter_scene_ssr.frag, possibly at a reduced resolution) over the
+// full-resolution linear HDR scene color.
+//
+// The reflection is stored premultiplied by its blend strength (rgb =
+// reflected color * strength, a = strength), so it upscales with plain
+// bilinear filtering and composites with a premultiplied "over". The output
+// follows the scene color's premultiplied-alpha contract.
+
+uniform sampler2D input_color;
+uniform sampler2D ssr_reflection;
+
+uniform CompositeInfo {
+  // x: debug view (0 = normal composite; nonzero shows the reflection buffer
+  // directly, for the trace's debug visualizations).
+  vec4 params;
+}
+composite;
+
+in vec2 v_uv;
+out vec4 frag_color;
+
+// Un-premultiplies a sampled premultiplied-alpha color.
+vec3 Unpremultiply(vec4 c) { return c.a > 0.0 ? c.rgb / c.a : vec3(0.0); }
+
+void main() {
+  vec4 refl = texture(ssr_reflection, v_uv);
+
+  int debug_view = int(composite.params.x + 0.5);
+  if (debug_view != 0) {
+    // The trace wrote its debug visualization opaquely; show it (upscaled).
+    frag_color = vec4(refl.rgb, 1.0);
+    return;
+  }
+
+  vec4 base = texture(input_color, v_uv);
+  vec3 base_rgb = Unpremultiply(base);
+  // Premultiplied over: base * (1 - strength) + reflected*strength (refl.rgb
+  // is already the reflected color premultiplied by strength).
+  vec3 out_rgb = base_rgb * (1.0 - refl.a) + refl.rgb;
+  frag_color = vec4(out_rgb * base.a, base.a);
+}


### PR DESCRIPTION
Adds an optional screen-space reflections (SSR) pass that layers sharp, view-dependent reflections on top of the image-based environment reflections every surface already receives. It is off by default and enabled through `Scene.screenSpaceReflections`, so a scene that does not use it pays nothing.

The trace reconstructs each pixel's view-space position and a smooth interpolated normal from a camera depth prepass, so it needs no G-buffer and fits the forward renderer. The prepass is the one ambient occlusion already uses, now shared and, when reflections are on, extended to also write the view-space normal into the depth target's spare channels. A reflected ray is marched through the depth buffer in screen space; a hit samples the already-lit scene color at the hit point, and a miss falls back to the environment reflection, so SSR only ever adds detail.

Controls on `ScreenSpaceReflectionsSettings`:
- `intensity`, `maxDistance`, and `thickness` (thickness controls hit acceptance only, decoupled from the ray geometry so it no longer shifts reflections)
- `stride` (pixels advanced per march step, the quality dial) and `maxSteps` (a hard cost ceiling), so sampling density is set by the stride rather than a reflection's on-screen length
- `blur` for glossy softening
- `distanceFadeStart`, so reflections taper out at whichever range limit binds first (world distance or the step budget) instead of hard-cutting
- `resolutionScale`, tracing the reflection layer at a fraction of the render size and bilinear-upscaling it while the rest of the image stays full resolution (the main mobile performance lever)
- `debugView` to inspect the trace's intermediate buffers

The pass runs as a trace at the reflection resolution that writes a premultiplied reflection buffer, then a full-resolution composite that upscales and blends it over the scene color. Backface rejection plus screen-edge, distance, and grazing confidence fades suppress the usual SSR artifacts.

Adds a "Screen-space Reflections" example with a live settings panel and a detachable free-fly camera.
