### PR TITLE
Add scene loading gate, pipeline warm-up, and off-thread glTF import

### DIFF
--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -172,6 +172,7 @@ export 'src/runtime_importer/gltf_resources.dart' show GltfResourceResolver;
 export 'src/scene_path.dart'
     show BezierPath, CatmullRomPath, PolylinePath, ScenePath, ScenePathFrame;
 export 'src/raycast.dart' show SceneRaycastHit, raycastNode, raycastNodeAll;
+export 'src/resource_group.dart' show ResourceGroup;
 export 'src/scene_pointer.dart' show ScenePointer;
 export 'src/scene.dart' show AntiAliasingMode, Scene, SceneGraph;
 export 'src/widget_texture.dart'
@@ -186,5 +187,10 @@ export 'src/sun_light.dart' show SunLight;
 export 'src/surface.dart' show Surface;
 export 'src/widgets/render_texture_view.dart' show RenderTextureView;
 export 'src/widgets/scene_view.dart'
-    show SceneCameraBuilder, SceneScope, SceneTickCallback, SceneView;
+    show
+        SceneCameraBuilder,
+        SceneLoadingBuilder,
+        SceneScope,
+        SceneTickCallback,
+        SceneView;
 export 'src/tone_mapping.dart' show ToneMappingMode;

--- a/packages/flutter_scene/lib/src/resource_group.dart
+++ b/packages/flutter_scene/lib/src/resource_group.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/foundation.dart';
+
+/// Tracks a set of in-flight resource loads so a scene can wait for all of
+/// them before it is shown, and report aggregate progress while they run.
+///
+/// Every loader in Flutter Scene returns a [Future] that completes only once
+/// the resource and its dependencies are decoded and resident on the GPU, so
+/// a completed future means "ready to render this frame". A [ResourceGroup]
+/// collects those futures, exposes a [progress] value for a loading bar, and
+/// completes [ready] once they have all settled. Pass one to a `SceneView`
+/// (via its `loading` argument) to hold the scene off-screen behind a loading
+/// widget until it is fully assembled, instead of drawing it half-built.
+///
+/// ```dart
+/// final loading = ResourceGroup();
+/// final terrain = loading.add(loadScene('terrain.fscene'));
+/// final env = loading.add(
+///   EnvironmentMap.fromAssets(radianceImagePath: 'sky.png'),
+/// );
+/// loading.addAll([
+///   Node.fromGlbAsset('player.glb'),
+///   Texture2D.fromAsset('coin.png'),
+/// ]);
+///
+/// // Drive a progress bar from loading.progress, or just await:
+/// await loading.ready;
+/// scene.add(await terrain);
+/// ```
+///
+/// [progress] counts completed loads over the total tracked, so it can jump
+/// backward if you [add] more loads after it has advanced. Track every load
+/// up front (before reading [progress]) to avoid that.
+/// {@category Assets and loading}
+class ResourceGroup {
+  /// Creates an empty group. A group with nothing tracked is immediately
+  /// [isReady], and its [ready] future is already complete.
+  ResourceGroup();
+
+  int _total = 0;
+  int _completed = 0;
+  final List<Object> _failures = <Object>[];
+  final List<Future<void>> _tracked = <Future<void>>[];
+  final ValueNotifier<double> _progress = ValueNotifier<double>(1.0);
+
+  /// Tracks [load] and returns it unchanged, so the call reads inline:
+  ///
+  /// ```dart
+  /// final node = await loading.add(Node.fromGlbAsset('player.glb'));
+  /// ```
+  ///
+  /// A failed load counts toward completion (so [ready] still resolves) and
+  /// its error is recorded in [failures]; it does not abort the group.
+  Future<T> add<T>(Future<T> load) {
+    _total++;
+    _updateProgress();
+    _tracked.add(
+      load.then(
+        (_) => _markSettled(),
+        onError: (Object error, StackTrace stack) {
+          _failures.add(error);
+          _markSettled();
+        },
+      ),
+    );
+    return load;
+  }
+
+  /// Tracks each of [loads]. Convenience for calling [add] in a loop when you
+  /// do not need the individual futures back.
+  void addAll(Iterable<Future<Object?>> loads) {
+    for (final load in loads) {
+      add(load);
+    }
+  }
+
+  /// Fraction of tracked loads that have settled, in the range 0 to 1.
+  ///
+  /// A [ValueListenable] so a loading widget can rebuild as it changes without
+  /// polling. It is 1 while the group is empty (nothing to wait for).
+  ValueListenable<double> get progress => _progress;
+
+  /// Completes once every load tracked so far has settled (succeeded or
+  /// failed). Never throws; inspect [failures] for any errors.
+  ///
+  /// Loads added after this getter is awaited are not included in that wait,
+  /// so add every load before awaiting.
+  Future<void> get ready => Future.wait(_tracked);
+
+  /// The number of loads tracked so far.
+  int get total => _total;
+
+  /// The number of tracked loads that have settled.
+  int get completed => _completed;
+
+  /// Whether every tracked load has settled.
+  bool get isReady => _completed >= _total;
+
+  /// Whether any tracked load failed.
+  bool get hasFailures => _failures.isNotEmpty;
+
+  /// The errors from any tracked loads that failed, in completion order.
+  List<Object> get failures => List<Object>.unmodifiable(_failures);
+
+  /// Releases the [progress] notifier. Call when the group is no longer used;
+  /// after disposal the group must not be added to or listened on.
+  void dispose() => _progress.dispose();
+
+  void _markSettled() {
+    _completed++;
+    _updateProgress();
+  }
+
+  void _updateProgress() {
+    _progress.value = _total == 0 ? 1.0 : _completed / _total;
+  }
+}

