### PR TITLE
Add distance fog, volumetric god rays, and a geometry-aware custom-pass API

### DIFF
--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -233,6 +233,42 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
     );
     return (scene: scene, camera: _shadowCamera());
   }),
+  // Distance fog: a near and a far cuboid, the far one fading toward the fog
+  // color, with height fog and sun in-scatter enabled so those branches of
+  // ApplyFog run too. Geometry stays central so the corners keep the clear
+  // color (the frame-sanity check). One scene covers the global per-fragment
+  // fog path across backends.
+  SmokeScene('fog', () {
+    final scene = Scene();
+    scene.fog
+      ..enabled = true
+      ..mode = FogMode.exponential
+      ..color = vm.Vector3(0.55, 0.62, 0.78)
+      ..density = 0.09
+      ..height = 0.0
+      ..heightFalloff = 0.2
+      ..sunInScatter = 0.6
+      ..sunInScatterExponent = 6.0;
+    scene.add(
+      Node()..addComponent(
+        DirectionalLightComponent(
+          DirectionalLight(direction: vm.Vector3(-0.5, -0.4, -0.75)),
+        ),
+      ),
+    );
+    // A near cuboid (lightly fogged) and a far one (heavily fogged toward the
+    // fog color), so the fog gradient is a clear visual-diff signal while the
+    // corners stay the magenta clear.
+    scene.add(_cuboid(vm.Vector4(0.85, 0.85, 0.88, 1.0), 0.0, 0.6));
+    scene.add(
+      _cuboid(vm.Vector4(0.85, 0.85, 0.88, 1.0), 0.0, 0.6)
+        ..localTransform =
+            vm.Matrix4.translation(vm.Vector3(-1.4, 0, -12)) *
+            vm.Matrix4.rotationY(0.6) *
+            vm.Matrix4.rotationX(0.3),
+    );
+    return (scene: scene, camera: _camera());
+  }),
 ];
 
 /// Renders one [SmokeScene] into a fixed-size [RepaintBoundary] over the

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -248,7 +248,10 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
       ..height = 0.0
       ..heightFalloff = 0.2
       ..sunInScatter = 0.6
