### PR TITLE
Add a driveable car physics example

### DIFF
--- a/examples/flutter_app/lib/example_physics_car.dart
+++ b/examples/flutter_app/lib/example_physics_car.dart
@@ -1,0 +1,456 @@
+import 'dart:math' as math;
+
+// flutter_scene's physics BoxShape clashes with Flutter's painting BoxShape,
+// and flutter_scene's Material class clashes with the Flutter Material widget.
+// This example uses the physics BoxShape and the Flutter Material widget, so
+// each conflicting name is hidden from the other import.
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart' hide BoxShape;
+import 'package:flutter/services.dart';
+import 'package:flutter_scene/scene.dart' hide Material;
+import 'package:flutter_scene_rapier/flutter_scene_rapier.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'character/character_controls.dart';
+import 'character/character_input.dart';
+import 'character/third_person_camera.dart';
+import 'example_settings.dart';
+import 'raycast_vehicle.dart';
+
+/// Drive a car with raycast wheels. WASD / arrow keys (or the on-screen
+/// joystick) steer and drive; the space bar (or the button) is the
+/// handbrake, and Shift boosts. The car is a single dynamic Rapier chassis;
+/// it can plow through the dynamic crates. Each wheel is a
+/// downward ray that applies suspension and tire forces, and the model's
+/// wheel nodes are posed to follow the suspension, steering, and roll.
+class ExamplePhysicsCar extends StatefulWidget {
+  const ExamplePhysicsCar({super.key});
+
+  @override
+  ExamplePhysicsCarState createState() => ExamplePhysicsCarState();
+}
+
+class ExamplePhysicsCarState extends State<ExamplePhysicsCar> {
+  final Scene scene = Scene();
+  late final RapierWorld world;
+
+  final CharacterInput _input = CharacterInput();
+  final ThirdPersonCamera _camera = ThirdPersonCamera(
+    distance: 16.0,
+    lookHeight: 1.5,
+    pitch: 0.34,
+  );
+
+  // The dynamic chassis body and its controller.
+  Node? _carNode;
+  RaycastVehicle? _vehicle;
+  bool _loaded = false;
+
+  // Where the car (re)spawns, a little above the ground.
+  static final vm.Vector3 _spawn = vm.Vector3(0, 0.9, 0);
+
+  // Speedometer readout, refreshed each frame without rebuilding the tree.
+  final ValueNotifier<double> _speed = ValueNotifier<double>(0.0);
+
+  @override
+  void initState() {
+    super.initState();
+
+    scene.root.addComponent(
+      DirectionalLightComponent(
+        DirectionalLight(
+          direction: vm.Vector3(-0.5, -1.0, -0.35),
+          intensity: 3.0,
+          castsShadow: true,
+          shadowMaxDistance: 60.0,
+        ),
+      ),
+    );
+
+    world = RapierWorld(gravity: vm.Vector3(0, -9.81, 0));
+    scene.root.addComponent(world);
+
+    _buildGround();
+    _buildCourse();
+    _buildProps();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final car = await loadScene('assets_src/fcar.glb');
+    final environment = await EnvironmentMap.fromAssets(
+      radianceImagePath: 'assets/little_paris_eiffel_tower.png',
+    );
+    if (!mounted) return;
+
+    scene.environment = environment;
+    scene.exposure = 2.5;
+    scene.skybox = Skybox(EnvironmentSkySource()..blurriness = 0.25);
+
+    _carNode = _buildCar(car);
+    scene.add(_carNode!);
+
+    // Point the chase camera at the car straight away.
+    _camera.yaw = 0.0;
+
+    setState(() => _loaded = true);
+  }
+
+  // --- Scene construction ---------------------------------------------------
+
+  Mesh _boxMesh(vm.Vector3 size, vm.Vector4 color, {double roughness = 0.7}) {
+    final material = PhysicallyBasedMaterial()
+      ..baseColorFactor = color
+      ..roughnessFactor = roughness
+      ..metallicFactor = 0.0;
+    return Mesh(CuboidGeometry(size), material);
+  }
+
+  Node _addStaticBox(
+    vm.Vector3 center,
+    vm.Vector3 halfExtents,
+    vm.Vector4 color, {
+    vm.Quaternion? rotation,
+    double friction = 1.0,
+  }) {
+    final transform = rotation == null
+        ? vm.Matrix4.translation(center)
+        : vm.Matrix4.compose(center, rotation, vm.Vector3.all(1.0));
+    final node = Node(
+      mesh: _boxMesh(halfExtents * 2.0, color),
+      localTransform: transform,
+    );
+    node.addComponent(RapierRigidBody(type: BodyType.fixed));
+    node.addComponent(
+      RapierCollider(
+        shape: BoxShape(halfExtents: halfExtents),
+        material: PhysicsMaterial(friction: friction, restitution: 0.0),
+      ),
+    );
+    scene.add(node);
+    return node;
+  }
+
+  // A dynamic crate the car can shove and scatter. Its density sets the mass,
+  // so lighter crates fly further.
+  Node _addDynamicBox(
+    vm.Vector3 center,
+    vm.Vector3 halfExtents,
+    vm.Vector4 color, {
+    double density = 2.0,
+  }) {
+    final node = Node(
+      mesh: _boxMesh(halfExtents * 2.0, color, roughness: 0.85),
+      localTransform: vm.Matrix4.translation(center),
+    );
+    node.addComponent(RapierRigidBody(type: BodyType.dynamic_));
+    node.addComponent(
+      RapierCollider(
+        shape: BoxShape(halfExtents: halfExtents),
+        material: PhysicsMaterial(
+          friction: 0.7,
+          restitution: 0.0,
+          density: density,
+        ),
+      ),
+    );
+    scene.add(node);
+    return node;
+  }
+
+  void _buildGround() {
+    _addStaticBox(
+      vm.Vector3(0, -0.5, 0),
+      vm.Vector3(120, 0.5, 120),
+      vm.Vector4(0.42, 0.46, 0.40, 1),
+    );
+  }
+
+  // A short course: a launch ramp, a couple of speed bumps, and low walls to
+  // bump into so the suspension and chassis physics are visible.
+  void _buildCourse() {
+    // Launch ramp ahead of the spawn (+X is the car's forward).
+    _addStaticBox(
+      vm.Vector3(34, 1.6, 0),
+      vm.Vector3(7, 0.4, 8),
+      vm.Vector4(0.80, 0.55, 0.30, 1),
+      rotation: vm.Quaternion.axisAngle(vm.Vector3(0, 0, 1), 0.32),
+    );
+
+    // A run of speed bumps off to one side.
+    for (var i = 0; i < 4; i++) {
+      _addStaticBox(
+        vm.Vector3(6.0 + i * 9.0, 0.18, -26),
+        vm.Vector3(4.5, 0.35, 5.0),
+        vm.Vector4(0.70, 0.72, 0.30, 1),
+      );
+    }
+
+    // A boundary of low walls, offset so it frames the play area.
+    const arena = 70.0;
+    final wallColor = vm.Vector4(0.55, 0.35, 0.35, 1);
+    _addStaticBox(
+      vm.Vector3(arena, 1.2, 0),
+      vm.Vector3(1.5, 1.2, arena),
+      wallColor,
+    );
+    _addStaticBox(
+      vm.Vector3(-arena, 1.2, 0),
+      vm.Vector3(1.5, 1.2, arena),
+      wallColor,
+    );
+    _addStaticBox(
+      vm.Vector3(0, 1.2, arena),
+      vm.Vector3(arena, 1.2, 1.5),
+      wallColor,
+    );
+    _addStaticBox(
+      vm.Vector3(0, 1.2, -arena),
+      vm.Vector3(arena, 1.2, 1.5),
+      wallColor,
+    );
+  }
+
+  // Scatterable dynamic obstacles the car can plow through: a crate pyramid, a
+  // tall stack, a row of skittles across the driving line, and loose crates.
+  void _buildProps() {
+    final crate = vm.Vector4(0.72, 0.52, 0.30, 1);
+    final crate2 = vm.Vector4(0.62, 0.44, 0.26, 1);
+    const half = 0.9; // Crate half-extent (1.8 units cubed).
+
+    vm.Vector3 crateHalf() => vm.Vector3.all(half);
+
+    // A 4-3-2-1 pyramid off to the right.
+    for (var level = 0; level < 4; level++) {
+      final count = 4 - level;
+      final y = half + level * (half * 2);
+      final z0 = -(count - 1) * half;
+      for (var i = 0; i < count; i++) {
+        _addDynamicBox(
+          vm.Vector3(17.0, y, 9.0 + z0 + i * (half * 2)),
+          crateHalf(),
+          i.isEven ? crate : crate2,
+        );
+      }
+    }
+
+    // A tall stack straight ahead to topple.
+    for (var i = 0; i < 5; i++) {
+      _addDynamicBox(
+        vm.Vector3(26.0, half + i * (half * 2), -7.0),
+        crateHalf(),
+        i.isEven ? crate : crate2,
+      );
+    }
+
+    // A row of tall skittles across the forward driving line.
+    final pin = vm.Vector4(0.85, 0.85, 0.88, 1);
+    for (var i = 0; i < 6; i++) {
+      _addDynamicBox(
+        vm.Vector3(14.0, 1.4, -4.5 + i * 1.8),
+        vm.Vector3(0.35, 1.4, 0.35),
+        pin,
+        density: 1.2,
+      );
+    }
+
+    // Loose crates scattered around the arena.
+    const scatter = [
+      [9.0, -12.0],
+      [12.0, -16.0],
+      [20.0, 2.0],
+      [22.0, 14.0],
+      [-14.0, 8.0],
+      [-20.0, -10.0],
+      [-9.0, -18.0],
+      [6.0, 20.0],
+    ];
+    for (var i = 0; i < scatter.length; i++) {
+      final s = scatter[i];
+      _addDynamicBox(
+        vm.Vector3(s[0], half, s[1]),
+        crateHalf(),
+        i.isEven ? crate : crate2,
+      );
+    }
+  }
+
+  // Builds the chassis body node with the car model parented under it, wires
+  // the four wheels to the vehicle controller, and returns the chassis node.
+  Node _buildCar(Node carModel) {
+    final chassis = Node(
+      name: 'CarChassis',
+      localTransform: vm.Matrix4.translation(_spawn),
+    );
+    chassis.add(carModel);
+
+    chassis.addComponent(
+      RapierRigidBody(
+        type: BodyType.dynamic_,
+        linearDamping: 0.08,
+        angularDamping: 0.85,
+        ccdEnabled: true,
+      ),
+    );
+    // A box wrapping the lower body, sitting just above the wheels so only the
+    // raycasts touch the ground. Kept low and shallow so the center of mass is
+    // low: a high COM makes lateral tire forces (applied at the contacts) roll
+    // the car over in turns. Its density sets the chassis mass.
+    chassis.addComponent(
+      RapierCollider(
+        shape: BoxShape(halfExtents: vm.Vector3(3.6, 0.55, 1.6)),
+        material: const PhysicsMaterial(
+          friction: 0.4,
+          restitution: 0.0,
+          density: 42.0,
+        ),
+        localPose: vm.Matrix4.translation(vm.Vector3(-0.2, 0.8, 0)),
+      ),
+    );
+
+    VehicleWheel wheel(
+      String name, {
+      required bool powered,
+      required bool steered,
+    }) {
+      final node = carModel.getChildByNamePath([name])!;
+      return VehicleWheel(node: node, powered: powered, steered: steered);
+    }
+
+    _vehicle = RaycastVehicle(
+      wheels: [
+        wheel('WheelFront.L', powered: false, steered: true),
+        wheel('WheelFront.R', powered: false, steered: true),
+        wheel('WheelBack.L', powered: true, steered: false),
+        wheel('WheelBack.R', powered: true, steered: false),
+      ],
+    );
+    chassis.addComponent(_vehicle!);
+    return chassis;
+  }
+
+  void _reset() {
+    final car = _carNode;
+    if (car == null) return;
+    // Unmount to destroy the dynamic body, replant it at the spawn pose, and
+    // remount so a fresh body is created there at rest.
+    scene.remove(car);
+    car.localTransform = vm.Matrix4.translation(_spawn);
+    scene.add(car);
+  }
+
+  @override
+  void dispose() {
+    _speed.dispose();
+    scene.removeAll();
+    super.dispose();
+  }
+
+  // --- Per-frame ------------------------------------------------------------
+
+  static const double _dragYawPerPixel = 0.006;
+  static const double _keyYawRate = 2.2;
+
+  void _onTick(Duration elapsed, double deltaSeconds) {
+    final dt = deltaSeconds.clamp(0.0, 0.05);
+    final vehicle = _vehicle;
+    final car = _carNode;
+    if (vehicle == null || car == null) return;
+
+    // Feed control intent to the vehicle. Forward on the stick drives, right
+    // steers right, space is the handbrake.
+    vehicle.throttle = _input.move.y.clamp(-1.0, 1.0);
+    vehicle.steer = _input.move.x.clamp(-1.0, 1.0);
+    vehicle.handbrake = _input.jump;
+    // Hold Shift to boost (harder acceleration).
+    vehicle.boost = HardwareKeyboard.instance.isShiftPressed;
+
+    // Manual camera orbit from a drag or the arrow keys.
+    final drag = _input.lookDelta.clone();
+    _input.lookDelta.setZero();
+    final manualYaw =
+        drag.x * _dragYawPerPixel + _input.lookRate.x * _keyYawRate * dt;
+    _camera.yaw += manualYaw;
+
+    scene.update(dt);
+
+    // Chase the car. When it is driving and the player is not orbiting, ease
+    // the camera behind the car's heading.
+    final carTransform = car.globalTransform;
+    final carPos = carTransform.getTranslation();
+    final forward = carTransform.transformed3(vm.Vector3(1, 0, 0))..sub(carPos);
+    final speed = vehicle.forwardSpeed;
+    if (manualYaw == 0 && speed.abs() > 1.5) {
+      final headingYaw = math.atan2(forward.x, forward.z);
+      // Face the way the car travels (reverse looks over the hood).
+      final target = speed >= 0 ? headingYaw : headingYaw + math.pi;
+      var delta = target - _camera.yaw;
+      delta = math.atan2(math.sin(delta), math.cos(delta)); // wrap to [-pi, pi]
+      _camera.yaw += delta * (1.0 - math.exp(-2.5 * dt));
+    }
+    _camera.follow(carPos, dt);
+
+    _speed.value = speed.abs();
+    exampleSettings.applyTo(scene);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_loaded) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return Stack(
+      children: [
+        CharacterControls(
+          input: _input,
+          child: SceneView(
+            scene,
+            cameraBuilder: (elapsed) => _camera.camera,
+            onTick: _onTick,
+          ),
+        ),
+        Positioned(top: 16, right: 16, child: _Speedometer(_speed)),
+        Positioned(
+          top: 16,
+          right: 140,
+          child: FloatingActionButton.small(
+            heroTag: 'car-reset',
+            onPressed: _reset,
+            child: const Icon(Icons.refresh),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Speedometer extends StatelessWidget {
+  const _Speedometer(this.speed);
+
+  final ValueListenable<double> speed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: ValueListenableBuilder<double>(
+        valueListenable: speed,
+        builder: (context, value, _) => Text(
+          // Roughly mph: units/s treated as m/s, converted and rounded for a
+          // lively readout.
+          '${(value * 2.23694).round()} mph',
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+            fontFeatures: [FontFeature.tabularFigures()],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -20,6 +20,7 @@ import 'example_logo.dart';
 import 'example_nav_route.dart';
 import 'example_physics.dart';
 import 'example_physics_box3d.dart';
+import 'example_physics_car.dart';
 import 'example_render_target.dart';
 import 'example_settings.dart';
 import 'example_shapes.dart';
@@ -96,6 +97,17 @@ class _MyAppState extends State<MyApp> {
             return const Center(child: CircularProgressIndicator());
           }
           return const ExamplePhysicsBox3d();
+        },
+      ),
+      'Car Physics': (context) => FutureBuilder<void>(
+        // Shares the Rapier backend with the Physics example, so it waits on
+        // the same wasm load before building its world.
+        future: _physicsReady,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          return const ExamplePhysicsCar();
         },
       ),
       'Shapes': (context) => FutureBuilder<void>(

--- a/examples/flutter_app/lib/raycast_vehicle.dart
+++ b/examples/flutter_app/lib/raycast_vehicle.dart
@@ -1,0 +1,300 @@
+import 'dart:math' as math;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_rapier/flutter_scene_rapier.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// One wheel of a [RaycastVehicle]: the visual node to pose, whether it is
+/// driven and/or steered, plus the per-frame suspension and spin state the
+/// controller writes.
+class VehicleWheel {
+  VehicleWheel({
+    required this.node,
+    required this.powered,
+    required this.steered,
+  });
+
+  /// The model node posed each frame (suspension travel, steer, spin).
+  final Node node;
+
+  /// Whether engine torque is applied through this wheel.
+  final bool powered;
+
+  /// Whether this wheel turns with the steering input.
+  final bool steered;
+
+  // Captured on mount: the wheel's rest local transform and its rest center
+  // in the chassis body frame (the ray's rest position). Re-captured on every
+  // mount so the car can be respawned (unmount + remount).
+  Matrix4 _restTransform = Matrix4.identity();
+  Vector3 _mountLocal = Vector3.zero();
+
+  // Live state.
+  bool grounded = false;
+  double _suspensionOffset = 0.0; // Upward visual offset from rest.
+  double _spin = 0.0; // Accumulated roll angle, radians.
+}
+
+/// A raycast (arcade) car built on a single dynamic chassis body. Each wheel
+/// is a downward ray from the chassis; where it hits the ground the
+/// controller applies a spring/damper suspension force plus tire friction
+/// (lateral grip and longitudinal drive/brake), all bounded by a per-wheel
+/// friction circle. The wheel model nodes are posed to follow the
+/// suspension, steering, and roll.
+///
+/// Attach it to the chassis node alongside a [RapierRigidBody] and a
+/// collider. Drive it by writing [throttle], [steer], and [handbrake] each
+/// frame.
+///
+/// The controller reads the live chassis pose from the Rapier body and
+/// raycasts through the shared world, so it only touches Rapier for those
+/// two hooks; the suspension and tire model are engine-agnostic.
+class RaycastVehicle extends Component {
+  RaycastVehicle({
+    required this.wheels,
+    this.wheelRadius = 0.58,
+    this.suspensionTravel = 0.35,
+    this.maxVisualLift = 0.22,
+    this.suspensionStiffness = 42000.0,
+    this.suspensionDamping = 4200.0,
+    this.engineForce = 14000.0,
+    this.boostForce = 9000.0,
+    this.brakeForce = 30000.0,
+    this.rollingResistance = 120.0,
+    this.lateralGrip = 16000.0,
+    this.tireFriction = 1.1,
+    this.maxSteerAngle = 0.5,
+    this.steerSpeed = 6.0,
+  });
+
+  final List<VehicleWheel> wheels;
+
+  /// Wheel radius in world units; sets where the ray meets the ground and
+  /// the roll rate.
+  final double wheelRadius;
+
+  /// Maximum suspension extension from the top mount to the wheel's rest.
+  final double suspensionTravel;
+
+  /// How far the wheel model may visually rise into its arch under
+  /// compression, independent of the physics [suspensionTravel]. Kept below
+  /// the arch clearance so a hard bump never pushes the wheel through the
+  /// body mesh, while the physics stays compliant.
+  final double maxVisualLift;
+
+  /// Spring rate (force per unit compression) and damper rate (force per
+  /// unit compression velocity).
+  final double suspensionStiffness;
+  final double suspensionDamping;
+
+  /// Longitudinal force a powered wheel applies at full throttle, and the
+  /// braking force at full handbrake. Both are clamped by the friction
+  /// circle so grip, not the raw number, sets the limit.
+  final double engineForce;
+  final double brakeForce;
+
+  /// Extra forward thrust applied at the chassis center while [boost] is held
+  /// and the car is driving forward on the ground. Applied at the center of
+  /// mass (not through the tires), so it is not grip-limited and does not
+  /// cause wheelspin, it just accelerates harder.
+  final double boostForce;
+
+  /// Passive longitudinal drag that slows a coasting car (force per m/s).
+  final double rollingResistance;
+
+  /// Lateral grip: sideways force per m/s of side-slip, before the friction
+  /// circle clamp. Higher corners harder before sliding.
+  final double lateralGrip;
+
+  /// Friction-circle coefficient: the combined tire force is capped at
+  /// `tireFriction * suspensionForce`, so a lightly loaded wheel grips less.
+  final double tireFriction;
+
+  /// Steering lock in radians, and how fast the steer angle eases toward the
+  /// input (per second).
+  final double maxSteerAngle;
+  final double steerSpeed;
+
+  /// Control inputs, written by the driver each frame. All in `[-1, 1]`
+  /// except [handbrake] and [boost].
+  double throttle = 0.0;
+  double steer = 0.0;
+  bool handbrake = false;
+  bool boost = false;
+
+  RapierRigidBody? _body;
+  RapierWorld? _world;
+  double _steerAngle = 0.0;
+
+  /// Forward speed along the chassis, in world units per second. Useful for a
+  /// speedometer readout.
+  double get forwardSpeed => _forwardSpeed;
+  double _forwardSpeed = 0.0;
+
+  @override
+  void onMount() {
+    final body = node.getComponent<RapierRigidBody>();
+    if (body == null) return;
+    _body = body;
+    _world = body.nativeWorld;
+
+    // Capture each wheel's rest pose and its rest center in the chassis body
+    // frame. Reading it from the live transforms keeps the controller
+    // agnostic to the model's import flip and layout. Capture once (the true
+    // rest), but zero the live state on every mount so a respawn starts clean.
+    final invBody = node.globalTransform.clone()..invert();
+    for (final wheel in wheels) {
+      if (!_captured) {
+        wheel._restTransform = wheel.node.localTransform.clone();
+        final worldCenter = wheel.node.globalTransform.getTranslation();
+        wheel._mountLocal = invBody.transformed3(worldCenter);
+      }
+      wheel._spin = 0.0;
+      wheel._suspensionOffset = 0.0;
+      wheel.grounded = false;
+    }
+    _captured = true;
+    _steerAngle = 0.0;
+    _forwardSpeed = 0.0;
+  }
+
+  bool _captured = false;
+
+  @override
+  void onUnmount() {
+    _body = null;
+    _world = null;
+  }
+
+  @override
+  void fixedUpdate(double fixedDt) {
+    final body = _body;
+    final world = _world;
+    if (body == null || world == null || fixedDt <= 0) return;
+
+    final origin = body.readNativeTranslation();
+    final basis = body.readNativeRotation().asRotationMatrix();
+    final up = basis.transformed(Vector3(0, 1, 0));
+    final chassisForward = basis.transformed(Vector3(1, 0, 0));
+
+    // Ease the steer angle toward the input so the wheels do not snap.
+    final targetSteer = steer.clamp(-1.0, 1.0) * maxSteerAngle;
+    _steerAngle +=
+        (targetSteer - _steerAngle) * (1.0 - math.exp(-steerSpeed * fixedDt));
+
+    final linVel = body.linearVelocity;
+    final angVel = body.angularVelocity;
+    _forwardSpeed = linVel.dot(chassisForward);
+
+    var anyGrounded = false;
+    for (final wheel in wheels) {
+      final mountWorld = origin + basis.transformed(wheel._mountLocal.clone());
+      final rayOrigin = mountWorld + up * suspensionTravel;
+      final hit = world.raycast(
+        Ray.originDirection(rayOrigin, -up),
+        maxDistance: suspensionTravel + wheelRadius,
+        // Rays read the drivable surface (fixed ground and ramps) and must
+        // skip the car's own dynamic chassis, so dynamic bodies are excluded.
+        // TODO(vehicle-ray-filter): drop this once raycast can exclude a
+        // specific body, so the car can also drive over dynamic props.
+        includeDynamic: false,
+      );
+
+      if (hit == null) {
+        wheel.grounded = false;
+        // Relax the wheel back to full droop while airborne.
+        wheel._suspensionOffset +=
+            (0.0 - wheel._suspensionOffset) * (1.0 - math.exp(-8.0 * fixedDt));
+        continue;
+      }
+      wheel.grounded = true;
+      anyGrounded = true;
+
+      // Suspension length from the top mount to the wheel center.
+      final currentLength = (hit.distance - wheelRadius).clamp(
+        0.0,
+        suspensionTravel,
+      );
+      // Visual lift is capped so the wheel never rises through the arch, even
+      // though the physics below uses the full compression.
+      wheel._suspensionOffset = math.min(
+        suspensionTravel - currentLength,
+        maxVisualLift,
+      );
+
+      // Velocity of the chassis at the contact point.
+      final r = hit.worldPoint - origin;
+      final pointVel = linVel + angVel.cross(r);
+
+      // Spring + damper along the suspension axis, never pulling down.
+      final upVel = pointVel.dot(up);
+      var suspensionForce =
+          suspensionStiffness * (suspensionTravel - currentLength) -
+          suspensionDamping * upVel;
+      if (suspensionForce < 0) suspensionForce = 0;
+      body.applyForce(up * suspensionForce, atWorldPoint: mountWorld);
+
+      // Tire basis in the contact plane. Right is up x forward; steered
+      // wheels rotate their basis about the chassis up axis.
+      var wheelForward = chassisForward.clone();
+      var wheelRight = up.cross(chassisForward)..normalize();
+      if (wheel.steered && _steerAngle != 0) {
+        final c = math.cos(_steerAngle);
+        final s = math.sin(_steerAngle);
+        final f = wheelForward * c + wheelRight * s;
+        final rt = wheelRight * c - wheelForward * s;
+        wheelForward = f;
+        wheelRight = rt;
+      }
+
+      final lonVel = pointVel.dot(wheelForward);
+      final latVel = pointVel.dot(wheelRight);
+
+      // Longitudinal: drive, handbrake, and passive rolling resistance.
+      var lonForce = 0.0;
+      if (wheel.powered) lonForce += throttle.clamp(-1.0, 1.0) * engineForce;
+      lonForce -= lonVel * rollingResistance;
+      if (handbrake) lonForce -= lonVel * brakeForce;
+
+      // Lateral: resist side-slip.
+      final latForce = -latVel * lateralGrip;
+
+      // Clamp the combined tire force to the friction circle set by load.
+      final maxForce = suspensionForce * tireFriction;
+      var fx = lonForce;
+      var fy = latForce;
+      final mag = math.sqrt(fx * fx + fy * fy);
+      if (maxForce > 0 && mag > maxForce) {
+        final k = maxForce / mag;
+        fx *= k;
+        fy *= k;
+      }
+      body.applyForce(
+        wheelForward * fx + wheelRight * fy,
+        atWorldPoint: hit.worldPoint,
+      );
+
+      // Roll the wheel from the ground speed under it.
+      wheel._spin += (lonVel / wheelRadius) * fixedDt;
+    }
+
+    // Boost: extra straight-line thrust at the chassis center while driving
+    // forward on the ground, so holding it accelerates harder.
+    final throttleForward = throttle.clamp(0.0, 1.0);
+    if (boost && anyGrounded && throttleForward > 0) {
+      body.applyForce(chassisForward * (boostForce * throttleForward));
+    }
+  }
+
+  @override
+  void update(double deltaSeconds) {
+    for (final wheel in wheels) {
+      final steerAngle = wheel.steered ? _steerAngle : 0.0;
+      wheel.node.localTransform =
+          Matrix4.translation(Vector3(0, wheel._suspensionOffset, 0)) *
+          wheel._restTransform *
+          Matrix4.rotationY(-steerAngle) *
+          Matrix4.rotationZ(-wheel._spin);
+    }
+  }
+}


### PR DESCRIPTION
Adds a driveable car physics example to the example app, built on the Rapier backend.

The car is a single dynamic chassis with four raycast wheels. Each wheel casts a ray down from the chassis and, where it meets the ground, applies a spring/damper suspension force plus tire friction (lateral grip and longitudinal drive/brake) bounded by a per-wheel friction circle. The model's wheel nodes are posed each frame to follow suspension travel, steering, and roll. The suspension and tire model are written against the shared physics contract (raycast and applyForce), so only the live pose reads are backend specific.

Drive with WASD/arrow keys or the on-screen joystick, space is the handbrake, and shift boosts. The car scatters dynamic crates around a small course (a launch ramp, speed bumps, a crate pyramid, a stack, and a row of skittles). A chase camera eases behind the car's heading, with an mph readout and a reset button.

Reuses fcar.glb from the asset corpus, whose named wheel nodes are posed individually. The new files are lib/raycast_vehicle.dart (a reusable RaycastVehicle component) and lib/example_physics_car.dart, wired into the example picker as "Car Physics".

Verified on macOS with Impeller. The cross-backend smoke matrix still needs a pass before merge.