### PR TITLE
Add Texture2D with mipmaps and a texture atlas, and fix image-based lighting

### DIFF
--- a/examples/flutter_app/lib/example_particles.dart
+++ b/examples/flutter_app/lib/example_particles.dart
@@ -9,7 +9,6 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart';
-import 'package:flutter_scene/gpu.dart' as fgpu;
 import 'package:flutter_scene/src/components/particle_emitter_component.dart';
 import 'package:flutter_scene/src/particles/distribution.dart';
 import 'package:flutter_scene/src/particles/emitter_shape.dart' as shape;
@@ -52,7 +51,9 @@ class ExampleParticlesState extends State<ExampleParticles> {
       ),
     );
 
-    final dot = await gpuTextureFromImage(await _softDotImage());
+    final dot = GpuTextureSource(
+      await gpuTextureFromImage(await _softDotImage()),
+    );
 
     scene.add(_smoke(dot)..localTransform = _at(-6.0));
     scene.add(_fire(dot)..localTransform = _at(-2.0));
@@ -67,7 +68,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
 
   // A rising alpha-blended smoke column: a slow upward cone, buoyant, swelling
   // and fading over life.
-  Node _smoke(fgpu.Texture dot) {
+  Node _smoke(TextureSource dot) {
     final system = ParticleSystem(
       maxParticles: 400,
       shape: const shape.ConeShape(angle: 0.25, radius: 0.25),
@@ -108,7 +109,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
 
   // An additive flame: a narrow upward cone that rises, swells then shrinks, and
   // shifts yellow -> orange -> red as it fades.
-  Node _fire(fgpu.Texture dot) {
+  Node _fire(TextureSource dot) {
     final system = ParticleSystem(
       maxParticles: 600,
       shape: const shape.ConeShape(angle: 0.22, radius: 0.22),
@@ -147,7 +148,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
 
   // An additive water fountain: a fast tight cone under gravity, fading from
   // bright cyan to deep blue.
-  Node _fountain(fgpu.Texture dot) {
+  Node _fountain(TextureSource dot) {
     final system = ParticleSystem(
       maxParticles: 500,
       shape: const shape.ConeShape(angle: 0.18, radius: 0.05),
@@ -176,7 +177,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
 
   // An additive spark burst: an explosion from a point every 1.4s, gravity plus
   // drag, short-lived, rendered as velocity-stretched streaks.
-  Node _sparks(fgpu.Texture dot) {
+  Node _sparks(TextureSource dot) {
     final system = ParticleSystem(
       maxParticles: 800,
       shape: const shape.SphereShape(

--- a/examples/flutter_app/lib/example_sprites.dart
+++ b/examples/flutter_app/lib/example_sprites.dart
@@ -99,7 +99,9 @@ class ExampleSpritesState extends State<ExampleSprites> {
       ),
     );
 
-    final dot = await gpuTextureFromImage(await _softDotImage());
+    final dot = GpuTextureSource(
+      await gpuTextureFromImage(await _softDotImage()),
+    );
 
     // Left: three overlapping alpha sprites at different depths.
     final colors = [

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -24,6 +24,45 @@
   constraint relaxes from exactly one to at most one of `camera`,
   `cameraBuilder`, or `viewsBuilder`.
 
+* Added `Texture2D` for textures with generated mipmaps and trilinear plus
+  anisotropic filtering, built from an asset, a `ui.Image`, or raw pixels
+  (`Texture2D.fromAsset`, `Texture2D.fromImage`, `Texture2D.fromPixels`).
+  `TextureContent` selects how each mip level is filtered (color in linear
+  light, raw data, or renormalized normals) and `TextureSampling` controls the
+  mip filter, maximum mip level, and anisotropy. The runtime glTF loader now
+  builds its textures as `Texture2D`, so imported models are mipmapped.
+
+* **Breaking:** the material texture slots (`baseColorTexture`,
+  `metallicRoughnessTexture`, `normalTexture`, `emissiveTexture`,
+  `occlusionTexture`) now hold a `TextureSource` rather than a raw
+  `gpu.Texture`. Assign a `Texture2D` or a `RenderTexture` directly, or wrap an
+  existing `gpu.Texture` in `GpuTextureSource`.
+
+* Added `TextureAtlas`, a helper for a uniform grid of packed tiles (voxel
+  faces, sprite sheets, terrain) that resolves per-tile UVs and can build a
+  `PhysicallyBasedMaterial` from its maps, along with
+  `generateSolidColorAtlasPixels` for a placeholder atlas.
+
+* Added geometric specular antialiasing to `PhysicallyBasedMaterial` via
+  `specularAntiAliasingVariance` and `specularAntiAliasingThreshold`, which
+  widen roughness where the shading normal varies quickly to curb distant
+  specular sparkle.
+
+* Fixed the split-sum specular sampling the BRDF integration lookup with its
+  roughness axis flipped, which gave rough surfaces mirror-strength
+  reflections and washed them out.
+
+* Fixed image-based lighting taking the shadow-ambient gate and the specular
+  Fresnel term from the normal-mapped normal, which darkened bumpy surfaces
+  under a low sun and made grazing reflections blotchy. Both now use the
+  geometric normal; the reflection direction still follows the normal map.
+
+* Fixed `normalScale` not being applied to the perturbed normal.
+
+* Screen-space reflections now fade out on rough surfaces. The camera depth
+  prepass carries per-pixel roughness, so smooth surfaces still reflect while
+  rough ones stop.
+
 ## 0.18.1
 
 * No code changes. Reworded the package description, added the Flutter Scene

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -112,6 +112,9 @@ export 'src/node.dart' show Node;
 export 'src/sprite.dart' show Sprite;
 export 'src/texture_atlas.dart'
     show TextureAtlas, generateSolidColorAtlasPixels;
+export 'src/texture/texture2d.dart'
+    show Texture2D, TextureSource, TextureSampling, GpuTextureSource;
+export 'src/texture/mipmap.dart' show TextureContent;
 export 'src/physics/basic/basic_collider.dart' show BasicCollider;
 export 'src/physics/basic/basic_kinematic_body.dart' show BasicKinematicBody;
 export 'src/physics/basic/basic_world.dart' show BasicPhysicsWorld;

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -110,6 +110,7 @@ export 'src/math_extensions.dart' show QuaternionSlerp, Vector3Lerp;
 export 'src/mesh.dart' show Mesh, MeshPrimitive;
 export 'src/node.dart' show Node;
 export 'src/sprite.dart' show Sprite;
+export 'src/texture_atlas.dart' show TextureAtlas;
 export 'src/physics/basic/basic_collider.dart' show BasicCollider;
 export 'src/physics/basic/basic_kinematic_body.dart' show BasicKinematicBody;
 export 'src/physics/basic/basic_world.dart' show BasicPhysicsWorld;

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -110,7 +110,8 @@ export 'src/math_extensions.dart' show QuaternionSlerp, Vector3Lerp;
 export 'src/mesh.dart' show Mesh, MeshPrimitive;
 export 'src/node.dart' show Node;
 export 'src/sprite.dart' show Sprite;
-export 'src/texture_atlas.dart' show TextureAtlas;
+export 'src/texture_atlas.dart'
+    show TextureAtlas, generateSolidColorAtlasPixels;
 export 'src/physics/basic/basic_collider.dart' show BasicCollider;
 export 'src/physics/basic/basic_kinematic_body.dart' show BasicKinematicBody;
 export 'src/physics/basic/basic_world.dart' show BasicPhysicsWorld;

--- a/packages/flutter_scene/lib/src/components/widget_component.dart
+++ b/packages/flutter_scene/lib/src/components/widget_component.dart
@@ -4,6 +4,7 @@ import 'package:flutter_scene/src/components/mesh_component.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/texture/texture2d.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/material/physically_based_material.dart';
 import 'package:flutter_scene/src/material/unlit_material.dart';
@@ -160,21 +161,22 @@ class WidgetComponent extends Component {
     _bind?.call(texture);
     if (!_createsSurface) return;
 
+    final source = GpuTextureSource(texture);
     final material = _material;
     if (material == null) {
       // Fully owned: unlit, alpha-blended.
       final owned = _ownedMaterial ??= UnlitMaterial()
         ..alphaMode = AlphaMode.blend;
-      owned.baseColorTexture = texture;
+      owned.baseColorTexture = source;
     } else if (_bind == null) {
       // Implicit binding for the known built-in materials; anything else
       // needs an explicit `bind` callback (typed material fields mean there
       // is no generic slot to assign).
       switch (material) {
         case UnlitMaterial():
-          material.baseColorTexture = texture;
+          material.baseColorTexture = source;
         case PhysicallyBasedMaterial():
-          material.baseColorTexture = texture;
+          material.baseColorTexture = source;
         default:
           throw StateError(
             'WidgetComponent cannot bind a ${material.runtimeType} '

--- a/packages/flutter_scene/lib/src/fscene/realize/particle_emitter_codec.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/particle_emitter_codec.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene/src/fscene/realize/component_schema.dart';
 import 'package:flutter_scene/src/fscene/realize/particle_property_values.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/geometry/billboard_geometry.dart';
+import 'package:flutter_scene/src/texture/texture2d.dart';
 import 'package:flutter_scene/src/material/sprite_material.dart';
 import 'package:flutter_scene/src/particles/distribution.dart';
 import 'package:flutter_scene/src/particles/emitter_shape.dart';
@@ -208,7 +209,9 @@ class ParticleEmitterCodec extends ComponentCodec {
     final textureRef = p['texture'];
     final resources = context.resources;
     if (textureRef is ResourceRefValue && resources != null) {
-      material.colorTexture = resources.texture(textureRef.id);
+      material.colorTexture = GpuTextureSource(
+        resources.texture(textureRef.id),
+      );
     }
 
     final component =

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -22,6 +22,7 @@ import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/geometry/primitives.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/texture/texture2d.dart';
 import 'package:flutter_scene/src/importer/constants.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/material/physically_based_material.dart';
@@ -482,13 +483,15 @@ class ResourceRealizer {
   // Resolves a texture property to either a gpu.Texture or, when the ref
   // points at a render-texture resource, the live RenderTexture handle
   // (material slots accept both).
-  Object? _textureRef(Map<String, PropertyValue> p, String key) {
+  // TODO(mipmaps): route offline (.fscene) textures through Texture2D so they
+  // get mipmaps too, like the runtime importer.
+  TextureSource? _textureRef(Map<String, PropertyValue> p, String key) {
     final v = p[key];
     if (v is! ResourceRefValue) return null;
     if (document.resource(v.id) is RenderTextureResource) {
       return realizeRenderTexture(document, v.id);
     }
-    return texture(v.id);
+    return GpuTextureSource(texture(v.id));
   }
 
   UnlitMaterial _unlit(Map<String, PropertyValue> p) {

--- a/packages/flutter_scene/lib/src/gpu/stub/shim_stubs.dart
+++ b/packages/flutter_scene/lib/src/gpu/stub/shim_stubs.dart
@@ -273,12 +273,14 @@ base class SamplerOptions {
     this.mipFilter = MipFilter.nearest,
     this.widthAddressMode = SamplerAddressMode.clampToEdge,
     this.heightAddressMode = SamplerAddressMode.clampToEdge,
+    this.maxAnisotropy = 1,
   });
   MinMagFilter minFilter;
   MinMagFilter magFilter;
   MipFilter mipFilter;
   SamplerAddressMode widthAddressMode;
   SamplerAddressMode heightAddressMode;
+  int maxAnisotropy;
 }
 
 base class DepthRange {

--- a/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
@@ -32,10 +32,21 @@ base class GpuContext {
     // Cache extensions we rely on for later phases.
     _gl.getExtension('EXT_color_buffer_float');
     _gl.getExtension('OES_texture_float_linear');
+    // Anisotropic filtering. MAX_TEXTURE_MAX_ANISOTROPY_EXT = 0x84FF.
+    if (_gl.getExtension('EXT_texture_filter_anisotropic') != null) {
+      final Object? max = _gl.getParameter(0x84FF);
+      _maxSupportedAnisotropy = max is num ? max.toInt() : 1;
+    }
   }
 
   late final web.OffscreenCanvas _canvas;
   late final web.WebGL2RenderingContext _gl;
+
+  int _maxSupportedAnisotropy = 1;
+
+  /// The device's maximum supported anisotropy (1 when the extension is
+  /// unavailable, which disables anisotropic filtering).
+  int get maxSupportedAnisotropy => _maxSupportedAnisotropy;
 
   /// The underlying `OffscreenCanvas`. Resized on demand by `snapshot`.
   web.OffscreenCanvas get canvas => _canvas;

--- a/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
@@ -105,6 +105,7 @@ base class SamplerOptions {
     this.mipFilter = MipFilter.nearest,
     this.widthAddressMode = SamplerAddressMode.clampToEdge,
     this.heightAddressMode = SamplerAddressMode.clampToEdge,
+    this.maxAnisotropy = 1,
   });
 
   MinMagFilter minFilter;
@@ -112,6 +113,11 @@ base class SamplerOptions {
   MipFilter mipFilter;
   SamplerAddressMode widthAddressMode;
   SamplerAddressMode heightAddressMode;
+
+  /// The maximum anisotropy clamp used when sampling. The default value of 1
+  /// disables anisotropic filtering. Mirrors `package:flutter_gpu`; applied via
+  /// `EXT_texture_filter_anisotropic` and clamped to the device maximum.
+  int maxAnisotropy;
 }
 
 base class DepthRange {
@@ -596,6 +602,15 @@ base class RenderPass {
         web.WebGL2RenderingContext.TEXTURE_WRAP_T,
         _glAddressMode(sampler.heightAddressMode),
       );
+      final maxAniso = _gpuContext.maxSupportedAnisotropy;
+      if (sampler.maxAnisotropy > 1 && maxAniso > 1) {
+        // EXT_texture_filter_anisotropic: TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE.
+        gl.texParameterf(
+          target,
+          0x84FE,
+          sampler.maxAnisotropy.clamp(1, maxAniso).toDouble(),
+        );
+      }
     }
   }
 

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -26,6 +26,13 @@ class EngineLightingUniforms {
   /// padding before `environment_transform` (so the block size is unchanged).
   static const fadeIndex = 137;
 
+  /// Default geometric-specular-antialiasing strength and threshold, matching
+  /// [PhysicallyBasedMaterial]'s defaults. Packed at [138]/[139] (the remaining
+  /// std140 padding after `fade`) so every lit material gets antialiasing by
+  /// default; a material that exposes the knobs overwrites these afterward.
+  static const defaultSpecularAaVariance = 0.15;
+  static const defaultSpecularAaThreshold = 0.2;
+
   /// Writes the engine lighting / IBL / shadow fields of `FragInfo` into
   /// [fragInfo] from [lighting] and [env]. Leaves the material-specific fields
   /// (color, factors, alpha mode) untouched for the caller to fill.
@@ -77,6 +84,11 @@ class EngineLightingUniforms {
     fragInfo[134] = light?.shadowFadeRange ?? 0.0;
     fragInfo[135] = light?.shadowSoftness ?? 0.0;
     fragInfo[136] = cascades.length.toDouble();
+    // Geometric specular antialiasing at [138]/[139] (specular_aa_variance and
+    // specular_aa_threshold). Defaults for every lit material; a material with
+    // its own knobs overwrites these after packInto.
+    fragInfo[138] = defaultSpecularAaVariance;
+    fragInfo[139] = defaultSpecularAaThreshold;
     // environment_transform: a mat4 carrying the 3x3 rotation; std140 mat4
     // columns are 16 bytes each, at [140], [144], [148], [152].
     final envTransform = lighting.environmentTransform.storage;

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -10,39 +10,21 @@ import 'package:flutter_scene/src/material/physically_based_material.dart';
 import 'package:flutter_scene/src/material/unlit_material.dart';
 import 'package:flutter_scene/src/render_texture.dart';
 import 'package:flutter_scene/src/shaders.dart';
-
-/// Validates a value assigned to a material texture slot.
-///
-/// Slots accept a [gpu.Texture], a [RenderTexture] (sampled live), or
-/// null; anything else throws an [ArgumentError]. Returns [value]. The
-/// setters are typed `Object?` because Dart has no overloads and the two
-/// accepted types share no usable supertype.
-@internal
-Object? checkTextureSource(Object? value, String name) {
-  if (value == null || value is gpu.Texture || value is RenderTexture) {
-    return value;
-  }
-  throw ArgumentError.value(
-    value,
-    name,
-    'Expected a gpu.Texture or a RenderTexture',
-  );
-}
+import 'package:flutter_scene/src/texture/texture2d.dart';
 
 /// Resolves a texture-slot value to the texture to sample this frame.
 ///
 /// A [RenderTexture] resolves to its latest completed frame (null before
 /// the first render, so the slot's placeholder applies).
 @internal
-gpu.Texture? resolveTextureSource(Object? source) =>
-    source is RenderTexture ? source.texture : source as gpu.Texture?;
+gpu.Texture? resolveTextureSource(TextureSource? source) =>
+    source?.sampledTexture;
 
-/// The sampler a texture-slot value asks for, or null to use the
-/// material's default. A [RenderTexture] carries its own
-/// [RenderTexture.sampling].
+/// The sampler a texture-slot value asks for, or null to use the material's
+/// default (only when there is no source; every [TextureSource] carries one).
 @internal
-gpu.SamplerOptions? textureSourceSampler(Object? source) =>
-    source is RenderTexture ? source.sampling.toSamplerOptions() : null;
+gpu.SamplerOptions? textureSourceSampler(TextureSource? source) =>
+    source?.sampledSampler;
 
 /// Base class for shading a [MeshPrimitive].
 ///

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -247,4 +247,17 @@ abstract class Material {
   bool isOpaque() {
     return true;
   }
+
+  /// The metallic-roughness texture the camera depth prepass samples so
+  /// screen-space reflections have a per-pixel roughness (roughness in G),
+  /// or null to use a fully-rough placeholder. The base material has none, so
+  /// it reads as fully rough and receives no screen-space reflection; a lit
+  /// material overrides this.
+  @internal
+  gpu.Texture? get reflectionRoughnessTexture => null;
+
+  /// The roughness multiplier applied to [reflectionRoughnessTexture] in the
+  /// depth prepass (the material's roughness factor).
+  @internal
+  double get reflectionRoughnessFactor => 1.0;
 }

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -4,6 +4,7 @@ import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/texture/texture2d.dart';
 
 import 'package:vector_math/vector_math.dart';
 
@@ -51,51 +52,34 @@ class PhysicallyBasedMaterial extends Material {
   /// (e.g. [metallicFactor], [roughnessFactor]) default to neutral and
   /// can be tweaked after construction.
   PhysicallyBasedMaterial({
-    gpu.Texture? baseColorTexture,
-    gpu.Texture? metallicRoughnessTexture,
-    gpu.Texture? normalTexture,
-    gpu.Texture? emissiveTexture,
-    gpu.Texture? occlusionTexture,
+    this.baseColorTexture,
+    this.metallicRoughnessTexture,
+    this.normalTexture,
+    this.emissiveTexture,
+    this.occlusionTexture,
     this.environment,
-  }) : _baseColorSource = baseColorTexture,
-       _metallicRoughnessSource = metallicRoughnessTexture,
-       _normalSource = normalTexture,
-       _emissiveSource = emissiveTexture,
-       _occlusionSource = occlusionTexture {
+  }) {
     setFragmentShaderName('StandardFragment');
   }
 
-  // Texture slots hold either a gpu.Texture or a live RenderTexture; the
-  // getters resolve to the texture sampled this frame, and the setters
-  // accept both (see checkTextureSource).
-  Object? _baseColorSource;
-  Object? _metallicRoughnessSource;
-  Object? _normalSource;
-  Object? _emissiveSource;
-  Object? _occlusionSource;
-
-  /// The raw slot sources (a gpu.Texture, a RenderTexture, or null), for
-  /// serialization, which must see the handle rather than the resolved
-  /// frame.
+  /// The raw slot sources, for serialization. Same values as the public slot
+  /// fields ([baseColorTexture] and friends).
   @internal
-  Object? get baseColorTextureSource => _baseColorSource;
+  TextureSource? get baseColorTextureSource => baseColorTexture;
   @internal
-  Object? get metallicRoughnessTextureSource => _metallicRoughnessSource;
+  TextureSource? get metallicRoughnessTextureSource => metallicRoughnessTexture;
   @internal
-  Object? get normalTextureSource => _normalSource;
+  TextureSource? get normalTextureSource => normalTexture;
   @internal
-  Object? get emissiveTextureSource => _emissiveSource;
+  TextureSource? get emissiveTextureSource => emissiveTexture;
   @internal
-  Object? get occlusionTextureSource => _occlusionSource;
+  TextureSource? get occlusionTextureSource => occlusionTexture;
 
   /// The albedo (base color) texture, sampled in linear space and
   /// multiplied by [baseColorFactor]. Defaults to white when null.
   ///
-  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live); the
-  /// getter resolves to the texture sampled this frame.
-  gpu.Texture? get baseColorTexture => resolveTextureSource(_baseColorSource);
-  set baseColorTexture(Object? value) =>
-      _baseColorSource = checkTextureSource(value, 'baseColorTexture');
+  /// Accepts a [Texture2D] or a `RenderTexture` (sampled live).
+  TextureSource? baseColorTexture;
 
   /// Linear RGBA tint multiplied with [baseColorTexture]. Alpha controls
   /// translucency: values below `1` push the material into the depth-
@@ -110,11 +94,8 @@ class PhysicallyBasedMaterial extends Material {
   /// The combined metallic-roughness texture (B = metallic,
   /// G = roughness). Defaults to white when null.
   ///
-  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live).
-  gpu.Texture? get metallicRoughnessTexture =>
-      resolveTextureSource(_metallicRoughnessSource);
-  set metallicRoughnessTexture(Object? value) => _metallicRoughnessSource =
-      checkTextureSource(value, 'metallicRoughnessTexture');
+  /// Accepts a [Texture2D] or a `RenderTexture` (sampled live).
+  TextureSource? metallicRoughnessTexture;
 
   /// Scalar multiplier applied to the metallic channel. `0` is fully
   /// dielectric, `1` is fully metallic.
@@ -126,10 +107,9 @@ class PhysicallyBasedMaterial extends Material {
 
   /// Tangent-space normal map. Defaults to a flat normal when null.
   ///
-  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live).
-  gpu.Texture? get normalTexture => resolveTextureSource(_normalSource);
-  set normalTexture(Object? value) =>
-      _normalSource = checkTextureSource(value, 'normalTexture');
+  /// Accepts a [Texture2D] (usually with [TextureContent.normal]) or a
+  /// `RenderTexture` (sampled live).
+  TextureSource? normalTexture;
 
   /// Strength of [normalTexture]'s perturbation. `1` is the unmodified
   /// map.
@@ -138,10 +118,8 @@ class PhysicallyBasedMaterial extends Material {
   /// Optional emissive texture. Defaults to white when null and is
   /// gated by [emissiveFactor].
   ///
-  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live).
-  gpu.Texture? get emissiveTexture => resolveTextureSource(_emissiveSource);
-  set emissiveTexture(Object? value) =>
-      _emissiveSource = checkTextureSource(value, 'emissiveTexture');
+  /// Accepts a [Texture2D] or a `RenderTexture` (sampled live).
+  TextureSource? emissiveTexture;
 
   /// Linear RGBA emissive tint. Alpha is unused; the default
   /// `Vector4.zero()` disables emission.
@@ -150,10 +128,8 @@ class PhysicallyBasedMaterial extends Material {
   /// Optional ambient-occlusion texture (R channel). Defaults to white
   /// when null.
   ///
-  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live).
-  gpu.Texture? get occlusionTexture => resolveTextureSource(_occlusionSource);
-  set occlusionTexture(Object? value) =>
-      _occlusionSource = checkTextureSource(value, 'occlusionTexture');
+  /// Accepts a [Texture2D] or a `RenderTexture` (sampled live).
+  TextureSource? occlusionTexture;
 
   /// Strength of [occlusionTexture]'s effect. `0` ignores the map; `1`
   /// applies it fully.
@@ -221,11 +197,11 @@ class PhysicallyBasedMaterial extends Material {
       transientsBuffer.emplace(ByteData.sublistView(fragInfo)),
     );
 
-    _bindSlot(pass, 'base_color_texture', _baseColorSource);
-    _bindSlot(pass, 'emissive_texture', _emissiveSource);
-    _bindSlot(pass, 'metallic_roughness_texture', _metallicRoughnessSource);
-    _bindSlot(pass, 'normal_texture', _normalSource, normal: true);
-    _bindSlot(pass, 'occlusion_texture', _occlusionSource);
+    _bindSlot(pass, 'base_color_texture', baseColorTexture);
+    _bindSlot(pass, 'emissive_texture', emissiveTexture);
+    _bindSlot(pass, 'metallic_roughness_texture', metallicRoughnessTexture);
+    _bindSlot(pass, 'normal_texture', normalTexture, normal: true);
+    _bindSlot(pass, 'occlusion_texture', occlusionTexture);
     // Image-based-lighting atlas, BRDF LUT, and shadow map. Shared with
     // PreprocessedMaterial: the sampler choices (radiance repeat/clamp, LUT
     // clamp/clamp, shadow bilinear/clamp) and the white shadow placeholder
@@ -250,7 +226,7 @@ class PhysicallyBasedMaterial extends Material {
   void _bindSlot(
     gpu.RenderPass pass,
     String name,
-    Object? source, {
+    TextureSource? source, {
     bool normal = false,
   }) {
     final resolved = resolveTextureSource(source);

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -149,6 +149,21 @@ class PhysicallyBasedMaterial extends Material {
   /// fragments whose alpha falls below this are discarded.
   double alphaCutoff = 0.5;
 
+  /// Strength of geometric specular antialiasing.
+  ///
+  /// A normal map or high-curvature surface carries more normal detail than a
+  /// pixel can resolve, which the specular highlight turns into shimmer as the
+  /// camera or surface moves. This estimates that sub-pixel normal variation
+  /// from screen-space derivatives and widens the effective roughness to
+  /// suppress it (Kaplanyan/Tokuyoshi). `0` disables the effect; the default
+  /// (`0.15`) matches the common recommendation.
+  double specularAntiAliasingVariance = 0.15;
+
+  /// Upper bound on the extra roughness [specularAntiAliasingVariance] may add,
+  /// in the squared-roughness domain. Caps the effect so strongly varying
+  /// normals cannot over-roughen a surface. Default `0.2`.
+  double specularAntiAliasingThreshold = 0.2;
+
   @override
   void bind(
     gpu.RenderPass pass,
@@ -173,6 +188,8 @@ class PhysicallyBasedMaterial extends Material {
     //   [125]     float occlusion_strength
     //   [132]     float alpha_mode (0 opaque, 1 mask, 2 blend)
     //   [133]     float alpha_cutoff
+    //   [138]     float specular_aa_variance
+    //   [139]     float specular_aa_threshold
     final fragInfo = Float32List(EngineLightingUniforms.fragInfoFloatCount);
     EngineLightingUniforms.packInto(fragInfo, lighting, env);
     fragInfo[0] = baseColorFactor.r;
@@ -191,6 +208,8 @@ class PhysicallyBasedMaterial extends Material {
     fragInfo[125] = occlusionStrength;
     fragInfo[132] = alphaMode.index.toDouble();
     fragInfo[133] = alphaCutoff;
+    fragInfo[138] = specularAntiAliasingVariance;
+    fragInfo[139] = specularAntiAliasingThreshold;
     fragInfo[EngineLightingUniforms.fadeIndex] = lodFade;
     pass.bindUniform(
       fragmentShader.getUniformSlot("FragInfo"),

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -259,6 +259,13 @@ class PhysicallyBasedMaterial extends Material {
   }
 
   @override
+  gpu.Texture? get reflectionRoughnessTexture =>
+      resolveTextureSource(metallicRoughnessTexture);
+
+  @override
+  double get reflectionRoughnessFactor => roughnessFactor;
+
+  @override
   bool isOpaque() {
     // BLEND always goes through the translucent pass. OPAQUE and MASK
     // are drawn in the opaque pass (MASK relies on the shader's

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/texture/texture2d.dart';
 
 /// A [Material] backed by a caller-supplied fragment shader.
 ///
@@ -148,18 +149,22 @@ class ShaderMaterial extends Material {
 
   /// Assign a texture to a sampler uniform by name.
   ///
-  /// [texture] accepts a [gpu.Texture] or a `RenderTexture` (sampled
-  /// live; an explicit [sampler] overrides the render texture's own
-  /// sampling). Pass `null` to clear the binding.
+  /// [texture] accepts a raw [gpu.Texture] (the low-level custom-shader path),
+  /// a [Texture2D], or a `RenderTexture` (sampled live; an explicit [sampler]
+  /// overrides the source's own sampling). Pass `null` to clear the binding.
   void setTexture(String name, Object? texture, {gpu.SamplerOptions? sampler}) {
     if (texture == null) {
       _textures.remove(name);
-    } else {
-      _textures[name] = _BoundTexture(
-        checkTextureSource(texture, 'texture')!,
-        sampler,
+      return;
+    }
+    if (texture is! gpu.Texture && texture is! TextureSource) {
+      throw ArgumentError.value(
+        texture,
+        'texture',
+        'Expected a gpu.Texture, a Texture2D, or a RenderTexture',
       );
     }
+    _textures[name] = _BoundTexture(texture, sampler);
   }
 
   /// Read back a previously-set texture binding, or `null` when none
@@ -168,7 +173,14 @@ class ShaderMaterial extends Material {
   /// A slot holding a `RenderTexture` resolves to its latest completed
   /// frame (null before the first render).
   gpu.Texture? getTexture(String name) =>
-      resolveTextureSource(_textures[name]?.source);
+      _resolveShaderTexture(_textures[name]?.source);
+
+  // ShaderMaterial accepts a raw gpu.Texture in addition to a TextureSource, so
+  // it resolves locally rather than through the material.dart helpers.
+  static gpu.Texture? _resolveShaderTexture(Object? source) =>
+      source is TextureSource ? source.sampledTexture : source as gpu.Texture?;
+  static gpu.SamplerOptions? _shaderTextureSampler(Object? source) =>
+      source is TextureSource ? source.sampledSampler : null;
 
   /// All currently-bound sampler names. Order is insertion order.
   Iterable<String> get textureNames => _textures.keys;
@@ -195,13 +207,13 @@ class ShaderMaterial extends Material {
     for (final entry in _textures.entries) {
       // An empty render texture (no completed frame yet) binds the white
       // placeholder so the sampler slot is never left dangling.
-      final resolved = resolveTextureSource(entry.value.source);
+      final resolved = _resolveShaderTexture(entry.value.source);
       pass.bindTexture(
         fragmentShader.getUniformSlot(entry.key),
         Material.whitePlaceholder(resolved),
         sampler:
             entry.value.sampler ??
-            textureSourceSampler(entry.value.source) ??
+            _shaderTextureSampler(entry.value.source) ??
             gpu.SamplerOptions(),
       );
     }

--- a/packages/flutter_scene/lib/src/material/sprite_material.dart
+++ b/packages/flutter_scene/lib/src/material/sprite_material.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/shaders.dart';
+import 'package:flutter_scene/src/texture/texture2d.dart';
 
 import 'package:vector_math/vector_math.dart';
 
@@ -39,19 +40,14 @@ class SpriteMaterial extends Material {
   ///
   /// When [colorTexture] is null a 1x1 white placeholder is used, so the
   /// sprite reduces to a flat [tint] times the per-instance color.
-  SpriteMaterial({gpu.Texture? colorTexture}) : _colorSource = colorTexture {
+  SpriteMaterial({this.colorTexture}) {
     setFragmentShader(baseShaderLibrary['SpriteFragment']!);
   }
 
-  Object? _colorSource;
-
   /// The sprite's color texture, sampled and multiplied by the per-instance
-  /// color and [tint]. Accepts a [gpu.Texture] or a `RenderTexture`; an empty
+  /// color and [tint]. Accepts a [Texture2D] or a `RenderTexture`; an empty
   /// slot resolves to a 1x1 white placeholder.
-  gpu.Texture get colorTexture =>
-      Material.whitePlaceholder(resolveTextureSource(_colorSource));
-  set colorTexture(Object? value) =>
-      _colorSource = checkTextureSource(value, 'colorTexture');
+  TextureSource? colorTexture;
 
   /// Linear RGBA tint multiplied into every sprite of this material.
   Vector4 tint = Colors.white;
@@ -99,8 +95,8 @@ class SpriteMaterial extends Material {
     );
     pass.bindTexture(
       fragmentShader.getUniformSlot('base_color_texture'),
-      colorTexture,
-      sampler: textureSourceSampler(_colorSource) ?? sampler,
+      Material.whitePlaceholder(resolveTextureSource(colorTexture)),
+      sampler: textureSourceSampler(colorTexture) ?? sampler,
     );
   }
 }

--- a/packages/flutter_scene/lib/src/material/unlit_material.dart
+++ b/packages/flutter_scene/lib/src/material/unlit_material.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/texture/texture2d.dart';
 import 'package:flutter_scene/src/material/physically_based_material.dart'
     show AlphaMode;
 
@@ -21,28 +22,21 @@ class UnlitMaterial extends Material {
   ///
   /// When [colorTexture] is null a 1×1 white placeholder is used so the
   /// final color reduces to [baseColorFactor].
-  UnlitMaterial({gpu.Texture? colorTexture}) : _baseColorSource = colorTexture {
+  UnlitMaterial({TextureSource? colorTexture})
+    : baseColorTexture = colorTexture {
     setFragmentShaderName('UnlitFragment');
   }
 
-  Object? _baseColorSource;
-
-  /// The raw slot source (a gpu.Texture, a RenderTexture, or null), for
-  /// serialization, which must see the handle rather than the resolved
-  /// frame.
+  /// The raw slot source, for serialization (same value as [baseColorTexture]).
   @internal
-  Object? get baseColorTextureSource => _baseColorSource;
+  TextureSource? get baseColorTextureSource => baseColorTexture;
 
   /// The base color texture, sampled and multiplied by [baseColorFactor].
   ///
-  /// Accepts a [gpu.Texture] or a `RenderTexture` (sampled live). The
-  /// getter never returns null; an empty slot (or a render texture with
-  /// no completed frame yet) resolves to a 1×1 white placeholder so the
-  /// final color reduces to [baseColorFactor].
-  gpu.Texture get baseColorTexture =>
-      Material.whitePlaceholder(resolveTextureSource(_baseColorSource));
-  set baseColorTexture(Object? value) =>
-      _baseColorSource = checkTextureSource(value, 'baseColorTexture');
+  /// Accepts a [Texture2D] or a `RenderTexture` (sampled live). An empty slot
+  /// (or a render texture with no completed frame yet) samples a 1×1 white
+  /// placeholder so the final color reduces to [baseColorFactor].
+  TextureSource? baseColorTexture;
 
   /// How the material's alpha is interpreted. [AlphaMode.opaque] ignores
   /// alpha; [AlphaMode.blend] routes the material through the depth-sorted
@@ -84,9 +78,9 @@ class UnlitMaterial extends Material {
     );
     pass.bindTexture(
       fragmentShader.getUniformSlot('base_color_texture'),
-      baseColorTexture,
+      Material.whitePlaceholder(resolveTextureSource(baseColorTexture)),
       sampler:
-          textureSourceSampler(_baseColorSource) ??
+          textureSourceSampler(baseColorTexture) ??
           gpu.SamplerOptions(
             widthAddressMode: gpu.SamplerAddressMode.repeat,
             heightAddressMode: gpu.SamplerAddressMode.repeat,

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -8,6 +8,7 @@ import 'package:vector_math/vector_math.dart';
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart'
     show bindUnskinnedFrameInfo;
+import 'package:flutter_scene/src/material/material.dart' show Material;
 import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/render/render_layers.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
@@ -194,6 +195,14 @@ class _DepthPrepassEncoder {
   static final gpu.Shader _depthNormalShader =
       baseShaderLibrary['LinearDepthNormalFragment']!;
 
+  // The roughness map is a tiled material texture; sample it with repeat.
+  static final gpu.SamplerOptions _roughnessSampler = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.linear,
+    magFilter: gpu.MinMagFilter.linear,
+    widthAddressMode: gpu.SamplerAddressMode.repeat,
+    heightAddressMode: gpu.SamplerAddressMode.repeat,
+  );
+
   // The fragment shader and its uniform-block name for this pass.
   gpu.Shader get _fragmentShader =>
       _writeNormals ? _depthNormalShader : _depthShader;
@@ -243,6 +252,18 @@ class _DepthPrepassEncoder {
       _boundPipeline = pipeline;
     }
     _renderPass.setPrimitiveType(geometry.primitiveType);
+    if (_writeNormals) {
+      // Carry this material's roughness so the reflection trace can fade out
+      // on rough surfaces. camera_forward.w holds the roughness factor; the
+      // map (a white placeholder when the material has none) supplies the
+      // per-pixel roughness in its green channel.
+      _depthInfo[3] = item.material.reflectionRoughnessFactor;
+      _renderPass.bindTexture(
+        _fragmentShader.getUniformSlot('metallic_roughness_texture'),
+        Material.whitePlaceholder(item.material.reflectionRoughnessTexture),
+        sampler: _roughnessSampler,
+      );
+    }
     _renderPass.bindUniform(
       _fragmentShader.getUniformSlot(_infoBlockName),
       _transientsBuffer.emplace(ByteData.sublistView(_depthInfo)),

--- a/packages/flutter_scene/lib/src/render_texture.dart
+++ b/packages/flutter_scene/lib/src/render_texture.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 
 import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/surface.dart';
+import 'package:flutter_scene/src/texture/texture2d.dart';
 
 /// When a [RenderTexture] re-renders.
 ///
@@ -115,7 +116,7 @@ class RenderTextureSampling {
 /// (including the target sampling itself, a mirror facing a mirror)
 /// samples the previous frame instead of forming a feedback loop.
 /// {@category Rendering}
-class RenderTexture extends ChangeNotifier {
+class RenderTexture extends ChangeNotifier implements TextureSource {
   /// Creates a render target of [width] x [height] physical pixels.
   RenderTexture({
     required int width,
@@ -124,6 +125,12 @@ class RenderTexture extends ChangeNotifier {
     this.sampling = const RenderTextureSampling(),
   }) : assert(width > 0 && height > 0, 'RenderTexture size must be positive'),
        _size = ui.Size(width.toDouble(), height.toDouble());
+
+  @override
+  gpu.Texture? get sampledTexture => texture;
+
+  @override
+  gpu.SamplerOptions get sampledSampler => sampling.toSamplerOptions();
 
   // The ring + transient pool live in a single-view Surface, the same
   // machinery (and frames-in-flight depth) backing the screen swapchain.

--- a/packages/flutter_scene/lib/src/runtime_importer/material_builder.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/material_builder.dart
@@ -1,15 +1,15 @@
-import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 import 'package:flutter_scene/src/importer/gltf.dart';
 
 import '../material/material.dart';
 import '../material/physically_based_material.dart';
 import '../material/unlit_material.dart';
+import '../texture/texture2d.dart';
 
 /// Builds an engine [Material] from a glTF material. Tier 2 wires up the
-/// texture slots from a pre-decoded list of [gpu.Texture]s indexed
+/// texture slots from a pre-decoded list of [Texture2D]s indexed
 /// 1:1 with `GltfDocument.textures`.
-Material buildMaterial(GltfMaterial? gm, List<gpu.Texture> textures) {
+Material buildMaterial(GltfMaterial? gm, List<Texture2D> textures) {
   if (gm == null) {
     return PhysicallyBasedMaterial();
   }
@@ -69,10 +69,7 @@ AlphaMode _alphaMode(String mode) {
   }
 }
 
-gpu.Texture? _resolveTexture(
-  GltfTextureInfo? info,
-  List<gpu.Texture> textures,
-) {
+Texture2D? _resolveTexture(GltfTextureInfo? info, List<Texture2D> textures) {
   if (info == null) return null;
   if (info.index < 0 || info.index >= textures.length) return null;
   return textures[info.index];

--- a/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 import 'package:flutter_scene/src/importer/gltf.dart';
 
@@ -9,6 +8,7 @@ import '../material/unlit_material.dart';
 import '../mesh.dart';
 import '../node.dart';
 import '../skin.dart';
+import '../texture/texture2d.dart';
 import 'animation_builder.dart';
 import 'geometry_builder.dart';
 import 'gltf_resources.dart';
@@ -63,7 +63,7 @@ Future<Node> _buildScene(
 ) async {
   // Decode all textures up front so material construction can reference
   // them by index without per-material async work.
-  final List<gpu.Texture> textures = await buildTextures(
+  final List<Texture2D> textures = await buildTextures(
     doc,
     bufferData,
     resolveUri: resolveUri,
@@ -153,7 +153,7 @@ void _populateNode({
   required GltfDocument doc,
   required Uint8List bufferData,
   required List<Node> engineNodes,
-  required List<gpu.Texture> textures,
+  required List<Texture2D> textures,
 }) {
   engineNode.name = resolveGltfNodeName(gltfNode.name, index);
   engineNode.localTransform = _localTransformFor(gltfNode);

--- a/packages/flutter_scene/lib/src/runtime_importer/texture_builder.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/texture_builder.dart
@@ -1,11 +1,10 @@
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/importer/gltf.dart';
 
-import '../asset_helpers.dart';
+import '../texture/texture2d.dart';
 import 'gltf_resources.dart';
 
 /// Decode each glTF texture into a [gpu.Texture]. Each entry in the returned
@@ -17,12 +16,12 @@ import 'gltf_resources.dart';
 /// (multi-file glTF). An image that can't be sourced or decoded falls
 /// back to a 1x1 white placeholder so material binding never sees a
 /// null texture.
-Future<List<gpu.Texture>> buildTextures(
+Future<List<Texture2D>> buildTextures(
   GltfDocument doc,
   Uint8List bufferData, {
   GltfResourceResolver? resolveUri,
 }) async {
-  final results = <gpu.Texture>[];
+  final results = <Texture2D>[];
   for (int i = 0; i < doc.textures.length; i++) {
     final tex = doc.textures[i];
     final imageIdx = tex.source;
@@ -79,22 +78,27 @@ Future<List<gpu.Texture>> buildTextures(
   return results;
 }
 
-Future<gpu.Texture> _decodeAndUpload(Uint8List bytes) async {
+// TODO(mipmaps): classify each image's content (color vs normal vs data) from
+// how materials reference it, so normal/metallic-roughness maps get linear
+// (renormalized) mips instead of the sRGB-color default.
+Future<Texture2D> _decodeAndUpload(Uint8List bytes) async {
   final codec = await ui.instantiateImageCodec(bytes);
   final frame = await codec.getNextFrame();
-  return gpuTextureFromImage(frame.image);
+  try {
+    return await Texture2D.fromImage(frame.image);
+  } finally {
+    frame.image.dispose();
+  }
 }
 
-gpu.Texture _placeholder() {
-  // Re-uses the static-resource white placeholder so we never insert null
-  // entries (callers can index directly without a null check).
-  return _whitePlaceholder ??= _makeWhite();
+Texture2D _placeholder() {
+  // Re-uses a shared 1x1 white texture so we never insert null entries.
+  return _whitePlaceholder ??= Texture2D.fromPixels(
+    Uint8List.fromList(<int>[255, 255, 255, 255]),
+    1,
+    1,
+    sampling: const TextureSampling(mipmaps: false),
+  );
 }
 
-gpu.Texture? _whitePlaceholder;
-
-gpu.Texture _makeWhite() {
-  final t = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 1, 1);
-  t.overwrite(Uint32List.fromList(<int>[0xFFFFFFFF]).buffer.asByteData());
-  return t;
-}
+Texture2D? _whitePlaceholder;

--- a/packages/flutter_scene/lib/src/sprite.dart
+++ b/packages/flutter_scene/lib/src/sprite.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_scene/src/geometry/billboard_geometry.dart';
-import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/material/sprite_material.dart';
 import 'package:flutter_scene/src/mesh.dart';
+import 'package:flutter_scene/src/texture/texture2d.dart';
 
 import 'package:vector_math/vector_math.dart';
 
@@ -20,7 +20,7 @@ import 'package:vector_math/vector_math.dart';
 class Sprite {
   /// Creates a sprite, optionally textured.
   Sprite({
-    gpu.Texture? texture,
+    TextureSource? texture,
     double width = 1.0,
     double height = 1.0,
     Vector4? color,

--- a/packages/flutter_scene/lib/src/texture/mipmap.dart
+++ b/packages/flutter_scene/lib/src/texture/mipmap.dart
@@ -1,0 +1,142 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+/// What a texture's pixels represent, which controls how mip levels are
+/// downsampled so the result is correct (color must average in linear light,
+/// normals must be averaged as vectors and renormalized).
+///
+/// {@category Assets and loading}
+enum TextureContent {
+  /// sRGB-encoded color (albedo, emissive). Averaged in linear light.
+  color,
+
+  /// Linear data (metallic-roughness, ambient occlusion). Averaged directly.
+  data,
+
+  /// A tangent-space normal map. Averaged as vectors and renormalized.
+  normal,
+}
+
+/// One mip level's RGBA8888 pixels.
+class MipLevel {
+  MipLevel(this.width, this.height, this.pixels);
+
+  final int width;
+  final int height;
+  final Uint8List pixels;
+}
+
+/// Builds the full mip chain (level 0 first) for RGBA8888 [pixels] of [width] x
+/// [height], downsampling with a 2x2 box filter appropriate for [content].
+///
+/// Each level halves the previous (floored, min 1) until 1x1. The result is
+/// suitable for uploading level by level to a mipmapped texture.
+List<MipLevel> generateMipChain(
+  Uint8List pixels,
+  int width,
+  int height,
+  TextureContent content,
+) {
+  final levels = <MipLevel>[MipLevel(width, height, pixels)];
+  var w = width;
+  var h = height;
+  var src = pixels;
+  while (w > 1 || h > 1) {
+    final nw = math.max(1, w >> 1);
+    final nh = math.max(1, h >> 1);
+    final dst = _downsample(src, w, h, nw, nh, content);
+    levels.add(MipLevel(nw, nh, dst));
+    src = dst;
+    w = nw;
+    h = nh;
+  }
+  return levels;
+}
+
+/// The number of mip levels for a [width] x [height] texture.
+int mipLevelCountFor(int width, int height) =>
+    (math.log(math.max(width, height)) / math.ln2).floor() + 1;
+
+Uint8List _downsample(
+  Uint8List src,
+  int sw,
+  int sh,
+  int dw,
+  int dh,
+  TextureContent content,
+) {
+  final dst = Uint8List(dw * dh * 4);
+  for (var y = 0; y < dh; y++) {
+    // Map each destination texel to a 2x2 (edge-clamped) block of the source.
+    final y0 = math.min(y * 2, sh - 1);
+    final y1 = math.min(y0 + 1, sh - 1);
+    for (var x = 0; x < dw; x++) {
+      final x0 = math.min(x * 2, sw - 1);
+      final x1 = math.min(x0 + 1, sw - 1);
+      final a = (y0 * sw + x0) * 4;
+      final b = (y0 * sw + x1) * 4;
+      final c = (y1 * sw + x0) * 4;
+      final d = (y1 * sw + x1) * 4;
+      final o = (y * dw + x) * 4;
+      switch (content) {
+        case TextureContent.color:
+          for (var ch = 0; ch < 3; ch++) {
+            final avg =
+                (_srgbToLinear(src[a + ch]) +
+                    _srgbToLinear(src[b + ch]) +
+                    _srgbToLinear(src[c + ch]) +
+                    _srgbToLinear(src[d + ch])) *
+                0.25;
+            dst[o + ch] = _linearToSrgb(avg);
+          }
+          dst[o + 3] =
+              ((src[a + 3] + src[b + 3] + src[c + 3] + src[d + 3]) + 2) ~/ 4;
+        case TextureContent.data:
+          for (var ch = 0; ch < 4; ch++) {
+            dst[o + ch] =
+                ((src[a + ch] + src[b + ch] + src[c + ch] + src[d + ch]) + 2) ~/
+                4;
+          }
+        case TextureContent.normal:
+          var nx = 0.0, ny = 0.0, nz = 0.0;
+          for (final p in [a, b, c, d]) {
+            nx += src[p] / 127.5 - 1.0;
+            ny += src[p + 1] / 127.5 - 1.0;
+            nz += src[p + 2] / 127.5 - 1.0;
+          }
+          final len = math.sqrt(nx * nx + ny * ny + nz * nz);
+          if (len > 1e-6) {
+            nx /= len;
+            ny /= len;
+            nz /= len;
+          } else {
+            nx = 0.0;
+            ny = 0.0;
+            nz = 1.0;
+          }
+          dst[o] = _encodeUnit(nx);
+          dst[o + 1] = _encodeUnit(ny);
+          dst[o + 2] = _encodeUnit(nz);
+          dst[o + 3] = 255;
+      }
+    }
+  }
+  return dst;
+}
+
+double _srgbToLinear(int byte) {
+  final c = byte / 255.0;
+  return c <= 0.04045
+      ? c / 12.92
+      : math.pow((c + 0.055) / 1.055, 2.4).toDouble();
+}
+
+int _linearToSrgb(double linear) {
+  final c = linear <= 0.0031308
+      ? linear * 12.92
+      : 1.055 * math.pow(linear, 1 / 2.4).toDouble() - 0.055;
+  return (c * 255.0).round().clamp(0, 255);
+}
+
+// Maps a [-1, 1] component to a [0, 255] byte.
+int _encodeUnit(double v) => ((v + 1.0) * 127.5).round().clamp(0, 255);

--- a/packages/flutter_scene/lib/src/texture/texture2d.dart
+++ b/packages/flutter_scene/lib/src/texture/texture2d.dart
@@ -1,0 +1,186 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/services.dart';
+
+import '../asset_helpers.dart';
+import '../gpu/gpu.dart' as gpu;
+import 'mipmap.dart';
+
+/// Something a material can sample: it yields the GPU texture to sample for the
+/// current frame and the sampler to bind it with. Implemented by [Texture2D]
+/// (a static image) and `RenderTexture` (a live, rendered-into texture).
+///
+/// {@category Assets and loading}
+abstract interface class TextureSource {
+  /// The GPU texture to sample this frame, or null when none is available yet
+  /// (a live source before its first frame; callers substitute a placeholder).
+  gpu.Texture? get sampledTexture;
+
+  /// The sampler this source is bound with.
+  gpu.SamplerOptions get sampledSampler;
+}
+
+/// Wraps a raw [gpu.Texture] as a [TextureSource], for advanced or interop
+/// cases that already own a GPU texture (widget/particle textures, custom
+/// pipelines) and do not need [Texture2D]'s image decode and mip generation.
+///
+/// {@category Assets and loading}
+class GpuTextureSource implements TextureSource {
+  GpuTextureSource(this.texture, {gpu.SamplerOptions? sampler})
+    : sampler =
+          sampler ??
+          gpu.SamplerOptions(
+            minFilter: gpu.MinMagFilter.linear,
+            magFilter: gpu.MinMagFilter.linear,
+            widthAddressMode: gpu.SamplerAddressMode.repeat,
+            heightAddressMode: gpu.SamplerAddressMode.repeat,
+          );
+
+  final gpu.Texture texture;
+  final gpu.SamplerOptions sampler;
+
+  @override
+  gpu.Texture? get sampledTexture => texture;
+
+  @override
+  gpu.SamplerOptions get sampledSampler => sampler;
+}
+
+/// How a texture is sampled. The defaults are trilinear, anisotropic, and
+/// mipmapped, the tasteful default for material textures viewed in 3D.
+///
+/// {@category Assets and loading}
+class TextureSampling {
+  const TextureSampling({
+    this.mipmaps = true,
+    this.maxMipmapLevels,
+    this.minFilter = gpu.MinMagFilter.linear,
+    this.magFilter = gpu.MinMagFilter.linear,
+    this.mipFilter = gpu.MipFilter.linear,
+    this.maxAnisotropy = 8,
+    this.addressMode = gpu.SamplerAddressMode.repeat,
+  });
+
+  /// Whether the texture carries a mip chain (built at creation) and is sampled
+  /// with mip filtering. Turn off for UI/full-screen sources never minified.
+  final bool mipmaps;
+
+  /// Caps the number of mip levels generated (null builds the full chain).
+  /// A texture atlas uses this so tiles stop shrinking before they merge into
+  /// their neighbors across the padding gutter.
+  final int? maxMipmapLevels;
+
+  final gpu.MinMagFilter minFilter;
+  final gpu.MinMagFilter magFilter;
+  final gpu.MipFilter mipFilter;
+
+  /// Maximum anisotropy (clamped to the device max). 1 disables it.
+  final int maxAnisotropy;
+
+  final gpu.SamplerAddressMode addressMode;
+
+  gpu.SamplerOptions toSamplerOptions() => gpu.SamplerOptions(
+    minFilter: minFilter,
+    magFilter: magFilter,
+    mipFilter: mipmaps ? mipFilter : gpu.MipFilter.nearest,
+    widthAddressMode: addressMode,
+    heightAddressMode: addressMode,
+    maxAnisotropy: maxAnisotropy,
+  );
+}
+
+/// A 2D image texture ready to bind to a material's texture slot.
+///
+/// Create one from an asset ([fromAsset]), a decoded `dart:ui` image
+/// ([fromImage]), or raw RGBA pixels ([fromPixels]). A mip chain is generated
+/// at creation, downsampled correctly for the texture's [TextureContent] (sRGB
+/// color averaged in linear light, normals renormalized), and the texture
+/// carries its own [TextureSampling] (trilinear + anisotropic by default).
+///
+/// ```dart
+/// final albedo = await Texture2D.fromAsset('assets/brick_color.png');
+/// final normal = await Texture2D.fromAsset('assets/brick_normal.png',
+///     content: TextureContent.normal);
+/// material.baseColorTexture = albedo;
+/// material.normalTexture = normal;
+/// ```
+/// {@category Assets and loading}
+class Texture2D implements TextureSource {
+  Texture2D._(this._texture, this._sampler);
+
+  final gpu.Texture _texture;
+  final gpu.SamplerOptions _sampler;
+
+  /// The underlying GPU texture, for advanced/interop use.
+  gpu.Texture get gpuTexture => _texture;
+
+  @override
+  gpu.Texture? get sampledTexture => _texture;
+
+  @override
+  gpu.SamplerOptions get sampledSampler => _sampler;
+
+  /// Builds a texture from RGBA8888 [pixels] (straight alpha, row-major) of
+  /// [width] x [height].
+  static Texture2D fromPixels(
+    Uint8List pixels,
+    int width,
+    int height, {
+    TextureContent content = TextureContent.color,
+    TextureSampling sampling = const TextureSampling(),
+  }) {
+    var levels = sampling.mipmaps
+        ? generateMipChain(pixels, width, height, content)
+        : <MipLevel>[MipLevel(width, height, pixels)];
+    final cap = sampling.maxMipmapLevels;
+    if (cap != null && cap >= 1 && cap < levels.length) {
+      levels = levels.sublist(0, cap);
+    }
+    final texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      width,
+      height,
+      mipLevelCount: levels.length,
+    );
+    for (var i = 0; i < levels.length; i++) {
+      texture.overwrite(ByteData.sublistView(levels[i].pixels), mipLevel: i);
+    }
+    return Texture2D._(texture, sampling.toSamplerOptions());
+  }
+
+  /// Builds a texture from a decoded [image].
+  static Future<Texture2D> fromImage(
+    ui.Image image, {
+    TextureContent content = TextureContent.color,
+    TextureSampling sampling = const TextureSampling(),
+  }) async {
+    final bytes = await image.toByteData(
+      format: ui.ImageByteFormat.rawStraightRgba,
+    );
+    if (bytes == null) {
+      throw Exception('Failed to read RGBA data from image.');
+    }
+    return fromPixels(
+      bytes.buffer.asUint8List(),
+      image.width,
+      image.height,
+      content: content,
+      sampling: sampling,
+    );
+  }
+
+  /// Loads, decodes, and uploads the image asset at [assetPath].
+  static Future<Texture2D> fromAsset(
+    String assetPath, {
+    TextureContent content = TextureContent.color,
+    TextureSampling sampling = const TextureSampling(),
+    AssetBundle? bundle,
+  }) async {
+    final image = await imageFromAsset(assetPath, bundle: bundle);
+    try {
+      return await fromImage(image, content: content, sampling: sampling);
+    } finally {
+      image.dispose();
+    }
+  }
+}

--- a/packages/flutter_scene/lib/src/texture/texture2d.dart
+++ b/packages/flutter_scene/lib/src/texture/texture2d.dart
@@ -79,14 +79,24 @@ class TextureSampling {
 
   final gpu.SamplerAddressMode addressMode;
 
-  gpu.SamplerOptions toSamplerOptions() => gpu.SamplerOptions(
-    minFilter: minFilter,
-    magFilter: magFilter,
-    mipFilter: mipmaps ? mipFilter : gpu.MipFilter.nearest,
-    widthAddressMode: addressMode,
-    heightAddressMode: addressMode,
-    maxAnisotropy: maxAnisotropy,
-  );
+  gpu.SamplerOptions toSamplerOptions() {
+    final effectiveMipFilter = mipmaps ? mipFilter : gpu.MipFilter.nearest;
+    // Anisotropic filtering requires linear min/mag/mip filtering; pairing it
+    // with any nearest filter is rejected, so drop it when a filter is nearest
+    // (e.g. a mipmaps-off UI texture).
+    final allLinear =
+        minFilter == gpu.MinMagFilter.linear &&
+        magFilter == gpu.MinMagFilter.linear &&
+        effectiveMipFilter == gpu.MipFilter.linear;
+    return gpu.SamplerOptions(
+      minFilter: minFilter,
+      magFilter: magFilter,
+      mipFilter: effectiveMipFilter,
+      widthAddressMode: addressMode,
+      heightAddressMode: addressMode,
+      maxAnisotropy: allLinear ? maxAnisotropy : 1,
+    );
+  }
 }
 
 /// A 2D image texture ready to bind to a material's texture slot.
@@ -132,9 +142,14 @@ class Texture2D implements TextureSource {
     var levels = sampling.mipmaps
         ? generateMipChain(pixels, width, height, content)
         : <MipLevel>[MipLevel(width, height, pixels)];
+    // The GPU allocator caps mip levels at fullMipCount (floor(log2(min(w, h)))),
+    // which is below the canonical chain length for non-square textures, so
+    // clamp before requesting the texture or creation throws a range error.
+    final maxLevels = gpu.Texture.fullMipCount(width, height);
     final cap = sampling.maxMipmapLevels;
-    if (cap != null && cap >= 1 && cap < levels.length) {
-      levels = levels.sublist(0, cap);
+    final limit = cap != null && cap >= 1 && cap < maxLevels ? cap : maxLevels;
+    if (limit < levels.length) {
+      levels = levels.sublist(0, limit);
     }
     final texture = gpu.gpuContext.createTexture(
       gpu.StorageMode.hostVisible,

--- a/packages/flutter_scene/lib/src/texture_atlas.dart
+++ b/packages/flutter_scene/lib/src/texture_atlas.dart
@@ -2,8 +2,8 @@ import 'dart:typed_data';
 
 import 'package:vector_math/vector_math.dart';
 
-import 'gpu/gpu.dart' as gpu;
 import 'material/physically_based_material.dart';
+import 'texture/texture2d.dart';
 
 /// A uniform grid texture atlas: one or more equally sized PBR maps packed as
 /// `columns` x `rows` square tiles, with an optional gutter of [padding] texels
@@ -52,10 +52,10 @@ class TextureAtlas {
   final int padding;
 
   /// Packed PBR maps, all sharing the same grid layout. Any may be null.
-  final gpu.Texture? baseColor;
-  final gpu.Texture? metallicRoughness;
-  final gpu.Texture? normal;
-  final gpu.Texture? occlusion;
+  final Texture2D? baseColor;
+  final Texture2D? metallicRoughness;
+  final Texture2D? normal;
+  final Texture2D? occlusion;
 
   /// Total number of tiles.
   int get tileCount => columns * rows;

--- a/packages/flutter_scene/lib/src/texture_atlas.dart
+++ b/packages/flutter_scene/lib/src/texture_atlas.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:vector_math/vector_math.dart';
 
 import 'gpu/gpu.dart' as gpu;
@@ -99,4 +101,50 @@ class TextureAtlas {
       occlusionTexture: occlusion,
     );
   }
+}
+
+/// Builds RGBA8888 pixels (row-major, top-left origin) for a placeholder grid
+/// atlas laid out to match a [TextureAtlas] with the same [columns], [tileSize],
+/// and [padding]. Each tile's whole cell (content plus padding gutter) is filled
+/// with its solid color from [tileColors] (`(r, g, b, a)` in `[0, 1]`), so a
+/// tile never bleeds into its neighbor. Cells past `tileColors.length` are left
+/// transparent.
+///
+/// This is a stand-in for a real texture pack: generate the pixels, upload them
+/// to a [gpu.Texture], and hand that to a [TextureAtlas]. Useful for tests and
+/// for bringing up the atlas path before final art exists.
+/// {@category Assets and loading}
+Uint8List generateSolidColorAtlasPixels({
+  required List<Vector4> tileColors,
+  required int columns,
+  required int tileSize,
+  int padding = 0,
+}) {
+  assert(columns > 0);
+  assert(tileSize > 0);
+  assert(padding >= 0);
+  final rows = (tileColors.length / columns).ceil();
+  final cell = tileSize + 2 * padding;
+  final width = columns * cell;
+  final height = rows * cell;
+  final pixels = Uint8List(width * height * 4); // Zero-filled = transparent.
+  for (var i = 0; i < tileColors.length; i++) {
+    final color = tileColors[i];
+    final r = (color.x * 255.0).round().clamp(0, 255);
+    final g = (color.y * 255.0).round().clamp(0, 255);
+    final b = (color.z * 255.0).round().clamp(0, 255);
+    final a = (color.w * 255.0).round().clamp(0, 255);
+    final x0 = (i % columns) * cell;
+    final y0 = (i ~/ columns) * cell;
+    for (var y = y0; y < y0 + cell; y++) {
+      var p = (y * width + x0) * 4;
+      for (var x = 0; x < cell; x++) {
+        pixels[p++] = r;
+        pixels[p++] = g;
+        pixels[p++] = b;
+        pixels[p++] = a;
+      }
+    }
+  }
+  return pixels;
 }

--- a/packages/flutter_scene/lib/src/texture_atlas.dart
+++ b/packages/flutter_scene/lib/src/texture_atlas.dart
@@ -1,0 +1,102 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'gpu/gpu.dart' as gpu;
+import 'material/physically_based_material.dart';
+
+/// A uniform grid texture atlas: one or more equally sized PBR maps packed as
+/// `columns` x `rows` square tiles, with an optional gutter of [padding] texels
+/// around each tile so mip sampling does not bleed across tile edges.
+///
+/// The atlas does the UV bookkeeping for tiled content (voxel block faces,
+/// sprite sheets, terrain tiles). Resolve a tile's atlas-space UV box with
+/// [tileBounds], or map a within-tile coordinate with [tileUv]; a mesh writes
+/// those UVs into its texture coordinates so a single material and draw call
+/// covers every tile.
+///
+/// Maps follow the glTF metallic-roughness convention ([baseColor],
+/// [metallicRoughness] with metallic in B and roughness in G, [normal],
+/// [occlusion]); [toMaterial] wires them into a [PhysicallyBasedMaterial].
+///
+/// This is a CPU-side atlas (one packed texture). Once Flutter GPU gains 2D
+/// array textures, a tile becomes an array layer and this padding/inset dance
+/// is no longer needed; see the texture-array work tracked upstream.
+/// {@category Assets and loading}
+class TextureAtlas {
+  /// Creates an atlas of [columns] x [rows] tiles, each [tileSize] texels
+  /// square, separated by [padding] texels of gutter. The PBR maps are
+  /// optional so the UV math can be used (and unit tested) on its own.
+  TextureAtlas({
+    required this.columns,
+    required this.rows,
+    required this.tileSize,
+    this.padding = 0,
+    this.baseColor,
+    this.metallicRoughness,
+    this.normal,
+    this.occlusion,
+  }) : assert(columns > 0),
+       assert(rows > 0),
+       assert(tileSize > 0),
+       assert(padding >= 0);
+
+  /// Tile grid dimensions.
+  final int columns;
+  final int rows;
+
+  /// Edge length of a tile's content area, in texels.
+  final int tileSize;
+
+  /// Gutter of (typically edge-replicated) texels around each tile, in texels.
+  final int padding;
+
+  /// Packed PBR maps, all sharing the same grid layout. Any may be null.
+  final gpu.Texture? baseColor;
+  final gpu.Texture? metallicRoughness;
+  final gpu.Texture? normal;
+  final gpu.Texture? occlusion;
+
+  /// Total number of tiles.
+  int get tileCount => columns * rows;
+
+  int get _cellSize => tileSize + 2 * padding;
+
+  /// Atlas dimensions in texels (including the padding gutters).
+  int get width => columns * _cellSize;
+  int get height => rows * _cellSize;
+
+  /// The atlas-space UV box of tile [index]'s content area as
+  /// `(minU, minV, maxU, maxV)`, inset past the padding gutter so sampling
+  /// stays inside the tile. Tiles are row-major with a top-left origin.
+  Vector4 tileBounds(int index) {
+    assert(index >= 0 && index < tileCount);
+    final col = index % columns;
+    final row = index ~/ columns;
+    final x0 = col * _cellSize + padding;
+    final y0 = row * _cellSize + padding;
+    final w = width.toDouble();
+    final h = height.toDouble();
+    return Vector4(x0 / w, y0 / h, (x0 + tileSize) / w, (y0 + tileSize) / h);
+  }
+
+  /// Maps a within-tile coordinate ([u], [v], each in `[0, 1]` with (0, 0) at
+  /// the tile's top-left) to an atlas UV for tile [index].
+  Vector2 tileUv(int index, double u, double v) {
+    final bounds = tileBounds(index);
+    return Vector2(
+      bounds.x + (bounds.z - bounds.x) * u,
+      bounds.y + (bounds.w - bounds.y) * v,
+    );
+  }
+
+  /// Builds a [PhysicallyBasedMaterial] bound to this atlas's maps. The factors
+  /// are left at their identity defaults so the textures drive the result; the
+  /// caller picks alpha mode, vertex-color weight, and so on.
+  PhysicallyBasedMaterial toMaterial() {
+    return PhysicallyBasedMaterial(
+      baseColorTexture: baseColor,
+      metallicRoughnessTexture: metallicRoughness,
+      normalTexture: normal,
+      occlusionTexture: occlusion,
+    );
+  }
+}

--- a/packages/flutter_scene/shaders/flutter_scene_linear_depth_normal.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_linear_depth_normal.frag
@@ -1,13 +1,15 @@
 // Fragment shader for the camera depth prepass when a consumer also needs
-// per-pixel normals (screen-space reflections).
+// per-pixel normals and roughness (screen-space reflections).
 //
 // Like LinearDepthFragment it writes planar view-space depth into the red
-// channel, but it also writes the smooth, interpolated view-space normal
-// into the green/blue/alpha channels of the same floating-point target (the
-// depth uses only red, so the normal rides along at no extra attachment
-// cost). Reflections need the shaded vertex normal, not a face normal
-// reconstructed from depth, so that curved surfaces reflect smoothly rather
-// than per-triangle.
+// channel, but it also packs the smooth interpolated view-space normal
+// (octahedral, two components) into green/blue and the perceptual roughness
+// into alpha of the same floating-point target, at no extra attachment cost.
+// Reflections need the shaded vertex normal, not a face normal reconstructed
+// from depth, so that curved surfaces reflect smoothly rather than
+// per-triangle; the roughness lets the trace fade out on rough surfaces
+// (which have no coherent screen-space reflection) and fall back to the
+// image-based reflection.
 //
 // Pairs with the engine's full vertex shaders (UnskinnedVertex /
 // SkinnedVertex), which provide the world-space v_normal and v_viewvector.
@@ -18,6 +20,7 @@
 
 uniform DepthNormalInfo {
   // xyz: normalized world-space camera forward (eye into the scene).
+  // w: perceptual roughness multiplier (the material's roughnessFactor).
   vec4 camera_forward;
   // xyz: world-space camera right axis.
   vec4 camera_right;
@@ -25,6 +28,22 @@ uniform DepthNormalInfo {
   vec4 camera_up;
 }
 info;
+
+// The material's metallic-roughness map (roughness in G), so the trace has a
+// per-pixel roughness. A white placeholder is bound for materials without one,
+// leaving roughness at the factor.
+uniform sampler2D metallic_roughness_texture;
+
+// Octahedral-encode a unit vector into two components in [-1, 1]. The prepass
+// target is float, so the encoding is stored directly; SsrFragment decodes it.
+vec2 OctEncode(vec3 n) {
+  n /= (abs(n.x) + abs(n.y) + abs(n.z));
+  vec2 e = n.z >= 0.0
+      ? n.xy
+      : (1.0 - abs(n.yx)) *
+            vec2(n.x >= 0.0 ? 1.0 : -1.0, n.y >= 0.0 ? 1.0 : -1.0);
+  return e;
+}
 
 void main() {
   // v_viewvector is (camera_position - world_position); negating it and
@@ -38,5 +57,11 @@ void main() {
                                     dot(n, info.camera_up.xyz),
                                     dot(n, info.camera_forward.xyz)));
 
-  frag_color = vec4(view_depth, view_normal);
+  float roughness = clamp(
+      texture(metallic_roughness_texture, v_texture_coords).g *
+          info.camera_forward.w,
+      0.0, 1.0);
+
+  vec2 oct = OctEncode(view_normal);
+  frag_color = vec4(view_depth, oct.x, oct.y, roughness);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_ssr.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssr.frag
@@ -87,6 +87,23 @@ vec2 UvFromView(vec3 p) {
 // Un-premultiplies a sampled premultiplied-alpha color.
 vec3 Unpremultiply(vec4 c) { return c.a > 0.0 ? c.rgb / c.a : vec3(0.0); }
 
+// Decodes a view-space normal octahedral-packed into two components by the
+// depth-normal prepass (LinearDepthNormalFragment).
+vec3 OctDecode(vec2 e) {
+  vec3 n = vec3(e, 1.0 - abs(e.x) - abs(e.y));
+  float t = max(-n.z, 0.0);
+  n.x += n.x >= 0.0 ? -t : t;
+  n.y += n.y >= 0.0 ? -t : t;
+  return normalize(n);
+}
+
+// Perceptual-roughness window over which the trace fades out: a screen-space
+// reflection is only coherent on smooth surfaces, so below kSsrRoughnessLow it
+// is full strength and above kSsrRoughnessHigh it is gone (the surface keeps
+// the image-based reflection instead).
+const float kSsrRoughnessLow = 0.25;
+const float kSsrRoughnessHigh = 0.55;
+
 void main() {
   float near = ssr.proj.z;
   float far = ssr.proj.w;
@@ -111,7 +128,7 @@ void main() {
     return;
   }
   if (debug_view == 3) {
-    vec3 dn = normalize(depth_sample.gba);
+    vec3 dn = OctDecode(depth_sample.gb);
     frag_color = vec4(dn * 0.5 + 0.5, 1.0);
     return;
   }
@@ -122,11 +139,21 @@ void main() {
     return;
   }
 
-  // The smooth, interpolated view-space normal written by the depth prepass
-  // (in green/blue/alpha). Using the shaded vertex normal rather than one
-  // reconstructed from depth keeps reflections smooth across curved
-  // surfaces instead of faceted per triangle.
-  vec3 normal = normalize(depth_sample.gba);
+  // The smooth, interpolated view-space normal (octahedral in green/blue) and
+  // perceptual roughness (alpha) written by the depth prepass. Using the
+  // shaded vertex normal rather than one reconstructed from depth keeps
+  // reflections smooth across curved surfaces instead of faceted per triangle.
+  vec3 normal = OctDecode(depth_sample.gb);
+  float roughness = depth_sample.a;
+
+  // Screen-space reflections are only coherent on smooth surfaces; fade the
+  // whole trace out as roughness rises, leaving the image-based reflection.
+  float roughness_fade =
+      1.0 - smoothstep(kSsrRoughnessLow, kSsrRoughnessHigh, roughness);
+  if (roughness_fade <= 0.0) {
+    frag_color = vec4(0.0);
+    return;
+  }
 
   // View-space reflection of the eye-to-pixel ray about the surface normal.
   vec3 incident = normalize(origin);
@@ -224,7 +251,7 @@ void main() {
       // that occluder's, not the reflected surface's. Reject it and keep
       // marching (so a valid surface further along can still be found, and
       // if none is, the pixel falls back to its image-based reflection).
-      vec3 hit_normal = normalize(texture(linear_depth, candidate_uv).gba);
+      vec3 hit_normal = OctDecode(texture(linear_depth, candidate_uv).gb);
       float facing_hit = -dot(reflection, hit_normal);
       if (facing_hit > 0.0) {
         hit_t = hi;
@@ -275,7 +302,8 @@ void main() {
   // roughness (a thin reflectivity prepass) instead of a global intensity.
   float facing = clamp(dot(normal, -incident), 0.0, 1.0);
   float fresnel = 0.04 + 0.96 * pow(1.0 - facing, 5.0);
-  float strength = clamp(confidence * intensity * fresnel, 0.0, 1.0);
+  float strength =
+      clamp(confidence * intensity * fresnel * roughness_fade, 0.0, 1.0);
 
   // Glossy blur of the reflected color. The radius grows with the blur
   // strength and the hit distance, so a rougher surface (or a more distant

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -38,8 +38,8 @@ void Surface(inout MaterialInputs material) {
   //       (camera_position - vertex_position).
   vec3 normal = normalize(v_normal);
   if (frag_info.has_normal_map > 0.5) {
-    normal =
-        PerturbNormal(normal_texture, normal, v_viewvector, v_texture_coords);
+    normal = PerturbNormal(normal_texture, normal, v_viewvector,
+                           v_texture_coords, frag_info.normal_scale);
   }
   material.normal = normal;
 

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -64,6 +64,16 @@ uniform FragInfo {
   // screen between them. Occupies std140 padding before the mat4, so the
   // block size is unchanged. See lod_fade.glsl.
   float fade;
+  // Geometric specular antialiasing (Kaplanyan/Tokuyoshi). specular_aa_variance
+  // scales the screen-space normal-derivative variance estimate; a normal map
+  // or high-curvature surface packs sub-pixel normal variation that the
+  // specular lobe otherwise turns into shimmer, so this widens roughness to
+  // average the lobe over the pixel's normal cone. specular_aa_threshold caps
+  // how much extra roughness it can add. A variance of 0 disables it. Both
+  // occupy the std140 padding after `fade` (before the mat4), so the block size
+  // is unchanged.
+  float specular_aa_variance;
+  float specular_aa_threshold;
   // Rotates the image-based-lighting environment: the diffuse-SH and
   // prefiltered-radiance lookup directions are transformed by this before
   // sampling. Identity leaves the environment unrotated. A mat4 (not mat3)

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -248,13 +248,21 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // camera.
   float n_dot_v = max(dot(normal, camera_normal), 0.0);
 
+  // The view angle for the image-based specular energy (Fresnel and the split-
+  // sum LUT) uses the geometric normal, not the perturbed one. That energy term
+  // is a macro-surface quantity, and near grazing the Fresnel is steep, so
+  // feeding it the normal-mapped n_dot_v turns sub-pixel normal detail into a
+  // blotchy brightness aliasing. The reflection direction below still uses the
+  // perturbed normal, so surface relief is preserved where it belongs.
+  float n_dot_v_energy = max(dot(GetWorldNormal(), camera_normal), 0.0);
+
   // reflect() needs the incident ray (camera -> surface); camera_normal
   // points surface -> camera, so negate it. Sampling the environment with
   // the un-negated vector would mirror reflections to the opposite side.
   vec3 reflection_normal = reflect(-camera_normal, normal);
 
   // Roughness-dependent Fresnel reflectance for the indirect specular lobe.
-  vec3 k_S = FresnelSchlickRoughness(n_dot_v, reflectance, roughness);
+  vec3 k_S = FresnelSchlickRoughness(n_dot_v_energy, reflectance, roughness);
 
   // The IBL environment can be rotated; transform the lookup directions.
   mat3 environment_transform = mat3(frag_info.environment_transform);
@@ -282,8 +290,10 @@ vec4 EvaluateLighting(MaterialInputs material) {
 
   // Split-sum DFG terms (Karis '13). The LUT is sampled slightly inside
   // [0, 1] to avoid edge-tap artifacts.
-  vec2 f_ab =
-      texture(brdf_lut, clamp(vec2(n_dot_v, 1.0 - roughness), 0.0, 0.99)).rg;
+  vec2 f_ab = texture(
+                  brdf_lut,
+                  clamp(vec2(n_dot_v_energy, 1.0 - roughness), 0.0, 0.99))
+                  .rg;
 
   // Single- and multiple-scattering energy compensation (Fdez-Aguera 2019;
   // see https://bruop.github.io/ibl/). Without the multiscatter term, rough

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -282,7 +282,8 @@ vec4 EvaluateLighting(MaterialInputs material) {
 
   // Split-sum DFG terms (Karis '13). The LUT is sampled slightly inside
   // [0, 1] to avoid edge-tap artifacts.
-  vec2 f_ab = texture(brdf_lut, clamp(vec2(n_dot_v, roughness), 0.0, 0.99)).rg;
+  vec2 f_ab =
+      texture(brdf_lut, clamp(vec2(n_dot_v, 1.0 - roughness), 0.0, 0.99)).rg;
 
   // Single- and multiple-scattering energy compensation (Fdez-Aguera 2019;
   // see https://bruop.github.io/ibl/). Without the multiscatter term, rough

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -308,12 +308,19 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // 0 (at or past the terminator) to 1 (sun-facing) over a small band, so the
   // sun's influence falls off smoothly rather than at a hard line.
   float n_dot_l = 0.0;
+  float geometric_n_dot_l = 0.0;
   vec3 light_vector = vec3(0.0);
   if (frag_info.has_directional_light > 0.5) {
     light_vector = -normalize(frag_info.directional_light_direction.xyz);
     n_dot_l = dot(normal, light_vector);
+    geometric_n_dot_l = dot(GetWorldNormal(), light_vector);
   }
-  float facing = clamp(n_dot_l / 0.15, 0.0, 1.0);
+  // Whether the surface faces the sun is a geometric property, so gate the
+  // shadow terms on the geometric normal. Using the perturbed normal lets a
+  // normal map's relief push n_dot_l across the terminator on a nearly sun-
+  // facing face (worst near a low sun), spuriously darkening the shadow-ambient
+  // term on bumpy top faces.
+  float facing = clamp(geometric_n_dot_l / 0.15, 0.0, 1.0);
 
   // Sun-shadow visibility (1 lit .. 0 shadowed). The shadow map is only
   // meaningful for sun-facing surfaces; a back face receives no sun by
@@ -323,7 +330,7 @@ vec4 EvaluateLighting(MaterialInputs material) {
   float shadow =
       (frag_info.has_directional_light > 0.5 && frag_info.casts_shadow > 0.5 &&
        facing > 0.0)
-          ? SampleShadow(v_position, normal)
+          ? SampleShadow(v_position, GetWorldNormal())
           : 1.0;
   float sun_visibility = facing * shadow;
 

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -206,6 +206,26 @@ vec4 EvaluateLighting(MaterialInputs material) {
   float metallic = material.metallic;
   float roughness = material.roughness;
 
+  // Geometric specular antialiasing (Kaplanyan/Tokuyoshi). A
+  // normal map or high-curvature surface carries more normal detail than a
+  // pixel can resolve; the specular lobe turns that sub-pixel variation into
+  // shimmering highlights. Estimate the variation from the screen-space
+  // derivatives of the shading normal and widen the roughness so the lobe is
+  // averaged over the pixel's cone of normals. The condition is on a uniform,
+  // so the derivatives are evaluated under uniform control flow.
+  if (frag_info.specular_aa_variance > 0.0) {
+    vec3 d_normal_x = dFdx(normal);
+    vec3 d_normal_y = dFdy(normal);
+    float variance = frag_info.specular_aa_variance *
+                     (dot(d_normal_x, d_normal_x) + dot(d_normal_y, d_normal_y));
+    float kernel = min(2.0 * variance, frag_info.specular_aa_threshold);
+    // Widen in the squared-roughness (alpha) domain, then convert back:
+    // alpha = roughness^2, so roughness^4 is the alpha^2 the kernel adds to.
+    float widened = clamp(roughness * roughness * roughness * roughness + kernel,
+                          0.0, 1.0);
+    roughness = clamp(sqrt(sqrt(widened)), kMinRoughness, 1.0);
+  }
+
   // Diffuse occlusion: the material's (baked) occlusion modulated by the
   // screen-space ambient occlusion when it is enabled. Occlusion only ever
   // affects indirect lighting, never the analytic direct light below.

--- a/packages/flutter_scene/shaders/normals.glsl
+++ b/packages/flutter_scene/shaders/normals.glsl
@@ -31,11 +31,14 @@ mat3 CotangentFrame(vec3 normal, vec3 view_vector, vec2 uv) {
 }
 
 vec3 PerturbNormal(sampler2D normal_tex, vec3 normal, vec3 view_vector,
-                   vec2 texcoord) {
+                   vec2 texcoord, float scale) {
   vec3 map = texture(normal_tex, texcoord).xyz;
   map = map * 255. / 127. - 128. / 127.;
   // map.z = sqrt(1. - dot(map.xy, map.xy));
   // map.y = -map.y;
+  // glTF normalScale: attenuate the tangent-plane (xy) components, leaving z, so
+  // a scale below 1 flattens the perturbation toward the geometric normal.
+  map.xy *= scale;
   mat3 TBN = CotangentFrame(normal, -view_vector, texcoord);
   return normalize(TBN * map).xyz;
 }

--- a/packages/flutter_scene/test/mipmap_test.dart
+++ b/packages/flutter_scene/test/mipmap_test.dart
@@ -1,0 +1,80 @@
+/// Covers CPU mip-chain generation: chain sizing, and content-aware
+/// downsampling (sRGB color averaged in linear light, data averaged directly,
+/// normals averaged as vectors and renormalized).
+library;
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/texture/mipmap.dart';
+import 'package:test/test.dart';
+
+Uint8List _solid(int w, int h, int r, int g, int b, int a) {
+  final p = Uint8List(w * h * 4);
+  for (var i = 0; i < w * h; i++) {
+    p[i * 4] = r;
+    p[i * 4 + 1] = g;
+    p[i * 4 + 2] = b;
+    p[i * 4 + 3] = a;
+  }
+  return p;
+}
+
+void main() {
+  test('mipLevelCountFor is floor(log2(max)) + 1', () {
+    expect(mipLevelCountFor(256, 256), 9);
+    expect(mipLevelCountFor(1, 1), 1);
+    expect(mipLevelCountFor(8, 2), 4);
+  });
+
+  test('chain halves down to 1x1 with level 0 first', () {
+    final chain = generateMipChain(
+      _solid(4, 4, 10, 20, 30, 255),
+      4,
+      4,
+      TextureContent.data,
+    );
+    expect(chain.map((l) => '${l.width}x${l.height}'), ['4x4', '2x2', '1x1']);
+    // A solid image stays solid at every level.
+    expect(chain.last.pixels, [10, 20, 30, 255]);
+  });
+
+  test('color content averages in linear light, not naively', () {
+    // A 2x2 checker of black and white. Naive byte average = 127; correct
+    // linear average is 0.5 in linear -> ~188 in sRGB.
+    final pixels = Uint8List.fromList([
+      0, 0, 0, 255, // black
+      255, 255, 255, 255, // white
+      255, 255, 255, 255, // white
+      0, 0, 0, 255, // black
+    ]);
+    final chain = generateMipChain(pixels, 2, 2, TextureContent.color);
+    final mip = chain[1].pixels; // 1x1
+    expect(mip[0], greaterThan(180));
+    expect(mip[0], lessThan(195));
+  });
+
+  test('data content averages bytes directly', () {
+    final pixels = Uint8List.fromList([
+      0, 0, 0, 0, //
+      255, 255, 255, 255, //
+      255, 255, 255, 255, //
+      0, 0, 0, 0, //
+    ]);
+    final chain = generateMipChain(pixels, 2, 2, TextureContent.data);
+    expect(chain[1].pixels, [128, 128, 128, 128]);
+  });
+
+  test('normal content renormalizes to a unit vector', () {
+    // Flat normals (0,0,1) encoded as (128,128,255) stay flat.
+    final chain = generateMipChain(
+      _solid(2, 2, 128, 128, 255, 255),
+      2,
+      2,
+      TextureContent.normal,
+    );
+    final mip = chain[1].pixels;
+    expect(mip[0], closeTo(128, 1));
+    expect(mip[1], closeTo(128, 1));
+    expect(mip[2], closeTo(255, 1));
+  });
+}

--- a/packages/flutter_scene/test/render_texture_test.dart
+++ b/packages/flutter_scene/test/render_texture_test.dart
@@ -117,28 +117,26 @@ void main() {
     return;
   }
 
-  test('material texture slots accept render textures', () async {
+  test('material texture slots accept texture sources', () async {
     await Scene.initializeStaticResources();
 
     final target = RenderTexture(width: 8, height: 8);
     final pbr = PhysicallyBasedMaterial();
 
-    // No completed frame yet resolves to null (placeholder applies at
-    // draw time).
+    // The slot holds the source; a render texture with no completed frame
+    // yet resolves (internally) to null so the placeholder applies at draw.
     pbr.baseColorTexture = target;
-    expect(pbr.baseColorTexture, isNull);
+    expect(pbr.baseColorTexture, same(target));
+    expect(target.sampledTexture, isNull);
 
-    // Static textures keep working verbatim, and bogus values throw.
-    final white = Material.getWhitePlaceholderTexture();
+    // A raw GPU texture can be bound via GpuTextureSource.
+    final white = GpuTextureSource(Material.getWhitePlaceholderTexture());
     pbr.baseColorTexture = white;
     expect(pbr.baseColorTexture, same(white));
-    expect(() => pbr.baseColorTexture = 'nope', throwsArgumentError);
 
     final unlit = UnlitMaterial();
     unlit.baseColorTexture = target;
-    // Unlit's getter never returns null; an empty render texture resolves
-    // to the white placeholder.
-    expect(unlit.baseColorTexture, same(white));
+    expect(unlit.baseColorTexture, same(target));
   });
 
   test('texture publishes on markUpdated, not on acquire', () async {

--- a/packages/flutter_scene/test/texture_atlas_test.dart
+++ b/packages/flutter_scene/test/texture_atlas_test.dart
@@ -1,0 +1,76 @@
+/// Covers the UV bookkeeping of [TextureAtlas]: grid dimensions, per-tile UV
+/// bounds with and without a padding gutter, row-major indexing, and the
+/// within-tile UV mapping.
+library;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math.dart';
+
+// Vector4/Vector2 are float32-backed, so compare with a float tolerance.
+const double _eps = 1e-6;
+
+void expectVec4(Vector4 actual, double x, double y, double z, double w) {
+  expect(actual.x, closeTo(x, _eps));
+  expect(actual.y, closeTo(y, _eps));
+  expect(actual.z, closeTo(z, _eps));
+  expect(actual.w, closeTo(w, _eps));
+}
+
+void main() {
+  group('TextureAtlas grid', () {
+    test('reports tile count and pixel dimensions (no padding)', () {
+      final atlas = TextureAtlas(columns: 4, rows: 2, tileSize: 16);
+      expect(atlas.tileCount, 8);
+      expect(atlas.width, 64);
+      expect(atlas.height, 32);
+    });
+
+    test('padding widens the cells', () {
+      final atlas = TextureAtlas(columns: 4, rows: 2, tileSize: 16, padding: 2);
+      // cell = 16 + 2*2 = 20.
+      expect(atlas.width, 80);
+      expect(atlas.height, 40);
+    });
+  });
+
+  group('tileBounds', () {
+    test('maps tiles row-major with a top-left origin (no padding)', () {
+      final atlas = TextureAtlas(columns: 4, rows: 2, tileSize: 16);
+      // width=64, height=32. Each tile is 0.25 wide, 0.5 tall.
+      // Tile 0 = top-left.
+      expectVec4(atlas.tileBounds(0), 0.0, 0.0, 0.25, 0.5);
+      // Tile 3 = top-right.
+      expectVec4(atlas.tileBounds(3), 0.75, 0.0, 1.0, 0.5);
+      // Tile 4 = start of the second row.
+      expectVec4(atlas.tileBounds(4), 0.0, 0.5, 0.25, 1.0);
+      // Tile 7 = bottom-right.
+      expectVec4(atlas.tileBounds(7), 0.75, 0.5, 1.0, 1.0);
+    });
+
+    test('insets past the padding gutter', () {
+      final atlas = TextureAtlas(columns: 2, rows: 1, tileSize: 16, padding: 2);
+      // cell=20, width=40, height=20.
+      // Tile 0 content starts at (padding, padding) = (2, 2), spans 16.
+      expectVec4(atlas.tileBounds(0), 2 / 40, 2 / 20, 18 / 40, 18 / 20);
+      // Tile 1 content starts at (20 + 2, 2) = (22, 2).
+      expectVec4(atlas.tileBounds(1), 22 / 40, 2 / 20, 38 / 40, 18 / 20);
+    });
+  });
+
+  group('tileUv', () {
+    test('maps within-tile corners to the tile bounds', () {
+      final atlas = TextureAtlas(columns: 4, rows: 2, tileSize: 16);
+      final bounds = atlas.tileBounds(5);
+      final topLeft = atlas.tileUv(5, 0, 0);
+      final bottomRight = atlas.tileUv(5, 1, 1);
+      final center = atlas.tileUv(5, 0.5, 0.5);
+      expect(topLeft.x, closeTo(bounds.x, _eps));
+      expect(topLeft.y, closeTo(bounds.y, _eps));
+      expect(bottomRight.x, closeTo(bounds.z, _eps));
+      expect(bottomRight.y, closeTo(bounds.w, _eps));
+      expect(center.x, closeTo((bounds.x + bounds.z) / 2, _eps));
+      expect(center.y, closeTo((bounds.y + bounds.w) / 2, _eps));
+    });
+  });
+}

--- a/packages/flutter_scene/test/texture_atlas_test.dart
+++ b/packages/flutter_scene/test/texture_atlas_test.dart
@@ -58,6 +58,78 @@ void main() {
     });
   });
 
+  group('generateSolidColorAtlasPixels', () {
+    // RGBA byte offset of pixel (x, y) in a row-major image of the given width.
+    int at(int x, int y, int width) => (y * width + x) * 4;
+
+    test('fills each cell (content and padding) with the tile color', () {
+      final red = Vector4(1, 0, 0, 1);
+      final green = Vector4(0, 1, 0, 1);
+      final pixels = generateSolidColorAtlasPixels(
+        tileColors: [red, green],
+        columns: 2,
+        tileSize: 2,
+        padding: 1,
+      );
+      // cell = 4, width = 8, height = 4.
+      const width = 8;
+      expect(pixels.length, 8 * 4 * 4);
+      // Tile 0 (red) content center at (1, 1).
+      expect(pixels.sublist(at(1, 1, width), at(1, 1, width) + 4), [
+        255,
+        0,
+        0,
+        255,
+      ]);
+      // Tile 0 padding corner at (0, 0) is still red (no bleed).
+      expect(pixels.sublist(at(0, 0, width), at(0, 0, width) + 4), [
+        255,
+        0,
+        0,
+        255,
+      ]);
+      // Tile 1 (green) starts at cell x = 4; content at (5, 1).
+      expect(pixels.sublist(at(5, 1, width), at(5, 1, width) + 4), [
+        0,
+        255,
+        0,
+        255,
+      ]);
+    });
+
+    test('leaves cells past the color list transparent', () {
+      // 2 columns, 3 colors -> 2 rows, tile 3 (index 3) is empty.
+      final pixels = generateSolidColorAtlasPixels(
+        tileColors: [
+          Vector4(1, 1, 1, 1),
+          Vector4(1, 1, 1, 1),
+          Vector4(1, 1, 1, 1),
+        ],
+        columns: 2,
+        tileSize: 1,
+      );
+      // width = 2, height = 2. Tile 3 is bottom-right at (1, 1).
+      const width = 2;
+      expect(pixels.sublist(at(1, 1, width), at(1, 1, width) + 4), [
+        0,
+        0,
+        0,
+        0,
+      ]);
+    });
+
+    test('lays out matching a TextureAtlas of the same params', () {
+      final atlas = TextureAtlas(columns: 4, rows: 2, tileSize: 16, padding: 2);
+      final pixels = generateSolidColorAtlasPixels(
+        tileColors: List.filled(8, Vector4(1, 1, 1, 1)),
+        columns: 4,
+        tileSize: 16,
+        padding: 2,
+      );
+      expect(pixels.length, atlas.width * atlas.height * 4);
+    });
+  });
+
   group('tileUv', () {
     test('maps within-tile corners to the tile bounds', () {
       final atlas = TextureAtlas(columns: 4, rows: 2, tileSize: 16);

--- a/packages/flutter_scene/test/texture_sampling_test.dart
+++ b/packages/flutter_scene/test/texture_sampling_test.dart
@@ -1,0 +1,36 @@
+/// Covers TextureSampling.toSamplerOptions: the trilinear + anisotropic
+/// defaults, and the guard that drops anisotropy when a filter is nearest
+/// (which the backend rejects).
+library;
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/texture/texture2d.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('defaults are trilinear and anisotropic', () {
+    final options = const TextureSampling().toSamplerOptions();
+    expect(options.minFilter, gpu.MinMagFilter.linear);
+    expect(options.magFilter, gpu.MinMagFilter.linear);
+    expect(options.mipFilter, gpu.MipFilter.linear);
+    expect(options.maxAnisotropy, 8);
+  });
+
+  test(
+    'disabling mipmaps forces a nearest mip filter and drops anisotropy',
+    () {
+      // A nearest mip filter cannot be paired with anisotropy > 1, so the guard
+      // must clamp it back to 1 to keep the sampler valid.
+      final options = const TextureSampling(mipmaps: false).toSamplerOptions();
+      expect(options.mipFilter, gpu.MipFilter.nearest);
+      expect(options.maxAnisotropy, 1);
+    },
+  );
+
+  test('a nearest min filter also drops anisotropy', () {
+    final options = const TextureSampling(
+      minFilter: gpu.MinMagFilter.nearest,
+    ).toSamplerOptions();
+    expect(options.maxAnisotropy, 1);
+  });
+}


### PR DESCRIPTION
Adds mipmapped, anisotropically filtered textures and a grid texture atlas, and fixes several image-based lighting bugs found while building a textured voxel scene.

The headline is `Texture2D`, a texture with generated mipmaps and trilinear plus anisotropic sampling, built from an asset, a `ui.Image`, or raw pixels. `TextureContent` chooses how each mip level is filtered (color in linear light, raw data, or renormalized normals) and `TextureSampling` controls the mip filter, maximum mip level, and anisotropy. The runtime glTF loader now routes its textures through `Texture2D`, so imported models are mipmapped.

Breaking change. The material texture slots (`baseColorTexture`, `metallicRoughnessTexture`, `normalTexture`, `emissiveTexture`, `occlusionTexture`) now hold a `TextureSource` instead of a raw `gpu.Texture`. Assign a `Texture2D` or a `RenderTexture` directly, or wrap an existing `gpu.Texture` in `GpuTextureSource`.

New API
- `Texture2D`, `TextureSource`, `GpuTextureSource`, `TextureSampling`, and `TextureContent`.
- `TextureAtlas` and `generateSolidColorAtlasPixels` for packing a uniform grid of tiles (voxel faces, sprite sheets, terrain); it resolves per-tile UVs and can build a `PhysicallyBasedMaterial` from its maps.
- Geometric specular antialiasing on `PhysicallyBasedMaterial` (`specularAntiAliasingVariance`, `specularAntiAliasingThreshold`), which widens roughness where the shading normal varies quickly to curb distant specular sparkle.

Fixes
- The split-sum specular sampled the BRDF integration lookup with its roughness axis flipped, so rough surfaces got mirror-strength reflections and washed out. Fixed.
- Image-based lighting took the shadow-ambient gate and the specular Fresnel term from the normal-mapped normal, which darkened bumpy surfaces under a low sun and made grazing reflections blotchy. Both now use the geometric normal; the reflection direction still follows the normal map.
- `normalScale` was not applied to the perturbed normal.
- Screen-space reflections now fade out on rough surfaces. The camera depth prepass carries per-pixel roughness, so smooth surfaces still reflect while rough ones stop.

Testing
- `flutter analyze` clean; 740 unit tests pass, with new coverage for mipmap generation, texture sampling, and the atlas.
- `dart_style` (master channel) formatting clean.
- `pana` 140/160; the two gaps are the pre-existing dartdoc tool crash and the WASM platform sub-check, neither introduced here (this branch adds no dependencies and no `dart:io` imports).
- Cross-backend smoke matrix (Metal/GLES/Vulkan/WebGL2) still to run before merge.
