### PR TITLE
Fix SSAO/SSR depth prepass for custom materials, add optional AO depth mip chain

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -13,6 +13,15 @@
   at a missing uniform slot. The generated fragment now keeps the block
   referenced through a zero-bound keep-alive, with no visible effect.
 
+* `AmbientOcclusionSettings.depthMipChain` (off by default) renders the
+  occlusion depth prepass at full resolution and samples it through a
+  downsampled mip chain, a level per sample distance. It keeps depth accurate
+  where the projection compresses a large range into few pixels (grazing
+  surfaces, vertex-displaced worlds), so near geometry's occlusion is not
+  contaminated by the far surface behind it, and keeps large radii
+  cache-friendly. The cost is a full-resolution prepass plus the chain build, so
+  it is best reserved for higher-end targets.
+
 * Widget-texture captures (`WidgetTexture`, `WidgetComponent`) now stay on the
   GPU. Each capture wraps the rasterized image's backing texture directly
   (`Texture.fromImage`) instead of reading the pixels back and re-uploading

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## 0.19.0
 
+* Ambient occlusion and screen-space reflections no longer sample the wrong
+  depth for double-sided (`culling: none`) materials. The depth prepass they
+  read culled every material back-face regardless of its own mode, so a
+  double-sided surface's camera-facing back faces were missing from the depth
+  and the effects shaded the farther surface behind them. The prepass now culls
+  each material with its own mode, matching the color pass.
+
+* A `.fmat` whose parameters are used only in its `vertex { }` stage no longer
+  crashes at draw time. When `Surface()` reads no parameter the compiler stripped
+  the fragment's `MaterialParams` block, and binding the parameters then pointed
+  at a missing uniform slot. The generated fragment now keeps the block
+  referenced through a zero-bound keep-alive, with no visible effect.
+
 * Widget-texture captures (`WidgetTexture`, `WidgetComponent`) now stay on the
   GPU. Each capture wraps the rasterized image's backing texture directly
   (`Texture.fromImage`) instead of reading the pixels back and re-uploading