--- a/packages/flutter_scene/lib/src/runtime_importer/geometry_builder.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/geometry_builder.dart
@@ -5,33 +5,15 @@ import 'package:flutter_scene/src/importer/gltf.dart';
 
 import '../geometry/geometry.dart';
 
-/// An engine [Geometry] built from a glTF mesh primitive, paired with
-/// its vertex count.
-class BuiltGeometry {
-  BuiltGeometry({required this.geometry, required this.vertexCount});
-  final Geometry geometry;
-  final int vertexCount;
-}
-
-/// Builds and GPU-uploads an engine [Geometry] from a glTF mesh
+/// GPU-uploads an engine [Geometry] from a [packGltfPrimitive]-packed
 /// primitive.
 ///
-/// The pure-data packing (vertex layout, index handling, normal
-/// generation) is done by [packGltfPrimitive]
-/// so the runtime GLB importer and the offline scene emitter share
-/// one implementation.
-BuiltGeometry buildGeometry({
-  required GltfMeshPrimitive primitive,
-  required List<GltfAccessor> accessors,
-  required List<GltfBufferView> bufferViews,
-  required Uint8List bufferData,
-}) {
-  final packed = packGltfPrimitive(
-    primitive: primitive,
-    accessors: accessors,
-    bufferViews: bufferViews,
-    bufferData: bufferData,
-  );
+/// The pure-data packing (vertex layout, index handling, normal generation)
+/// is done by [packGltfPrimitive], off the raster thread on a background
+/// isolate for the runtime importer; this upload half must run on the raster
+/// thread. Keeping them split is what lets a large model pack without stalling
+/// the UI. The offline scene emitter shares the same packer.
+Geometry geometryFromPacked(PackedPrimitive packed) {
   final Geometry geometry = packed.isSkinned
       ? SkinnedGeometry()
       : UnskinnedGeometry();
@@ -41,5 +23,5 @@ BuiltGeometry buildGeometry({
     ByteData.sublistView(packed.indexBytes),
     indexType: packed.indices32Bit ? gpu.IndexType.int32 : gpu.IndexType.int16,
   );
-  return BuiltGeometry(geometry: geometry, vertexCount: packed.vertexCount);
+  return geometry;
 }

--- a/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
@@ -31,7 +31,8 @@ Future<Node> importGlb(Uint8List bytes) async {
     glbBinaryChunk: container.binaryChunk,
     resolveUri: null,
   );
-  return _buildScene(doc, bufferData, null);
+  final packed = await _packPrimitives(doc, bufferData);
+  return _buildScene(doc, bufferData, packed, null);
 }
 
 /// Parse a multi-file glTF document into a [Node] tree.
@@ -51,14 +52,57 @@ Future<Node> importGltf(
     glbBinaryChunk: Uint8List(0),
     resolveUri: resolveUri,
   );
-  return _buildScene(doc, bufferData, resolveUri);
+  final packed = await _packPrimitives(doc, bufferData);
+  return _buildScene(doc, bufferData, packed, resolveUri);
 }
 