-      ..sunInScatterExponent = 6.0;
+      ..sunInScatterExponent = 6.0
+      // Blend the fog color toward the sky sampled in the view direction so the
+      // env-sampling fog path is exercised too.
+      ..skyColorInfluence = 0.7;
     scene.add(
       Node()..addComponent(
         DirectionalLightComponent(

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -22,6 +22,31 @@
   cache-friendly. The cost is a full-resolution prepass plus the chain build, so
   it is best reserved for higher-end targets.
 
+* Distance fog. `scene.fog` (a `Fog`, off by default) fades geometry toward a
+  fog color with distance, applied per-fragment in linear HDR before tone
+  mapping so it is exposed and tone-mapped along with the scene. It supports
+  linear, exponential, and exponential-squared falloff (`FogMode`), a maximum
+  opacity, a cutoff distance, an exponential height term that thins fog with
+  altitude, and an in-scattering glow toward the directional light. Its
+  `skyColorInfluence` blends the fog color toward the environment sampled in the
+  view direction, so distant geometry dissolves into the sky and horizon instead
+  of a flat wall.
+
+* Custom render passes can now read the scene's geometry, not just its color. A
+  `CustomRenderPass` declares the buffers it needs through a `RenderInput` set
+  (`depth`, `normals`, `shadowMap`); the engine produces them that frame and
+  exposes them on `RenderPassContext` (`sceneDepthLinear`, `shadowMap`,
+  `shadowInfo`, `cameraInfo`), so a full-screen pass can reconstruct world
+  positions and sample the shadow map. This turns the custom-pass API into a
+  general depth- and shadow-aware post-process system.
+
+* Volumetric god rays. `scene.godRays` (a `GodRaysSettings`, off by default)
+  draws directional light shafts by marching the view ray against the cascaded
+  shadow map and adding single-scattering to the HDR scene color, with controls
+  for intensity, density, Henyey-Greenstein anisotropy, step count, maximum
+  distance, jitter, and a color. It requires a shadow-casting directional light
+  and a perspective camera.
+
 * Widget-texture captures (`WidgetTexture`, `WidgetComponent`) now stay on the
   GPU. Each capture wraps the rasterized image's backing texture directly
   (`Texture.fromImage`) instead of reading the pixels back and re-uploading

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -73,6 +73,7 @@ export 'src/importer/scene_registry.dart'
 export 'src/ambient_occlusion.dart'
     show AmbientOcclusionSettings, SpecularAmbientOcclusionMode;
 export 'src/fog.dart' show Fog, FogMode;
+export 'src/god_rays.dart' show GodRaysSettings;
 export 'src/screen_space_reflections.dart'
     show ScreenSpaceReflectionsSettings, SsrDebugView;
 export 'src/asset_helpers.dart'

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -99,7 +99,7 @@ export 'src/instanced_mesh.dart' show InstancedMesh;
 export 'src/light.dart'
     show DirectionalLight, Lighting, ShadowCascade, ShadowCasterFaces;
 export 'src/render/custom_render_pass.dart'
-    show CustomRenderPass, RenderPassContext, RenderStage;
+    show CustomRenderPass, RenderInput, RenderPassContext, RenderStage;
 export 'src/render/object_filter.dart' show NodeFilter;
 export 'src/render/render_layers.dart'
     show kRenderLayerAll, kRenderLayerDefault;

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -72,6 +72,7 @@ export 'src/importer/scene_registry.dart'
 
 export 'src/ambient_occlusion.dart'
     show AmbientOcclusionSettings, SpecularAmbientOcclusionMode;
+export 'src/fog.dart' show Fog, FogMode;
 export 'src/screen_space_reflections.dart'
     show ScreenSpaceReflectionsSettings, SsrDebugView;
 export 'src/asset_helpers.dart'

--- a/packages/flutter_scene/lib/src/fog.dart
+++ b/packages/flutter_scene/lib/src/fog.dart
@@ -1,0 +1,82 @@
+import 'dart:math' as math;
+
+import 'package:vector_math/vector_math.dart';
+
+/// How fog density grows with distance from the camera.
+///
+/// [linear] ramps from [Fog.start] to [Fog.end]; [exponential] and
+/// [exponentialSquared] are density-driven (Beer-Lambert), the exponential
+/// modes matching what most real-time engines call `exp`/`exp2`.
+/// {@category Lighting and environment}
+enum FogMode { none, linear, exponential, exponentialSquared }
+
+/// Distance fog for a [Scene]: geometry blends toward [color] the farther it is
+/// from the camera, evaluated per-fragment in linear HDR before tone mapping so
+/// fog is exposed and tone-mapped along with the scene.
+///
+/// Fog is a `Scene` setting (`scene.fog`), off by default. Set [enabled] and a
+/// [mode] to turn it on. It applies to lit and unlit materials alike (the
+/// skybox is left unfogged, so set [color] to your horizon color for distant
+/// geometry to dissolve into the sky).
+///
+/// Two cheap extras: [heightFalloff] makes the fog ground-hugging (thinning with
+/// altitude, [exponential] mode only), and [sunInScatter] adds a glow toward the
+/// scene's directional light so looking into the sun through fog brightens.
+/// {@category Lighting and environment}
+class Fog {
+  /// Whether fog is applied. False (the default) leaves the scene unfogged even
+  /// if a [mode] is set.
+  bool enabled = false;
+
+  /// The distance-to-density curve. [FogMode.none] disables fog regardless of
+  /// [enabled].
+  FogMode mode = FogMode.exponential;
+
+  /// Fog color, linear (not sRGB). Distant opaque geometry converges to this, so
+  /// matching it to the horizon color makes geometry dissolve into the sky.
+  Vector3 color = Vector3(0.6, 0.7, 0.8);
+
+  /// Density for [FogMode.exponential] and [FogMode.exponentialSquared]. Larger
+  /// is thicker. See [visibilityDensity] for a distance-based way to set it.
+  double density = 0.02;
+
+  /// Distance at which fog begins. For [FogMode.linear] this is the near end; for
+  /// the exponential modes it offsets where accumulation starts (near geometry
+  /// stays clear).
+  double start = 0.0;
+
+  /// Distance at which [FogMode.linear] reaches full [maxOpacity]. Unused by the
+  /// exponential modes.
+  double end = 200.0;
+
+  /// Upper bound on fog opacity (0 to 1). Below 1 the fog never fully hides
+  /// distant geometry, so a bright sky still shows through.
+  double maxOpacity = 1.0;
+
+  /// Distance past which fog is not applied (0 disables the cutoff). Useful to
+  /// exclude a far layer that already reads as hazed.
+  double cutoffDistance = 0.0;
+
+  /// Reference altitude (world Y) for height fog: where the fog is densest.
+  double height = 0.0;
+
+  /// How fast fog thins with altitude above [height] (0 = uniform, no height
+  /// fog). Only affects [FogMode.exponential]. Larger hugs the ground more
+  /// tightly.
+  double heightFalloff = 0.0;
+
+  /// Strength of the in-scattering glow toward the scene's directional light
+  /// (0 = off). Cheap sun-through-fog without volumetrics.
+  double sunInScatter = 0.0;
+
+  /// Tightness of the sun in-scatter cone: larger concentrates the glow near the
+  /// sun. Only meaningful when [sunInScatter] is above 0.
+  double sunInScatterExponent = 8.0;
+
+  /// The [density] that makes objects roughly [meters] away fade to a
+  /// low-contrast haze, via Koschmieder's law (contrast threshold `0.02`). A
+  /// convenience for authoring exponential fog by visibility distance instead of
+  /// a raw coefficient.
+  static double visibilityDensity(double meters) =>
+      meters <= 0.0 ? 0.0 : -math.log(0.02) / meters;
+}

--- a/packages/flutter_scene/lib/src/fog.dart
+++ b/packages/flutter_scene/lib/src/fog.dart
@@ -36,6 +36,14 @@ class Fog {
   /// matching it to the horizon color makes geometry dissolve into the sky.
   Vector3 color = Vector3(0.6, 0.7, 0.8);
 
+  /// How much the fog color is taken from the sky instead of [color] (0 = flat
+  /// [color], 1 = fully the environment sampled in the view direction). Above 0,
+  /// far geometry fades into the actual sky/horizon behind it (aerial
+  /// perspective) rather than a flat wall of [color]. Sampled from the
+  /// image-based-lighting environment, so it applies to lit materials; unlit
+  /// materials always use the flat [color].
+  double skyColorInfluence = 0.0;
+
   /// Density for [FogMode.exponential] and [FogMode.exponentialSquared]. Larger
   /// is thicker. See [visibilityDensity] for a distance-based way to set it.
   double density = 0.02;

--- a/packages/flutter_scene/lib/src/god_rays.dart
+++ b/packages/flutter_scene/lib/src/god_rays.dart
@@ -26,8 +26,7 @@ class GodRaysSettings {
   /// Overall brightness of the in-scattered light.
   double intensity = 1.0;
 
-  /// Scattering density along the ray. Higher is thicker and brighter shafts
-  /// (and more extinction with distance).
+  /// Scattering strength along the ray: how thick and bright the shafts read.
   double density = 0.5;
 
   /// Henyey-Greenstein phase asymmetry (`-1` to `1`). Positive concentrates the
@@ -46,8 +45,9 @@ class GodRaysSettings {
   /// noise. `0` disables it.
   double jitter = 1.0;
 
-  /// A tint multiplied with the directional light color. White uses the light's
-  /// own color.
+  /// The shaft color. This is used directly (not the light's direct radiance),
+  /// so shafts show even for a shadow-only sun whose direct intensity is zero;
+  /// tint it to match the sun. White by default.
   Vector3 color = Vector3(1.0, 1.0, 1.0);
 }
 

--- a/packages/flutter_scene/lib/src/god_rays.dart
+++ b/packages/flutter_scene/lib/src/god_rays.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/render/custom_render_pass.dart';
+import 'package:flutter_scene/src/shaders.dart';
+
+/// Directional volumetric god rays (crepuscular rays / light shafts).
+///
+/// A full-screen post-process that marches the view ray against the scene's
+/// directional light shadow map, accumulating single-scattering so sunlight
+/// streaming through gaps in geometry is visible as shafts. Off by default; set
+/// [enabled]. It requires a shadow-casting [DirectionalLight] and a
+/// [PerspectiveCamera] (it reads the cascaded shadow map and the camera depth);
+/// it is skipped otherwise.
+///
+/// The march is per-pixel and samples the shadow map at every step, so it is a
+/// desktop-leaning effect on mobile/web: keep [stepCount] low and [maxDistance]
+/// bounded. See `Scene.godRays`.
+/// {@category Lighting and environment}
+class GodRaysSettings {
+  /// Whether god rays are drawn. Off by default.
+  bool enabled = false;
+
+  /// Overall brightness of the in-scattered light.
+  double intensity = 1.0;
+
+  /// Scattering density along the ray. Higher is thicker and brighter shafts
+  /// (and more extinction with distance).
+  double density = 0.5;
+
+  /// Henyey-Greenstein phase asymmetry (`-1` to `1`). Positive concentrates the
+  /// glow toward the sun (forward scattering); `0` is uniform.
+  double anisotropy = 0.7;
+
+  /// Ray-march steps per pixel. More steps reduce banding at a linear cost;
+  /// clamped to `1..64`. Pair a low count with [jitter].
+  int stepCount = 24;
+
+  /// Maximum distance the ray marches, in world units. Bounds the cost and
+  /// keeps far pixels from marching the whole depth range.
+  double maxDistance = 200.0;
+
+  /// Dither applied to the ray start (in steps) to trade banding for fine
+  /// noise. `0` disables it.
+  double jitter = 1.0;
+
+  /// A tint multiplied with the directional light color. White uses the light's
+  /// own color.
+  Vector3 color = Vector3(1.0, 1.0, 1.0);
+}
+
+/// The engine-inserted [CustomRenderPass] that renders [GodRaysSettings]. It
+/// declares the depth and shadow inputs it needs and, when they are available,
+/// marches the god-rays shader over the HDR scene color. Not user-facing;
+/// `Scene` adds it when `scene.godRays.enabled`.
+class GodRaysPass extends CustomRenderPass {
+  GodRaysPass(this.settings);
+
+  final GodRaysSettings settings;
+
+  gpu.Shader? _shaderCache;
+  gpu.Shader get _shader =>
+      _shaderCache ??= baseShaderLibrary['GodRaysFragment']!;
+
+  @override
+  String get name => 'god_rays';
+
+  @override
+  RenderStage get stage => RenderStage.afterScene;
+
+  @override
+  Set<RenderInput> get inputs => const {
+    RenderInput.depth,
+    RenderInput.shadowMap,
+  };
+
+  @override
+  void execute(RenderPassContext context) {
+    final depth = context.sceneDepthLinear;
+    final shadowMap = context.shadowMap;
+    final shadowInfo = context.shadowInfo;
+    // No depth or no shadow-casting directional light this frame: leave the
+    // scene color untouched (writing nothing keeps the chain intact).
+    if (depth == null || shadowMap == null || shadowInfo == null) return;
+
+    context.applyShader(
+      _shader,
+      textures: {'input_depth': depth, 'input_shadow': shadowMap},
+      uniforms: {
+        'PostCameraInfo': context.cameraInfo,
+        'PostShadowInfo': shadowInfo,
+        'GodRaysInfo': _packSettings(),
+      },
+      frameInfo: true,
+    );
+  }
+
+  ByteData _packSettings() {
+    final steps = settings.stepCount.clamp(1, 64).toDouble();
+    final g = settings.anisotropy.clamp(-0.95, 0.95);
+    final f = Float32List(12)
+      ..[0] = settings.intensity
+      ..[1] = settings.density
+      ..[2] = g
+      ..[3] = steps
+      ..[4] = settings.maxDistance
+      ..[5] = settings.jitter
+      ..[8] = settings.color.x
+      ..[9] = settings.color.y
+      ..[10] = settings.color.z;
+    return ByteData.sublistView(f);
+  }
+}

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/fog.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 
 /// Which faces of a shadow caster are rendered into the shadow map (the
@@ -370,10 +371,15 @@ class Lighting {
     this.ssaoMap,
     this.specularOcclusionMode = 0.0,
     this.viewportSize = ui.Size.zero,
+    this.fog,
   }) : environmentTransform = environmentTransform ?? Matrix3.identity();
 
   /// The image-based-lighting environment in effect for this draw.
   final EnvironmentMap environmentMap;
+
+  /// The scene's distance fog, or null when fog is off for this frame. Applied
+  /// per-fragment by every material in linear HDR before tone mapping.
+  final Fog? fog;
 
   /// A secondary environment cross-faded with [environmentMap] by
   /// [environmentBlend], or null when a single environment is in effect.

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:flutter_scene/src/fog.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/environment.dart';
@@ -114,6 +115,58 @@ class EngineLightingUniforms {
         ? lighting.environmentBlend.clamp(0.0, 1.0)
         : 0.0;
     fragInfo[161] = light?.shadowAmbientStrength.clamp(0.0, 1.0) ?? 0.0;
+  }
+
+  /// Packs the `FogInfo` block (6 vec4s / 24 floats, see `shaders/fog.glsl`)
+  /// from [lighting]'s fog and directional light, and binds it on [shader].
+  /// Every material shader declares `FogInfo`, so this is always bound; when
+  /// there is no fog the `enabled` flag is 0 and `ApplyFog` is a no-op.
+  static void bindFog(
+    gpu.RenderPass pass,
+    gpu.Shader shader,
+    gpu.HostBuffer transientsBuffer,
+    Lighting lighting,
+  ) {
+    final fog = lighting.fog;
+    final buffer = Float32List(24);
+    if (fog != null && fog.enabled && fog.mode != FogMode.none) {
+      // params0: mode, enabled, maxOpacity.
+      buffer[0] = fog.mode.index.toDouble();
+      buffer[1] = 1.0;
+      buffer[2] = fog.maxOpacity.clamp(0.0, 1.0);
+      // params1: density, start, end, cutoffDistance.
+      buffer[4] = fog.density;
+      buffer[5] = fog.start;
+      buffer[6] = fog.end;
+      buffer[7] = fog.cutoffDistance;
+      // params2: height, heightFalloff, sunInScatter, sunExponent.
+      buffer[8] = fog.height;
+      buffer[9] = fog.heightFalloff;
+      buffer[10] = fog.sunInScatter;
+      buffer[11] = fog.sunInScatterExponent;
+      // color.
+      buffer[12] = fog.color.x;
+      buffer[13] = fog.color.y;
+      buffer[14] = fog.color.z;
+      // sun color * intensity + has-sun, and sun travel direction. Reuses the
+      // scene's directional light (the same source packInto uses for lighting).
+      final light = lighting.directionalLight;
+      if (light != null && fog.sunInScatter > 0.0) {
+        buffer[16] = light.color.x * light.intensity;
+        buffer[17] = light.color.y * light.intensity;
+        buffer[18] = light.color.z * light.intensity;
+        buffer[19] = 1.0; // has-sun
+        final direction = lighting.directionalLightDirection ?? light.direction;
+        buffer[20] = direction.x;
+        buffer[21] = direction.y;
+        buffer[22] = direction.z;
+      }
+    }
+    // buffer[1] left 0 (disabled) when there is no active fog.
+    pass.bindUniform(
+      shader.getUniformSlot('FogInfo'),
+      transientsBuffer.emplace(ByteData.sublistView(buffer)),
+    );
   }
 
   // Tiny constant uniform blocks (std140, 16 bytes) selecting the bound

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -130,10 +130,11 @@ class EngineLightingUniforms {
     final fog = lighting.fog;
     final buffer = Float32List(24);
     if (fog != null && fog.enabled && fog.mode != FogMode.none) {
-      // params0: mode, enabled, maxOpacity.
+      // params0: mode, enabled, maxOpacity, sky-color influence.
       buffer[0] = fog.mode.index.toDouble();
       buffer[1] = 1.0;
       buffer[2] = fog.maxOpacity.clamp(0.0, 1.0);
+      buffer[3] = fog.skyColorInfluence.clamp(0.0, 1.0);
       // params1: density, start, end, cutoffDistance.
       buffer[4] = fog.density;
       buffer[5] = fog.start;

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -231,6 +231,12 @@ class PhysicallyBasedMaterial extends Material {
       lighting,
       env,
     );
+    EngineLightingUniforms.bindFog(
+      pass,
+      fragmentShader,
+      transientsBuffer,
+      lighting,
+    );
   }
 
   static final gpu.SamplerOptions _repeatSampler = gpu.SamplerOptions(

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -130,6 +130,15 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
         lighting,
         env,
       );
+      // Lit `.fmat` shaders include the lighting framework (and thus fog.glsl),
+      // so they carry the FogInfo block. Unlit `.fmat` shaders do not; fog on
+      // those is a TODO(fog): give the unlit `.fmat` template the fog block.
+      EngineLightingUniforms.bindFog(
+        pass,
+        fragmentShader,
+        transientsBuffer,
+        lighting,
+      );
     }
 
     parameters.bind(pass, fragmentShader, transientsBuffer);

--- a/packages/flutter_scene/lib/src/material/unlit_material.dart
+++ b/packages/flutter_scene/lib/src/material/unlit_material.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/texture/texture2d.dart';
 import 'package:flutter_scene/src/material/physically_based_material.dart'
@@ -85,6 +86,13 @@ class UnlitMaterial extends Material {
             widthAddressMode: gpu.SamplerAddressMode.repeat,
             heightAddressMode: gpu.SamplerAddressMode.repeat,
           ),
+    );
+    // The unlit shader carries the FogInfo block (fog.glsl) too.
+    EngineLightingUniforms.bindFog(
+      pass,
+      fragmentShader,
+      transientsBuffer,
+      lighting,
     );
   }
 }

--- a/packages/flutter_scene/lib/src/render/custom_render_pass.dart
+++ b/packages/flutter_scene/lib/src/render/custom_render_pass.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -6,14 +7,43 @@ import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/render/depth_prepass.dart';
 import 'package:flutter_scene/src/render/object_filter.dart';
 import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/render/resolve_pass.dart';
 import 'package:flutter_scene/src/render/scene_pass.dart';
+import 'package:flutter_scene/src/render/shadow_pass.dart';
 import 'package:flutter_scene/src/shader_uniform_bindings.dart';
 import 'package:flutter_scene/src/shaders.dart';
+
+/// Packs the `PostShadowInfo` std140 block a depth-aware custom pass reads
+/// (exposed as [RenderPassContext.shadowInfo]) from the frame's [cascades],
+/// the light's world-space travel [direction], and its [color] premultiplied by
+/// intensity. Layout: `mat4 light_space_matrix[4]` (world -> cascade clip),
+/// `vec4 cascade_splits` (view-space split distance per cascade), `vec4
+/// light_direction` (xyz direction, w = cascade count), `vec4 light_color`.
+ByteData packPostShadowInfo(
+  List<ShadowCascade> cascades,
+  Vector3 direction,
+  Vector3 color,
+) {
+  final f = Float32List(76); // 4 mat4 + 3 vec4
+  final count = cascades.length < 4 ? cascades.length : 4;
+  for (var i = 0; i < count; i++) {
+    f.setRange(i * 16, i * 16 + 16, cascades[i].lightSpaceMatrix.storage);
+    f[64 + i] = cascades[i].splitDistance;
+  }
+  f[68] = direction.x;
+  f[69] = direction.y;
+  f[70] = direction.z;
+  f[71] = count.toDouble();
+  f[72] = color.x;
+  f[73] = color.y;
+  f[74] = color.z;
+  return ByteData.sublistView(f);
+}
 
 /// A named anchor point in the built-in render pipeline where a
 /// [CustomRenderPass] runs. Ordering within one stage follows the order the
@@ -40,6 +70,31 @@ enum RenderStage {
   /// At the very end, after anti-aliasing and display-referred custom
   /// effects (the overlay slot the built-in selection outline uses).
   afterAntiAliasing,
+}
+
+/// An engine geometry buffer a [CustomRenderPass] can request through
+/// [CustomRenderPass.inputs]. Declaring one makes the engine produce it this
+/// frame and exposes it on the [RenderPassContext], so a pass can read the
+/// scene's geometry (depth, normals, shadows), not just its color. Together
+/// they turn the custom-pass API into a general depth/shadow-aware
+/// post-process system (contact shadows, custom occlusion, volumetrics, and so
+/// on).
+/// {@category Rendering}
+enum RenderInput {
+  /// The linear (view-space) depth buffer, on
+  /// [RenderPassContext.sceneDepthLinear]. Needs a perspective camera;
+  /// reconstruct positions with [RenderPassContext.cameraInfo].
+  depth,
+
+  /// View-space normals, octahedral-packed into the green/blue channels of the
+  /// same buffer as [depth] (which this implies).
+  normals,
+
+  /// The directional light's cascaded shadow map, on
+  /// [RenderPassContext.shadowMap], with [RenderPassContext.shadowInfo] for its
+  /// cascade transforms. Null unless the scene has a shadow-casting directional
+  /// light.
+  shadowMap,
 }
 
 /// A user-supplied render pass inserted into the built-in pipeline at a
@@ -73,6 +128,11 @@ abstract class CustomRenderPass {
 
   /// Where in the pipeline this pass runs.
   RenderStage get stage;
+
+  /// The engine geometry buffers this pass reads, beyond the always-available
+  /// scene color. Declaring one makes the engine produce it this frame and
+  /// exposes it on the [RenderPassContext]. Empty by default (color only).
+  Set<RenderInput> get inputs => const {};
 
   /// Whether this pass runs. A disabled pass is skipped entirely (it never
   /// consumes a buffer), so toggling it does not disturb the rest of the
@@ -161,10 +221,53 @@ class RenderPassContext {
   gpu.Texture get displayColor =>
       _context.blackboard.require<gpu.Texture>(kDisplayColorBlackboardKey);
 
-  /// The linear (view-space) depth buffer, or null when no depth prepass ran
-  /// this frame (it only runs when ambient occlusion is enabled).
+  /// The linear (view-space) depth buffer: planar view-space depth (world
+  /// units) in the red channel, with the octahedral-packed view-space normal in
+  /// green/blue when [RenderInput.normals] was requested. Non-null when the pass
+  /// declared [RenderInput.depth] (or [RenderInput.normals]) and the camera is
+  /// perspective; also present when ambient occlusion or reflections ran.
   gpu.Texture? get sceneDepthLinear =>
       _context.blackboard.get<gpu.Texture>(kLinearDepthBlackboardKey);
+
+  /// The directional light's cascaded shadow map atlas (a horizontal strip of
+  /// `shadowInfo` cascade tiles, window-space depth in the red channel).
+  /// Non-null when the pass declared [RenderInput.shadowMap] and the scene has
+  /// a shadow-casting directional light. Pair with [shadowInfo].
+  gpu.Texture? get shadowMap =>
+      _context.blackboard.get<gpu.Texture>(kShadowMapBlackboardKey);
+
+  /// The packed `PostShadowInfo` std140 uniform block matching [shadowMap]:
+  /// four `mat4` world->cascade-clip matrices, a `vec4` of the cascades'
+  /// view-space split distances, a `vec4` light direction (xyz world travel
+  /// direction, w = cascade count), and a `vec4` light color (rgb, premultiplied
+  /// by intensity). Bind it under a `PostShadowInfo` block via
+  /// [applyShader]'s `uniforms`. Null when [shadowMap] is null.
+  ByteData? get shadowInfo =>
+      _context.blackboard.get<ByteData>(kShadowUniformBlackboardKey);
+
+  /// A packed `PostCameraInfo` std140 uniform block for reconstructing world
+  /// positions from [sceneDepthLinear]: a `vec4` `(tan(fovX/2), tan(fovY/2),
+  /// near, far)`, the `mat4` inverse view matrix (view space -> world), and a
+  /// `vec4` camera world position. Bind it under a `PostCameraInfo` block via
+  /// [applyShader]'s `uniforms`. The projection terms are zero for a
+  /// non-perspective camera (where depth is unavailable).
+  ByteData get cameraInfo {
+    final f = Float32List(24); // vec4 + mat4 + vec4
+    final projection = camera.projection;
+    if (projection is PerspectiveProjection && dimensions.height > 0) {
+      final tanY = math.tan(projection.fovRadiansY * 0.5);
+      f[0] = tanY * (dimensions.width / dimensions.height);
+      f[1] = tanY;
+      f[2] = projection.near;
+      f[3] = projection.far;
+    }
+    final inverseView = camera.getViewMatrix()..invert();
+    f.setRange(4, 20, inverseView.storage);
+    f[20] = camera.position.x;
+    f[21] = camera.position.y;
+    f[22] = camera.position.z;
+    return ByteData.sublistView(f);
+  }
 
   // Whether this stage operates on the HDR scene color or the display image.
   Object get _chainKey =>

--- a/packages/flutter_scene/lib/src/render/custom_render_pass.dart
+++ b/packages/flutter_scene/lib/src/render/custom_render_pass.dart
@@ -246,13 +246,16 @@ class RenderPassContext {
       _context.blackboard.get<ByteData>(kShadowUniformBlackboardKey);
 
   /// A packed `PostCameraInfo` std140 uniform block for reconstructing world
-  /// positions from [sceneDepthLinear]: a `vec4` `(tan(fovX/2), tan(fovY/2),
-  /// near, far)`, the `mat4` inverse view matrix (view space -> world), and a
-  /// `vec4` camera world position. Bind it under a `PostCameraInfo` block via
-  /// [applyShader]'s `uniforms`. The projection terms are zero for a
-  /// non-perspective camera (where depth is unavailable).
+  /// positions from [sceneDepthLinear]. Layout: a `vec4` `(tan(fovX/2),
+  /// tan(fovY/2), near, far)`, then the camera basis as three `vec4`s (right,
+  /// up, forward, matching the depth prepass's view space: the eye at the origin
+  /// looking down +forward), then a `vec4` camera world position. Reconstruct
+  /// with `viewZ = depth; viewXY = (2*uv - 1 flipped) * viewZ * tangents;
+  /// world = position + right*viewX + up*viewY + forward*viewZ`. Bind it under a
+  /// `PostCameraInfo` block via [applyShader]'s `uniforms`. The projection terms
+  /// are zero for a non-perspective camera (where depth is unavailable).
   ByteData get cameraInfo {
-    final f = Float32List(24); // vec4 + mat4 + vec4
+    final f = Float32List(20); // 5 vec4
     final projection = camera.projection;
     if (projection is PerspectiveProjection && dimensions.height > 0) {
       final tanY = math.tan(projection.fovRadiansY * 0.5);
@@ -261,11 +264,23 @@ class RenderPassContext {
       f[2] = projection.near;
       f[3] = projection.far;
     }
-    final inverseView = camera.getViewMatrix()..invert();
-    f.setRange(4, 20, inverseView.storage);
-    f[20] = camera.position.x;
-    f[21] = camera.position.y;
-    f[22] = camera.position.z;
+    // The same view basis the depth prepass encodes against (eye at origin
+    // looking down +forward), so a reconstructed view point maps to world.
+    final forward = camera.forward.normalized();
+    final right = camera.up.cross(forward)..normalize();
+    final up = forward.cross(right)..normalize();
+    f[4] = right.x;
+    f[5] = right.y;
+    f[6] = right.z;
+    f[8] = up.x;
+    f[9] = up.y;
+    f[10] = up.z;
+    f[12] = forward.x;
+    f[13] = forward.y;
+    f[14] = forward.z;
+    f[16] = camera.position.x;
+    f[17] = camera.position.y;
+    f[18] = camera.position.z;
     return ByteData.sublistView(f);
   }
 

--- a/packages/flutter_scene/lib/src/render/scene_pass.dart
+++ b/packages/flutter_scene/lib/src/render/scene_pass.dart
@@ -4,6 +4,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/fog.dart';
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/render/render_graph.dart';
@@ -44,6 +45,7 @@ class ScenePass extends RenderGraphPass {
     List<ShadowCascade> cascades = const [],
     double specularOcclusionMode = 0.0,
     int layerMask = kRenderLayerAll,
+    Fog? fog,
   }) : _camera = camera,
        _layerMask = layerMask,
        _renderScene = renderScene,
@@ -58,7 +60,8 @@ class ScenePass extends RenderGraphPass {
        _directionalLight = directionalLight,
        _directionalLightDirection = directionalLightDirection,
        _cascades = cascades,
-       _specularOcclusionMode = specularOcclusionMode;
+       _specularOcclusionMode = specularOcclusionMode,
+       _fog = fog;
 
   final Camera _camera;
   final RenderScene _renderScene;
@@ -75,6 +78,7 @@ class ScenePass extends RenderGraphPass {
   final int _layerMask;
   final List<ShadowCascade> _cascades;
   final double _specularOcclusionMode;
+  final Fog? _fog;
 
   static const gpu.PixelFormat _hdrFormat = gpu.PixelFormat.r16g16b16a16Float;
 
@@ -147,6 +151,7 @@ class ScenePass extends RenderGraphPass {
       ssaoMap: ssaoMap,
       specularOcclusionMode: ssaoMap == null ? 0.0 : _specularOcclusionMode,
       viewportSize: _dimensions,
+      fog: _fog,
     );
 
     final commandBuffer = gpu.gpuContext.createCommandBuffer();

--- a/packages/flutter_scene/lib/src/render/shadow_pass.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_pass.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 
@@ -10,6 +12,12 @@ import 'package:flutter_scene/src/render/shadow_encoder.dart';
 /// directional shadow map atlas (a depth-in-`.r` fp32 texture). The
 /// downstream scene pass reads it from here.
 const String kShadowMapBlackboardKey = 'directional_shadow_map';
+
+/// Render-graph blackboard key under which [ShadowPass] publishes the packed
+/// shadow uniform (the `PostShadowInfo` std140 block: per-cascade world->light
+/// matrices, split distances, the light direction + cascade count, and the
+/// light color). A depth-aware custom pass reads it to sample the shadow map.
+const String kShadowUniformBlackboardKey = 'shadow_uniform';
 
 /// Renders the scene's depth from a directional light into a cascaded
 /// shadow map atlas and publishes it on the render-graph blackboard.
@@ -26,16 +34,21 @@ class ShadowPass extends RenderGraphPass {
     required int tileResolution,
     required ShadowCasterFaces casterFaces,
     required Vector3 cameraPosition,
+    ByteData? shadowUniform,
   }) : _renderScene = renderScene,
        _cascades = cascades,
        _tileResolution = tileResolution,
        _casterFaces = casterFaces,
-       _cameraPosition = cameraPosition;
+       _cameraPosition = cameraPosition,
+       _shadowUniform = shadowUniform;
 
   final RenderScene _renderScene;
   final List<ShadowCascade> _cascades;
   final int _tileResolution;
   final ShadowCasterFaces _casterFaces;
+
+  // The packed PostShadowInfo block, published for depth-aware custom passes.
+  final ByteData? _shadowUniform;
 
   // Bound as FrameInfo.camera_position so a `vertex { }` material's
   // camera-relative displacement bends shadow casters the same way as the
@@ -109,5 +122,9 @@ class ShadowPass extends RenderGraphPass {
 
     commandBuffer.submit();
     context.blackboard.set(kShadowMapBlackboardKey, color);
+    final shadowUniform = _shadowUniform;
+    if (shadowUniform != null) {
+      context.blackboard.set(kShadowUniformBlackboardKey, shadowUniform);
+    }
   }
 }

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -1016,6 +1016,14 @@ base class Scene implements SceneGraph {
           )
         : const <ShadowCascade>[];
 
+    // The geometry buffers the enabled custom passes request, so the engine
+    // produces depth/normals even without AO/SSR and publishes the shadow
+    // uniform for depth-aware passes.
+    final customInputs = <RenderInput>{};
+    for (final pass in _renderPasses) {
+      if (pass.enabled) customInputs.addAll(pass.inputs);
+    }
+
     final graph = RenderGraph();
     if (cascades.isNotEmpty) {
       graph.addPass(
@@ -1025,6 +1033,13 @@ base class Scene implements SceneGraph {
           tileResolution: light!.shadowMapResolution,
           casterFaces: light.shadowCasterFaces,
           cameraPosition: camera.position,
+          shadowUniform: customInputs.contains(RenderInput.shadowMap)
+              ? packPostShadowInfo(
+                  cascades,
+                  lightDirection ?? light.direction,
+                  light.color * light.intensity,
+                )
+              : null,
         ),
       );
     }
@@ -1038,9 +1053,13 @@ base class Scene implements SceneGraph {
     // Reflections run after the scene is drawn (they sample the lit color),
     // so capture whether they apply here and add the pass below.
     final wantSsr = perspectiveCamera != null && screenSpaceReflections.enabled;
+    // A custom pass may request depth/normals; normals imply depth.
+    final wantCustomNormals = customInputs.contains(RenderInput.normals);
+    final wantCustomDepth =
+        wantCustomNormals || customInputs.contains(RenderInput.depth);
     if (perspectiveCamera != null) {
       final wantAo = ambientOcclusion.enabled;
-      if (wantAo || wantSsr) {
+      if (wantAo || wantSsr || wantCustomDepth) {
         // Ambient occlusion evaluates its chain (depth prepass, occlusion,
         // blur) at one resolution so depth is sampled 1:1 (a half-resolution
         // occlusion pass reading a full-resolution depth would alias on fine
@@ -1066,7 +1085,7 @@ base class Scene implements SceneGraph {
             cameraForward: cameraForward,
             farDepth: perspectiveCamera.far,
             layerMask: view.layerMask,
-            writeNormals: wantSsr,
+            writeNormals: wantSsr || wantCustomNormals,
             cameraRight: cameraRight,
             cameraUp: cameraUp,
           ),

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -9,6 +9,7 @@ import 'ambient_occlusion.dart';
 import 'camera.dart';
 import 'components/camera_component.dart';
 import 'components/directional_light_component.dart';
+import 'fog.dart';
 import 'light.dart';
 import 'material/environment.dart';
 import 'material/material.dart';
@@ -581,6 +582,11 @@ base class Scene implements SceneGraph {
   final ScreenSpaceReflectionsSettings screenSpaceReflections =
       ScreenSpaceReflectionsSettings();
 
+  /// Distance fog. Off by default; set [Fog.enabled] and a [Fog.mode] to turn it
+  /// on. Applied per-fragment by every material in linear HDR before tone
+  /// mapping, so it works on any camera type.
+  final Fog fog = Fog();
+
   @override
   void add(Node child) {
     root.add(child);
@@ -1098,6 +1104,7 @@ base class Scene implements SceneGraph {
         cascades: cascades,
         specularOcclusionMode: ambientOcclusion.specularMode.index.toDouble(),
         layerMask: view.layerMask,
+        fog: fog,
       ),
     );
     // Screen-space reflections refine the lit HDR color in place, before

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -10,6 +10,7 @@ import 'camera.dart';
 import 'components/camera_component.dart';
 import 'components/directional_light_component.dart';
 import 'fog.dart';
+import 'god_rays.dart';
 import 'light.dart';
 import 'material/environment.dart';
 import 'material/material.dart';
@@ -587,6 +588,13 @@ base class Scene implements SceneGraph {
   /// mapping, so it works on any camera type.
   final Fog fog = Fog();
 
+  /// Directional volumetric god rays. Off by default; set
+  /// [GodRaysSettings.enabled] to turn them on. Requires a shadow-casting
+  /// [DirectionalLight] and a [PerspectiveCamera] (they march the cascaded
+  /// shadow map against the camera depth); skipped otherwise.
+  final GodRaysSettings godRays = GodRaysSettings();
+  late final GodRaysPass _godRaysPass = GodRaysPass(godRays);
+
   @override
   void add(Node child) {
     root.add(child);
@@ -1016,13 +1024,21 @@ base class Scene implements SceneGraph {
           )
         : const <ShadowCascade>[];
 
-    // The geometry buffers the enabled custom passes request, so the engine
-    // produces depth/normals even without AO/SSR and publishes the shadow
-    // uniform for depth-aware passes.
+    // God rays march the cascaded shadow map against the camera depth, so they
+    // need both and a shadow-casting directional light.
+    final wantGodRays =
+        godRays.enabled &&
+        camera.projection is PerspectiveProjection &&
+        cascades.isNotEmpty;
+
+    // The geometry buffers the enabled custom passes (and god rays) request, so
+    // the engine produces depth/normals even without AO/SSR and publishes the
+    // shadow uniform for depth-aware passes.
     final customInputs = <RenderInput>{};
     for (final pass in _renderPasses) {
       if (pass.enabled) customInputs.addAll(pass.inputs);
     }
+    if (wantGodRays) customInputs.addAll(_godRaysPass.inputs);
 
     final graph = RenderGraph();
     if (cascades.isNotEmpty) {
@@ -1158,6 +1174,31 @@ base class Scene implements SceneGraph {
     final height = pixelSize.height.toInt();
     final postTime =
         DateTime.now().millisecondsSinceEpoch.remainder(100000) / 1000.0;
+
+    // Volumetric god rays, in HDR right after the scene (and reflections), so
+    // the in-scattered light tone-maps with the rest of the frame. Built on the
+    // custom-pass API: it reads the depth + shadow inputs it declared.
+    if (wantGodRays) {
+      graph.addPass(
+        UserRenderGraphPass(
+          pass: _godRaysPass,
+          camera: camera,
+          dimensions: pixelSize,
+          destination: pool.acquire(
+            TransientTextureDescriptor.color(
+              width: width,
+              height: height,
+              format: gpu.PixelFormat.r16g16b16a16Float,
+              debugName: 'god_rays',
+            ),
+          ),
+          renderScene: renderScene,
+          viewLayerMask: view.layerMask,
+          passIndex: 0,
+          time: postTime,
+        ),
+      );
+    }
 
     // Custom HDR passes right after the scene is drawn.
     _addHdrCustomPasses(

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -43,6 +43,10 @@
         "type": "fragment",
         "file": "shaders/flutter_scene_outline.frag"
     },
+    "GodRaysFragment": {
+        "type": "fragment",
+        "file": "shaders/flutter_scene_god_rays.frag"
+    },
     "SsaoFragment": {
         "type": "fragment",
         "file": "shaders/flutter_scene_ssao.frag"

--- a/packages/flutter_scene/shaders/flutter_scene_god_rays.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_god_rays.frag
@@ -135,21 +135,25 @@ void main() {
   float denom = 1.0 + g * g - 2.0 * g * cos_theta;
   float phase = (1.0 - g * g) / (4.0 * kPi * pow(max(denom, 1e-4), 1.5));
 
+  // Accumulate the lit fraction of the ray. Averaging (rather than a strong
+  // Beer-Lambert extinction) keeps the shafts long instead of collapsing all
+  // the in-scatter into the first step near the camera; density scales the
+  // overall thickness.
   int count = int(shadow.light_direction.w + 0.5);
-  float scatter = 0.0;
-  float transmittance = 1.0;
+  float lit_sum = 0.0;
   for (int i = 0; i < kMaxSteps; i++) {
     if (i >= steps) break;
     vec3 p =
         cam.camera_position.xyz + ray_dir * (offset + float(i) * step_len);
-    float visible = ShadowVisibility(p, count);
-    transmittance *= exp(-density * step_len);
-    scatter += visible * density * step_len * transmittance;
+    lit_sum += ShadowVisibility(p, count);
   }
+  float avg_lit = lit_sum / float(steps);
 
-  vec3 sun_color = shadow.light_color.rgb * god.color.rgb;
-  vec3 in_scatter = sun_color * scatter * phase * god.params0.x;
+  // The shaft color is the god-rays color directly (default white), not the
+  // light's direct radiance: a shadow-only sun (intensityScale 0, all lighting
+  // from the IBL) has zero direct color, but its shafts should still show.
   // Additive single-scattering: adds light along the view path; coverage
   // (alpha) is unchanged. Premultiplied HDR, before tone mapping.
+  vec3 in_scatter = god.color.rgb * avg_lit * phase * density * god.params0.x;
   frag_color = vec4(scene.rgb + in_scatter, scene.a);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_god_rays.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_god_rays.frag
@@ -1,0 +1,155 @@
+// Directional volumetric god rays (crepuscular rays) as a full-screen
+// post-process. Marches the view ray from the camera to the depth-buffer
+// surface, sampling the directional light's cascaded shadow map per step to
+// decide where sunlight reaches, and accumulates single-scattering with a
+// Henyey-Greenstein phase and Beer-Lambert extinction. The in-scattered light
+// is added to the linear-HDR scene color before tone mapping.
+//
+// Runs through the custom-pass API: `input_color` is the scene color,
+// `input_depth` the engine's linear (view-space) depth, `input_shadow` the
+// cascaded shadow atlas, with PostCameraInfo/PostShadowInfo describing how to
+// reconstruct world positions and sample the cascades.
+
+uniform sampler2D input_color;
+uniform sampler2D input_depth;
+uniform sampler2D input_shadow;
+
+// resolution: (w, h, 1/w, 1/h). frame: (time, -, -, -). Bound by applyShader.
+uniform PostFrameInfo {
+  vec4 resolution;
+  vec4 frame;
+}
+post_frame;
+
+// projection: (tan(fovX/2), tan(fovY/2), near, far). Then the view basis
+// (right, up, forward) and the camera world position.
+uniform PostCameraInfo {
+  vec4 projection;
+  vec4 camera_right;
+  vec4 camera_up;
+  vec4 camera_forward;
+  vec4 camera_position;
+}
+cam;
+
+// Per-cascade world->light-clip matrices, view-space split distances, the light
+// travel direction (xyz) with the cascade count in w, and the light color.
+uniform PostShadowInfo {
+  mat4 light_space_matrix[4];
+  vec4 cascade_splits;
+  vec4 light_direction;
+  vec4 light_color;
+}
+shadow;
+
+// params0: (intensity, density, anisotropy g, step count).
+// params1: (max distance, jitter, -, -). color: rgb tint * the light color.
+uniform GodRaysInfo {
+  vec4 params0;
+  vec4 params1;
+  vec4 color;
+}
+god;
+
+in vec2 v_uv;
+out vec4 frag_color;
+
+const float kPi = 3.14159265359;
+const int kMaxSteps = 64;
+// A small light-clip-space bias so a lit volume sample does not shadow itself
+// against the surface that cast into the same texel.
+const float kShadowBias = 0.0015;
+
+// Reconstructs the view-space position at [uv] from the linear depth (the eye
+// at the origin looking down +forward; see PostCameraInfo).
+vec3 ViewPositionAt(vec2 uv) {
+  float z = texture(input_depth, uv).r;
+  vec2 ndc = vec2(2.0 * uv.x - 1.0, 1.0 - 2.0 * uv.y);
+  return vec3(ndc.x * z * cam.projection.x, ndc.y * z * cam.projection.y, z);
+}
+
+// One cascade's shadow test for world point P: transform into the cascade's
+// clip space; if the point lies inside the tile, sample the atlas and return
+// 1 (lit) or 0 (shadowed) through [result]. Returns whether the point was
+// inside this cascade. Unrolled with literal indices at the call sites, since
+// dynamic indexing of the uniform matrix array is invalid on GLES 1.00.
+#define TRY_CASCADE(IDX, P, COUNT, RESULT)                                 \
+  {                                                                        \
+    vec4 lc = shadow.light_space_matrix[IDX] * vec4(P, 1.0);               \
+    vec3 proj = lc.xyz / lc.w;                                             \
+    if (abs(proj.x) < 1.0 && abs(proj.y) < 1.0) {                          \
+      vec2 tile_uv = proj.xy * 0.5 + 0.5;                                  \
+      vec2 atlas_uv = vec2((float(IDX) + tile_uv.x) / float(COUNT),        \
+                           tile_uv.y);                                     \
+      atlas_uv.y = 1.0 - atlas_uv.y; /* atlas stored top-down */           \
+      float caster = texture(input_shadow, atlas_uv).r;                    \
+      RESULT = (proj.z - kShadowBias) <= caster ? 1.0 : 0.0;               \
+      return RESULT;                                                       \
+    }                                                                      \
+  }
+
+// Sunlight visibility at world point P (1 lit, 0 shadowed). Points outside all
+// cascades are treated as lit.
+float ShadowVisibility(vec3 p, int count) {
+  float result = 1.0;
+  TRY_CASCADE(0, p, count, result);
+  if (count > 1) TRY_CASCADE(1, p, count, result);
+  if (count > 2) TRY_CASCADE(2, p, count, result);
+  if (count > 3) TRY_CASCADE(3, p, count, result);
+  return 1.0;
+}
+
+// Interleaved gradient noise (Jimenez), animated by frame time, to jitter the
+// ray start and trade banding for fine noise.
+float DitherNoise(vec2 frag) {
+  vec3 magic = vec3(0.06711056, 0.00583715, 52.9829189);
+  return fract(magic.z * fract(dot(frag + post_frame.frame.x, magic.xy)));
+}
+
+void main() {
+  vec4 scene = texture(input_color, v_uv);
+
+  float density = god.params0.y;
+  int steps = int(god.params0.w + 0.5);
+  float max_distance = god.params1.x;
+
+  // The ray from the camera to the reconstructed surface (clamped to the fog
+  // range). Where no geometry drew (depth at the far plane) the ray still
+  // marches the full range, so shafts cross the open sky.
+  vec3 view_pos = ViewPositionAt(v_uv);
+  vec3 world_end = cam.camera_position.xyz +
+                   cam.camera_right.xyz * view_pos.x +
+                   cam.camera_up.xyz * view_pos.y +
+                   cam.camera_forward.xyz * view_pos.z;
+  vec3 to_end = world_end - cam.camera_position.xyz;
+  float ray_len = min(length(to_end), max_distance);
+  vec3 ray_dir = to_end / max(length(to_end), 1e-4);
+
+  float step_len = ray_len / float(steps);
+  float offset = DitherNoise(gl_FragCoord.xy) * step_len * god.params1.y;
+
+  // Henyey-Greenstein phase toward the light: brightest looking into the sun.
+  vec3 to_sun = -normalize(shadow.light_direction.xyz);
+  float cos_theta = dot(ray_dir, to_sun);
+  float g = god.params0.z;
+  float denom = 1.0 + g * g - 2.0 * g * cos_theta;
+  float phase = (1.0 - g * g) / (4.0 * kPi * pow(max(denom, 1e-4), 1.5));
+
+  int count = int(shadow.light_direction.w + 0.5);
+  float scatter = 0.0;
+  float transmittance = 1.0;
+  for (int i = 0; i < kMaxSteps; i++) {
+    if (i >= steps) break;
+    vec3 p =
+        cam.camera_position.xyz + ray_dir * (offset + float(i) * step_len);
+    float visible = ShadowVisibility(p, count);
+    transmittance *= exp(-density * step_len);
+    scatter += visible * density * step_len * transmittance;
+  }
+
+  vec3 sun_color = shadow.light_color.rgb * god.color.rgb;
+  vec3 in_scatter = sun_color * scatter * phase * god.params0.x;
+  // Additive single-scattering: adds light along the view path; coverage
+  // (alpha) is unchanged. Premultiplied HDR, before tone mapping.
+  frag_color = vec4(scene.rgb + in_scatter, scene.a);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_unlit.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_unlit.frag
@@ -18,6 +18,10 @@ in vec4 v_color;
 
 out vec4 frag_color;
 
+// Distance fog (the FogInfo block + ApplyFog). Declared after the varyings it
+// reads (v_position, v_viewvector).
+#include <fog.glsl>
+
 const float kGamma = 2.2;
 vec3 SRGBToLinear(vec3 color) { return pow(color, vec3(kGamma)); }
 
@@ -30,5 +34,5 @@ void main() {
   // pass applies display encoding. Output is premultiplied by alpha.
   vec3 rgb = SRGBToLinear(base.rgb) * vertex_color.rgb * frag_info.color.rgb;
   float alpha = base.a * vertex_color.a * frag_info.color.a;
-  frag_color = vec4(rgb, 1.0) * alpha;
+  frag_color = ApplyFog(vec4(rgb, 1.0) * alpha);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_unlit.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_unlit.frag
@@ -34,5 +34,8 @@ void main() {
   // pass applies display encoding. Output is premultiplied by alpha.
   vec3 rgb = SRGBToLinear(base.rgb) * vertex_color.rgb * frag_info.color.rgb;
   float alpha = base.a * vertex_color.a * frag_info.color.a;
-  frag_color = ApplyFog(vec4(rgb, 1.0) * alpha);
+  // Unlit has no environment bound, so pass the flat fog color as the sky color;
+  // the sky-color mix in ApplyFog is then inert (sky-colored fog is a lit-path
+  // feature).
+  frag_color = ApplyFog(vec4(rgb, 1.0) * alpha, fog.color.rgb);
 }

--- a/packages/flutter_scene/shaders/fog.glsl
+++ b/packages/flutter_scene/shaders/fog.glsl
@@ -1,0 +1,108 @@
+// Distance fog shared by every material shader. Applied per-fragment on the
+// linear-HDR premultiplied-alpha color a material produces, before the
+// tone-mapping resolve pass, so fog is scene-referred radiance that exposure and
+// tone mapping act on along with the rest of the scene.
+//
+// The FogInfo block is self-contained (it does not depend on either material's
+// FragInfo layout) so lit and unlit shaders share one declaration. It is packed
+// and bound by EngineLightingUniforms.bindFog. Uses the world-space varyings
+// v_position and v_viewvector (= cameraPosition - fragmentPosition).
+
+uniform FogInfo {
+  // x: mode (0 none, 1 linear, 2 exponential, 3 exponential-squared)
+  // y: enabled (> 0.5)   z: maximum opacity   w: unused
+  vec4 params0;
+  // x: density   y: start distance   z: end distance   w: cutoff distance
+  // (<= 0 disables the cutoff)
+  vec4 params1;
+  // x: height (reference altitude)   y: height falloff (0 = uniform)
+  // z: sun in-scatter strength (0 = off)   w: sun in-scatter exponent
+  vec4 params2;
+  // rgb: flat fog color (linear)   w: unused
+  vec4 color;
+  // rgb: directional light color * intensity (linear)   w: has-sun (> 0.5)
+  vec4 sun;
+  // xyz: directional light travel direction (world space, toward the scene)
+  vec4 sun_dir;
+}
+fog;
+
+// Blends [premult_color] (linear HDR, premultiplied by its own alpha) toward the
+// fog color by the distance-based fog factor. Returns the fogged premultiplied
+// color; alpha (coverage) is left unchanged so a transparent fragment adds no
+// fog (the geometry behind it is fogged by its own, farther fragment).
+vec4 ApplyFog(vec4 premult_color) {
+  if (fog.params0.y < 0.5) {
+    return premult_color;
+  }
+  int mode = int(fog.params0.x + 0.5);
+  if (mode == 0) {
+    return premult_color;
+  }
+
+  float d = length(v_viewvector); // camera -> fragment distance
+  float cutoff = fog.params1.w;
+  if (cutoff > 0.0 && d > cutoff) {
+    return premult_color; // e.g. exclude an already-hazed skybox / far layer
+  }
+
+  float density = fog.params1.x;
+  float start = fog.params1.y;
+  float end = fog.params1.z;
+  float falloff = fog.params2.y;
+
+  float fog_factor;
+  if (mode == 1) {
+    // Linear near/far.
+    fog_factor = clamp((d - start) / max(end - start, 1e-4), 0.0, 1.0);
+  } else if (mode == 2) {
+    // Exponential, optionally height-modulated. With falloff <= 0 the height
+    // integral collapses to a uniform-density path (plain exponential fog).
+    float optical;
+    if (falloff > 1e-5) {
+      // Analytic integral of an exponential height-density profile along the
+      // view ray (Beer-Lambert). density(y) = density * exp(-falloff*(y-height)).
+      vec3 frag_pos = v_position;
+      vec3 camera_pos = v_position + v_viewvector;
+      float height = fog.params2.x;
+      float density_at_camera = density * exp(-falloff * (camera_pos.y - height));
+      float density_at_frag = density * exp(-falloff * (frag_pos.y - height));
+      float fh = falloff * (frag_pos.y - camera_pos.y);
+      // Average density over the ray's vertical span (the horizontal limit is
+      // handled by falling back to the camera-altitude density).
+      float per_meter = (abs(fh) > 0.00125)
+                            ? (density_at_camera - density_at_frag) / fh
+                            : density_at_camera;
+      optical = per_meter * max(d - start, 0.0);
+    } else {
+      optical = density * max(d - start, 0.0);
+    }
+    fog_factor = 1.0 - exp(-optical);
+  } else {
+    // Exponential-squared.
+    float x = density * max(d - start, 0.0);
+    fog_factor = 1.0 - exp(-x * x);
+  }
+  fog_factor = min(fog_factor, fog.params0.z);
+  if (fog_factor <= 0.0) {
+    return premult_color;
+  }
+
+  vec3 fog_color = fog.color.rgb;
+  // Cheap sun in-scatter: brighten the fog toward the directional light, so
+  // looking into the sun through fog glows. No volumetrics.
+  if (fog.sun.w > 0.5 && fog.params2.z > 0.0) {
+    vec3 ray_dir = -normalize(v_viewvector); // camera -> fragment
+    vec3 to_sun = -normalize(fog.sun_dir.xyz); // toward the light source
+    float sun_amount = max(dot(ray_dir, to_sun), 0.0);
+    float glow = pow(sun_amount, fog.params2.w);
+    fog_color += fog.sun.rgb * glow * fog.params2.z;
+  }
+
+  // Premultiplied-alpha "over": fog color scaled by the fragment's own alpha,
+  // coverage unchanged. For opaque (a = 1) this is the intuitive
+  // mix(rgb, fog_color, f); for a transparent gap (a = 0) it adds nothing.
+  float a = premult_color.a;
+  vec3 rgb = mix(premult_color.rgb, fog_color * a, fog_factor);
+  return vec4(rgb, a);
+}

--- a/packages/flutter_scene/shaders/fog.glsl
+++ b/packages/flutter_scene/shaders/fog.glsl
@@ -10,7 +10,8 @@
 
 uniform FogInfo {
   // x: mode (0 none, 1 linear, 2 exponential, 3 exponential-squared)
-  // y: enabled (> 0.5)   z: maximum opacity   w: unused
+  // y: enabled (> 0.5)   z: maximum opacity   w: sky-color influence (0 = flat
+  // color, 1 = fully the sky color sampled in the view direction)
   vec4 params0;
   // x: density   y: start distance   z: end distance   w: cutoff distance
   // (<= 0 disables the cutoff)
@@ -28,10 +29,14 @@ uniform FogInfo {
 fog;
 
 // Blends [premult_color] (linear HDR, premultiplied by its own alpha) toward the
-// fog color by the distance-based fog factor. Returns the fogged premultiplied
+// fog color by the distance-based fog factor. [sky_color] is the environment
+// radiance sampled in the view direction (the lit path supplies it; the unlit
+// path passes the flat fog color, making the sky mix inert); the fog color
+// lerps from the flat color toward it by the sky-color influence, so far
+// geometry dissolves into the sky behind it. Returns the fogged premultiplied
 // color; alpha (coverage) is left unchanged so a transparent fragment adds no
 // fog (the geometry behind it is fogged by its own, farther fragment).
-vec4 ApplyFog(vec4 premult_color) {
+vec4 ApplyFog(vec4 premult_color, vec3 sky_color) {
   if (fog.params0.y < 0.5) {
     return premult_color;
   }
@@ -88,7 +93,9 @@ vec4 ApplyFog(vec4 premult_color) {
     return premult_color;
   }
 
-  vec3 fog_color = fog.color.rgb;
+  // Fog color: the flat color, lerped toward the sky sampled in the view
+  // direction so distant geometry blends into the sky/horizon behind it.
+  vec3 fog_color = mix(fog.color.rgb, sky_color, fog.params0.w);
   // Cheap sun in-scatter: brighten the fog toward the directional light, so
   // looking into the sun through fog glows. No volumetrics.
   if (fog.sun.w > 0.5 && fog.params2.z > 0.0) {

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -10,6 +10,9 @@
 // the `prefiltered_radiance`, `brdf_lut`, and `shadow_map` samplers, the
 // MaterialInputs struct (material_inputs.glsl), and pbr.glsl + texture.glsl.
 
+// Distance fog (the FogInfo block + ApplyFog), applied to the final lit color.
+#include <fog.glsl>
+
 // Evaluates the L2 diffuse-irradiance SH polynomial in direction `n`.
 // The coefficients already include the cosine convolution and 1/pi, so
 // the result is E(n)/pi. Must use the same real-SH basis the CPU-side
@@ -381,5 +384,5 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // resolve pass (see flutter_scene_resolve.frag), so this writes into a
   // floating-point scene-color target.
   vec3 out_color = ambient + direct + emissive;
-  return vec4(out_color, 1.0) * alpha;
+  return ApplyFog(vec4(out_color, 1.0) * alpha);
 }

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -384,5 +384,27 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // resolve pass (see flutter_scene_resolve.frag), so this writes into a
   // floating-point scene-color target.
   vec3 out_color = ambient + direct + emissive;
-  return ApplyFog(vec4(out_color, 1.0) * alpha);
+
+  // Sky-colored fog: when active, sample the environment in the view direction
+  // (rotated by the same environment_transform, cross-faded like the IBL, and
+  // scaled by environment_intensity) so far geometry dissolves into the sky
+  // behind it, matching the unfogged skybox at the horizon. Only sampled when
+  // fog and its sky-color influence are on, so it is free otherwise.
+  vec3 sky_fog_color = fog.color.rgb;
+  if (fog.params0.y > 0.5 && fog.params0.w > 0.0) {
+    const float kSkyFogRoughness = 0.15;
+    vec3 sky_dir = environment_transform * normalize(-v_viewvector);
+    sky_fog_color = SampleRadianceEnv(
+        prefiltered_radiance, prefiltered_radiance_cube, sky_dir,
+        kSkyFogRoughness);
+    if (env_blend > 0.0) {
+      sky_fog_color = mix(
+          sky_fog_color,
+          SampleRadianceEnv(prefiltered_radiance_b, prefiltered_radiance_cube_b,
+                            sky_dir, kSkyFogRoughness),
+          env_blend);
+    }
+    sky_fog_color *= frag_info.environment_intensity;
+  }
+  return ApplyFog(vec4(out_color, 1.0) * alpha, sky_fog_color);
 }

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -392,7 +392,10 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // fog and its sky-color influence are on, so it is free otherwise.
   vec3 sky_fog_color = fog.color.rgb;
   if (fog.params0.y > 0.5 && fog.params0.w > 0.0) {
-    const float kSkyFogRoughness = 0.15;
+    // Sample the sharpest prefiltered level: the fog color should match the
+    // crisp skybox as closely as the environment resolution allows, so avoid
+    // extra roughness blur on top of the bake.
+    const float kSkyFogRoughness = 0.0;
     vec3 sky_dir = environment_transform * normalize(-v_viewvector);
     sky_fog_color = SampleRadianceEnv(
         prefiltered_radiance, prefiltered_radiance_cube, sky_dir,

--- a/packages/flutter_scene/test/custom_render_pass_test.dart
+++ b/packages/flutter_scene/test/custom_render_pass_test.dart
@@ -1,8 +1,4 @@
-import 'dart:typed_data';
-
 import 'package:flutter_scene/scene.dart';
-// ignore: implementation_imports
-import 'package:flutter_scene/src/light.dart';
 // ignore: implementation_imports
 import 'package:flutter_scene/src/render/custom_render_pass.dart'
     show packPostShadowInfo;
@@ -43,7 +39,7 @@ void main() {
 
   test('packPostShadowInfo matches the PostShadowInfo std140 layout', () {
     final c0 = ShadowCascade(
-      lightSpaceMatrix: Matrix4.identity()..scale(2.0, 3.0, 4.0),
+      lightSpaceMatrix: Matrix4.identity()..scaleByDouble(2.0, 3.0, 4.0, 1.0),
       splitDistance: 10.0,
       boxSize: 5.0,
     );

--- a/packages/flutter_scene/test/custom_render_pass_test.dart
+++ b/packages/flutter_scene/test/custom_render_pass_test.dart
@@ -1,0 +1,76 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/scene.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/light.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/render/custom_render_pass.dart'
+    show packPostShadowInfo;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+class _NoopPass extends CustomRenderPass {
+  @override
+  String get name => 'noop';
+  @override
+  RenderStage get stage => RenderStage.afterScene;
+  @override
+  void execute(RenderPassContext context) {}
+}
+
+class _DepthPass extends CustomRenderPass {
+  @override
+  String get name => 'depth';
+  @override
+  RenderStage get stage => RenderStage.beforeToneMapping;
+  @override
+  Set<RenderInput> get inputs => const {
+    RenderInput.depth,
+    RenderInput.shadowMap,
+  };
+  @override
+  void execute(RenderPassContext context) {}
+}
+
+void main() {
+  test(
+    'CustomRenderPass.inputs defaults to empty; declared inputs surface',
+    () {
+      expect(_NoopPass().inputs, isEmpty);
+      expect(_DepthPass().inputs, {RenderInput.depth, RenderInput.shadowMap});
+    },
+  );
+
+  test('packPostShadowInfo matches the PostShadowInfo std140 layout', () {
+    final c0 = ShadowCascade(
+      lightSpaceMatrix: Matrix4.identity()..scale(2.0, 3.0, 4.0),
+      splitDistance: 10.0,
+      boxSize: 5.0,
+    );
+    final c1 = ShadowCascade(
+      lightSpaceMatrix: Matrix4.zero(),
+      splitDistance: 40.0,
+      boxSize: 20.0,
+    );
+    final bytes = packPostShadowInfo(
+      [c0, c1],
+      Vector3(0.0, -1.0, 0.0),
+      Vector3(1.0, 0.9, 0.8),
+    );
+    final f = bytes.buffer.asFloat32List(bytes.offsetInBytes, 76);
+
+    // mat4 light_space_matrix[4] at [0..63]: cascades 0 and 1, rest zero.
+    expect(f.sublist(0, 16), c0.lightSpaceMatrix.storage);
+    expect(f.sublist(16, 32), c1.lightSpaceMatrix.storage);
+    expect(f.sublist(32, 64).every((v) => v == 0.0), isTrue);
+    // vec4 cascade_splits at [64..67].
+    expect(f[64], 10.0);
+    expect(f[65], 40.0);
+    // vec4 light_direction (xyz + count) at [68..71].
+    expect([f[68], f[69], f[70], f[71]], [0.0, -1.0, 0.0, 2.0]);
+    // vec4 light_color at [72..75].
+    expect(f[72], closeTo(1.0, 1e-6));
+    expect(f[73], closeTo(0.9, 1e-6));
+    expect(f[74], closeTo(0.8, 1e-6));
+  });
+}

--- a/packages/flutter_scene/test/fog_test.dart
+++ b/packages/flutter_scene/test/fog_test.dart
@@ -1,0 +1,36 @@
+import 'dart:math' as math;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('fog defaults to off with an exponential mode ready', () {
+    final fog = Fog();
+    expect(fog.enabled, isFalse);
+    expect(fog.mode, FogMode.exponential);
+    expect(fog.maxOpacity, 1.0);
+    expect(fog.heightFalloff, 0.0);
+    expect(fog.sunInScatter, 0.0);
+  });
+
+  test('FogMode indices match the shader mode ids', () {
+    // fog.glsl switches on 0 none, 1 linear, 2 exponential, 3 exp2.
+    expect(FogMode.none.index, 0);
+    expect(FogMode.linear.index, 1);
+    expect(FogMode.exponential.index, 2);
+    expect(FogMode.exponentialSquared.index, 3);
+  });
+
+  test('visibilityDensity maps a distance to a Beer-Lambert density', () {
+    // At the visibility distance, exp(-density*d) should equal the 0.02
+    // contrast threshold, so density = -ln(0.02)/d.
+    final density = Fog.visibilityDensity(100.0);
+    expect(density, greaterThan(0.0));
+    // Round-trip: transmittance at 100 m is ~0.02.
+    expect(math.exp(-density * 100.0), closeTo(0.02, 1e-9));
+    // Nearer visibility means denser fog.
+    expect(Fog.visibilityDensity(50.0), greaterThan(density));
+    // Non-positive distance is a safe zero.
+    expect(Fog.visibilityDensity(0.0), 0.0);
+  });
+}


### PR DESCRIPTION
Adds three related rendering features, all off by default.

Distance fog (`scene.fog`) fades geometry toward a fog color with distance, applied per-fragment in linear HDR before the tone-mapping resolve pass so it is exposed and tone-mapped along with the scene. It supports linear, exponential, and exponential-squared falloff (`FogMode`), a maximum opacity, a cutoff distance, an exponential height term that thins fog with altitude, and an in-scattering glow toward the directional light. `skyColorInfluence` blends the fog color toward the environment sampled in the view direction (aerial perspective), so distant geometry dissolves into the sky and horizon instead of a flat wall. The blend is premultiplied-alpha correct, so translucent geometry fogs without double-fogging the background behind it.

A geometry-aware custom-pass API. A `CustomRenderPass` can now declare the buffers it reads through a `RenderInput` set (`depth`, `normals`, `shadowMap`); the engine produces them that frame (running the depth prepass even without ambient occlusion or reflections, and publishing the shadow uniform) and exposes them on `RenderPassContext` as `sceneDepthLinear`, `shadowMap`, `shadowInfo` (a packed cascade block), and `cameraInfo` (for reconstructing world position from depth). This turns the existing custom-pass API into a general depth- and shadow-aware post-process system, so contact shadows, custom occlusion, depth of field, and custom volumetrics are all expressible with user GLSL. The additions are inert for passes that do not declare inputs.

Volumetric god rays (`scene.godRays`) draw directional light shafts by marching the view ray against the cascaded shadow map and adding single-scattering with a Henyey-Greenstein phase to the HDR scene color. They are built on the custom-pass API above and double as its reference implementation. Controls cover intensity, density, anisotropy, step count, maximum distance, jitter, and a color. It requires a shadow-casting directional light and a perspective camera. The march is full-resolution per-pixel, so a half-resolution tier with a bilateral upsample is a planned follow-up.

Verified on Metal (macOS): the smoke-render matrix passes with a new fog scene, and existing scenes are unchanged (the additions are inert when off). New unit tests cover the fog settings, the shadow-uniform packing, and the custom-pass input declaration. The full cross-backend matrix (GLES/Vulkan/WebGL2) runs in CI.
