### PR TITLE
Wrap widget-texture captures as GPU textures instead of copying bytes

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## 0.19.0
 
+* Widget-texture captures (`WidgetTexture`, `WidgetComponent`) now stay on the
+  GPU. Each capture wraps the rasterized image's backing texture directly
+  (`Texture.fromImage`) instead of reading the pixels back and re-uploading
+  them, removing the per-capture CPU round trip. Backends where the image is
+  not texture-backed (the web backend, software rendering) keep the readback
+  path automatically. The texture object published by
+  `WidgetTextureController` is now replaced across captures on the wrapped
+  path, so `WidgetComponent`'s `bind` callback re-fires per capture; listeners
+  that re-bind on change (the documented contract) are unaffected.
+
 * Built-in materials and geometries can now be constructed before
   `Scene.initializeStaticResources()` finishes loading the base shader bundle.
   Each resolves its shader from the base library lazily on first render (which

--- a/packages/flutter_scene/lib/src/components/widget_component.dart
+++ b/packages/flutter_scene/lib/src/components/widget_component.dart
@@ -44,9 +44,10 @@ enum WidgetInput {
 ///    mesh is created at all (for surfaces that already exist, like a screen
 ///    inside an imported model).
 ///
-/// The texture object is stable across captures (overwritten in place) and
-/// replaced only when the capture size changes; [bind] re-fires exactly on
-/// replacement.
+/// Each capture wraps the rasterized image's backing texture directly, so
+/// the texture object is replaced across captures and [bind] re-fires per
+/// capture (on the readback fallback path it is overwritten in place and
+/// [bind] re-fires only when the capture size changes).
 /// {@category Widgets}
 // TODO(widget-component): WidgetInput.automatic via ScenePointer (phase 3).
 // TODO(fscene): serialize the component spec (size, policy, geometry) with a

--- a/packages/flutter_scene/lib/src/gpu/stub/shim_stubs.dart
+++ b/packages/flutter_scene/lib/src/gpu/stub/shim_stubs.dart
@@ -89,6 +89,8 @@ base class Texture {
   Texture._() {
     _stub();
   }
+  factory Texture.fromImage(GpuContext gpuContext, ui.Image image) =>
+      Texture._();
   StorageMode get storageMode => _stub();
   PixelFormat get format => _stub();
   int get width => _stub();

--- a/packages/flutter_scene/lib/src/gpu/web/texture.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/texture.dart
@@ -176,6 +176,19 @@ base class Texture {
     _valid = true;
   }
 
+  /// Wrapping a `ui.Image`'s backing texture is not possible on this backend:
+  /// the framework rasterizes with its own WebGL context, and browsers do not
+  /// share textures across contexts. Always throws, mirroring flutter_gpu's
+  /// contract for an image that is not backed by a compatible GPU texture;
+  /// callers fall back to `Image.toByteData` plus [overwrite].
+  factory Texture.fromImage(GpuContext gpuContext, ui.Image image) {
+    throw Exception(
+      'Texture.fromImage could not wrap the image because it is not backed '
+      'by a compatible GPU texture. The web backend cannot share textures '
+      'with the framework; read the image back and upload it instead.',
+    );
+  }
+
   final GpuContext _gpuContext;
   final StorageMode storageMode;
   final PixelFormat format;

--- a/packages/flutter_scene/lib/src/widget_texture.dart
+++ b/packages/flutter_scene/lib/src/widget_texture.dart
@@ -15,8 +15,8 @@ sealed class WidgetUpdatePolicy {
 
   /// Capture every frame while attached (the default). Captures are
   /// throttled to one in flight, and the recording itself reuses the
-  /// child's retained layers, so the steady-state cost is the rasterize
-  /// and readback of content that is actually changing.
+  /// child's retained layers, so the steady-state cost is rasterizing
+  /// the content that is actually changing.
   ///
   /// Per-frame capture is the only trigger that observes every change:
   /// repaints inside the child's own repaint boundaries (scrollable items,
@@ -49,17 +49,15 @@ class _ManualUpdatePolicy extends WidgetUpdatePolicy {
 ///
 /// Bind [texture] to any material texture slot (for example
 /// `PhysicallyBasedMaterial.baseColorTexture`). It is null until the first
-/// capture completes; listen for changes to pick it up (the texture object is
-/// also replaced when the capture size changes).
+/// capture completes; listen for changes to pick it up, and expect the
+/// texture object itself to be replaced across captures.
 ///
-/// Captures round-trip through the CPU today (rasterize, read back, upload),
-/// so treat this as a correct-but-slow path: captures are throttled to one in
-/// flight and only run when the child subtree actually repaints, but each one
-/// costs a readback on the raster thread plus a byte upload.
+/// A capture rasterizes the child and wraps the resulting image's backing
+/// GPU texture directly (`gpu.Texture.fromImage`), so no pixel data crosses
+/// the CPU. On backends where the image cannot be wrapped (the web backend,
+/// software rendering) it falls back to reading the bytes back and uploading
+/// them. Captures are throttled to one in flight either way.
 /// {@category Widgets}
-// TODO(widget-textures): keep the snapshot on the GPU once the engine can
-// wrap a ui.Image's backing texture as a flutter_gpu texture (the planned
-// gpu.Texture.fromImage); the capture and binding API stays the same.
 class WidgetTextureController extends ChangeNotifier {
   gpu.Texture? _texture;
   Duration _lastCaptureDuration = Duration.zero;
@@ -69,16 +67,31 @@ class WidgetTextureController extends ChangeNotifier {
   /// The most recent capture, or null before the first one completes.
   gpu.Texture? get texture => _texture;
 
-  /// Wall-clock duration of the last capture round trip (rasterize, read
-  /// back, upload), for diagnostics.
+  /// Wall-clock duration of the last capture (rasterize and wrap, plus the
+  /// readback and upload on the fallback path), for diagnostics.
   Duration get lastCaptureDuration => _lastCaptureDuration;
 
   /// Total completed captures, for diagnostics.
   int get captureCount => _captureCount;
 
-  void _publish(ByteData bytes, int width, int height, Duration elapsed) {
+  /// Publishes a capture wrapped directly from the rasterized image's
+  /// backing texture (the zero-copy path).
+  void _publishWrapped(gpu.Texture texture, Duration elapsed) {
+    _texture = texture;
+    _lastCaptureDuration = elapsed;
+    _captureCount++;
+    notifyListeners();
+  }
+
+  /// Publishes a capture from read-back bytes (the fallback path). The
+  /// backing texture is reused and overwritten in place while the capture
+  /// size is stable.
+  void _publishBytes(ByteData bytes, int width, int height, Duration elapsed) {
     var texture = _texture;
-    if (texture == null || texture.width != width || texture.height != height) {
+    if (texture == null ||
+        texture.width != width ||
+        texture.height != height ||
+        texture.storageMode != gpu.StorageMode.hostVisible) {
       texture = gpu.gpuContext.createTexture(
         gpu.StorageMode.hostVisible,
         width,
@@ -441,6 +454,11 @@ class _RenderWidgetTexture extends RenderProxyBox {
     }
   }
 
+  // Whether gpu.Texture.fromImage can wrap captures on this backend. Cleared
+  // by the first failed wrap (the web backend, software rendering) so later
+  // captures skip straight to the readback fallback.
+  bool _wrapSupported = true;
+
   Future<void> _pumpCapture() async {
     if (_captureInFlight) return;
     _captureInFlight = true;
@@ -455,18 +473,39 @@ class _RenderWidgetTexture extends RenderProxyBox {
             Offset.zero & _captureSize,
             pixelRatio: _pixelRatio,
           );
-          final bytes = await image.toByteData(
-            format: ui.ImageByteFormat.rawStraightRgba,
-          );
-          if (bytes != null && attached) {
-            _controller._publish(
-              bytes,
-              image.width,
-              image.height,
-              stopwatch.elapsed,
-            );
+          try {
+            gpu.Texture? wrapped;
+            if (_wrapSupported) {
+              try {
+                wrapped = gpu.Texture.fromImage(gpu.gpuContext, image);
+              } on Exception {
+                // The image is not backed by a wrappable GPU texture on this
+                // backend; read back and upload from here on.
+                _wrapSupported = false;
+              }
+            }
+            if (!attached) {
+              // Detached mid-capture; drop the result.
+            } else if (wrapped != null) {
+              _controller._publishWrapped(wrapped, stopwatch.elapsed);
+            } else {
+              final bytes = await image.toByteData(
+                format: ui.ImageByteFormat.rawStraightRgba,
+              );
+              if (bytes != null && attached) {
+                _controller._publishBytes(
+                  bytes,
+                  image.width,
+                  image.height,
+                  stopwatch.elapsed,
+                );
+              }
+            }
+          } finally {
+            // A wrapped texture shares the image's storage and keeps it
+            // alive, so disposing the image is safe on both paths.
+            image.dispose();
           }
-          image.dispose();
         } finally {
           layer.dispose();
         }


### PR DESCRIPTION
Widget-texture captures (`WidgetTexture`, `WidgetComponent`) previously round-tripped every capture through the CPU, rasterize, `Image.toByteData`, then re-upload into a `gpu.Texture`. `Texture.fromImage` can now wrap the rasterized image's backing GPU texture directly, so captures stay on the GPU with no pixel copy.

The wrap is capability-detected, not platform-gated. It is attempted on the first capture; on backends where the image is not texture-backed (the web backend, software rendering, which is what `flutter test` uses) it throws, the host latches onto the readback path, and behavior is unchanged there. The readback path additionally refuses to reuse a non-host-visible texture, so the two paths can never interleave writes onto one texture.

One behavioral note, on the wrapped path the published texture object is replaced per capture instead of overwritten in place. `WidgetComponent` already re-binds on object change, so its `bind` callback now fires per capture; the documented listen-and-rebind contract is unchanged. The public API is untouched.

The web shim and the analyzer stub gain the `Texture.fromImage` surface. The web implementation throws the same contract exception flutter_gpu uses for an image with no wrappable texture, since browsers cannot share textures across WebGL contexts; if a faster web ingestion path becomes available later, it slots in behind the same API.

Verified on macOS (widget-texture example renders, the in-screen controls stay interactive, captures on the wrapped path) and Chrome (fallback latches silently, no per-frame errors, example behaves as before). `flutter analyze` clean and all 740 tests pass, which exercises the fallback path end to end.