-/// Builds the [Node] tree from a parsed document and its resolved
-/// buffer. Shared by the GLB and multi-file glTF entry points.
+/// Packs every mesh primitive's vertex/index data on a background isolate,
+/// off the UI thread, so a large model does not stall the app while it loads.
+///
+/// Returns the packed primitives indexed `[meshIndex][primitiveIndex]`, with a
+/// null entry for each non-triangle primitive (skipped, see [_populateNode]).
+/// The GPU upload of these buffers still happens on the raster thread, in
+/// [geometryFromPacked]; only the pure-data packing moves off it. On the web,
+/// where [compute] runs inline, this is a no-op indirection.
+///
+/// TODO(runtime-import-offload): the JSON parse and the skin/animation accessor
+/// decode still run on the calling thread. They are small next to vertex
+/// packing, but could also move onto the isolate (parse from raw bytes there,
+/// return the packed skins/animations too) to fully offload a heavy import.
+Future<List<List<PackedPrimitive?>>> _packPrimitives(
+  GltfDocument doc,
+  Uint8List bufferData,
+) => compute(_packPrimitivesIsolate, (doc: doc, bufferData: bufferData));
+
+// Top-level so it can run on a background isolate. Packs each primitive with
+// the shared [packGltfPrimitive]; non-triangle topologies pack to null.
+List<List<PackedPrimitive?>> _packPrimitivesIsolate(
+  ({GltfDocument doc, Uint8List bufferData}) input,
+) {
+  final doc = input.doc;
+  return [
+    for (final mesh in doc.meshes)
+      [
+        for (final p in mesh.primitives)
+          if (p.mode != 4)
+            null
+          else
+            packGltfPrimitive(
+              primitive: p,
+              accessors: doc.accessors,
+              bufferViews: doc.bufferViews,
+              bufferData: input.bufferData,
+            ),
+      ],
+  ];
+}
+
+/// Builds the [Node] tree from a parsed document, its resolved buffer, and its
+/// pre-packed primitives. Shared by the GLB and multi-file glTF entry points.
 Future<Node> _buildScene(
   GltfDocument doc,
   Uint8List bufferData,
+  List<List<PackedPrimitive?>> packed,
   GltfResourceResolver? resolveUri,
 ) async {
   // Decode all textures up front so material construction can reference
@@ -79,7 +123,7 @@ Future<Node> _buildScene(
       engineNode: engineNodes[i],
       gltfNode: doc.nodes[i],
       doc: doc,
-      bufferData: bufferData,
+      packed: packed,
       engineNodes: engineNodes,
       textures: textures,
     );
@@ -151,7 +195,7 @@ void _populateNode({
   required Node engineNode,
   required GltfNode gltfNode,
   required GltfDocument doc,
-  required Uint8List bufferData,
+  required List<List<PackedPrimitive?>> packed,
   required List<Node> engineNodes,
   required List<Texture2D> textures,
 }) {
@@ -160,26 +204,25 @@ void _populateNode({
 
   if (gltfNode.mesh != null) {
     final gltfMesh = doc.meshes[gltfNode.mesh!];
+    final packedMesh = packed[gltfNode.mesh!];
     final primitives = <MeshPrimitive>[];
-    for (final p in gltfMesh.primitives) {
-      // Skip non-triangle topologies for now; they need shader/render-state
-      // support that flutter_scene's pipeline doesn't currently expose.
-      if (p.mode != 4) {
+    for (int pi = 0; pi < gltfMesh.primitives.length; pi++) {
+      final p = gltfMesh.primitives[pi];
+      final packedPrimitive = packedMesh[pi];
+      // A null entry is a non-triangle topology skipped during packing; they
+      // need shader/render-state support that flutter_scene's pipeline doesn't
+      // currently expose.
+      if (packedPrimitive == null) {
         debugPrint(
           'Skipping mesh primitive with unsupported topology mode ${p.mode}',
         );
         continue;
       }
-      final built = buildGeometry(
-        primitive: p,
-        accessors: doc.accessors,
-        bufferViews: doc.bufferViews,
-        bufferData: bufferData,
-      );
+      final geometry = geometryFromPacked(packedPrimitive);
       final material = p.material != null
           ? buildMaterial(doc.materials[p.material!], textures)
           : UnlitMaterial();
-      primitives.add(MeshPrimitive(built.geometry, material));
+      primitives.add(MeshPrimitive(geometry, material));
     }
     if (primitives.isNotEmpty) {
       engineNode.mesh = Mesh.primitives(primitives: primitives);

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -112,6 +112,17 @@ base class Scene implements SceneGraph {
   static Future<void>? _initializeStaticResources;
   static bool _readyToRender = false;
 
+  /// Whether the engine's shared static resources (the base shader library and
+  /// the material BRDF lookup table) have finished loading, so any scene can
+  /// render this frame.
+  ///
+  /// Rendering is gated on this: a `SceneView` shows its loading widget, and a
+  /// direct [render] call is skipped, until it is `true`. Await
+  /// [initializeStaticResources] (or use a `SceneView` with a `loadingBuilder`)
+  /// to react to it.
+  /// {@category Assets and loading}
+  static bool get isReadyToRender => _readyToRender;
+
   /// Computes the linear exposure multiplier for a physical pinhole
   /// camera, the way photographers reason about it: [aperture] (f-stops),
   /// [shutterSpeed] (seconds), and sensor [iso].

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -744,6 +744,43 @@ base class Scene implements SceneGraph {
     );
   }
 
+  /// Compiles the render pipelines and uploads the GPU resources this scene
+  /// needs, by encoding one frame offscreen and discarding it, so the first
+  /// visible frame does not stall while shaders compile or textures upload.
+  ///
+  /// Pass the same [views] the scene will be shown with: their cameras,
+  /// anti-aliasing, render targets, and this scene's lights and post-process
+  /// settings determine which pipeline variants compile, so a warm-up frame
+  /// must match the real one (the offscreen frame is rendered tiny, since a
+  /// pipeline's identity does not depend on resolution). Populate the scene
+  /// first; warm-up encodes whatever is attached when it runs.
+  ///
+  /// A `SceneView` with `warmUp: true` calls this before it reveals the scene.
+  /// Awaiting it is optional and safe to repeat. It awaits
+  /// [initializeStaticResources] first. On backends that compile pipelines
+  /// lazily on first draw (the common case) this front-loads that cost; on a
+  /// backend that compiles asynchronously it kicks compilation off without
+  /// blocking on completion.
+  /// {@category Assets and loading}
+  Future<void> warmUp(List<RenderView> views) async {
+    await initializeStaticResources();
+    if (views.isEmpty) {
+      return;
+    }
+    // Advance a zero step so the warm-up frame does not move the scene's clock
+    // forward before the first real frame (render then skips its implicit
+    // wall-clock tick).
+    update(0.0);
+    // Encode one real frame into a discarded recording. The GPU passes (and so
+    // the pipeline compilations and resource uploads) are submitted during
+    // rendering; only the final canvas blit is thrown away. A small area is
+    // enough because pipeline identity is resolution-independent.
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
+    renderViews(views, canvas, region: const ui.Rect.fromLTWH(0, 0, 64, 64));
+    recorder.endRecording().dispose();
+  }
+
   /// Renders a list of [views] of this scene onto [canvas].
   ///
   /// Each [RenderView] binds a camera to a normalized sub-rectangle of

--- a/packages/flutter_scene/lib/src/widgets/scene_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/hot_reload/hot_reload_coordinator.dart';
 import 'package:flutter_scene/src/render_view.dart';
 import 'package:flutter_scene/src/components/widget_component.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter_scene/src/resource_group.dart';
 import 'package:flutter_scene/src/scene.dart';
 import 'package:flutter_scene/src/scene_pointer.dart';
 import 'package:flutter_scene/src/widget_texture.dart';
@@ -31,6 +32,12 @@ typedef SceneViewsBuilder = List<RenderView> Function(Duration elapsed);
 /// {@category Widgets}
 typedef SceneTickCallback =
     void Function(Duration elapsed, double deltaSeconds);
+
+/// Builds the widget shown while a [SceneView] waits for its resources to load,
+/// given the current load [progress] (0 to 1). See [SceneView.loadingBuilder].
+/// {@category Widgets}
+typedef SceneLoadingBuilder =
+    Widget Function(BuildContext context, double progress);
 
 /// A widget that renders a [Scene] and drives its per-frame repaint.
 ///
@@ -83,6 +90,9 @@ class SceneView extends StatefulWidget {
     this.autoTick = true,
     this.pixelRatio,
     this.onTick,
+    this.loading,
+    this.loadingBuilder,
+    this.revealMinDuration = Duration.zero,
     this.debugWidgetInput = false,
   }) : assert(
          (camera != null ? 1 : 0) +
@@ -125,7 +135,33 @@ class SceneView extends StatefulWidget {
   final bool debugWidgetInput;
 
   /// Called once per frame while ticking. See [SceneTickCallback].
+  ///
+  /// When the view is gated by [loading] or [loadingBuilder], it is not called
+  /// while the loading widget is shown (per-frame app logic stays paused until
+  /// the scene is revealed), and its first call after reveal carries a
+  /// single-frame delta rather than the whole loading time.
   final SceneTickCallback? onTick;
+
+  /// Resources this view waits for before it reveals the scene.
+  ///
+  /// While the group is loading (and while the engine's shared static
+  /// resources are still initializing), the scene is held off-screen and
+  /// [loadingBuilder] is shown in its place, so a half-built scene is never
+  /// drawn. Once the group and static resources are ready, the fully assembled
+  /// scene is revealed in one frame. Leave null to render as soon as static
+  /// resources are ready (the historical behavior).
+  final ResourceGroup? loading;
+
+  /// Builds the widget shown while the view waits to reveal the scene.
+  ///
+  /// Called with the current load [progress] (the [loading] group's progress,
+  /// or 0 until static resources are ready when there is no group). When null,
+  /// the space is left blank until the scene is revealed.
+  final SceneLoadingBuilder? loadingBuilder;
+
+  /// The minimum time the loading widget stays up once shown, so a fast load
+  /// does not flash it for a single frame. Defaults to [Duration.zero].
+  final Duration revealMinDuration;
 
   /// Resolves the camera for a single-view frame.
   ///
@@ -165,11 +201,33 @@ class _SceneViewState extends State<SceneView>
   Ticker? _ticker;
   Duration _lastTick = Duration.zero;
 
+  // Zero-based clock: the ticker's raw elapsed at the moment the scene is
+  // revealed, subtracted from later ticks so the visible scene starts its time
+  // (and its first frame delta) from zero rather than from app launch.
+  Duration _tickOrigin = Duration.zero;
+
+  // Whether the scene is being drawn yet. While gated (see `_gated`) it stays
+  // false until static resources and the `loading` group are ready, and the
+  // loading widget shows instead. Ungated views reveal immediately, so this is
+  // true from the first frame and behavior matches a view with no loading args.
+  bool _revealed = false;
+  // Bumps on each reveal watch so a stale async wait (after the loading group
+  // is swapped) cannot reveal the wrong generation.
+  int _revealGeneration = 0;
+
+  // A view gates rendering only when it opts in with a `loading` group or a
+  // `loadingBuilder`; otherwise it renders as soon as it can, unchanged.
+  bool get _gated => widget.loading != null || widget.loadingBuilder != null;
+
   @override
   void initState() {
     super.initState();
     if (widget.autoTick) {
       _ticker = createTicker(_onTick)..start();
+    }
+    _revealed = !_gated;
+    if (_gated) {
+      _startRevealWatch();
     }
   }
 
@@ -180,16 +238,51 @@ class _SceneViewState extends State<SceneView>
       _ticker?.dispose();
       _ticker = widget.autoTick ? (createTicker(_onTick)..start()) : null;
     }
+    // A new set of resources to wait for (or newly gated): hold the scene again
+    // until they load.
+    final gatedBefore =
+        oldWidget.loading != null || oldWidget.loadingBuilder != null;
+    if (widget.loading != oldWidget.loading || _gated != gatedBefore) {
+      _revealed = !_gated;
+      if (_gated) {
+        _startRevealWatch();
+      }
+    }
     // Repaint immediately so a changed camera / scene is reflected even when
     // not auto-ticking.
     _repaint.notify();
   }
 
+  // Waits for the engine's shared static resources and the `loading` group,
+  // then reveals the scene (after `revealMinDuration`), so a half-built scene
+  // is never drawn.
+  Future<void> _startRevealWatch() async {
+    final generation = ++_revealGeneration;
+    final start = DateTime.now();
+    await Scene.initializeStaticResources();
+    await widget.loading?.ready;
+    final remaining =
+        widget.revealMinDuration - DateTime.now().difference(start);
+    if (remaining > Duration.zero) {
+      await Future<void>.delayed(remaining);
+    }
+    if (!mounted || generation != _revealGeneration) return;
+    setState(() => _revealed = true);
+  }
+
   void _onTick(Duration elapsed) {
-    final deltaSeconds = (elapsed - _lastTick).inMicroseconds / 1e6;
-    _lastTick = elapsed;
-    _elapsed.value = elapsed;
-    widget.onTick?.call(elapsed, deltaSeconds);
+    if (!_revealed) {
+      // Hold the origin at the latest tick so the first revealed frame's delta
+      // is a single frame, not the whole time spent on the loading screen.
+      _tickOrigin = elapsed;
+      _lastTick = Duration.zero;
+      return;
+    }
+    final revealElapsed = elapsed - _tickOrigin;
+    final deltaSeconds = (revealElapsed - _lastTick).inMicroseconds / 1e6;
+    _lastTick = revealElapsed;
+    _elapsed.value = revealElapsed;
+    widget.onTick?.call(revealElapsed, deltaSeconds);
     _repaint.notify();
   }
 
@@ -310,6 +403,9 @@ class _SceneViewState extends State<SceneView>
       child: LayoutBuilder(
         builder: (context, constraints) {
           _viewSize = constraints.biggest;
+          if (!_revealed) {
+            return _buildLoading(context);
+          }
           return Listener(
             // Translucent: forwarded events still reach the app's own
             // gesture handlers; the scene never wins a gesture arena.
@@ -373,6 +469,25 @@ class _SceneViewState extends State<SceneView>
           );
         },
       ),
+    );
+  }
+
+  // The placeholder shown before the scene is revealed. Rebuilds as the
+  // loading group's progress advances so a progress bar can animate.
+  Widget _buildLoading(BuildContext context) {
+    final builder = widget.loadingBuilder;
+    if (builder == null) {
+      return const SizedBox.expand();
+    }
+    final progress = widget.loading?.progress;
+    if (progress == null) {
+      // No group to measure: progress reads 0 until static resources flip the
+      // view to revealed.
+      return builder(context, 0.0);
+    }
+    return ValueListenableBuilder<double>(
+      valueListenable: progress,
+      builder: (context, value, _) => builder(context, value),
     );
   }
 

--- a/packages/flutter_scene/lib/src/widgets/scene_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view.dart
@@ -93,6 +93,7 @@ class SceneView extends StatefulWidget {
     this.loading,
     this.loadingBuilder,
     this.revealMinDuration = Duration.zero,
+    this.warmUp = false,
     this.debugWidgetInput = false,
   }) : assert(
          (camera != null ? 1 : 0) +
@@ -163,6 +164,15 @@ class SceneView extends StatefulWidget {
   /// does not flash it for a single frame. Defaults to [Duration.zero].
   final Duration revealMinDuration;
 
+  /// Whether to compile the scene's render pipelines before revealing it, so
+  /// the first visible frame does not stall while shaders compile.
+  ///
+  /// When true, the view calls [Scene.warmUp] with its own views once the
+  /// [loading] group (if any) is ready, and reveals only after. This gates the
+  /// view even without a [loading] group or [loadingBuilder]. Populate the
+  /// scene before warm-up runs (loads tracked by [loading] are awaited first).
+  final bool warmUp;
+
   /// Resolves the camera for a single-view frame.
   ///
   /// Precedence: the explicit [camera], then [cameraBuilder] evaluated at
@@ -215,9 +225,11 @@ class _SceneViewState extends State<SceneView>
   // is swapped) cannot reveal the wrong generation.
   int _revealGeneration = 0;
 
-  // A view gates rendering only when it opts in with a `loading` group or a
-  // `loadingBuilder`; otherwise it renders as soon as it can, unchanged.
-  bool get _gated => widget.loading != null || widget.loadingBuilder != null;
+  // A view gates rendering only when it opts in with a `loading` group, a
+  // `loadingBuilder`, or `warmUp`; otherwise it renders as soon as it can,
+  // unchanged.
+  bool get _gated =>
+      widget.loading != null || widget.loadingBuilder != null || widget.warmUp;
 
   @override
   void initState() {
@@ -241,7 +253,9 @@ class _SceneViewState extends State<SceneView>
     // A new set of resources to wait for (or newly gated): hold the scene again
     // until they load.
     final gatedBefore =
-        oldWidget.loading != null || oldWidget.loadingBuilder != null;
+        oldWidget.loading != null ||
+        oldWidget.loadingBuilder != null ||
+        oldWidget.warmUp;
     if (widget.loading != oldWidget.loading || _gated != gatedBefore) {
       _revealed = !_gated;
       if (_gated) {
@@ -260,7 +274,15 @@ class _SceneViewState extends State<SceneView>
     final generation = ++_revealGeneration;
     final start = DateTime.now();
     await Scene.initializeStaticResources();
+    if (!mounted || generation != _revealGeneration) return;
     await widget.loading?.ready;
+    if (!mounted || generation != _revealGeneration) return;
+    // Compile the pipelines the first frame needs while the loading widget is
+    // still up, so the reveal frame does not stall.
+    if (widget.warmUp) {
+      await widget.scene.warmUp(_warmUpViews());
+      if (!mounted || generation != _revealGeneration) return;
+    }
     final remaining =
         widget.revealMinDuration - DateTime.now().difference(start);
     if (remaining > Duration.zero) {
@@ -269,6 +291,11 @@ class _SceneViewState extends State<SceneView>
     if (!mounted || generation != _revealGeneration) return;
     setState(() => _revealed = true);
   }
+
+  // The views to warm up, matching what the first rendered frame will use.
+  List<RenderView> _warmUpViews() => widget.viewsBuilder != null
+      ? _viewsForFrame()
+      : [RenderView(camera: _cameraForFrame())];
 
   void _onTick(Duration elapsed) {
     if (!_revealed) {

--- a/packages/flutter_scene/test/resource_group_test.dart
+++ b/packages/flutter_scene/test/resource_group_test.dart
@@ -1,0 +1,103 @@
+// Unit tests for ResourceGroup. Pure Dart (no GPU/Impeller), so these run
+// under a plain `flutter test`.
+
+import 'dart:async';
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('empty group is immediately ready', () async {
+    final group = ResourceGroup();
+    expect(group.isReady, isTrue);
+    expect(group.total, 0);
+    expect(group.completed, 0);
+    expect(group.progress.value, 1.0);
+    await group.ready; // completes without hanging
+    group.dispose();
+  });
+
+  test('add returns the same future and tracks completion', () async {
+    final group = ResourceGroup();
+    final completer = Completer<int>();
+    final returned = group.add(completer.future);
+
+    expect(identical(returned, completer.future), isTrue);
+    expect(group.total, 1);
+    expect(group.completed, 0);
+    expect(group.isReady, isFalse);
+    expect(group.progress.value, 0.0);
+
+    completer.complete(42);
+    await group.ready;
+
+    expect(group.completed, 1);
+    expect(group.isReady, isTrue);
+    expect(group.progress.value, 1.0);
+    expect(await returned, 42);
+    group.dispose();
+  });
+
+  test('progress advances as loads settle', () async {
+    final group = ResourceGroup();
+    final a = Completer<void>();
+    final b = Completer<void>();
+    final c = Completer<void>();
+    group.addAll([a.future, b.future, c.future]);
+
+    expect(group.total, 3);
+    expect(group.progress.value, 0.0);
+
+    a.complete();
+    await Future<void>.delayed(Duration.zero);
+    expect(group.completed, 1);
+    expect(group.progress.value, closeTo(1 / 3, 1e-9));
+
+    b.complete();
+    c.complete();
+    await group.ready;
+    expect(group.progress.value, 1.0);
+    group.dispose();
+  });
+
+  test(
+    'a failed load counts as settled and is recorded, ready never throws',
+    () async {
+      final group = ResourceGroup();
+      final ok = Completer<void>();
+      final bad = Completer<void>();
+      group.add(ok.future);
+      group.add(bad.future);
+
+      ok.complete();
+      bad.completeError(StateError('boom'));
+
+      await group.ready; // must not throw
+      expect(group.isReady, isTrue);
+      expect(group.hasFailures, isTrue);
+      expect(group.failures, hasLength(1));
+      expect(group.failures.single, isA<StateError>());
+      group.dispose();
+    },
+  );
+
+  test('progress notifies listeners', () async {
+    final group = ResourceGroup();
+    final values = <double>[];
+    group.progress.addListener(() => values.add(group.progress.value));
+
+    final a = Completer<void>();
+    final b = Completer<void>();
+    group.add(a.future); // total 1 -> progress 0.0
+    group.add(b.future); // total 2 -> progress 0.0 (still)
+
+    a.complete();
+    await Future<void>.delayed(Duration.zero);
+    b.complete();
+    await group.ready;
+
+    expect(values, isNotEmpty);
+    expect(values.last, 1.0);
+    group.dispose();
+  });
+}


### PR DESCRIPTION
Scenes can now hold rendering until their content is loaded, so they no longer flash half-built (objects at the origin, one group drawn before another) while assets stream in. This adds an opt-in loading gate, an offscreen pipeline warm-up, and off-UI-thread geometry packing.

`ResourceGroup` tracks a set of in-flight loads, reports aggregate progress as a `ValueListenable<double>`, and completes when they have all settled (recording any errors without aborting).

`SceneView` gains `loading`, `loadingBuilder`, and `revealMinDuration`. When either `loading` or `loadingBuilder` is set, the view holds the scene off-screen behind the loading widget until the engine's shared static resources and the tracked loads are ready, then reveals the fully assembled scene in one frame. While gated, per-frame ticking is paused and the first tick after reveal carries a single-frame delta. `revealMinDuration` keeps a fast load from flashing the loading widget. A view with no loading arguments renders exactly as before.

`Scene.warmUp` compiles the scene's render pipelines and uploads its GPU resources ahead of the first visible frame by encoding one frame offscreen and discarding it, so the first frame does not stall while shaders compile. It renders through the real view path at a tiny size, since a pipeline's identity does not depend on resolution, so it compiles exactly the variants the first frame uses. `SceneView` gains a `warmUp` flag that runs it once the loading group is ready, before reveal; it gates the view on its own.

The runtime glTF/GLB importer now packs mesh geometry on a background isolate, so loading a large model no longer stalls the UI thread with that work. The document is parsed and its buffers resolved on the calling thread, every primitive is packed on the isolate, and the packed buffers are uploaded to the GPU on the raster thread as before. The shared packer is unchanged, so imported geometry is byte-for-byte identical. On the web, where the isolate helper runs inline, this is transparent.

`Scene.isReadyToRender` exposes the shared static-resource state.

All of it is additive and non-breaking. 771 tests pass, and the changes are exercised end to end by a downstream app on Metal (loading screen, warm-up, and the off-thread import of a skinned, animated model). The render-path pieces still want a run across the full smoke matrix, which CI covers.
