### PR TITLE
Add flutter_scene_box3d, a box3d physics backend

### DIFF
--- a/examples/flutter_app/lib/example_physics_box3d.dart
+++ b/examples/flutter_app/lib/example_physics_box3d.dart
@@ -1,0 +1,398 @@
+import 'dart:math' as math;
+
+// flutter_scene's physics BoxShape clashes with Flutter's painting BoxShape,
+// and flutter_scene's Material clashes with the Flutter Material widget, so
+// each conflicting name is hidden from the other import.
+import 'package:flutter/material.dart' hide BoxShape;
+import 'package:flutter_scene/scene.dart' hide Material;
+import 'package:flutter_scene_box3d/flutter_scene_box3d.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+import 'quake_camera.dart';
+
+/// A box3d physics playground. A stack of boxes, a swinging pendulum rope
+/// (spherical joints), and a code-driven kinematic spinner sit on the
+/// ground. Tap to drop a random shape from above, drag to look, and WASD/QE
+/// to fly the camera.
+class ExamplePhysicsBox3d extends StatefulWidget {
+  const ExamplePhysicsBox3d({super.key});
+
+  @override
+  State<ExamplePhysicsBox3d> createState() => _ExamplePhysicsBox3dState();
+}
+
+class _ExamplePhysicsBox3dState extends State<ExamplePhysicsBox3d> {
+  final Scene scene = Scene();
+  late final Box3dPhysicsWorld world;
+
+  final QuakeCamera _camera = QuakeCamera(
+    position: vm.Vector3(0, 5, 14),
+    pitch: -0.3,
+  )..speed = 8.0;
+  final FocusNode _sceneFocus = FocusNode(debugLabel: 'box3d-scene');
+  PerspectiveCamera? _perspective;
+  Size _viewSize = Size.zero;
+
+  // Bodies dropped by tapping, retired oldest-first past the cap.
+  static const int _maxDropped = 40;
+  final List<Node> _dropped = [];
+  final math.Random _rng = math.Random(11);
+
+  // The code-driven kinematic spinner bar.
+  Node? _spinner;
+  double _spinnerAngle = 0.0;
+  static final vm.Vector3 _spinnerCenter = vm.Vector3(-6, 0.7, 0);
+
+  static final List<vm.Vector4> _palette = [
+    vm.Vector4(0.91, 0.30, 0.35, 1),
+    vm.Vector4(0.95, 0.61, 0.24, 1),
+    vm.Vector4(0.96, 0.82, 0.25, 1),
+    vm.Vector4(0.42, 0.74, 0.40, 1),
+    vm.Vector4(0.30, 0.62, 0.86, 1),
+    vm.Vector4(0.56, 0.42, 0.80, 1),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    scene.root.addComponent(
+      DirectionalLightComponent(
+        DirectionalLight(
+          direction: vm.Vector3(-0.6, -1.0, -0.45),
+          intensity: 3.0,
+          castsShadow: true,
+          shadowMaxDistance: 40.0,
+        ),
+      ),
+    );
+    scene.environmentIntensity = 0.6;
+
+    world = Box3dPhysicsWorld(gravity: vm.Vector3(0, -9.81, 0));
+    scene.root.addComponent(world);
+
+    _buildGround();
+    _buildStack();
+    _buildPendulum();
+    _buildSpinner();
+  }
+
+  @override
+  void dispose() {
+    _sceneFocus.dispose();
+    super.dispose();
+  }
+
+  // --- Scene construction ---------------------------------------------------
+
+  Mesh _boxMesh(vm.Vector3 size, vm.Vector4 color, {double roughness = 0.5}) {
+    final material = PhysicallyBasedMaterial()
+      ..baseColorFactor = color
+      ..roughnessFactor = roughness
+      ..metallicFactor = 0.0;
+    return Mesh(CuboidGeometry(size), material);
+  }
+
+  Node _addBody({
+    required vm.Vector3 position,
+    required BodyType type,
+    required Mesh mesh,
+    required Shape shape,
+    vm.Quaternion? rotation,
+    PhysicsMaterial material = PhysicsMaterial.defaultMaterial,
+    double linearDamping = 0,
+    double angularDamping = 0,
+  }) {
+    final transform = rotation == null
+        ? vm.Matrix4.translation(position)
+        : vm.Matrix4.compose(position, rotation, vm.Vector3.all(1.0));
+    final node = Node(mesh: mesh, localTransform: transform);
+    node.addComponent(
+      Box3dRigidBody(
+        type: type,
+        linearDamping: linearDamping,
+        angularDamping: angularDamping,
+      ),
+    );
+    node.addComponent(Box3dCollider(shape: shape, material: material));
+    scene.add(node);
+    return node;
+  }
+
+  void _buildGround() {
+    final half = vm.Vector3(24, 0.5, 24);
+    _addBody(
+      position: vm.Vector3(0, -0.5, 0),
+      type: BodyType.fixed,
+      mesh: _boxMesh(
+        half * 2.0,
+        vm.Vector4(0.55, 0.58, 0.62, 1),
+        roughness: 0.9,
+      ),
+      shape: BoxShape(halfExtents: half),
+      material: const PhysicsMaterial(friction: 0.9),
+    );
+  }
+
+  // A 3-2-1 pyramid of dynamic boxes.
+  void _buildStack() {
+    const spacing = 1.04;
+    for (var row = 0; row < 3; row++) {
+      final count = 3 - row;
+      final y = 0.5 + row * 1.0;
+      final startX = -(count - 1) / 2 * spacing;
+      for (var i = 0; i < count; i++) {
+        _addBody(
+          position: vm.Vector3(startX + i * spacing, y, -6),
+          type: BodyType.dynamic_,
+          mesh: _boxMesh(vm.Vector3.all(1.0), _palette[row]),
+          shape: BoxShape(halfExtents: vm.Vector3.all(0.5)),
+          material: const PhysicsMaterial(friction: 0.8),
+        );
+      }
+    }
+  }
+
+  // A rope of beads linked by spherical joints, anchored to the world at the
+  // top so it swings freely.
+  void _buildPendulum() {
+    const topY = 5.0, nBeads = 6, spacing = 0.5, beadR = 0.22;
+    const half = spacing / 2;
+    final anchor = vm.Vector3(6, topY, 0);
+    final geometry = SphereGeometry(radius: beadR);
+    final material = PhysicallyBasedMaterial()
+      ..baseColorFactor = vm.Vector4(0.75, 0.72, 0.5, 1)
+      ..roughnessFactor = 0.4
+      ..metallicFactor = 0.1;
+
+    Node? prev;
+    for (var i = 0; i < nBeads; i++) {
+      final node = Node(
+        mesh: Mesh(geometry, material),
+        localTransform: vm.Matrix4.translation(
+          vm.Vector3(anchor.x, topY - half - i * spacing, anchor.z),
+        ),
+      );
+      node.addComponent(
+        Box3dRigidBody(
+          type: BodyType.dynamic_,
+          linearDamping: 0.2,
+          angularDamping: 0.4,
+        ),
+      );
+      node.addComponent(Box3dCollider(shape: const SphereShape(radius: beadR)));
+      scene.add(node);
+      node.addComponent(
+        i == 0
+            ? Box3dSphericalJoint(
+                localAnchorA: vm.Vector3(0, half, 0),
+                localAnchorB: anchor.clone(),
+              )
+            : Box3dSphericalJoint(
+                otherNode: prev,
+                localAnchorA: vm.Vector3(0, half, 0),
+                localAnchorB: vm.Vector3(0, -half, 0),
+              ),
+      );
+      prev = node;
+    }
+    // Give the bottom bead a shove so the pendulum starts swinging.
+    prev?.getComponent<Box3dRigidBody>()?.linearVelocity = vm.Vector3(0, 0, 4);
+  }
+
+  // A kinematic bar sweeping a horizontal circle, driven by code each frame.
+  void _buildSpinner() {
+    _spinner = _addBody(
+      position: _spinnerCenter,
+      type: BodyType.kinematic,
+      mesh: _boxMesh(vm.Vector3(6, 0.4, 0.4), vm.Vector4(0.88, 0.22, 0.26, 1)),
+      shape: BoxShape(halfExtents: vm.Vector3(3, 0.2, 0.2)),
+      material: const PhysicsMaterial(friction: 0.4),
+    );
+  }
+
+  // --- Interaction ----------------------------------------------------------
+
+  void _onTick(Duration elapsed, double deltaSeconds) {
+    final dt = deltaSeconds.clamp(0.0, 0.05);
+    // Spin the kinematic bar by writing its node transform; the body syncs
+    // to the node each fixed step and shoves whatever it hits.
+    final spinner = _spinner;
+    if (spinner != null) {
+      _spinnerAngle += 1.2 * dt;
+      spinner.localTransform = vm.Matrix4.compose(
+        _spinnerCenter,
+        vm.Quaternion.axisAngle(vm.Vector3(0, 1, 0), _spinnerAngle),
+        vm.Vector3.all(1.0),
+      );
+    }
+    scene.update(dt);
+    exampleSettings.applyTo(scene);
+  }
+
+  // Drops a random shape from above wherever the tap ray meets the scene.
+  void _dropAt(Offset screenPosition) {
+    final camera = _perspective;
+    if (camera == null || _viewSize.isEmpty) return;
+    final ray = camera.screenPointToRay(screenPosition, _viewSize);
+    final hit = scene.raycast(ray);
+    final target = hit?.worldPoint ?? _intersectGround(ray);
+    if (target == null) return;
+    _drop(vm.Vector3(target.x, target.y + 7.0, target.z));
+  }
+
+  vm.Vector3? _intersectGround(vm.Ray ray) {
+    final dirY = ray.direction.y;
+    if (dirY.abs() < 1e-6) return null;
+    final t = -ray.origin.y / dirY;
+    if (t < 0) return null;
+    return ray.origin + ray.direction.scaled(t);
+  }
+
+  void _drop(vm.Vector3 position) {
+    final color = _palette[_rng.nextInt(_palette.length)];
+    final material = PhysicallyBasedMaterial()
+      ..baseColorFactor = color
+      ..roughnessFactor = 0.45
+      ..metallicFactor = 0.05;
+    final rotation = vm.Quaternion.euler(
+      _rng.nextDouble() * math.pi * 2,
+      _rng.nextDouble() * math.pi * 2,
+      _rng.nextDouble() * math.pi * 2,
+    );
+    // Cycle through the shapes box3d supports as analytic colliders.
+    final Geometry geometry;
+    final Shape shape;
+    switch (_rng.nextInt(4)) {
+      case 0:
+        final g = SphereGeometry(radius: 0.5);
+        geometry = g;
+        shape = g.collisionShape;
+      case 1:
+        final g = CapsuleGeometry(radius: 0.35, height: 1.2);
+        geometry = g;
+        shape = g.collisionShape;
+      case 2:
+        final g = CylinderGeometry(
+          bottomRadius: 0.5,
+          topRadius: 0.5,
+          height: 1.0,
+        );
+        geometry = g;
+        shape = g.collisionShape;
+      default:
+        final g = CuboidGeometry(vm.Vector3.all(1.0));
+        geometry = g;
+        shape = g.collisionShape;
+    }
+    final node = _addBodyMesh(
+      Mesh(geometry, material),
+      shape,
+      position,
+      rotation,
+    );
+    _dropped.add(node);
+    if (_dropped.length > _maxDropped) {
+      scene.remove(_dropped.removeAt(0));
+    }
+  }
+
+  Node _addBodyMesh(
+    Mesh mesh,
+    Shape shape,
+    vm.Vector3 position,
+    vm.Quaternion rotation,
+  ) {
+    final node = Node(
+      mesh: mesh,
+      localTransform: vm.Matrix4.compose(position, rotation, vm.Vector3.all(1)),
+    );
+    node.addComponent(Box3dRigidBody(type: BodyType.dynamic_));
+    node.addComponent(
+      Box3dCollider(
+        shape: shape,
+        material: const PhysicsMaterial(friction: 0.6, restitution: 0.1),
+      ),
+    );
+    scene.add(node);
+    return node;
+  }
+
+  void _clear() {
+    setState(() {
+      for (final node in _dropped) {
+        scene.remove(node);
+      }
+      _dropped.clear();
+    });
+  }
+
+  // --- Build ----------------------------------------------------------------
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Focus(
+            focusNode: _sceneFocus,
+            autofocus: true,
+            onKeyEvent: _camera.onKeyEvent,
+            child: Listener(
+              onPointerDown: (_) => _sceneFocus.requestFocus(),
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTapUp: (details) => _dropAt(details.localPosition),
+                onPanUpdate: (details) => _camera.look(details.delta),
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    _viewSize = constraints.biggest;
+                    return SceneView(
+                      scene,
+                      cameraBuilder: (elapsed) {
+                        _camera.move(elapsed.inMicroseconds / 1e6);
+                        return _perspective = _camera.camera;
+                      },
+                      onTick: _onTick,
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          top: 8,
+          left: 0,
+          right: 0,
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: Card(
+              color: Colors.black54,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Text(
+                      'Tap to drop a shape  •  drag to look  •  WASD/QE to move',
+                      style: TextStyle(color: Colors.white70, fontSize: 12),
+                    ),
+                    const SizedBox(height: 6),
+                    FilledButton.tonal(
+                      onPressed: _dropped.isEmpty ? null : _clear,
+                      child: const Text('Clear dropped'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -4,6 +4,8 @@ import 'package:flutter_scene/scene.dart'
     show AntiAliasingMode, Scene, PostInsertion, SpecularAmbientOcclusionMode;
 import 'package:flutter_scene_rapier/flutter_scene_rapier.dart'
     show RapierWorld;
+import 'package:flutter_scene_box3d/flutter_scene_box3d.dart'
+    show Box3dPhysicsWorld;
 import 'package:example_app/example_animation.dart';
 
 import 'example_cuboid.dart';
@@ -17,6 +19,7 @@ import 'example_lod.dart';
 import 'example_logo.dart';
 import 'example_nav_route.dart';
 import 'example_physics.dart';
+import 'example_physics_box3d.dart';
 import 'example_render_target.dart';
 import 'example_settings.dart';
 import 'example_shapes.dart';
@@ -50,6 +53,7 @@ class _MyAppState extends State<MyApp> {
   // soon as the app starts, but only the Physics example waits on it, so
   // the other examples are not delayed by it. A no-op on native.
   final Future<void> _physicsReady = RapierWorld.ensureInitialized();
+  final Future<void> _box3dReady = Box3dPhysicsWorld.ensureInitialized();
 
   @override
   void initState() {
@@ -81,6 +85,17 @@ class _MyAppState extends State<MyApp> {
             return const Center(child: CircularProgressIndicator());
           }
           return const ExamplePhysics();
+        },
+      ),
+      'Physics (box3d)': (context) => FutureBuilder<void>(
+        // The box3d backend readiness (a no-op on native; the wasm load on
+        // the web) before a world can be built.
+        future: _box3dReady,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          return const ExamplePhysicsBox3d();
         },
       ),
       'Shapes': (context) => FutureBuilder<void>(

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -18,6 +18,10 @@ dependencies:
   # in a Rust build hook, so building this app now requires cargo.
   flutter_scene_rapier:
     path: ../../packages/flutter_scene_rapier
+  # box3d physics backend, used by the Physics (box3d) example. Compiles
+  # box3d from source through a C build hook.
+  flutter_scene_box3d:
+    path: ../../packages/flutter_scene_box3d
   hooks: ^2.0.0
   http: ^1.2.0
   path_provider: ^2.1.0

--- a/packages/flutter_scene_box3d/CHANGELOG.md
+++ b/packages/flutter_scene_box3d/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 0.1.0
+
+- Initial release. Implements the flutter_scene physics contract against
+  box3d: rigid bodies, colliders (sphere, box, capsule, cylinder, convex
+  hull, triangle mesh, height field, compound), scene queries, and contact /
+  trigger events. Joints and explicit mass override are not yet wired up.

--- a/packages/flutter_scene_box3d/LICENSE
+++ b/packages/flutter_scene_box3d/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2025 Brandon DeRosier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+This package distributes precompiled binaries (and a WebAssembly module)
+of a Rust shim that statically links third-party Rust crates, chiefly the
+Dimforge Rapier physics engine. Those components are licensed separately;
+see THIRD_PARTY_NOTICES.md.

--- a/packages/flutter_scene_box3d/README.md
+++ b/packages/flutter_scene_box3d/README.md
@@ -1,0 +1,70 @@
+# flutter_scene_box3d
+
+A [box3d](https://github.com/erincatto/box3d) physics backend for
+[flutter_scene](https://pub.dev/packages/flutter_scene). It implements the
+abstract physics contract from `flutter_scene` (rigid bodies, colliders,
+queries, and collision events) against the box3d engine, through the
+engine-agnostic [box3d](https://pub.dev/packages/box3d) Dart package.
+
+> **Status: experimental.** Requires the Flutter **master** channel (it
+> builds on Flutter GPU / Impeller). The API may change between releases.
+
+## Quick start
+
+Add a `Box3dPhysicsWorld` to the scene root, then attach a `Box3dRigidBody`
+and a `Box3dCollider` to the nodes you want simulated (the body must be
+added before the collider). The scene advances physics on a fixed timestep
+and interpolates transforms for you.
+
+```dart
+import 'package:flutter_scene/scene.dart' hide Material;
+import 'package:flutter_scene_box3d/flutter_scene_box3d.dart';
+import 'package:vector_math/vector_math.dart';
+
+await Box3dPhysicsWorld.ensureInitialized();
+
+final scene = Scene();
+final world = Box3dPhysicsWorld(gravity: Vector3(0, -9.81, 0));
+scene.root.addComponent(world);
+
+// A static floor.
+final floor = Node(localTransform: Matrix4.translation(Vector3(0, -0.5, 0)));
+floor.addComponent(Box3dRigidBody(type: BodyType.fixed));
+floor.addComponent(Box3dCollider(shape: BoxShape(halfExtents: Vector3(10, 0.5, 10))));
+scene.add(floor);
+
+// A falling dynamic box.
+final box = Node(localTransform: Matrix4.translation(Vector3(0, 5, 0)));
+box.addComponent(Box3dRigidBody(type: BodyType.dynamic_));
+box.addComponent(Box3dCollider(shape: BoxShape(halfExtents: Vector3.all(0.5))));
+scene.add(box);
+
+world.collisions.listen((event) {
+  // CollisionBegan / CollisionEnded / TriggerEntered / TriggerExited
+});
+```
+
+Each frame, advance and render the scene:
+
+```dart
+scene.update(deltaSeconds); // steps physics + interpolates
+scene.render(camera, canvas, viewport: Offset.zero & size);
+```
+
+Scene queries run through `world.raycast`, `world.raycastAll`,
+`world.overlapSphere`, `world.overlapBox`, and `world.shapeCast`.
+
+## Supported shapes
+
+Sphere, box, capsule, cylinder, convex hull, triangle mesh, height field,
+and compound. A collider's `localPose` is baked into the shape geometry; a
+non-identity pose on a cylinder or height field is not supported yet.
+
+## Not yet implemented
+
+Joints and an explicit mass / inertia override are not wired up yet (box3d
+derives mass from collider density). See the `TODO` notes in the source.
+
+## License
+
+MIT (see `LICENSE`).

--- a/packages/flutter_scene_box3d/dart_test.yaml
+++ b/packages/flutter_scene_box3d/dart_test.yaml
@@ -1,0 +1,3 @@
+# box3d keeps worlds in process-global state, so run test suites one at a
+# time to avoid parallel isolates racing on it.
+concurrency: 1

--- a/packages/flutter_scene_box3d/lib/flutter_scene_box3d.dart
+++ b/packages/flutter_scene_box3d/lib/flutter_scene_box3d.dart
@@ -15,5 +15,6 @@
 library;
 
 export 'src/box3d_collider.dart';
+export 'src/box3d_joint.dart';
 export 'src/box3d_physics_world.dart' show Box3dPhysicsWorld;
 export 'src/box3d_rigid_body.dart';

--- a/packages/flutter_scene_box3d/lib/flutter_scene_box3d.dart
+++ b/packages/flutter_scene_box3d/lib/flutter_scene_box3d.dart
@@ -1,0 +1,19 @@
+/// box3d physics backend for flutter_scene.
+///
+/// Implements the abstract [PhysicsWorld], [RigidBody], and [Collider]
+/// contract from `package:flutter_scene` against the box3d engine. Construct
+/// a [Box3dPhysicsWorld] and attach it to your scene root, then attach
+/// [Box3dRigidBody] and [Box3dCollider] components to nodes that should
+/// participate in the simulation.
+///
+/// The scene advances physics on a fixed timestep and interpolates dynamic
+/// body transforms for rendering. Rigid bodies, the full shape hierarchy,
+/// axis locks, sleeping, kinematic transform sync, scene queries (raycast,
+/// overlap, shape cast), and contact / trigger events all run through
+/// box3d. Await [Box3dPhysicsWorld.ensureInitialized] once before creating a
+/// world.
+library;
+
+export 'src/box3d_collider.dart';
+export 'src/box3d_physics_world.dart' show Box3dPhysicsWorld;
+export 'src/box3d_rigid_body.dart';

--- a/packages/flutter_scene_box3d/lib/src/box3d_collider.dart
+++ b/packages/flutter_scene_box3d/lib/src/box3d_collider.dart
@@ -1,0 +1,282 @@
+import 'dart:typed_data';
+
+import 'package:box3d/box3d.dart' as b3;
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
+
+import 'box3d_physics_world.dart';
+import 'box3d_rigid_body.dart';
+
+/// [Collider] backed by box3d.
+///
+/// Cooks its [shape] into one or more box3d shapes on mount and attaches
+/// them to the sibling [Box3dRigidBody]. Material, collision layer/mask,
+/// and the trigger flag pass through. Contact and sensor events are enabled
+/// on every shape so the world's collision stream sees them.
+///
+/// [localPose] is baked into the shape geometry: a non-identity pose turns a
+/// box into an equivalent convex hull and transforms hull/mesh points.
+/// TODO(box3d-collider-localpose): a non-identity pose on a cylinder or
+/// height field throws, since box3d cannot offset those through the current
+/// package surface. TODO(box3d-combine-rules): PhysicsMaterial combine rules
+/// are not represented by box3d.
+class Box3dCollider extends Collider {
+  Box3dCollider({
+    required Shape shape,
+    PhysicsMaterial material = PhysicsMaterial.defaultMaterial,
+    int collisionLayer = 0xFFFFFFFF,
+    int collisionMask = 0xFFFFFFFF,
+    bool isTrigger = false,
+    Matrix4? localPose,
+  }) : _shape = shape,
+       _material = material,
+       _collisionLayer = collisionLayer,
+       _collisionMask = collisionMask,
+       _isTrigger = isTrigger,
+       _localPose = localPose ?? Matrix4.identity();
+
+  Shape _shape;
+  PhysicsMaterial _material;
+  int _collisionLayer;
+  int _collisionMask;
+  bool _isTrigger;
+  Matrix4 _localPose;
+
+  Box3dPhysicsWorld? _world;
+  List<b3.Box3dShape> _shapes = const [];
+
+  /// Every box3d shape this component owns (one per leaf primitive; a
+  /// compound produces several). Empty before mount or when the shape could
+  /// not be cooked.
+  List<b3.Box3dShape> get nativeShapes => List.unmodifiable(_shapes);
+
+  @override
+  void onMount() {
+    final world = findAncestorBox3dWorld(node);
+    if (world == null) return;
+    final body = node.getComponent<Box3dRigidBody>()?.nativeBody;
+    if (body == null) {
+      throw StateError(
+        'Box3dCollider requires a sibling Box3dRigidBody on the same node. '
+        'Attach a Box3dRigidBody first.',
+      );
+    }
+    _world = world;
+    _shapes = _cook(_shape, _localPose, body);
+    for (final shape in _shapes) {
+      shape.setCollisionFilter(category: _collisionLayer, mask: _collisionMask);
+      shape.contactEventsEnabled = true;
+      shape.sensorEventsEnabled = true;
+      world.rememberCollider(shape.handle, this);
+    }
+  }
+
+  @override
+  void onUnmount() {
+    final world = _world;
+    if (world != null) {
+      for (final shape in _shapes) {
+        world.forgetCollider(shape.handle);
+        shape.destroy();
+      }
+    }
+    _world = null;
+    _shapes = const [];
+  }
+
+  void _rebuild() {
+    if (_world == null) return;
+    onUnmount();
+    onMount();
+  }
+
+  b3.Box3dMaterial get _b3Material => b3.Box3dMaterial(
+    friction: _material.friction,
+    restitution: _material.restitution,
+    density: _material.density,
+  );
+
+  List<b3.Box3dShape> _cook(Shape shape, Matrix4 pose, b3.Box3dBody body) {
+    switch (shape) {
+      case SphereShape():
+        return [
+          body.addSphere(
+            shape.radius,
+            center: pose.getTranslation(),
+            material: _b3Material,
+            isSensor: _isTrigger,
+          ),
+        ];
+      case BoxShape():
+        if (pose.isIdentity()) {
+          return [
+            body.addBox(
+              shape.halfExtents,
+              material: _b3Material,
+              isSensor: _isTrigger,
+            ),
+          ];
+        }
+        // An offset/rotated box is expressed as the convex hull of its eight
+        // transformed corners.
+        final hull = body.addConvexHull(
+          _boxCorners(shape.halfExtents, pose),
+          material: _b3Material,
+          isSensor: _isTrigger,
+        );
+        return hull == null ? const [] : [hull];
+      case CapsuleShape():
+        final a = pose.transformed3(Vector3(0, -shape.halfHeight, 0));
+        final b = pose.transformed3(Vector3(0, shape.halfHeight, 0));
+        return [
+          body.addCapsule(
+            shape.radius,
+            pointA: a,
+            pointB: b,
+            material: _b3Material,
+            isSensor: _isTrigger,
+          ),
+        ];
+      case CylinderShape():
+        if (!pose.isIdentity()) {
+          throw UnsupportedError(
+            'Box3dCollider does not support a non-identity localPose on a '
+            'CylinderShape yet.',
+          );
+        }
+        return [
+          body.addCylinder(
+            shape.halfHeight,
+            shape.radius,
+            material: _b3Material,
+            isSensor: _isTrigger,
+          ),
+        ];
+      case ConvexHullShape():
+        final hull = body.addConvexHull(
+          _transformPoints(shape.points, pose),
+          material: _b3Material,
+          isSensor: _isTrigger,
+        );
+        return hull == null ? const [] : [hull];
+      case TriMeshShape():
+        final mesh = body.addTriMesh(
+          _transformPoints(shape.vertices, pose),
+          shape.indices,
+          material: _b3Material,
+          isSensor: _isTrigger,
+        );
+        return mesh == null ? const [] : [mesh];
+      case HeightFieldShape():
+        if (!pose.isIdentity()) {
+          throw UnsupportedError(
+            'Box3dCollider does not support a non-identity localPose on a '
+            'HeightFieldShape yet.',
+          );
+        }
+        final field = body.addHeightField(
+          countX: shape.width,
+          countZ: shape.depth,
+          heights: shape.heights,
+          scale: shape.scale,
+          material: _b3Material,
+          isSensor: _isTrigger,
+        );
+        return field == null ? const [] : [field];
+      case CompoundShape():
+        return [
+          for (final child in shape.children)
+            ..._cook(child.shape, pose.multiplied(child.localPose), body),
+        ];
+    }
+  }
+
+  // The eight corners of a box (half extents [h]) transformed by [pose],
+  // packed as xyz triplets.
+  static Float32List _boxCorners(Vector3 h, Matrix4 pose) {
+    final out = Float32List(24);
+    var i = 0;
+    for (final sx in const [-1.0, 1.0]) {
+      for (final sy in const [-1.0, 1.0]) {
+        for (final sz in const [-1.0, 1.0]) {
+          final v = pose.transformed3(Vector3(sx * h.x, sy * h.y, sz * h.z));
+          out[i++] = v.x;
+          out[i++] = v.y;
+          out[i++] = v.z;
+        }
+      }
+    }
+    return out;
+  }
+
+  // Copies [src] (packed xyz) transformed by [pose].
+  static Float32List _transformPoints(Float32List src, Matrix4 pose) {
+    if (pose.isIdentity()) return src;
+    final out = Float32List(src.length);
+    for (var i = 0; i < src.length; i += 3) {
+      final v = pose.transformed3(Vector3(src[i], src[i + 1], src[i + 2]));
+      out[i] = v.x;
+      out[i + 1] = v.y;
+      out[i + 2] = v.z;
+    }
+    return out;
+  }
+
+  @override
+  Shape get shape => _shape;
+  @override
+  set shape(Shape value) {
+    _shape = value;
+    _rebuild();
+  }
+
+  @override
+  PhysicsMaterial get material => _material;
+  @override
+  set material(PhysicsMaterial value) {
+    _material = value;
+    for (final shape in _shapes) {
+      shape.setMaterial(_b3Material);
+    }
+  }
+
+  @override
+  int get collisionLayer => _collisionLayer;
+  @override
+  set collisionLayer(int value) {
+    _collisionLayer = value;
+    _pushFilter();
+  }
+
+  @override
+  int get collisionMask => _collisionMask;
+  @override
+  set collisionMask(int value) {
+    _collisionMask = value;
+    _pushFilter();
+  }
+
+  void _pushFilter() {
+    for (final shape in _shapes) {
+      shape.setCollisionFilter(category: _collisionLayer, mask: _collisionMask);
+    }
+  }
+
+  @override
+  bool get isTrigger => _isTrigger;
+  @override
+  set isTrigger(bool value) {
+    if (_isTrigger == value) return;
+    _isTrigger = value;
+    // box3d fixes the sensor flag at shape creation, so re-cook.
+    _rebuild();
+  }
+
+  @override
+  Matrix4 get localPose => _localPose;
+  @override
+  set localPose(Matrix4 value) {
+    _localPose = value;
+    _rebuild();
+  }
+}

--- a/packages/flutter_scene_box3d/lib/src/box3d_joint.dart
+++ b/packages/flutter_scene_box3d/lib/src/box3d_joint.dart
@@ -1,0 +1,462 @@
+import 'package:box3d/box3d.dart' as b3;
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
+
+import 'box3d_physics_world.dart';
+import 'box3d_rigid_body.dart';
+
+/// Shared lifecycle for the box3d-backed joints.
+///
+/// A joint links the [Box3dRigidBody] on its own node to the body on
+/// [otherNode]; a null [otherNode] anchors to the world through an implicit
+/// static body at the origin, so the B-side anchor is in world space.
+///
+/// box3d exposes joint creation and destruction but no in-place
+/// reconfiguration, so parameter setters recreate the joint while the two
+/// resolved bodies (and any world-anchor body) stay put.
+mixin _Box3dJointMixin on Joint {
+  Box3dPhysicsWorld? _world;
+  b3.Box3dJoint? _joint;
+  b3.Box3dBody? _bodyA;
+  b3.Box3dBody? _bodyB;
+  b3.Box3dBody? _anchorBody;
+
+  /// The box3d joint once mounted, or null.
+  b3.Box3dJoint? get nativeJoint => _joint;
+
+  // Builds the joint on the two resolved bodies. Implemented per subclass.
+  b3.Box3dJoint _create(
+    b3.Box3dWorld world,
+    b3.Box3dBody bodyA,
+    b3.Box3dBody bodyB,
+  );
+
+  /// The current world transform of a resolved body, for frame math.
+  static Matrix4 worldOf(b3.Box3dBody body) =>
+      Matrix4.compose(body.position, body.rotation, Vector3(1, 1, 1));
+
+  @override
+  void onMount() {
+    final world = findAncestorBox3dWorld(node);
+    if (world == null) {
+      throw StateError('A box3d joint must be mounted under a Box3dWorld.');
+    }
+    final bodyA = node.getComponent<Box3dRigidBody>()?.nativeBody;
+    if (bodyA == null) {
+      throw StateError(
+        'A box3d joint requires a mounted Box3dRigidBody on its own node.',
+      );
+    }
+    final b3.Box3dBody bodyB;
+    final other = otherNode;
+    if (other == null) {
+      _anchorBody = world.nativeWorld.createBody(
+        type: b3.Box3dBodyType.static_,
+      );
+      bodyB = _anchorBody!;
+    } else {
+      final handle = other.getComponent<Box3dRigidBody>()?.nativeBody;
+      if (handle == null) {
+        throw StateError(
+          'A box3d joint requires a mounted Box3dRigidBody on its otherNode.',
+        );
+      }
+      bodyB = handle;
+    }
+    _world = world;
+    _bodyA = bodyA;
+    _bodyB = bodyB;
+    _joint = _create(world.nativeWorld, bodyA, bodyB);
+  }
+
+  // Recreates the joint (setters call this so parameter changes take effect).
+  void _recreate() {
+    final world = _world;
+    final bodyA = _bodyA;
+    final bodyB = _bodyB;
+    if (world == null || bodyA == null || bodyB == null) return;
+    _joint?.destroy();
+    _joint = _create(world.nativeWorld, bodyA, bodyB);
+  }
+
+  @override
+  void onUnmount() {
+    _joint?.destroy();
+    _anchorBody?.destroy();
+    _world = null;
+    _joint = null;
+    _bodyA = null;
+    _bodyB = null;
+    _anchorBody = null;
+  }
+}
+
+/// [FixedJoint] backed by box3d. Welds the two bodies, holding their
+/// relative pose at the moment the joint mounts. Pass a null [otherNode] to
+/// weld the body to the world.
+class Box3dFixedJoint extends FixedJoint with _Box3dJointMixin {
+  Box3dFixedJoint({Node? otherNode, bool collisionsEnabled = false})
+    : _otherNode = otherNode,
+      _collisionsEnabled = collisionsEnabled;
+
+  final Node? _otherNode;
+  bool _collisionsEnabled;
+
+  @override
+  Node? get otherNode => _otherNode;
+
+  @override
+  bool get collisionsEnabled => _collisionsEnabled;
+  @override
+  set collisionsEnabled(bool value) {
+    _collisionsEnabled = value;
+    _recreate();
+  }
+
+  @override
+  b3.Box3dJoint _create(
+    b3.Box3dWorld world,
+    b3.Box3dBody bodyA,
+    b3.Box3dBody bodyB,
+  ) {
+    // Choose frames so the weld holds the current relative pose:
+    // worldA * frameA == worldB * frameB with frameA at A's origin.
+    final worldA = _Box3dJointMixin.worldOf(bodyA);
+    final worldB = _Box3dJointMixin.worldOf(bodyB);
+    final relative = Matrix4.inverted(worldB)..multiply(worldA);
+    return world.createWeldJoint(
+      bodyA,
+      bodyB,
+      frameB: b3.Box3dFrame(
+        position: relative.getTranslation(),
+        rotation: Quaternion.fromRotation(relative.getRotation()),
+      ),
+      collideConnected: _collisionsEnabled,
+    );
+  }
+}
+
+/// [SphericalJoint] backed by box3d: a ball-and-socket about the shared
+/// anchor. Pass a null [otherNode] to anchor to the world.
+class Box3dSphericalJoint extends SphericalJoint with _Box3dJointMixin {
+  Box3dSphericalJoint({
+    Node? otherNode,
+    Vector3? localAnchorA,
+    Vector3? localAnchorB,
+    bool collisionsEnabled = false,
+  }) : _otherNode = otherNode,
+       _localAnchorA = localAnchorA ?? Vector3.zero(),
+       _localAnchorB = localAnchorB ?? Vector3.zero(),
+       _collisionsEnabled = collisionsEnabled;
+
+  final Node? _otherNode;
+  Vector3 _localAnchorA;
+  Vector3 _localAnchorB;
+  bool _collisionsEnabled;
+
+  @override
+  Node? get otherNode => _otherNode;
+
+  @override
+  Vector3 get localAnchorA => _localAnchorA;
+  @override
+  set localAnchorA(Vector3 value) {
+    _localAnchorA = value;
+    _recreate();
+  }
+
+  @override
+  Vector3 get localAnchorB => _localAnchorB;
+  @override
+  set localAnchorB(Vector3 value) {
+    _localAnchorB = value;
+    _recreate();
+  }
+
+  @override
+  bool get collisionsEnabled => _collisionsEnabled;
+  @override
+  set collisionsEnabled(bool value) {
+    _collisionsEnabled = value;
+    _recreate();
+  }
+
+  @override
+  b3.Box3dJoint _create(
+    b3.Box3dWorld world,
+    b3.Box3dBody bodyA,
+    b3.Box3dBody bodyB,
+  ) => world.createSphericalJoint(
+    bodyA,
+    bodyB,
+    frameA: b3.Box3dFrame(position: _localAnchorA),
+    frameB: b3.Box3dFrame(position: _localAnchorB),
+    collideConnected: _collisionsEnabled,
+  );
+}
+
+/// [RevoluteJoint] backed by box3d: a hinge about a shared axis, with
+/// optional angular limits and a velocity motor. Pass a null [otherNode] to
+/// hinge against the world.
+class Box3dRevoluteJoint extends RevoluteJoint with _Box3dJointMixin {
+  Box3dRevoluteJoint({
+    Node? otherNode,
+    required Vector3 axis,
+    Vector3? localAnchorA,
+    Vector3? localAnchorB,
+    double? lowerLimit,
+    double? upperLimit,
+    double? motorTargetVelocity,
+    double? motorMaxForce,
+    bool collisionsEnabled = false,
+  }) : _otherNode = otherNode,
+       _localAxisA = axis.normalized(),
+       _localAxisB = axis.normalized(),
+       _localAnchorA = localAnchorA ?? Vector3.zero(),
+       _localAnchorB = localAnchorB ?? Vector3.zero(),
+       _lowerLimit = lowerLimit,
+       _upperLimit = upperLimit,
+       _motorTargetVelocity = motorTargetVelocity,
+       _motorMaxForce = motorMaxForce,
+       _collisionsEnabled = collisionsEnabled;
+
+  final Node? _otherNode;
+  Vector3 _localAnchorA;
+  Vector3 _localAnchorB;
+  Vector3 _localAxisA;
+  Vector3 _localAxisB;
+  double? _lowerLimit;
+  double? _upperLimit;
+  double? _motorTargetVelocity;
+  double? _motorMaxForce;
+  bool _collisionsEnabled;
+
+  @override
+  Node? get otherNode => _otherNode;
+
+  @override
+  Vector3 get localAnchorA => _localAnchorA;
+  @override
+  set localAnchorA(Vector3 value) {
+    _localAnchorA = value;
+    _recreate();
+  }
+
+  @override
+  Vector3 get localAnchorB => _localAnchorB;
+  @override
+  set localAnchorB(Vector3 value) {
+    _localAnchorB = value;
+    _recreate();
+  }
+
+  @override
+  Vector3 get localAxisA => _localAxisA;
+  @override
+  set localAxisA(Vector3 value) {
+    _localAxisA = value.normalized();
+    _recreate();
+  }
+
+  @override
+  Vector3 get localAxisB => _localAxisB;
+  @override
+  set localAxisB(Vector3 value) {
+    _localAxisB = value.normalized();
+    _recreate();
+  }
+
+  @override
+  double? get lowerLimit => _lowerLimit;
+  @override
+  set lowerLimit(double? value) {
+    _lowerLimit = value;
+    _recreate();
+  }
+
+  @override
+  double? get upperLimit => _upperLimit;
+  @override
+  set upperLimit(double? value) {
+    _upperLimit = value;
+    _recreate();
+  }
+
+  @override
+  double? get motorTargetVelocity => _motorTargetVelocity;
+  @override
+  set motorTargetVelocity(double? value) {
+    _motorTargetVelocity = value;
+    _recreate();
+  }
+
+  @override
+  double? get motorMaxForce => _motorMaxForce;
+  @override
+  set motorMaxForce(double? value) {
+    _motorMaxForce = value;
+    _recreate();
+  }
+
+  @override
+  bool get collisionsEnabled => _collisionsEnabled;
+  @override
+  set collisionsEnabled(bool value) {
+    _collisionsEnabled = value;
+    _recreate();
+  }
+
+  @override
+  b3.Box3dJoint _create(
+    b3.Box3dWorld world,
+    b3.Box3dBody bodyA,
+    b3.Box3dBody bodyB,
+  ) => world.createRevoluteJoint(
+    bodyA,
+    bodyB,
+    frameA: b3.Box3dFrame.pointAxis(_localAnchorA, _localAxisA),
+    frameB: b3.Box3dFrame.pointAxis(_localAnchorB, _localAxisB),
+    lowerLimit: _lowerLimit,
+    upperLimit: _upperLimit,
+    motorSpeed: _motorTargetVelocity,
+    maxMotorTorque: _motorMaxForce,
+    collideConnected: _collisionsEnabled,
+  );
+}
+
+/// [PrismaticJoint] backed by box3d: a slider along a shared axis, with
+/// optional linear limits and a velocity motor. Pass a null [otherNode] to
+/// slide against the world.
+class Box3dPrismaticJoint extends PrismaticJoint with _Box3dJointMixin {
+  Box3dPrismaticJoint({
+    Node? otherNode,
+    required Vector3 axis,
+    Vector3? localAnchorA,
+    Vector3? localAnchorB,
+    double? lowerLimit,
+    double? upperLimit,
+    double? motorTargetVelocity,
+    double? motorMaxForce,
+    bool collisionsEnabled = false,
+  }) : _otherNode = otherNode,
+       _localAxisA = axis.normalized(),
+       _localAxisB = axis.normalized(),
+       _localAnchorA = localAnchorA ?? Vector3.zero(),
+       _localAnchorB = localAnchorB ?? Vector3.zero(),
+       _lowerLimit = lowerLimit,
+       _upperLimit = upperLimit,
+       _motorTargetVelocity = motorTargetVelocity,
+       _motorMaxForce = motorMaxForce,
+       _collisionsEnabled = collisionsEnabled;
+
+  final Node? _otherNode;
+  Vector3 _localAnchorA;
+  Vector3 _localAnchorB;
+  Vector3 _localAxisA;
+  Vector3 _localAxisB;
+  double? _lowerLimit;
+  double? _upperLimit;
+  double? _motorTargetVelocity;
+  double? _motorMaxForce;
+  bool _collisionsEnabled;
+
+  @override
+  Node? get otherNode => _otherNode;
+
+  @override
+  Vector3 get localAnchorA => _localAnchorA;
+  @override
+  set localAnchorA(Vector3 value) {
+    _localAnchorA = value;
+    _recreate();
+  }
+
+  @override
+  Vector3 get localAnchorB => _localAnchorB;
+  @override
+  set localAnchorB(Vector3 value) {
+    _localAnchorB = value;
+    _recreate();
+  }
+
+  @override
+  Vector3 get localAxisA => _localAxisA;
+  @override
+  set localAxisA(Vector3 value) {
+    _localAxisA = value.normalized();
+    _recreate();
+  }
+
+  @override
+  Vector3 get localAxisB => _localAxisB;
+  @override
+  set localAxisB(Vector3 value) {
+    _localAxisB = value.normalized();
+    _recreate();
+  }
+
+  @override
+  double? get lowerLimit => _lowerLimit;
+  @override
+  set lowerLimit(double? value) {
+    _lowerLimit = value;
+    _recreate();
+  }
+
+  @override
+  double? get upperLimit => _upperLimit;
+  @override
+  set upperLimit(double? value) {
+    _upperLimit = value;
+    _recreate();
+  }
+
+  @override
+  double? get motorTargetVelocity => _motorTargetVelocity;
+  @override
+  set motorTargetVelocity(double? value) {
+    _motorTargetVelocity = value;
+    _recreate();
+  }
+
+  @override
+  double? get motorMaxForce => _motorMaxForce;
+  @override
+  set motorMaxForce(double? value) {
+    _motorMaxForce = value;
+    _recreate();
+  }
+
+  @override
+  bool get collisionsEnabled => _collisionsEnabled;
+  @override
+  set collisionsEnabled(bool value) {
+    _collisionsEnabled = value;
+    _recreate();
+  }
+
+  @override
+  b3.Box3dJoint _create(
+    b3.Box3dWorld world,
+    b3.Box3dBody bodyA,
+    b3.Box3dBody bodyB,
+  ) => world.createPrismaticJoint(
+    bodyA,
+    bodyB,
+    // A prismatic joint's slide axis is the frame's local X.
+    frameA: b3.Box3dFrame.pointAxisX(_localAnchorA, _localAxisA),
+    frameB: b3.Box3dFrame.pointAxisX(_localAnchorB, _localAxisB),
+    // box3d measures this joint's translation opposite to the contract's
+    // convention (positive along +axis) when the own node is body A, so
+    // negate and swap the limits and negate the motor velocity.
+    lowerLimit: _upperLimit == null ? null : -_upperLimit!,
+    upperLimit: _lowerLimit == null ? null : -_lowerLimit!,
+    motorSpeed: _motorTargetVelocity == null ? null : -_motorTargetVelocity!,
+    maxMotorForce: _motorMaxForce,
+    collideConnected: _collisionsEnabled,
+  );
+}
+
+// TODO(box3d-generic-joint): box3d has no 6-DOF generic joint, so
+// GenericJoint from the flutter_scene contract is not implemented by this
+// backend. Use the fixed, spherical, revolute, or prismatic joints instead.

--- a/packages/flutter_scene_box3d/lib/src/box3d_physics_world.dart
+++ b/packages/flutter_scene_box3d/lib/src/box3d_physics_world.dart
@@ -1,0 +1,392 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:box3d/box3d.dart' as b3;
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
+
+import 'box3d_collider.dart';
+
+/// [PhysicsWorld] backed by the box3d engine.
+///
+/// Wraps a box3d [b3.Box3dWorld]. [step] advances the simulation and
+/// captures each dynamic body's pose; [interpolateTransforms] lerps and
+/// slerps those poses between steps and writes them back to the owning
+/// [Node]. Scene queries forward to box3d and resolve hits to the owning
+/// [Box3dCollider]. Contact and trigger lifecycle events are emitted on
+/// [collisions] after each step.
+///
+/// Call [Box3dPhysicsWorld.ensureInitialized] once during startup before
+/// constructing a world (a no-op on native platforms).
+class Box3dPhysicsWorld extends PhysicsWorld {
+  Box3dPhysicsWorld({Vector3? gravity})
+    : _world = b3.Box3dWorld(gravity: gravity) {
+    if (gravity != null) this.gravity = gravity;
+  }
+
+  /// Prepares the box3d backend so a [Box3dPhysicsWorld] can be
+  /// constructed. Returns immediately on native targets; on the web it
+  /// loads the WebAssembly module. Await it once during startup.
+  static Future<void> ensureInitialized() => b3.Box3d.ensureInitialized();
+
+  final b3.Box3dWorld _world;
+
+  /// The underlying box3d world. For use by [Box3dRigidBody] and
+  /// [Box3dCollider] to create bodies and shapes.
+  b3.Box3dWorld get nativeWorld => _world;
+
+  // Tracks each registered body so interpolateTransforms can write back
+  // dynamic poses.
+  final Map<int, _BodyRecord> _bodies = {};
+
+  // Maps a box3d shape handle to the owning collider, for resolving query
+  // hits and collision events back to components.
+  final Map<int, Box3dCollider> _collidersByHandle = {};
+
+  double _interpolationAlpha = 0.0;
+
+  /// The residual fraction in `[0, 1]` of the last [interpolateTransforms]:
+  /// how far the renderer is between the previous and current fixed steps.
+  double get interpolationAlpha => _interpolationAlpha;
+
+  @override
+  String get backendName => 'box3d';
+
+  final StreamController<CollisionEvent> _events =
+      StreamController<CollisionEvent>.broadcast();
+
+  @override
+  Stream<CollisionEvent> get collisions => _events.stream;
+
+  /// Registers a body created on [nativeWorld] so its dynamic pose is
+  /// interpolated. Called from [Box3dRigidBody.onMount].
+  void registerBody(b3.Box3dBody body, Node node, BodyType type) {
+    _bodies[body.handle] = _BodyRecord(body, node, type);
+  }
+
+  /// Stops tracking a body. Called from [Box3dRigidBody.onUnmount].
+  void unregisterBody(int handle) => _bodies.remove(handle);
+
+  void rememberCollider(int handle, Box3dCollider collider) =>
+      _collidersByHandle[handle] = collider;
+
+  void forgetCollider(int handle) => _collidersByHandle.remove(handle);
+
+  @override
+  void onUnmount() {
+    _events.close();
+    _world.dispose();
+  }
+
+  @override
+  void step(double fixedDt) {
+    final g = gravity;
+    _world.gravity = g;
+    _world.step(fixedDt);
+    for (final record in _bodies.values) {
+      if (record.type != BodyType.dynamic_) continue;
+      record.prevTranslation.setFrom(record.currTranslation);
+      record.prevRotation.setFrom(record.currRotation);
+      record.currTranslation.setFrom(record.body.position);
+      record.currRotation.setFrom(record.body.rotation);
+    }
+    _drainEvents();
+  }
+
+  @override
+  void interpolateTransforms(double alpha) {
+    _interpolationAlpha = alpha;
+    final t = Vector3.zero();
+    for (final record in _bodies.values) {
+      if (record.type != BodyType.dynamic_) continue;
+      t
+        ..setFrom(record.currTranslation)
+        ..sub(record.prevTranslation)
+        ..scale(alpha)
+        ..add(record.prevTranslation);
+      final rot = _slerp(record.prevRotation, record.currRotation, alpha);
+      final worldPose = Matrix4.compose(t, rot, Vector3(1, 1, 1));
+      final parent = record.node.parent;
+      if (parent == null) {
+        record.node.localTransform = worldPose;
+      } else {
+        final parentInverse = Matrix4.inverted(parent.globalTransform);
+        record.node.localTransform = parentInverse.multiplied(worldPose);
+      }
+      record.node.markTransformDirty();
+    }
+  }
+
+  // Drains box3d's per-step events and re-emits them as flutter_scene
+  // collision events, resolving shape handles to colliders.
+  void _drainEvents() {
+    if (!_events.hasListener) return;
+    final events = _world.drainEvents();
+    for (final e in events.contactBegan) {
+      final a = _collidersByHandle[e.shapeA];
+      final b = _collidersByHandle[e.shapeB];
+      if (a == null || b == null) continue;
+      _events.add(
+        CollisionBegan(
+          nodeA: a.node,
+          nodeB: b.node,
+          colliderA: a,
+          colliderB: b,
+          contacts: [
+            for (final p in e.points)
+              ContactPoint(
+                worldPosition: p.position,
+                worldNormal: p.normal,
+                impulse: p.impulse,
+                separation: p.separation,
+              ),
+          ],
+        ),
+      );
+    }
+    for (final e in events.contactEnded) {
+      final a = _collidersByHandle[e.shapeA];
+      final b = _collidersByHandle[e.shapeB];
+      if (a == null || b == null) continue;
+      _events.add(
+        CollisionEnded(
+          nodeA: a.node,
+          nodeB: b.node,
+          colliderA: a,
+          colliderB: b,
+        ),
+      );
+    }
+    for (final e in events.sensorBegan) {
+      final sensor = _collidersByHandle[e.sensorShape];
+      final visitor = _collidersByHandle[e.visitorShape];
+      if (sensor == null || visitor == null) continue;
+      _events.add(
+        TriggerEntered(
+          nodeA: sensor.node,
+          nodeB: visitor.node,
+          colliderA: sensor,
+          colliderB: visitor,
+        ),
+      );
+    }
+    for (final e in events.sensorEnded) {
+      final sensor = _collidersByHandle[e.sensorShape];
+      final visitor = _collidersByHandle[e.visitorShape];
+      if (sensor == null || visitor == null) continue;
+      _events.add(
+        TriggerExited(
+          nodeA: sensor.node,
+          nodeB: visitor.node,
+          colliderA: sensor,
+          colliderB: visitor,
+        ),
+      );
+    }
+  }
+
+  // --- Scene queries ---------------------------------------------------------
+  //
+  // box3d's category/mask filter matches flutter_scene's layer/mask
+  // semantics. The include* body-type flags are not part of box3d's query
+  // filter; TODO(box3d-query-typefilter) apply them by post-filtering hits
+  // on the owning body type once bodies expose it here.
+
+  @override
+  RaycastHit? raycast(
+    Ray ray, {
+    double maxDistance = double.infinity,
+    int layerMask = 0xFFFFFFFF,
+    bool includeFixed = true,
+    bool includeKinematic = true,
+    bool includeDynamic = true,
+    bool includeTriggers = false,
+  }) {
+    final hit = _world.raycast(
+      ray.origin,
+      ray.direction,
+      maxDistance: maxDistance.isFinite ? maxDistance : 1e6,
+      mask: layerMask,
+    );
+    return hit == null ? null : _raycastHit(hit);
+  }
+
+  @override
+  List<RaycastHit> raycastAll(
+    Ray ray, {
+    double maxDistance = double.infinity,
+    int layerMask = 0xFFFFFFFF,
+    bool includeFixed = true,
+    bool includeKinematic = true,
+    bool includeDynamic = true,
+    bool includeTriggers = false,
+  }) {
+    final hits = _world.raycastAll(
+      ray.origin,
+      ray.direction,
+      maxDistance: maxDistance.isFinite ? maxDistance : 1e6,
+      mask: layerMask,
+    );
+    return [
+      for (final h in hits)
+        if (_raycastHit(h) case final resolved?) resolved,
+    ];
+  }
+
+  @override
+  List<OverlapHit> overlapSphere(
+    Vector3 center,
+    double radius, {
+    int layerMask = 0xFFFFFFFF,
+    bool includeFixed = true,
+    bool includeKinematic = true,
+    bool includeDynamic = true,
+    bool includeTriggers = false,
+  }) => _overlapHits(_world.overlapSphere(center, radius, mask: layerMask));
+
+  @override
+  List<OverlapHit> overlapBox(
+    Vector3 center,
+    Vector3 halfExtents,
+    Quaternion rotation, {
+    int layerMask = 0xFFFFFFFF,
+    bool includeFixed = true,
+    bool includeKinematic = true,
+    bool includeDynamic = true,
+    bool includeTriggers = false,
+  }) => _overlapHits(
+    _world.overlapBox(center, halfExtents, rotation: rotation, mask: layerMask),
+  );
+
+  @override
+  ShapeCastHit? shapeCast(
+    Shape shape,
+    Matrix4 from,
+    Vector3 direction,
+    double distance, {
+    int layerMask = 0xFFFFFFFF,
+    bool includeFixed = true,
+    bool includeKinematic = true,
+    bool includeDynamic = true,
+    bool includeTriggers = false,
+  }) {
+    final origin = from.getTranslation();
+    final b3.Box3dRayHit? hit;
+    switch (shape) {
+      case SphereShape():
+        hit = _world.shapeCastSphere(
+          origin,
+          shape.radius,
+          direction,
+          maxDistance: distance,
+          mask: layerMask,
+        );
+      case BoxShape():
+        hit = _world.shapeCastBox(
+          origin,
+          shape.halfExtents,
+          direction,
+          rotation: Quaternion.fromRotation(from.getRotation()),
+          maxDistance: distance,
+          mask: layerMask,
+        );
+      default:
+        // TODO(box3d-shapecast-shapes): box3d shape casts are wired for
+        // sphere and box probes; capsule, cylinder, hull, mesh, and
+        // heightfield probes are not exposed through the package yet.
+        throw UnsupportedError(
+          'Box3dPhysicsWorld.shapeCast supports sphere and box probes; '
+          '${shape.runtimeType} cannot be used as a cast probe.',
+        );
+    }
+    if (hit == null) return null;
+    final collider = _collidersByHandle[hit.shape];
+    if (collider == null) return null;
+    return ShapeCastHit(
+      node: collider.node,
+      collider: collider,
+      worldPoint: hit.point,
+      worldNormal: hit.normal,
+      distance: hit.distance,
+    );
+  }
+
+  RaycastHit? _raycastHit(b3.Box3dRayHit hit) {
+    final collider = _collidersByHandle[hit.shape];
+    if (collider == null) return null;
+    return RaycastHit(
+      node: collider.node,
+      collider: collider,
+      worldPoint: hit.point,
+      worldNormal: hit.normal,
+      distance: hit.distance,
+    );
+  }
+
+  List<OverlapHit> _overlapHits(List<int> handles) => [
+    for (final handle in handles)
+      if (_collidersByHandle[handle] case final collider?)
+        OverlapHit(node: collider.node, collider: collider),
+  ];
+}
+
+/// Walks [start] and its ancestors for a [Box3dPhysicsWorld] component.
+Box3dPhysicsWorld? findAncestorBox3dWorld(Node start) {
+  Node? current = start;
+  while (current != null) {
+    final world = current.getComponent<Box3dPhysicsWorld>();
+    if (world != null) return world;
+    current = current.parent;
+  }
+  return null;
+}
+
+class _BodyRecord {
+  _BodyRecord(this.body, this.node, this.type)
+    : prevTranslation = body.position,
+      currTranslation = body.position,
+      prevRotation = body.rotation,
+      currRotation = body.rotation;
+
+  final b3.Box3dBody body;
+  final Node node;
+  final BodyType type;
+  final Vector3 prevTranslation;
+  final Vector3 currTranslation;
+  final Quaternion prevRotation;
+  final Quaternion currRotation;
+}
+
+/// Shortest-arc quaternion slerp between [a] and [b] by [t], falling back
+/// to normalized-lerp when the rotations are nearly identical.
+Quaternion _slerp(Quaternion a, Quaternion b, double t) {
+  var bx = b.x, by = b.y, bz = b.z, bw = b.w;
+  var dot = a.x * bx + a.y * by + a.z * bz + a.w * bw;
+  if (dot < 0) {
+    bx = -bx;
+    by = -by;
+    bz = -bz;
+    bw = -bw;
+    dot = -dot;
+  }
+  if (dot > 0.9995) {
+    return Quaternion(
+      a.x + t * (bx - a.x),
+      a.y + t * (by - a.y),
+      a.z + t * (bz - a.z),
+      a.w + t * (bw - a.w),
+    )..normalize();
+  }
+  final theta0 = math.acos(dot.clamp(-1.0, 1.0));
+  final theta = theta0 * t;
+  final sinTheta = math.sin(theta);
+  final sinTheta0 = math.sin(theta0);
+  final s0 = math.cos(theta) - dot * sinTheta / sinTheta0;
+  final s1 = sinTheta / sinTheta0;
+  return Quaternion(
+    a.x * s0 + bx * s1,
+    a.y * s0 + by * s1,
+    a.z * s0 + bz * s1,
+    a.w * s0 + bw * s1,
+  );
+}

--- a/packages/flutter_scene_box3d/lib/src/box3d_rigid_body.dart
+++ b/packages/flutter_scene_box3d/lib/src/box3d_rigid_body.dart
@@ -1,0 +1,245 @@
+import 'package:box3d/box3d.dart' as b3;
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
+
+import 'box3d_physics_world.dart';
+
+/// [RigidBody] backed by box3d.
+///
+/// Registers with the nearest ancestor [Box3dPhysicsWorld] on mount and
+/// creates a box3d body at the owning node's world transform. Velocity and
+/// sleep state read live from box3d; other properties are cached and pushed
+/// on each setter.
+///
+/// TODO(box3d-mass-override): [mass] and [inertiaTensor] are stored but not
+/// pushed to box3d, which derives mass and inertia from collider density.
+/// Applying an explicit mass needs box3d's SetMassData, not yet exposed by
+/// the box3d package.
+class Box3dRigidBody extends RigidBody {
+  Box3dRigidBody({
+    BodyType type = BodyType.dynamic_,
+    double? mass,
+    Matrix3? inertiaTensor,
+    Vector3? linearVelocity,
+    Vector3? angularVelocity,
+    double linearDamping = 0,
+    double angularDamping = 0,
+    bool useGravity = true,
+    bool ccdEnabled = false,
+    Vector3? linearAxisLocks,
+    Vector3? angularAxisLocks,
+  }) : _type = type,
+       _mass = mass,
+       _inertiaTensor = inertiaTensor,
+       _linearVelocity = linearVelocity ?? Vector3.zero(),
+       _angularVelocity = angularVelocity ?? Vector3.zero(),
+       _linearDamping = linearDamping,
+       _angularDamping = angularDamping,
+       _useGravity = useGravity,
+       _ccdEnabled = ccdEnabled,
+       _linearAxisLocks = linearAxisLocks ?? Vector3(1, 1, 1),
+       _angularAxisLocks = angularAxisLocks ?? Vector3(1, 1, 1);
+
+  BodyType _type;
+  double? _mass;
+  Matrix3? _inertiaTensor;
+  Vector3 _linearVelocity;
+  Vector3 _angularVelocity;
+  double _linearDamping;
+  double _angularDamping;
+  bool _useGravity;
+  bool _ccdEnabled;
+  Vector3 _linearAxisLocks;
+  Vector3 _angularAxisLocks;
+  bool _sleeping = false;
+
+  Box3dPhysicsWorld? _world;
+  b3.Box3dBody? _body;
+
+  /// The box3d body once mounted, or null. Used by [Box3dCollider] to
+  /// attach shapes to the right body.
+  b3.Box3dBody? get nativeBody => _body;
+
+  static b3.Box3dBodyType _kind(BodyType type) => switch (type) {
+    BodyType.fixed => b3.Box3dBodyType.static_,
+    BodyType.kinematic => b3.Box3dBodyType.kinematic,
+    BodyType.dynamic_ => b3.Box3dBodyType.dynamic_,
+  };
+
+  void _applyLocks() {
+    final body = _body;
+    if (body == null) return;
+    body.setMotionLocks(
+      linearX: _linearAxisLocks.x == 0,
+      linearY: _linearAxisLocks.y == 0,
+      linearZ: _linearAxisLocks.z == 0,
+      angularX: _angularAxisLocks.x == 0,
+      angularY: _angularAxisLocks.y == 0,
+      angularZ: _angularAxisLocks.z == 0,
+    );
+  }
+
+  @override
+  void onMount() {
+    final world = findAncestorBox3dWorld(node);
+    if (world == null) return;
+    _world = world;
+    final transform = node.globalTransform;
+    final body = world.nativeWorld.createBody(
+      type: _kind(_type),
+      position: transform.getTranslation(),
+      rotation: Quaternion.fromRotation(transform.getRotation()),
+    );
+    _body = body;
+    world.registerBody(body, node, _type);
+
+    body.linearVelocity = _linearVelocity;
+    body.angularVelocity = _angularVelocity;
+    if (_linearDamping != 0) body.linearDamping = _linearDamping;
+    if (_angularDamping != 0) body.angularDamping = _angularDamping;
+    if (!_useGravity) body.gravityScale = 0;
+    if (_ccdEnabled) body.isBullet = true;
+    _applyLocks();
+  }
+
+  @override
+  void onUnmount() {
+    final world = _world;
+    final body = _body;
+    if (world != null && body != null) {
+      world.unregisterBody(body.handle);
+      body.destroy();
+    }
+    _world = null;
+    _body = null;
+  }
+
+  @override
+  void fixedUpdate(double fixedDt) {
+    // Drive a kinematic body from its node transform each step so it sweeps
+    // through the simulation.
+    if (_type != BodyType.kinematic) return;
+    final body = _body;
+    if (body == null) return;
+    final transform = node.globalTransform;
+    body.setTransform(
+      transform.getTranslation(),
+      Quaternion.fromRotation(transform.getRotation()),
+    );
+  }
+
+  @override
+  BodyType get type => _type;
+  set type(BodyType value) {
+    if (_type == value) return;
+    _type = value;
+    _body?.type = _kind(value);
+  }
+
+  @override
+  double? get mass => _mass;
+  @override
+  set mass(double? value) => _mass = value;
+
+  @override
+  Matrix3? get inertiaTensor => _inertiaTensor;
+  @override
+  set inertiaTensor(Matrix3? value) => _inertiaTensor = value;
+
+  @override
+  Vector3 get linearVelocity => _body?.linearVelocity ?? _linearVelocity;
+  @override
+  set linearVelocity(Vector3 value) {
+    _linearVelocity = value;
+    _body?.linearVelocity = value;
+  }
+
+  @override
+  Vector3 get angularVelocity => _body?.angularVelocity ?? _angularVelocity;
+  @override
+  set angularVelocity(Vector3 value) {
+    _angularVelocity = value;
+    _body?.angularVelocity = value;
+  }
+
+  @override
+  double get linearDamping => _linearDamping;
+  @override
+  set linearDamping(double value) {
+    _linearDamping = value;
+    _body?.linearDamping = value;
+  }
+
+  @override
+  double get angularDamping => _angularDamping;
+  @override
+  set angularDamping(double value) {
+    _angularDamping = value;
+    _body?.angularDamping = value;
+  }
+
+  @override
+  bool get useGravity => _useGravity;
+  @override
+  set useGravity(bool value) {
+    _useGravity = value;
+    _body?.gravityScale = value ? 1.0 : 0.0;
+  }
+
+  @override
+  bool get ccdEnabled => _ccdEnabled;
+  @override
+  set ccdEnabled(bool value) {
+    _ccdEnabled = value;
+    _body?.isBullet = value;
+  }
+
+  @override
+  Vector3 get linearAxisLocks => _linearAxisLocks;
+  @override
+  set linearAxisLocks(Vector3 value) {
+    _linearAxisLocks = value;
+    _applyLocks();
+  }
+
+  @override
+  Vector3 get angularAxisLocks => _angularAxisLocks;
+  @override
+  set angularAxisLocks(Vector3 value) {
+    _angularAxisLocks = value;
+    _applyLocks();
+  }
+
+  @override
+  bool get isSleeping {
+    final body = _body;
+    return body != null ? !body.isAwake : _sleeping;
+  }
+
+  @override
+  void wakeUp() {
+    _sleeping = false;
+    _body?.wakeUp();
+  }
+
+  @override
+  void putToSleep() {
+    _sleeping = true;
+    _body?.sleep();
+  }
+
+  @override
+  void applyForce(Vector3 force, {Vector3? atWorldPoint}) =>
+      _body?.applyForce(force, point: atWorldPoint);
+
+  @override
+  void applyImpulse(Vector3 impulse, {Vector3? atWorldPoint}) =>
+      _body?.applyImpulse(impulse, point: atWorldPoint);
+
+  @override
+  void applyTorque(Vector3 torque) => _body?.applyTorque(torque);
+
+  @override
+  void applyAngularImpulse(Vector3 impulse) =>
+      _body?.applyAngularImpulse(impulse);
+}

--- a/packages/flutter_scene_box3d/pubspec.yaml
+++ b/packages/flutter_scene_box3d/pubspec.yaml
@@ -1,0 +1,37 @@
+name: flutter_scene_box3d
+description: box3d physics backend for flutter_scene. Implements the abstract physics contract from flutter_scene against the box3d engine.
+repository: https://github.com/bdero/flutter_scene
+homepage: https://github.com/bdero/flutter_scene
+version: 0.1.0
+
+topics:
+  - physics
+  - box3d
+  - gamedev
+  - collision
+
+platforms:
+  macos:
+  ios:
+  android:
+  windows:
+  linux:
+  web:
+
+resolution: workspace
+
+environment:
+  sdk: ^3.10.0
+  flutter: ">=3.29.0-1.0.pre.242"
+
+dependencies:
+  box3d: ^0.1.0
+  flutter:
+    sdk: flutter
+  flutter_scene: ^0.18.0
+  vector_math: ^2.1.4
+
+dev_dependencies:
+  flutter_lints: ^5.0.0
+  flutter_test:
+    sdk: flutter

--- a/packages/flutter_scene_box3d/test/box3d_integration_test.dart
+++ b/packages/flutter_scene_box3d/test/box3d_integration_test.dart
@@ -1,0 +1,184 @@
+// Drives the flutter_scene physics contract against box3d end to end:
+// bodies and colliders are mounted, stepped, and the interpolated node
+// transform is read back.
+//
+// ignore_for_file: invalid_use_of_internal_member
+//
+// Component.mount / step / interpolateTransforms are internal to
+// flutter_scene; these tests call them directly because the test root is
+// not part of a live RenderScene (which would need a Flutter GPU context).
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_box3d/flutter_scene_box3d.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+Node _bootWorld({Vector3? gravity}) {
+  final root = Node();
+  final world = Box3dPhysicsWorld(gravity: gravity);
+  root.addComponent(world);
+  world.mount();
+  return root;
+}
+
+// Mounts a node carrying a body and collider under [root].
+(Node, Box3dRigidBody) _addBody(
+  Node root, {
+  required BodyType type,
+  required Shape shape,
+  required Vector3 position,
+  bool isTrigger = false,
+}) {
+  final node = Node(localTransform: Matrix4.translation(position));
+  final body = Box3dRigidBody(type: type);
+  node.addComponent(body);
+  root.add(node);
+  body.mount();
+  final collider = Box3dCollider(shape: shape, isTrigger: isTrigger);
+  node.addComponent(collider);
+  collider.mount();
+  return (node, body);
+}
+
+void main() {
+  setUpAll(Box3dPhysicsWorld.ensureInitialized);
+
+  void run(Box3dPhysicsWorld world, {int steps = 240}) {
+    for (var i = 0; i < steps; i++) {
+      world.step(1 / 60);
+    }
+    world.interpolateTransforms(1);
+  }
+
+  test('a dynamic box falls and rests on a fixed floor', () {
+    final root = _bootWorld(gravity: Vector3(0, -10, 0));
+    final world = root.getComponent<Box3dPhysicsWorld>()!;
+
+    _addBody(
+      root,
+      type: BodyType.fixed,
+      shape: BoxShape(halfExtents: Vector3(50, 0.5, 50)),
+      position: Vector3(0, -0.5, 0),
+    );
+    final (box, _) = _addBody(
+      root,
+      type: BodyType.dynamic_,
+      shape: BoxShape(halfExtents: Vector3.all(0.5)),
+      position: Vector3(0, 5, 0),
+    );
+
+    run(world);
+
+    // The interpolated node transform should show the box resting on the
+    // floor, its center half its height above y = 0.
+    final p = box.globalTransform.getTranslation();
+    expect(p.y, closeTo(0.5, 0.1));
+    expect(p.x, closeTo(0, 0.1));
+  });
+
+  test('a fixed body holds its position under gravity', () {
+    final root = _bootWorld(gravity: Vector3(0, -10, 0));
+    final world = root.getComponent<Box3dPhysicsWorld>()!;
+    final (node, _) = _addBody(
+      root,
+      type: BodyType.fixed,
+      shape: SphereShape(radius: 0.5),
+      position: Vector3(1, 2, 3),
+    );
+
+    run(world, steps: 60);
+
+    final p = node.globalTransform.getTranslation();
+    expect(p.x, closeTo(1, 1e-4));
+    expect(p.y, closeTo(2, 1e-4));
+    expect(p.z, closeTo(3, 1e-4));
+  });
+
+  test('a trigger reports enter and exit as a body falls through', () {
+    final root = _bootWorld(gravity: Vector3(0, -10, 0));
+    final world = root.getComponent<Box3dPhysicsWorld>()!;
+
+    final entered = <TriggerEntered>[];
+    final exited = <TriggerExited>[];
+    world.collisions.listen((e) {
+      if (e is TriggerEntered) entered.add(e);
+      if (e is TriggerExited) exited.add(e);
+    });
+
+    _addBody(
+      root,
+      type: BodyType.fixed,
+      shape: BoxShape(halfExtents: Vector3(2, 0.5, 2)),
+      position: Vector3(0, 0, 0),
+      isTrigger: true,
+    );
+    _addBody(
+      root,
+      type: BodyType.dynamic_,
+      shape: SphereShape(radius: 0.25),
+      position: Vector3(0, 3, 0),
+    );
+
+    // Let microtasks deliver the broadcast-stream events between steps.
+    for (var i = 0; i < 240; i++) {
+      world.step(1 / 60);
+    }
+    return Future<void>.delayed(Duration.zero, () {
+      expect(entered, hasLength(1));
+      expect(exited, hasLength(1));
+    });
+  });
+
+  test('raycast resolves to the hit collider and node', () {
+    final root = _bootWorld(gravity: Vector3(0, 0, 0));
+    final world = root.getComponent<Box3dPhysicsWorld>()!;
+    final (target, _) = _addBody(
+      root,
+      type: BodyType.fixed,
+      shape: BoxShape(halfExtents: Vector3.all(0.5)),
+      position: Vector3(5, 0, 0),
+    );
+    world.step(1 / 60); // build the broad phase
+
+    final hit = world.raycast(
+      Ray.originDirection(Vector3(0, 0, 0), Vector3(1, 0, 0)),
+    );
+    expect(hit, isNotNull);
+    expect(hit!.node, same(target));
+    expect(hit.worldPoint.x, closeTo(4.5, 0.05));
+  });
+
+  test('a compound collider rests on its lower box', () {
+    final root = _bootWorld(gravity: Vector3(0, -10, 0));
+    final world = root.getComponent<Box3dPhysicsWorld>()!;
+    _addBody(
+      root,
+      type: BodyType.fixed,
+      shape: BoxShape(halfExtents: Vector3(50, 0.5, 50)),
+      position: Vector3(0, -0.5, 0),
+    );
+    final (node, _) = _addBody(
+      root,
+      type: BodyType.dynamic_,
+      shape: CompoundShape(
+        children: [
+          CompoundChild(
+            shape: BoxShape(halfExtents: Vector3.all(0.5)),
+            localPose: Matrix4.translation(Vector3(0, 0.5, 0)),
+          ),
+          CompoundChild(
+            shape: SphereShape(radius: 0.5),
+            localPose: Matrix4.translation(Vector3(0, -0.5, 0)),
+          ),
+        ],
+      ),
+      position: Vector3(0, 5, 0),
+    );
+
+    run(world);
+    // The sphere child sits at local y = -0.5 with radius 0.5, so its lowest
+    // point is 1.0 below the body origin. Resting on the floor puts the body
+    // origin near y = 1.0.
+    expect(node.globalTransform.getTranslation().y, closeTo(1.0, 0.15));
+  });
+}

--- a/packages/flutter_scene_box3d/test/box3d_integration_test.dart
+++ b/packages/flutter_scene_box3d/test/box3d_integration_test.dart
@@ -148,6 +148,29 @@ void main() {
     expect(hit.worldPoint.x, closeTo(4.5, 0.05));
   });
 
+  test('unmounting a body and collider does not crash (double-free guard)', () {
+    // box3d cascades body destruction to its shapes, and a node's components
+    // unmount in an order that can destroy the body before the collider.
+    // Repeat enough to mirror the example app's body-cap churn.
+    final root = _bootWorld(gravity: Vector3(0, -10, 0));
+    final world = root.getComponent<Box3dPhysicsWorld>()!;
+    for (var i = 0; i < 30; i++) {
+      final node = Node(localTransform: Matrix4.translation(Vector3(0, 5, 0)));
+      final body = Box3dRigidBody(type: BodyType.dynamic_);
+      node.addComponent(body);
+      root.add(node);
+      body.mount();
+      final collider = Box3dCollider(
+        shape: BoxShape(halfExtents: Vector3.all(0.5)),
+      );
+      node.addComponent(collider);
+      collider.mount();
+      world.step(1 / 60);
+      root.remove(node); // unmounts body + collider
+    }
+    world.step(1 / 60);
+  });
+
   test('a compound collider rests on its lower box', () {
     final root = _bootWorld(gravity: Vector3(0, -10, 0));
     final world = root.getComponent<Box3dPhysicsWorld>()!;

--- a/packages/flutter_scene_box3d/test/box3d_joint_test.dart
+++ b/packages/flutter_scene_box3d/test/box3d_joint_test.dart
@@ -1,0 +1,146 @@
+// Joint behaviour through the flutter_scene contract against box3d.
+//
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'dart:math' as math;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_box3d/flutter_scene_box3d.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+Node _bootWorld({Vector3? gravity}) {
+  final root = Node();
+  final world = Box3dPhysicsWorld(gravity: gravity);
+  root.addComponent(world);
+  world.mount();
+  return root;
+}
+
+// Mounts a node with a body and a box collider under [root].
+(Node, Box3dRigidBody) _addBox(
+  Node root, {
+  required BodyType type,
+  required Vector3 position,
+  Vector3? halfExtents,
+}) {
+  final node = Node(localTransform: Matrix4.translation(position));
+  final body = Box3dRigidBody(type: type);
+  node.addComponent(body);
+  root.add(node);
+  body.mount();
+  final collider = Box3dCollider(
+    shape: BoxShape(halfExtents: halfExtents ?? Vector3.all(0.5)),
+  );
+  node.addComponent(collider);
+  collider.mount();
+  return (node, body);
+}
+
+void main() {
+  setUpAll(Box3dPhysicsWorld.ensureInitialized);
+
+  void run(Box3dPhysicsWorld world, {int steps = 180}) {
+    for (var i = 0; i < steps; i++) {
+      world.step(1 / 60);
+    }
+    world.interpolateTransforms(1);
+  }
+
+  test('a fixed joint holds a body welded to the world', () {
+    final root = _bootWorld(gravity: Vector3(0, -10, 0));
+    final world = root.getComponent<Box3dPhysicsWorld>()!;
+    final (node, _) = _addBox(
+      root,
+      type: BodyType.dynamic_,
+      position: Vector3(2, 3, 0),
+    );
+
+    final joint = Box3dFixedJoint();
+    node.addComponent(joint);
+    joint.mount();
+
+    run(world);
+    // Welded to the world at its start pose, it barely moves under gravity.
+    final p = node.globalTransform.getTranslation();
+    expect(p.x, closeTo(2, 0.05));
+    expect(p.y, closeTo(3, 0.05));
+  });
+
+  test('a spherical joint hangs a body like a pendulum', () {
+    final root = _bootWorld(gravity: Vector3(0, -10, 0));
+    final world = root.getComponent<Box3dPhysicsWorld>()!;
+    final (node, _) = _addBox(
+      root,
+      type: BodyType.dynamic_,
+      position: Vector3(0, -2, 0),
+    );
+
+    // Socket 2 units above the body (in world space via the world anchor).
+    final joint = Box3dSphericalJoint(
+      localAnchorA: Vector3(0, 2, 0),
+      localAnchorB: Vector3(0, 0, 0),
+    );
+    node.addComponent(joint);
+    joint.mount();
+
+    run(world, steps: 300);
+    // Stays roughly 2 units from the anchor point at the origin.
+    expect(node.globalTransform.getTranslation().length, closeTo(2, 0.2));
+  });
+
+  test('a revolute joint with limits stops the swing', () {
+    final root = _bootWorld(gravity: Vector3(0, -10, 0));
+    final world = root.getComponent<Box3dPhysicsWorld>()!;
+    // Arm offset along +X so gravity torques the hinge at the origin.
+    final (node, _) = _addBox(
+      root,
+      type: BodyType.dynamic_,
+      position: Vector3(1, 0, 0),
+      halfExtents: Vector3(1, 0.1, 0.1),
+    );
+
+    final joint = Box3dRevoluteJoint(
+      axis: Vector3(0, 0, 1),
+      localAnchorA: Vector3(-1, 0, 0), // hinge at the arm's inner end
+      localAnchorB: Vector3(0, 0, 0), // world origin
+      lowerLimit: -math.pi / 4,
+      upperLimit: 0,
+    );
+    node.addComponent(joint);
+    joint.mount();
+
+    run(world, steps: 300);
+    // The arm swings down but the -45 degree lower limit keeps its end from
+    // hanging fully vertical.
+    final y = node.globalTransform.getTranslation().y;
+    expect(y, lessThan(0));
+    expect(y, greaterThan(-0.85));
+  });
+
+  test('a prismatic joint confines motion to its axis', () {
+    final root = _bootWorld(gravity: Vector3(0, -10, 0));
+    final world = root.getComponent<Box3dPhysicsWorld>()!;
+    final (node, _) = _addBox(
+      root,
+      type: BodyType.dynamic_,
+      position: Vector3(0, 0, 0),
+    );
+
+    // Slide axis is Y, limited to [-2, 0], anchored to the world.
+    final joint = Box3dPrismaticJoint(
+      axis: Vector3(0, 1, 0),
+      lowerLimit: -2,
+      upperLimit: 0,
+    );
+    node.addComponent(joint);
+    joint.mount();
+
+    run(world, steps: 300);
+    final p = node.globalTransform.getTranslation();
+    // Falls along Y to the lower limit; X and Z stay pinned.
+    expect(p.x, closeTo(0, 0.05));
+    expect(p.z, closeTo(0, 0.05));
+    expect(p.y, closeTo(-2, 0.15));
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 workspace:
   - packages/flutter_scene
   - packages/flutter_scene_rapier
+  - packages/flutter_scene_box3d
   - packages/flutter_scene_editor_core
   - packages/flutter_scene_editor
   - packages/flutter_scene_mcp


### PR DESCRIPTION
Adds flutter_scene_box3d, a box3d physics backend that implements the abstract physics contract against the box3d engine through the engine-agnostic box3d package (published separately).

Box3dPhysicsWorld drives the fixed-step simulation and interpolates dynamic transforms, resolves scene queries, and emits contact and trigger events. Box3dRigidBody and Box3dCollider mirror the rapier backend component lifecycle; colliders cook the full shape set (sphere, box, capsule, cylinder, convex hull, triangle mesh, height field, compound) with the local pose baked into geometry. Weld, revolute, prismatic, and spherical joints are supported. Native and web (WebAssembly) both work. Adds a "Physics (box3d)" example. Joints of the 6-DOF generic kind and an explicit mass override are left as documented TODOs.
