### PR TITLE
Refresh the Argos baseline on merge, and stop merges cancelling the nightly

### DIFF
--- a/.github/workflows/smoke_render.yml
+++ b/.github/workflows/smoke_render.yml
@@ -3,11 +3,11 @@ name: smoke render
 # Renders a small set of deterministic scenes against the latest Flutter master
 # and uploads the frames to Argos for visual diffing. Catches rendering
 # regressions (black screen / nothing drawn / unlit) that crash tests miss.
-# Runs on pull requests, manually, and daily, uploading to Argos so each PR
-# diffs against the nightly master baseline. Also runs on pushes to master, but
-# those render without uploading to Argos (the smoke tests still guard against
-# crashes; skipping the upload keeps the Argos quota for PRs and the nightly
-# baseline). Notifies Discord when a non-PR run fails.
+# Runs on pull requests, manually, daily, and on pushes to master, uploading the
+# frames to Argos. A PR diffs against the master baseline; a push to master (a
+# merge) and the nightly schedule both refresh that baseline, so an approved
+# rendering change lands as soon as it merges instead of waiting for the next
+# night. Notifies Discord when a non-PR run fails.
 
 on:
   workflow_dispatch:
@@ -18,9 +18,11 @@ on:
   pull_request:
     branches: [master]
 
-# A new push to a branch or PR supersedes its still-running render.
+# A new push or PR commit supersedes its still-running render. The event name is
+# part of the key so a merge (push to master) does not cancel a running nightly
+# (schedule) on the same ref, which would skip that baseline refresh.
 concurrency:
-  group: smoke-render-${{ github.ref }}
+  group: smoke-render-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -29,7 +31,8 @@ jobs:
     with:
       flutter_channel: master
       label: Flutter master
-      # Render (run the smoke tests) on master pushes, but don't upload to
-      # Argos; PRs and the nightly schedule still upload.
-      upload_argos_on_push: false
+      # Upload on master pushes too, so a merge refreshes the Argos baseline
+      # immediately (an approved rendering change lands on merge, not only at
+      # the next nightly).
+      upload_argos_on_push: true
     secrets: inherit


### PR DESCRIPTION
Approved golden changes were not landing after merge: the same smoke-render diffs kept re-appearing on every PR, re-approved each time, and never stuck.

Two causes, both here:

**The baseline only refreshed at the nightly, not on merge.** `upload_argos_on_push` was `false`, so a merge rendered but uploaded nothing to Argos; only the nightly `schedule` run refreshed the master baseline. And approving the images on a PR approves the *PR* build (so the PR check goes green), it does not advance the master/reference baseline. So an approved change did not become the baseline on merge, and the next PR diffed against the stale baseline and showed the same delta again. This flips `upload_argos_on_push` to `true` so a push to master (a merge) uploads and refreshes the baseline immediately.

**A merge could cancel the nightly.** The concurrency group was `smoke-render-${{ github.ref }}`, and the nightly (`schedule`) and a merge (`push`) are both `refs/heads/master`, so with `cancel-in-progress` a merge landing during the nightly window cancelled that night's render and skipped its baseline refresh (observed on the 2026-07-02 nightly, cancelled 24s before a merge push). The group now includes the event name so those two never collide.

One dashboard note (not in this repo): for a merge to *auto-apply* as the new baseline, the reference (master) branch needs auto-approval on in the Argos project settings. That was previously turned off to guard against empty/corrupt nightly baselines, but the empty-screenshot guard now prevents that at the source, so re-enabling auto-approval is reasonable. With it off, the uploaded master build (from the merge or nightly) still has to be accepted manually before it becomes the baseline.