--- a/packages/flutter_scene/lib/src/ambient_occlusion.dart
+++ b/packages/flutter_scene/lib/src/ambient_occlusion.dart
@@ -46,6 +46,19 @@ class AmbientOcclusionSettings {
   /// cost of fine detail. Recommended on mobile.
   bool halfResolution = true;
 
+  /// Renders the depth prepass at full resolution and samples it through a
+  /// downsampled mip chain (a level per sample distance), instead of rasterising
+  /// the depth at the occlusion resolution.
+  ///
+  /// This is the Scalable Ambient Obscurance depth-mip design. It keeps the
+  /// depth accurate where the projection compresses a large range into few
+  /// pixels (a steep grazing surface or a vertex-displaced "curved world"), so
+  /// the occlusion of near geometry is not contaminated by the far surface
+  /// behind it, and it keeps large radii cache-friendly. The cost is a
+  /// full-resolution depth prepass plus the chain build, so it is off by default
+  /// and best reserved for higher-end targets.
+  bool depthMipChain = false;
+
   /// How indirect specular reflections are occluded. See
   /// [SpecularAmbientOcclusionMode].
   SpecularAmbientOcclusionMode specularMode = SpecularAmbientOcclusionMode.none;

--- a/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
@@ -26,6 +26,17 @@ const String kVertexKeepAliveBlock = 'VertexKeepAlive';
 /// The GLES-fold-safe instance name for [kVertexKeepAliveBlock].
 const String kVertexKeepAliveInstance = 'vertex_keep_alive';
 
+/// The uniform block a generated fragment declares to keep the `MaterialParams`
+/// block live when `Surface()` reads no parameter (e.g. a material whose
+/// parameters are used only in its `Vertex()` stage). The runtime binds it to
+/// zero, so it has no effect; without it the optimizer strips the unreferenced
+/// block, its uniform slot is then absent, and binding the parameters crashes
+/// the Metal backend.
+const String kFragmentKeepAliveBlock = 'FragmentKeepAlive';
+
+/// The GLES-fold-safe instance name for [kFragmentKeepAliveBlock].
+const String kFragmentKeepAliveInstance = 'fragment_keep_alive';
+
 /// The engine vertex variants a material with a `vertex { }` block generates a
 /// shader for, mapping the sidecar key the runtime selects by to the shared
 /// body include that variant reuses. The keys correspond to the geometry a
@@ -95,6 +106,12 @@ String emitFragmentGlsl(FmatMaterial material) {
     sb.writeln('}');
     sb.writeln('$kMaterialParamsInstance;');
     sb.writeln();
+    // Bound to zero by the runtime; main() multiplies a MaterialParams field by
+    // it so the block cannot be optimized out when Surface() reads no parameter
+    // (its uniform slot would then be missing and binding it would crash).
+    sb.writeln('uniform $kFragmentKeepAliveBlock { vec4 keep_alive; }');
+    sb.writeln('$kFragmentKeepAliveInstance;');
+    sb.writeln();
   }
 
   final samplers = material.samplerParameters.toList();
@@ -112,6 +129,16 @@ String emitFragmentGlsl(FmatMaterial material) {
   sb.writeln('void main() {');
   sb.writeln('  MaterialInputs material = InitMaterialInputs();');
   sb.writeln('  Surface(material);');
+  if (uniforms.isNotEmpty) {
+    final first = uniforms.first;
+    final scalar = first.type.glslType == 'float'
+        ? 'material_params.${first.name}'
+        : 'material_params.${first.name}.x';
+    sb.writeln(
+      '  material.base_color.r += '
+      '$kFragmentKeepAliveInstance.keep_alive.x * $scalar;',
+    );
+  }
   if (lit) {
     sb.writeln('  frag_color = EvaluateLighting(material);');
   } else {

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -246,16 +246,26 @@ abstract class Material {
     gpu.HostBuffer transientsBuffer,
     Lighting lighting,
   ) {
-    // Double-sided is honored only for opaque materials. A translucent
-    // material is always back-face culled: drawing both sides would blend the
-    // overlapping front and back surfaces in triangle-index order rather than
-    // depth order (the translucent pass has no per-fragment sorting), which
-    // seams thick double-sided glass. Single-sided draws just the outer
-    // surface.
-    final cullBackFace = !doubleSided || !isOpaque();
-    pass.setCullMode(cullBackFace ? gpu.CullMode.backFace : gpu.CullMode.none);
+    pass.setCullMode(renderCullMode);
     pass.setWindingOrder(gpu.WindingOrder.counterClockwise);
   }
+
+  /// The face-culling mode geometry drawn with this material renders with.
+  ///
+  /// Passes that draw the geometry without calling [bind] (the depth/normal
+  /// prepass behind SSAO and SSR) read this to cull the same faces the color
+  /// pass does. If they disagree, a double-sided material's back faces are
+  /// missing from the prepass and screen-space effects sample the wrong
+  /// (farther) surface where a front face is actually drawn.
+  ///
+  /// Double-sided is honored only for opaque materials. A translucent material
+  /// is always back-face culled: drawing both sides would blend the overlapping
+  /// front and back surfaces in triangle-index order rather than depth order
+  /// (the translucent pass has no per-fragment sorting), which seams thick
+  /// double-sided glass.
+  @internal
+  gpu.CullMode get renderCullMode =>
+      (!doubleSided || !isOpaque()) ? gpu.CullMode.backFace : gpu.CullMode.none;
 
   /// Whether geometry rendered with this material is fully opaque.
   ///

--- a/packages/flutter_scene/lib/src/material/material_parameters.dart
+++ b/packages/flutter_scene/lib/src/material/material_parameters.dart
@@ -2,7 +2,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' show Color;
 
-import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/foundation.dart' show internal, visibleForTesting;
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/fmat/fmat_ast.dart';
@@ -392,6 +392,12 @@ class MaterialParameters {
     }
     throw ArgumentError('Unknown material parameter "$name".');
   }
+
+  /// Whether this material has a non-empty `MaterialParams` uniform block (any
+  /// non-sampler parameters). When false the generated shaders declare no block
+  /// and none is bound.
+  @internal
+  bool get hasUniformBlock => _block.lengthInBytes > 0;
 
   /// Binds only the `MaterialParams` uniform block on [shader] into [pass],
   /// not the sampler parameters. Used to make the block available to the

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -1,5 +1,4 @@
-import 'dart:typed_data';
-
+import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/src/fmat/fmat_ast.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/hot_reload/hot_reloadable_fmat.dart';
@@ -114,7 +113,7 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
     gpu.HostBuffer transientsBuffer,
     Lighting lighting,
   ) {
-    pass.setCullMode(_cullMode(_culling));
+    pass.setCullMode(renderCullMode);
     pass.setWindingOrder(gpu.WindingOrder.counterClockwise);
 
     if (shadingModel == FmatShadingModel.lit) {
@@ -134,10 +133,24 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
     }
 
     parameters.bind(pass, fragmentShader, transientsBuffer);
+    // Bind the fragment keep-alive block (name matches kFragmentKeepAliveBlock
+    // in the emitter) to zero. The generated fragment references MaterialParams
+    // through it so the block is not optimized out when Surface() reads no
+    // parameter; it is declared only when the material has such a block.
+    if (parameters.hasUniformBlock) {
+      pass.bindUniform(
+        fragmentShader.getUniformSlot('FragmentKeepAlive'),
+        transientsBuffer.emplace(_zeroKeepAlive),
+      );
+    }
   }
 
   @override
   bool isOpaque() => _blending == FmatBlending.opaque;
+
+  @override
+  @internal
+  gpu.CullMode get renderCullMode => _cullMode(_culling);
 }
 
 gpu.CullMode _cullMode(FmatCulling culling) => switch (culling) {

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -155,9 +155,9 @@ class _DepthPrepassEncoder {
     _renderPass.setDepthWriteEnable(true);
     _renderPass.setColorBlendEnable(false);
     _renderPass.setDepthCompareOperation(gpu.CompareFunction.lessEqual);
-    // Match the standard materials' winding / culling so the same faces
-    // that are visible contribute depth.
-    _renderPass.setCullMode(gpu.CullMode.backFace);
+    // Winding and culling are matched to each material per draw in [submit]
+    // (winding follows the node/instance parity, culling follows the material's
+    // own mode), so the same faces the color pass draws contribute depth.
     _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
     // The camera axes are constant across the pass. Pack them once and
     // rebind per draw (clearBindings drops the binding between draws). The
@@ -235,6 +235,10 @@ class _DepthPrepassEncoder {
       }
     }
     _renderPass.clearBindings();
+    // Cull the same faces as the color pass; a double-sided (culling: none)
+    // material must stay double-sided here, or its camera-facing back faces are
+    // absent from the prepass and SSAO/SSR read the farther surface behind them.
+    _renderPass.setCullMode(item.material.renderCullMode);
     final geometry = item.geometry;
     // Unskinned geometry draws depth through a position-only shader and layout
     // (fetching only position); skinned geometry has no such variant, so it

--- a/packages/flutter_scene/lib/src/render/ssao_pass.dart
+++ b/packages/flutter_scene/lib/src/render/ssao_pass.dart
@@ -105,15 +105,87 @@ class SsaoPass extends RenderGraphPass {
   static final gpu.Shader _vertexShader =
       baseShaderLibrary['FullscreenVertex']!;
   static final gpu.Shader _fragmentShader = baseShaderLibrary['SsaoFragment']!;
+  static final gpu.Shader _downsampleShader =
+      baseShaderLibrary['DepthDownsampleFragment']!;
+
+  // The depth mip chain matches the fp32 linear-depth prepass format.
+  static const gpu.PixelFormat _depthFormat = gpu.PixelFormat.r32g32b32a32Float;
 
   @override
   String get name => 'SsaoPass';
+
+  // Downsamples [source] into a half-size (rounded down) depth level via the
+  // depth-downsample shader (nearest 2x2 minimum). Used to build the SAO chain.
+  gpu.Texture _downsampleDepth(
+    RenderGraphContext context,
+    gpu.Texture source,
+    int width,
+    int height,
+  ) {
+    final target = context.texturePool.acquire(
+      TransientTextureDescriptor.color(
+        width: width,
+        height: height,
+        format: _depthFormat,
+        debugName: 'depth_mip',
+      ),
+    );
+    final commandBuffer = gpu.gpuContext.createCommandBuffer();
+    final renderPass = commandBuffer.createRenderPass(
+      gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: target)),
+    );
+    renderPass.bindPipeline(
+      gpu.gpuContext.createRenderPipeline(_vertexShader, _downsampleShader),
+    );
+    renderPass.setColorBlendEnable(false);
+    bindVertexBufferCompat(renderPass, _fullscreenQuad(), 6);
+    renderPass.bindTexture(
+      _downsampleShader.getUniformSlot('source'),
+      source,
+      sampler: _nearestClamp,
+    );
+    drawCompat(renderPass, 6);
+    commandBuffer.submit();
+    return target;
+  }
 
   @override
   void execute(RenderGraphContext context) {
     final linearDepth = context.blackboard.require<gpu.Texture>(
       kLinearDepthBlackboardKey,
     );
+
+    // Build the depth mip chain from the (full-resolution) linear depth so the
+    // occlusion samples a coarser level the further each tap reaches. When
+    // disabled the three slots reuse the base depth and the shader stays at
+    // level 0, so behaviour is unchanged.
+    var mip1 = linearDepth;
+    var mip2 = linearDepth;
+    var mip3 = linearDepth;
+    var mipLevels = 1;
+    if (_settings.depthMipChain) {
+      final fw = _dimensions.width.toInt();
+      final fh = _dimensions.height.toInt();
+      mip1 = _downsampleDepth(
+        context,
+        linearDepth,
+        math.max(1, fw ~/ 2),
+        math.max(1, fh ~/ 2),
+      );
+      mip2 = _downsampleDepth(
+        context,
+        mip1,
+        math.max(1, fw ~/ 4),
+        math.max(1, fh ~/ 4),
+      );
+      mip3 = _downsampleDepth(
+        context,
+        mip2,
+        math.max(1, fw ~/ 8),
+        math.max(1, fh ~/ 8),
+      );
+      mipLevels = 4;
+    }
 
     final aoSize = ambientOcclusionTargetSize(_dimensions, _settings);
     final aoWidth = aoSize.width.toInt();
@@ -157,10 +229,26 @@ class SsaoPass extends RenderGraphPass {
       ..[9] = _settings.bias
       ..[10] = _settings.intensity
       ..[11] = projScale
-      ..[12] = _settings.sampleCount.toDouble();
+      ..[12] = _settings.sampleCount.toDouble()
+      ..[13] = mipLevels.toDouble();
     renderPass.bindUniform(
       _fragmentShader.getUniformSlot('SsaoInfo'),
       context.transientsBuffer.emplace(ByteData.sublistView(info)),
+    );
+    renderPass.bindTexture(
+      _fragmentShader.getUniformSlot('depth_mip1'),
+      mip1,
+      sampler: _nearestClamp,
+    );
+    renderPass.bindTexture(
+      _fragmentShader.getUniformSlot('depth_mip2'),
+      mip2,
+      sampler: _nearestClamp,
+    );
+    renderPass.bindTexture(
+      _fragmentShader.getUniformSlot('depth_mip3'),
+      mip3,
+      sampler: _nearestClamp,
     );
     renderPass.bindTexture(
       _fragmentShader.getUniformSlot('linear_depth'),

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -1039,10 +1039,11 @@ base class Scene implements SceneGraph {
         // blur) at one resolution so depth is sampled 1:1 (a half-resolution
         // occlusion pass reading a full-resolution depth would alias on fine
         // geometry). Size the prepass to occlusion's target whenever it is on
-        // so its behavior is unchanged; reflections sample whatever
-        // resolution is published. With only reflections on, use full
-        // resolution.
-        final depthDimensions = wantAo
+        // so its behavior is unchanged; reflections sample whatever resolution
+        // is published. With only reflections on, use full resolution. The
+        // depth-mip-chain path (SsaoPass builds the reduced levels) wants a
+        // full-resolution base, so it also renders the prepass full size.
+        final depthDimensions = (wantAo && !ambientOcclusion.depthMipChain)
             ? ambientOcclusionTargetSize(pixelSize, ambientOcclusion)
             : pixelSize;
         // Reflections need the interpolated view-space normal, so the prepass

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -47,6 +47,10 @@
         "type": "fragment",
         "file": "shaders/flutter_scene_ssao.frag"
     },
+    "DepthDownsampleFragment": {
+        "type": "fragment",
+        "file": "shaders/flutter_scene_depth_downsample.frag"
+    },
     "SsaoBlurFragment": {
         "type": "fragment",
         "file": "shaders/flutter_scene_ssao_blur.frag"

--- a/packages/flutter_scene/shaders/flutter_scene_depth_downsample.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_depth_downsample.frag
@@ -1,0 +1,26 @@
+// Depth downsample for the ambient-occlusion depth mip chain (Scalable Ambient
+// Obscurance). Halves the resolution, writing the nearest (minimum) view-space
+// depth of each source 2x2 block into the target level.
+//
+// Linear depth is fp32 and sampled with nearest filtering (float textures are
+// not always filterable on GLES/WebGL2, and depth must not be averaged across a
+// silhouette), so this reads the four source texels exactly with texelFetch
+// rather than a filtered tap. Taking the minimum is conservative: a coarse level
+// never hides an occluder, it can only slightly over-darken, which the
+// per-sample level selection keeps to the far, low-weight samples.
+
+uniform sampler2D source;
+
+in vec2 v_uv;
+
+out vec4 frag_color;
+
+void main() {
+  ivec2 base = ivec2(gl_FragCoord.xy) * 2;
+  ivec2 maxCoord = textureSize(source, 0) - ivec2(1);
+  float d0 = texelFetch(source, min(base + ivec2(0, 0), maxCoord), 0).r;
+  float d1 = texelFetch(source, min(base + ivec2(1, 0), maxCoord), 0).r;
+  float d2 = texelFetch(source, min(base + ivec2(0, 1), maxCoord), 0).r;
+  float d3 = texelFetch(source, min(base + ivec2(1, 1), maxCoord), 0).r;
+  frag_color = vec4(min(min(d0, d1), min(d2, d3)), 0.0, 0.0, 1.0);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_ssao.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_ssao.frag
@@ -11,6 +11,13 @@
 
 uniform sampler2D linear_depth;
 
+// Downsampled copies of the depth for the SAO mip chain (half, quarter, and
+// eighth resolution). When the chain is disabled these are all bound to
+// linear_depth and params2.y is 1, so the sample loop only ever reads level 0.
+uniform sampler2D depth_mip1;
+uniform sampler2D depth_mip2;
+uniform sampler2D depth_mip3;
+
 uniform SsaoInfo {
   // x, y: occlusion target size in pixels. z, w: its reciprocal.
   vec4 viewport;
@@ -19,7 +26,7 @@ uniform SsaoInfo {
   // x: radius (world units). y: bias (world units). z: intensity (final
   // contrast power). w: projection scale (pixels per world unit at depth 1).
   vec4 params;
-  // x: sample count.
+  // x: sample count. y: mip level count (1 disables the chain).
   vec4 params2;
 }
 ssao;
@@ -44,8 +51,16 @@ const float kEdgeFadeMax = 0.04;
 // places the eye at the origin looking down +Z (the convention the depth
 // prepass writes), so the stored planar depth is the view-space Z and the
 // X/Y follow from the projection tangents.
-vec3 ViewPositionAt(vec2 uv) {
-  float z = texture(linear_depth, uv).r;
+// Fetches the view-space depth at [uv] from level [level] of the depth chain.
+float DepthAtLevel(vec2 uv, int level) {
+  if (level <= 0) return texture(linear_depth, uv).r;
+  if (level == 1) return texture(depth_mip1, uv).r;
+  if (level == 2) return texture(depth_mip2, uv).r;
+  return texture(depth_mip3, uv).r;
+}
+
+vec3 ViewPositionAt(vec2 uv, int level) {
+  float z = DepthAtLevel(uv, level);
   // NDC from the full-screen UV (V runs downward in the UV).
   vec2 ndc = vec2(2.0 * uv.x - 1.0, 1.0 - 2.0 * uv.y);
   return vec3(ndc.x * z * ssao.proj.x, ndc.y * z * ssao.proj.y, z);
@@ -57,9 +72,10 @@ void main() {
   float intensity = ssao.params.z;
   float proj_scale = ssao.params.w;
   int sample_count = int(ssao.params2.x);
+  int mip_levels = int(ssao.params2.y);
   float far = ssao.proj.w;
 
-  vec3 origin = ViewPositionAt(v_uv);
+  vec3 origin = ViewPositionAt(v_uv, 0);
 
   // Background texels (no geometry) are unoccluded.
   if (origin.z >= far) {
@@ -82,10 +98,6 @@ void main() {
 
   // Screen-space disk radius: the world radius projected to this depth.
   float screen_radius = proj_scale * radius / origin.z;
-  // TODO(flutter_scene): SAO keeps large radii cache-friendly by sampling a
-  // MIP chain of the depth buffer (selecting a level per sample by screen
-  // radius). A single level is enough for typical radii; add the chain (like
-  // the bloom downsample chain) if large-radius occlusion shows cache cost.
 
   // Interleaved rotation: 16 well-separated angles tiled over a 4x4 screen
   // block (the golden-ratio sequence spreads them, and neighbours differ
@@ -109,10 +121,21 @@ void main() {
     // streaks on receding surfaces).
     float sample_radius = sqrt((float(i) + 0.5) / float(sample_count));
     float theta = float(i) * kGoldenAngle + rotation;
-    vec2 offset = vec2(cos(theta), sin(theta)) * (sample_radius * screen_radius);
+    float pixel_radius = sample_radius * screen_radius;
+    vec2 offset = vec2(cos(theta), sin(theta)) * pixel_radius;
     vec2 sample_uv = v_uv + offset * ssao.viewport.zw;
 
-    vec3 q = ViewPositionAt(sample_uv);
+    // Read the depth from a coarser level as the sample gets further away, so
+    // far taps read pre-reduced depth (cache-friendly) and, with a full-
+    // resolution level 0, near geometry is not contaminated by the surface
+    // behind it where the projection compresses depth. Level 0 when the chain
+    // is disabled (mip_levels <= 1).
+    int level = 0;
+    if (mip_levels > 1) {
+      level = clamp(
+          int(floor(log2(max(1.0, pixel_radius)))) - 3, 0, mip_levels - 1);
+    }
+    vec3 q = ViewPositionAt(sample_uv, level);
     vec3 v = q - origin;
     float vv = dot(v, v);
     float vn = dot(v, normal);

--- a/packages/flutter_scene/test/fmat_test.dart
+++ b/packages/flutter_scene/test/fmat_test.dart
@@ -131,6 +131,34 @@ fragment {
         contains('vec4(material.base_color.rgb, 1.0) * material.base_color.a'),
       );
     });
+
+    test('keeps MaterialParams live when the fragment reads no parameter', () {
+      // A parameter used only in the vertex stage: the fragment must still
+      // reference MaterialParams (through the zero-bound keep-alive) so the
+      // block is not optimized out and its uniform slot stays bindable, which
+      // otherwise crashes the Metal backend when the parameters are bound.
+      final c = compileFmat('''
+material {
+  name: "P",
+  shading_model: unlit,
+  parameters: [ { type: float, name: k, default: 1.0 } ],
+}
+fragment {
+  void Surface(inout MaterialInputs material) {
+    material.base_color = vec4(1.0);
+  }
+}
+''');
+      expect(c.glsl, contains('uniform MaterialParams {'));
+      expect(
+        c.glsl,
+        contains('uniform FragmentKeepAlive { vec4 keep_alive; }'),
+      );
+      expect(
+        c.glsl,
+        contains('fragment_keep_alive.keep_alive.x * material_params.k'),
+      );
+    });
   });
 
   group('sidecar', () {


### PR DESCRIPTION
Three rendering fixes surfaced while building a vertex-displacement (curved world) effect.

**Depth prepass honors per-material culling.** The linear-depth/normal prepass behind SSAO and SSR hard-coded back-face culling, but the color pass culls per each material's own mode. A double-sided (`culling: none`) material had its camera-facing back faces dropped from the prepass, so the effects recorded the farther surface behind them and shaded the wrong depth (background occlusion composited onto a foreground face). The prepass now sets the cull mode per draw from `Material.renderCullMode`, matching the color pass. Winding was already matched per draw.

**A `.fmat` with vertex-only parameters no longer crashes.** When a material's parameters are used only in its `vertex { }` stage, `Surface()` reads none, so the compiler stripped the fragment's `MaterialParams` block and binding the parameters hit a missing uniform slot, segfaulting the Metal backend at draw time. The generated fragment now keeps the block alive through a zero-bound `FragmentKeepAlive` (mirroring the existing vertex keep-alive), with no visible effect.

**Optional AO depth mip chain.** `AmbientOcclusionSettings.depthMipChain` (off by default) renders the occlusion depth prepass at full resolution and samples it through a downsampled mip chain, a level per sample distance (the Scalable Ambient Obscurance depth-mip design). It keeps depth accurate where the projection compresses a large range into few pixels (grazing surfaces, vertex-displaced worlds), so near geometry's occlusion is not contaminated by the far surface behind it, and keeps large radii cache-friendly. The chain is built bloom-style from separate downsampled textures (no GPU mipmap generation, so it runs on WebGL2). Off by default because it adds a full-resolution prepass plus the chain build, heavier than the half-resolution default recommended on mobile.

Verified on macOS/Metal through a consuming app (the curved-world case, where all three showed up). The cross-backend smoke matrix (GLES, Vulkan, WebGL2) still needs to run, especially for the new depth-downsample shader's `texelFetch` and fp32 path through the WebGL2 GLSL-ES transpile.
