### PR TITLE
Add point and spot lights, unlimited lights via culling, and spot shadows

### DIFF
--- a/examples/flutter_app/lib/example_lights.dart
+++ b/examples/flutter_app/lib/example_lights.dart
@@ -4,9 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
-/// Point and spot lights orbiting a small set of matte shapes. The ambient
-/// (image-based) light is turned down and there is no directional sun, so the
-/// colored point lights and the overhead spot are what light the scene.
+/// A grid of colored point lights over a grid of shapes. There are far more
+/// lights than the per-object budget, but each light has a finite range and
+/// reaches only nearby shapes, so per-object culling keeps every fragment cheap
+/// while the scene as a whole holds an unlimited number of lights.
 class ExampleLights extends StatefulWidget {
   const ExampleLights({super.key});
 
@@ -14,18 +15,13 @@ class ExampleLights extends StatefulWidget {
   ExampleLightsState createState() => ExampleLightsState();
 }
 
-/// Moves the owning node around a horizontal circle, so a light attached to
-/// the node orbits the scene.
-class _OrbitComponent extends Component {
-  _OrbitComponent({
-    required this.radius,
-    required this.height,
-    required this.speed,
-    required this.phase,
-  });
+/// Bobs the owning node up and down about a base position, so its light drifts
+/// and the culling (and light pools) update every frame.
+class _BobComponent extends Component {
+  _BobComponent(this.base, this.amplitude, this.speed, this.phase);
 
-  final double radius;
-  final double height;
+  final vm.Vector3 base;
+  final double amplitude;
   final double speed;
   final double phase;
   double _elapsed = 0.0;
@@ -33,138 +29,115 @@ class _OrbitComponent extends Component {
   @override
   void update(double deltaSeconds) {
     _elapsed += deltaSeconds;
-    final angle = _elapsed * speed + phase;
     node.localTransform = vm.Matrix4.translation(
-      vm.Vector3(cos(angle) * radius, height, sin(angle) * radius),
+      vm.Vector3(
+        base.x,
+        base.y + sin(_elapsed * speed + phase) * amplitude,
+        base.z,
+      ),
     );
   }
 }
+
+const int _grid = 5; // _grid * _grid lights and shapes
+const double _spacing = 6.0;
 
 class ExampleLightsState extends State<ExampleLights> {
   Scene scene = Scene();
 
   @override
   void initState() {
-    // Dim the image-based ambient and drop the sun so the punctual lights are
-    // what the eye reads.
+    // Dim the image-based ambient and drop the sun so the colored point lights
+    // are what the eye reads. Reflect the lit scene off the floor.
     scene.environmentIntensity = 0.1;
     scene.directionalLight = null;
-
-    // Reflect the lit scene off the floor.
     scene.screenSpaceReflections.enabled = true;
 
-    // A dark, near-polished floor so the colored light pools and the spheres
-    // reflect in it.
+    final extent = (_grid - 1) * _spacing / 2;
+
+    // A dark, near-polished floor large enough to hold the grid, so the light
+    // pools and shapes reflect in it.
+    final floorSize = _grid * _spacing + 6;
     scene.add(
       Node(
         mesh: Mesh(
-          CuboidGeometry(vm.Vector3(24, 0.2, 24)),
+          CuboidGeometry(vm.Vector3(floorSize, 0.2, floorSize)),
           PhysicallyBasedMaterial()
             ..baseColorFactor = vm.Vector4(0.05, 0.05, 0.06, 1)
-            ..roughnessFactor = 0.08
+            ..roughnessFactor = 0.1
             ..metallicFactor = 0.0,
         ),
         localTransform: vm.Matrix4.translation(vm.Vector3(0, -1.2, 0)),
       ),
     );
 
-    // A ring of spheres spanning a range of material properties: alternating
-    // metal and dielectric, roughness increasing around the ring.
-    final sphereColors = <vm.Vector4>[
-      vm.Vector4(0.95, 0.64, 0.54, 1), // copper-ish
-      vm.Vector4(0.9, 0.9, 0.92, 1), // silver-ish
-      vm.Vector4(1.0, 0.86, 0.57, 1), // gold-ish
-      vm.Vector4(0.8, 0.85, 0.9, 1),
-      vm.Vector4(0.85, 0.85, 0.85, 1),
-      vm.Vector4(0.75, 0.8, 0.85, 1),
-    ];
-    for (var i = 0; i < 6; i++) {
-      final angle = i / 6 * 2 * pi;
-      scene.add(
-        Node(
-          mesh: Mesh(
-            SphereGeometry(radius: 0.7),
-            PhysicallyBasedMaterial()
-              ..baseColorFactor = sphereColors[i]
-              // Alternate metal and dielectric; sweep roughness around the ring
-              // so the same lights read across smooth-to-rough surfaces.
-              ..metallicFactor = i.isEven ? 1.0 : 0.0
-              ..roughnessFactor = 0.05 + i / 5 * 0.7,
-          ),
-          localTransform: vm.Matrix4.translation(
-            vm.Vector3(cos(angle) * 4, 0, sin(angle) * 4),
-          ),
-        ),
-      );
-    }
+    var index = 0;
+    for (var i = 0; i < _grid; i++) {
+      for (var j = 0; j < _grid; j++) {
+        final x = i * _spacing - extent;
+        final z = j * _spacing - extent;
+        final t = index / (_grid * _grid);
 
-    // Three colored point lights orbiting at different phases, each marked by
-    // a small unlit sphere so its position is visible.
-    final colors = <vm.Vector3>[
-      vm.Vector3(1.0, 0.2, 0.2),
-      vm.Vector3(0.2, 1.0, 0.3),
-      vm.Vector3(0.3, 0.4, 1.0),
-    ];
-    for (var i = 0; i < colors.length; i++) {
-      final node = Node()
-        ..addComponent(
-          PointLightComponent(
-            PointLight(color: colors[i], intensity: 22.0, range: 14.0),
-          ),
-        )
-        ..addComponent(
-          _OrbitComponent(
-            radius: 5.5,
-            height: 1.5,
-            speed: 0.6,
-            phase: i / colors.length * 2 * pi,
+        // A shape at the grid cell, its material sweeping metal/dielectric and
+        // roughness across the grid.
+        scene.add(
+          Node(
+            mesh: Mesh(
+              SphereGeometry(radius: 1.0),
+              PhysicallyBasedMaterial()
+                ..baseColorFactor = vm.Vector4(0.85, 0.85, 0.87, 1)
+                ..metallicFactor = index.isEven ? 1.0 : 0.0
+                ..roughnessFactor = 0.1 + t * 0.6,
+            ),
+            localTransform: vm.Matrix4.translation(vm.Vector3(x, 0, z)),
           ),
         );
-      node.add(
-        Node(
-          mesh: Mesh(
-            SphereGeometry(radius: 0.12),
-            UnlitMaterial()
-              ..baseColorFactor = vm.Vector4(
-                colors[i].x,
-                colors[i].y,
-                colors[i].z,
-                1,
-              ),
-          ),
-        ),
-      );
-      scene.add(node);
-    }
 
-    // A warm overhead spot light pointing straight down at the center.
-    scene.add(
-      Node(localTransform: vm.Matrix4.translation(vm.Vector3(0, 8, 0)))
-        ..addComponent(
-          SpotLightComponent(
-            SpotLight(
-              color: vm.Vector3(1.0, 0.9, 0.7),
-              intensity: 60.0,
-              range: 20.0,
-              direction: vm.Vector3(0, -1, 0),
-              innerConeAngle: 0.15,
-              outerConeAngle: 0.5,
+        // A colored point light above the cell. Its range (7) reaches only the
+        // neighboring cells, so no shape is lit by more than a handful of the
+        // grid's lights even though the whole grid has many.
+        final color = HSVColor.fromAHSV(1.0, t * 360.0, 0.9, 1.0).toColor();
+        final rgb = vm.Vector3(
+          color.r.toDouble(),
+          color.g.toDouble(),
+          color.b.toDouble(),
+        );
+        final lightNode = Node()
+          ..addComponent(
+            PointLightComponent(
+              PointLight(color: rgb, intensity: 14.0, range: 7.0),
+            ),
+          )
+          ..addComponent(
+            _BobComponent(vm.Vector3(x, 2.0, z), 0.8, 1.2, index.toDouble()),
+          );
+        // A small unlit sphere marks each light's position.
+        lightNode.add(
+          Node(
+            mesh: Mesh(
+              SphereGeometry(radius: 0.12),
+              UnlitMaterial()
+                ..baseColorFactor = vm.Vector4(rgb.x, rgb.y, rgb.z, 1),
             ),
           ),
-        ),
-    );
+        );
+        scene.add(lightNode);
+        index++;
+      }
+    }
 
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
+    final radius = _grid * _spacing * 0.9;
     return SceneView(
       scene,
       cameraBuilder: (elapsed) {
-        final t = elapsed.inMicroseconds / 1e6 * 0.25;
+        final t = elapsed.inMicroseconds / 1e6 * 0.15;
         return PerspectiveCamera(
-          position: vm.Vector3(sin(t) * 11, 6, cos(t) * 11),
+          position: vm.Vector3(sin(t) * radius, radius * 0.7, cos(t) * radius),
           target: vm.Vector3(0, -0.5, 0),
         );
       },

--- a/examples/flutter_app/lib/example_lights.dart
+++ b/examples/flutter_app/lib/example_lights.dart
@@ -50,21 +50,34 @@ class ExampleLightsState extends State<ExampleLights> {
     scene.environmentIntensity = 0.1;
     scene.directionalLight = null;
 
-    // A matte floor to catch the light pools.
+    // Reflect the lit scene off the floor.
+    scene.screenSpaceReflections.enabled = true;
+
+    // A dark, near-polished floor so the colored light pools and the spheres
+    // reflect in it.
     scene.add(
       Node(
         mesh: Mesh(
           CuboidGeometry(vm.Vector3(24, 0.2, 24)),
           PhysicallyBasedMaterial()
-            ..baseColorFactor = vm.Vector4(0.6, 0.6, 0.62, 1)
-            ..roughnessFactor = 0.85
+            ..baseColorFactor = vm.Vector4(0.05, 0.05, 0.06, 1)
+            ..roughnessFactor = 0.08
             ..metallicFactor = 0.0,
         ),
         localTransform: vm.Matrix4.translation(vm.Vector3(0, -1.2, 0)),
       ),
     );
 
-    // A ring of shapes for the lights to sweep across.
+    // A ring of spheres spanning a range of material properties: alternating
+    // metal and dielectric, roughness increasing around the ring.
+    final sphereColors = <vm.Vector4>[
+      vm.Vector4(0.95, 0.64, 0.54, 1), // copper-ish
+      vm.Vector4(0.9, 0.9, 0.92, 1), // silver-ish
+      vm.Vector4(1.0, 0.86, 0.57, 1), // gold-ish
+      vm.Vector4(0.8, 0.85, 0.9, 1),
+      vm.Vector4(0.85, 0.85, 0.85, 1),
+      vm.Vector4(0.75, 0.8, 0.85, 1),
+    ];
     for (var i = 0; i < 6; i++) {
       final angle = i / 6 * 2 * pi;
       scene.add(
@@ -72,9 +85,11 @@ class ExampleLightsState extends State<ExampleLights> {
           mesh: Mesh(
             SphereGeometry(radius: 0.7),
             PhysicallyBasedMaterial()
-              ..baseColorFactor = vm.Vector4(0.85, 0.85, 0.85, 1)
-              ..roughnessFactor = 0.5
-              ..metallicFactor = 0.0,
+              ..baseColorFactor = sphereColors[i]
+              // Alternate metal and dielectric; sweep roughness around the ring
+              // so the same lights read across smooth-to-rough surfaces.
+              ..metallicFactor = i.isEven ? 1.0 : 0.0
+              ..roughnessFactor = 0.05 + i / 5 * 0.7,
           ),
           localTransform: vm.Matrix4.translation(
             vm.Vector3(cos(angle) * 4, 0, sin(angle) * 4),

--- a/examples/flutter_app/lib/example_lights.dart
+++ b/examples/flutter_app/lib/example_lights.dart
@@ -1,0 +1,158 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+/// Point and spot lights orbiting a small set of matte shapes. The ambient
+/// (image-based) light is turned down and there is no directional sun, so the
+/// colored point lights and the overhead spot are what light the scene.
+class ExampleLights extends StatefulWidget {
+  const ExampleLights({super.key});
+
+  @override
+  ExampleLightsState createState() => ExampleLightsState();
+}
+
+/// Moves the owning node around a horizontal circle, so a light attached to
+/// the node orbits the scene.
+class _OrbitComponent extends Component {
+  _OrbitComponent({
+    required this.radius,
+    required this.height,
+    required this.speed,
+    required this.phase,
+  });
+
+  final double radius;
+  final double height;
+  final double speed;
+  final double phase;
+  double _elapsed = 0.0;
+
+  @override
+  void update(double deltaSeconds) {
+    _elapsed += deltaSeconds;
+    final angle = _elapsed * speed + phase;
+    node.localTransform = vm.Matrix4.translation(
+      vm.Vector3(cos(angle) * radius, height, sin(angle) * radius),
+    );
+  }
+}
+
+class ExampleLightsState extends State<ExampleLights> {
+  Scene scene = Scene();
+
+  @override
+  void initState() {
+    // Dim the image-based ambient and drop the sun so the punctual lights are
+    // what the eye reads.
+    scene.environmentIntensity = 0.1;
+    scene.directionalLight = null;
+
+    // A matte floor to catch the light pools.
+    scene.add(
+      Node(
+        mesh: Mesh(
+          CuboidGeometry(vm.Vector3(24, 0.2, 24)),
+          PhysicallyBasedMaterial()
+            ..baseColorFactor = vm.Vector4(0.6, 0.6, 0.62, 1)
+            ..roughnessFactor = 0.85
+            ..metallicFactor = 0.0,
+        ),
+        localTransform: vm.Matrix4.translation(vm.Vector3(0, -1.2, 0)),
+      ),
+    );
+
+    // A ring of shapes for the lights to sweep across.
+    for (var i = 0; i < 6; i++) {
+      final angle = i / 6 * 2 * pi;
+      scene.add(
+        Node(
+          mesh: Mesh(
+            SphereGeometry(radius: 0.7),
+            PhysicallyBasedMaterial()
+              ..baseColorFactor = vm.Vector4(0.85, 0.85, 0.85, 1)
+              ..roughnessFactor = 0.5
+              ..metallicFactor = 0.0,
+          ),
+          localTransform: vm.Matrix4.translation(
+            vm.Vector3(cos(angle) * 4, 0, sin(angle) * 4),
+          ),
+        ),
+      );
+    }
+
+    // Three colored point lights orbiting at different phases, each marked by
+    // a small unlit sphere so its position is visible.
+    final colors = <vm.Vector3>[
+      vm.Vector3(1.0, 0.2, 0.2),
+      vm.Vector3(0.2, 1.0, 0.3),
+      vm.Vector3(0.3, 0.4, 1.0),
+    ];
+    for (var i = 0; i < colors.length; i++) {
+      final node = Node()
+        ..addComponent(
+          PointLightComponent(
+            PointLight(color: colors[i], intensity: 22.0, range: 14.0),
+          ),
+        )
+        ..addComponent(
+          _OrbitComponent(
+            radius: 5.5,
+            height: 1.5,
+            speed: 0.6,
+            phase: i / colors.length * 2 * pi,
+          ),
+        );
+      node.add(
+        Node(
+          mesh: Mesh(
+            SphereGeometry(radius: 0.12),
+            UnlitMaterial()
+              ..baseColorFactor = vm.Vector4(
+                colors[i].x,
+                colors[i].y,
+                colors[i].z,
+                1,
+              ),
+          ),
+        ),
+      );
+      scene.add(node);
+    }
+
+    // A warm overhead spot light pointing straight down at the center.
+    scene.add(
+      Node(localTransform: vm.Matrix4.translation(vm.Vector3(0, 8, 0)))
+        ..addComponent(
+          SpotLightComponent(
+            SpotLight(
+              color: vm.Vector3(1.0, 0.9, 0.7),
+              intensity: 60.0,
+              range: 20.0,
+              direction: vm.Vector3(0, -1, 0),
+              innerConeAngle: 0.15,
+              outerConeAngle: 0.5,
+            ),
+          ),
+        ),
+    );
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SceneView(
+      scene,
+      cameraBuilder: (elapsed) {
+        final t = elapsed.inMicroseconds / 1e6 * 0.25;
+        return PerspectiveCamera(
+          position: vm.Vector3(sin(t) * 11, 6, cos(t) * 11),
+          target: vm.Vector3(0, -0.5, 0),
+        );
+      },
+    );
+  }
+}

--- a/examples/flutter_app/lib/example_lights.dart
+++ b/examples/flutter_app/lib/example_lights.dart
@@ -55,28 +55,30 @@ class ExampleLightsState extends State<ExampleLights> {
 
     final extent = (_grid - 1) * _spacing / 2;
 
-    // A dark, near-polished floor large enough to hold the grid, so the light
-    // pools and shapes reflect in it.
-    final floorSize = _grid * _spacing + 6;
-    scene.add(
-      Node(
-        mesh: Mesh(
-          CuboidGeometry(vm.Vector3(floorSize, 0.2, floorSize)),
-          PhysicallyBasedMaterial()
-            ..baseColorFactor = vm.Vector4(0.05, 0.05, 0.06, 1)
-            ..roughnessFactor = 0.1
-            ..metallicFactor = 0.0,
-        ),
-        localTransform: vm.Matrix4.translation(vm.Vector3(0, -1.2, 0)),
-      ),
-    );
-
     var index = 0;
     for (var i = 0; i < _grid; i++) {
       for (var j = 0; j < _grid; j++) {
         final x = i * _spacing - extent;
         final z = j * _spacing - extent;
         final t = index / (_grid * _grid);
+
+        // The floor is tiled, one dark near-polished tile per cell, rather than
+        // one large slab: per-object culling gives each object the lights that
+        // reach it, so a single floor spanning every light would be reached by
+        // all of them at once (and exceed the per-object budget). Tiling keeps
+        // each piece within reach of only its local lights.
+        scene.add(
+          Node(
+            mesh: Mesh(
+              CuboidGeometry(vm.Vector3(_spacing, 0.2, _spacing)),
+              PhysicallyBasedMaterial()
+                ..baseColorFactor = vm.Vector4(0.05, 0.05, 0.06, 1)
+                ..roughnessFactor = 0.1
+                ..metallicFactor = 0.0,
+            ),
+            localTransform: vm.Matrix4.translation(vm.Vector3(x, -1.2, z)),
+          ),
+        );
 
         // A shape at the grid cell, its material sweeping metal/dielectric and
         // roughness across the grid.

--- a/examples/flutter_app/lib/example_spot_shadow.dart
+++ b/examples/flutter_app/lib/example_spot_shadow.dart
@@ -1,0 +1,124 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+/// A single shadow-casting spot light orbiting above a few occluders on a
+/// floor, so their shadows sweep across it as the light moves.
+class ExampleSpotShadow extends StatefulWidget {
+  const ExampleSpotShadow({super.key});
+
+  @override
+  ExampleSpotShadowState createState() => ExampleSpotShadowState();
+}
+
+/// Orbits the owning node around a horizontal circle above the scene, aiming a
+/// spot light straight down, so its cone (and the occluders' shadows) sweep.
+class _OrbitAimDownComponent extends Component {
+  _OrbitAimDownComponent(this.radius, this.height, this.speed);
+
+  final double radius;
+  final double height;
+  final double speed;
+  double _elapsed = 0.0;
+
+  @override
+  void update(double deltaSeconds) {
+    _elapsed += deltaSeconds;
+    final a = _elapsed * speed;
+    node.localTransform = vm.Matrix4.translation(
+      vm.Vector3(cos(a) * radius, height, sin(a) * radius),
+    );
+  }
+}
+
+class ExampleSpotShadowState extends State<ExampleSpotShadow> {
+  Scene scene = Scene();
+
+  @override
+  void initState() {
+    // A dim ambient so shadowed areas are dark but not pitch black; no sun.
+    scene.environmentIntensity = 0.12;
+    scene.directionalLight = null;
+
+    // Floor.
+    scene.add(
+      Node(
+        mesh: Mesh(
+          CuboidGeometry(vm.Vector3(30, 0.4, 30)),
+          PhysicallyBasedMaterial()
+            ..baseColorFactor = vm.Vector4(0.55, 0.55, 0.58, 1)
+            ..roughnessFactor = 0.85
+            ..metallicFactor = 0.0,
+        ),
+        localTransform: vm.Matrix4.translation(vm.Vector3(0, -1.2, 0)),
+      ),
+    );
+
+    // A ring of occluders for the spot to cast shadows from.
+    final palette = <vm.Vector4>[
+      vm.Vector4(0.9, 0.4, 0.35, 1),
+      vm.Vector4(0.4, 0.8, 0.5, 1),
+      vm.Vector4(0.45, 0.55, 0.95, 1),
+      vm.Vector4(0.9, 0.8, 0.4, 1),
+      vm.Vector4(0.8, 0.5, 0.9, 1),
+    ];
+    for (var i = 0; i < palette.length; i++) {
+      final a = i / palette.length * 2 * pi;
+      scene.add(
+        Node(
+          mesh: Mesh(
+            i.isEven
+                ? CuboidGeometry(vm.Vector3(1.4, 2.4, 1.4))
+                : SphereGeometry(radius: 1.0),
+            PhysicallyBasedMaterial()
+              ..baseColorFactor = palette[i]
+              ..roughnessFactor = 0.6
+              ..metallicFactor = 0.0,
+          ),
+          localTransform: vm.Matrix4.translation(
+            vm.Vector3(cos(a) * 4.5, 0.0, sin(a) * 4.5),
+          ),
+        ),
+      );
+    }
+
+    // The shadow-casting spot: high overhead, aimed straight down, orbiting so
+    // the occluders' shadows sweep across the floor.
+    scene.add(
+      Node()
+        ..addComponent(
+          SpotLightComponent(
+            SpotLight(
+              color: vm.Vector3(1.0, 0.97, 0.9),
+              intensity: 120.0,
+              range: 40.0,
+              direction: vm.Vector3(0, -1, 0),
+              innerConeAngle: 0.35,
+              outerConeAngle: 0.6,
+              castsShadow: true,
+              shadowMapResolution: 1024,
+            ),
+          ),
+        )
+        ..addComponent(_OrbitAimDownComponent(3.5, 12.0, 0.5)),
+    );
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SceneView(
+      scene,
+      cameraBuilder: (elapsed) {
+        final t = elapsed.inMicroseconds / 1e6 * 0.2;
+        return PerspectiveCamera(
+          position: vm.Vector3(sin(t) * 16, 11, cos(t) * 16),
+          target: vm.Vector3(0, -0.5, 0),
+        );
+      },
+    );
+  }
+}

--- a/examples/flutter_app/lib/example_spot_shadow.dart
+++ b/examples/flutter_app/lib/example_spot_shadow.dart
@@ -103,13 +103,14 @@ class ExampleSpotShadowState extends State<ExampleSpotShadow> {
     // the occluders' shadows sweep across the floor.
     spot = SpotLight(
       color: vm.Vector3(1.0, 0.97, 0.9),
-      intensity: 120.0,
-      range: 40.0,
+      intensity: 199.0,
+      range: 60.0,
       direction: vm.Vector3(0, -1, 0),
-      innerConeAngle: 0.35,
-      outerConeAngle: 0.6,
+      innerConeAngle: 0.6,
+      outerConeAngle: 0.81,
       castsShadow: true,
       shadowMapResolution: 1024,
+      shadowNear: 0.02,
     );
     scene.add(
       Node()

--- a/examples/flutter_app/lib/example_spot_shadow.dart
+++ b/examples/flutter_app/lib/example_spot_shadow.dart
@@ -5,7 +5,8 @@ import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 /// A single shadow-casting spot light orbiting above a few occluders on a
-/// floor, so their shadows sweep across it as the light moves.
+/// floor, with a live settings panel (bottom-left) for the shadow parameters
+/// and the spotlight, so the shadow quality can be tuned interactively.
 class ExampleSpotShadow extends StatefulWidget {
   const ExampleSpotShadow({super.key});
 
@@ -36,27 +37,35 @@ class _OrbitAimDownComponent extends Component {
 class ExampleSpotShadowState extends State<ExampleSpotShadow> {
   Scene scene = Scene();
 
+  // The live spot light, mutated by the settings panel. The renderer reads its
+  // fields fresh each frame, so edits take effect immediately.
+  late final SpotLight spot;
+
   @override
   void initState() {
     // A dim ambient so shadowed areas are dark but not pitch black; no sun.
     scene.environmentIntensity = 0.12;
     scene.directionalLight = null;
+    // Reflect the scene off the floor, so the occluders' reflections reveal
+    // exactly where they meet (or float above) it.
+    scene.screenSpaceReflections.enabled = true;
 
-    // Floor.
+    // A dark, near-polished floor.
     scene.add(
       Node(
         mesh: Mesh(
           CuboidGeometry(vm.Vector3(30, 0.4, 30)),
           PhysicallyBasedMaterial()
-            ..baseColorFactor = vm.Vector4(0.55, 0.55, 0.58, 1)
-            ..roughnessFactor = 0.85
+            ..baseColorFactor = vm.Vector4(0.08, 0.08, 0.1, 1)
+            ..roughnessFactor = 0.08
             ..metallicFactor = 0.0,
         ),
         localTransform: vm.Matrix4.translation(vm.Vector3(0, -1.2, 0)),
       ),
     );
 
-    // A ring of occluders for the spot to cast shadows from.
+    // A ring of occluders for the spot to cast shadows from, seated on the
+    // floor (its top surface is at y = -1.0).
     final palette = <vm.Vector4>[
       vm.Vector4(0.9, 0.4, 0.35, 1),
       vm.Vector4(0.4, 0.8, 0.5, 1),
@@ -66,19 +75,25 @@ class ExampleSpotShadowState extends State<ExampleSpotShadow> {
     ];
     for (var i = 0; i < palette.length; i++) {
       final a = i / palette.length * 2 * pi;
+      final material = PhysicallyBasedMaterial()
+        ..baseColorFactor = palette[i]
+        ..roughnessFactor = 0.6
+        ..metallicFactor = 0.0;
+      // Seat each shape so its base sits on the floor top (y = -1.0).
+      final Geometry geometry;
+      final double centerY;
+      if (i.isEven) {
+        geometry = CuboidGeometry(vm.Vector3(1.4, 2.4, 1.4));
+        centerY = -1.0 + 1.2; // half-height above the floor top
+      } else {
+        geometry = SphereGeometry(radius: 1.0);
+        centerY = -1.0 + 1.0;
+      }
       scene.add(
         Node(
-          mesh: Mesh(
-            i.isEven
-                ? CuboidGeometry(vm.Vector3(1.4, 2.4, 1.4))
-                : SphereGeometry(radius: 1.0),
-            PhysicallyBasedMaterial()
-              ..baseColorFactor = palette[i]
-              ..roughnessFactor = 0.6
-              ..metallicFactor = 0.0,
-          ),
+          mesh: Mesh(geometry, material),
           localTransform: vm.Matrix4.translation(
-            vm.Vector3(cos(a) * 4.5, 0.0, sin(a) * 4.5),
+            vm.Vector3(cos(a) * 4.5, centerY, sin(a) * 4.5),
           ),
         ),
       );
@@ -86,22 +101,19 @@ class ExampleSpotShadowState extends State<ExampleSpotShadow> {
 
     // The shadow-casting spot: high overhead, aimed straight down, orbiting so
     // the occluders' shadows sweep across the floor.
+    spot = SpotLight(
+      color: vm.Vector3(1.0, 0.97, 0.9),
+      intensity: 120.0,
+      range: 40.0,
+      direction: vm.Vector3(0, -1, 0),
+      innerConeAngle: 0.35,
+      outerConeAngle: 0.6,
+      castsShadow: true,
+      shadowMapResolution: 1024,
+    );
     scene.add(
       Node()
-        ..addComponent(
-          SpotLightComponent(
-            SpotLight(
-              color: vm.Vector3(1.0, 0.97, 0.9),
-              intensity: 120.0,
-              range: 40.0,
-              direction: vm.Vector3(0, -1, 0),
-              innerConeAngle: 0.35,
-              outerConeAngle: 0.6,
-              castsShadow: true,
-              shadowMapResolution: 1024,
-            ),
-          ),
-        )
+        ..addComponent(SpotLightComponent(spot))
         ..addComponent(_OrbitAimDownComponent(3.5, 12.0, 0.5)),
     );
 
@@ -110,15 +122,190 @@ class ExampleSpotShadowState extends State<ExampleSpotShadow> {
 
   @override
   Widget build(BuildContext context) {
-    return SceneView(
-      scene,
-      cameraBuilder: (elapsed) {
-        final t = elapsed.inMicroseconds / 1e6 * 0.2;
-        return PerspectiveCamera(
-          position: vm.Vector3(sin(t) * 16, 11, cos(t) * 16),
-          target: vm.Vector3(0, -0.5, 0),
-        );
-      },
+    return Stack(
+      children: [
+        SceneView(
+          scene,
+          cameraBuilder: (elapsed) {
+            final t = elapsed.inMicroseconds / 1e6 * 0.2;
+            return PerspectiveCamera(
+              position: vm.Vector3(sin(t) * 16, 11, cos(t) * 16),
+              target: vm.Vector3(0, -0.5, 0),
+            );
+          },
+        ),
+        Positioned(
+          left: 8,
+          bottom: 8,
+          child: _SettingsPanel(spot: spot, onChanged: () => setState(() {})),
+        ),
+      ],
+    );
+  }
+}
+
+/// A compact panel of sliders and dropdowns bound to [spot]. [onChanged] is
+/// called after every edit so the host rebuilds (the slider positions update;
+/// the scene picks up the new values on its next frame).
+class _SettingsPanel extends StatelessWidget {
+  const _SettingsPanel({required this.spot, required this.onChanged});
+
+  final SpotLight spot;
+  final VoidCallback onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 300,
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: DefaultTextStyle(
+        style: const TextStyle(color: Colors.white, fontSize: 12),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(context).size.height * 0.7,
+          ),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _header('Shadow'),
+                _dropdown<ShadowCasterFaces>(
+                  'Caster faces',
+                  spot.shadowCasterFaces,
+                  ShadowCasterFaces.values,
+                  (v) => v.name,
+                  (v) {
+                    spot.shadowCasterFaces = v;
+                    onChanged();
+                  },
+                ),
+                _dropdown<int>(
+                  'Resolution',
+                  spot.shadowMapResolution,
+                  const [256, 512, 1024, 2048],
+                  (v) => '$v',
+                  (v) {
+                    spot.shadowMapResolution = v;
+                    onChanged();
+                  },
+                ),
+                _slider('Depth bias', spot.shadowDepthBias, 0.0, 0.02, 4, (v) {
+                  spot.shadowDepthBias = v;
+                  onChanged();
+                }),
+                _slider('Normal bias', spot.shadowNormalBias, 0.0, 0.2, 3, (v) {
+                  spot.shadowNormalBias = v;
+                  onChanged();
+                }),
+                _slider('Near', spot.shadowNear, 0.02, 3.0, 2, (v) {
+                  spot.shadowNear = v;
+                  onChanged();
+                }),
+                const SizedBox(height: 8),
+                _header('Spot light'),
+                _slider('Intensity', spot.intensity, 0.0, 300.0, 0, (v) {
+                  spot.intensity = v;
+                  onChanged();
+                }),
+                _slider('Range', spot.range, 5.0, 60.0, 1, (v) {
+                  spot.range = v;
+                  onChanged();
+                }),
+                _slider('Inner cone', spot.innerConeAngle, 0.0, 1.4, 2, (v) {
+                  spot.innerConeAngle = min(v, spot.outerConeAngle - 0.01);
+                  onChanged();
+                }),
+                _slider('Outer cone', spot.outerConeAngle, 0.1, 1.5, 2, (v) {
+                  spot.outerConeAngle = max(v, spot.innerConeAngle + 0.01);
+                  onChanged();
+                }),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _header(String text) => Padding(
+    padding: const EdgeInsets.only(bottom: 4),
+    child: Text(
+      text,
+      style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+    ),
+  );
+
+  Widget _slider(
+    String label,
+    double value,
+    double min,
+    double max,
+    int digits,
+    ValueChanged<double> onChanged,
+  ) {
+    return Row(
+      children: [
+        SizedBox(width: 92, child: Text(label)),
+        Expanded(
+          child: SliderTheme(
+            data: const SliderThemeData(
+              trackHeight: 2,
+              overlayShape: RoundSliderOverlayShape(overlayRadius: 10),
+            ),
+            child: Slider(
+              value: value.clamp(min, max),
+              min: min,
+              max: max,
+              onChanged: onChanged,
+            ),
+          ),
+        ),
+        SizedBox(
+          width: 46,
+          child: Text(
+            value.toStringAsFixed(digits),
+            textAlign: TextAlign.right,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _dropdown<T>(
+    String label,
+    T value,
+    List<T> options,
+    String Function(T) name,
+    ValueChanged<T> onChanged,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          SizedBox(width: 92, child: Text(label)),
+          Expanded(
+            child: DropdownButton<T>(
+              value: value,
+              isDense: true,
+              isExpanded: true,
+              dropdownColor: const Color(0xFF303030),
+              style: const TextStyle(color: Colors.white, fontSize: 12),
+              items: [
+                for (final option in options)
+                  DropdownMenuItem<T>(value: option, child: Text(name(option))),
+              ],
+              onChanged: (v) {
+                if (v != null) onChanged(v);
+              },
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/examples/flutter_app/lib/example_spot_shadow.dart
+++ b/examples/flutter_app/lib/example_spot_shadow.dart
@@ -207,6 +207,10 @@ class _SettingsPanel extends StatelessWidget {
                   spot.shadowNear = v;
                   onChanged();
                 }),
+                _slider('Softness', spot.shadowSoftness, 0.0, 4.0, 2, (v) {
+                  spot.shadowSoftness = v;
+                  onChanged();
+                }),
                 const SizedBox(height: 8),
                 _header('Spot light'),
                 _slider('Intensity', spot.intensity, 0.0, 300.0, 0, (v) {

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:example_app/example_animation.dart';
 
 import 'example_cuboid.dart';
 import 'example_lights.dart';
+import 'example_spot_shadow.dart';
 import 'example_fscene.dart';
 import 'example_fscene_animated.dart';
 import 'example_fscene_import.dart';
@@ -68,6 +69,7 @@ class _MyAppState extends State<MyApp> {
       'Flutter Logo': (context) => const ExampleLogo(),
       'Cuboid': (context) => const ExampleCuboid(),
       'Lights': (context) => const ExampleLights(),
+      'Spot Shadow': (context) => const ExampleSpotShadow(),
       'Sprites': (context) => const ExampleSprites(),
       'Particles': (context) => const ExampleParticles(),
       'Instancing': (context) => const ExampleInstancing(),

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene_box3d/flutter_scene_box3d.dart'
 import 'package:example_app/example_animation.dart';
 
 import 'example_cuboid.dart';
+import 'example_lights.dart';
 import 'example_fscene.dart';
 import 'example_fscene_animated.dart';
 import 'example_fscene_import.dart';
@@ -66,6 +67,7 @@ class _MyAppState extends State<MyApp> {
       'Animation': (context) => const ExampleAnimation(),
       'Flutter Logo': (context) => const ExampleLogo(),
       'Cuboid': (context) => const ExampleCuboid(),
+      'Lights': (context) => const ExampleLights(),
       'Sprites': (context) => const ExampleSprites(),
       'Particles': (context) => const ExampleParticles(),
       'Instancing': (context) => const ExampleInstancing(),

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -94,11 +94,19 @@ export 'src/components/instanced_mesh_component.dart'
     show InstancedMeshComponent;
 export 'src/components/lod_component.dart' show LodComponent;
 export 'src/components/mesh_component.dart' show MeshComponent;
+export 'src/components/point_light_component.dart' show PointLightComponent;
+export 'src/components/spot_light_component.dart' show SpotLightComponent;
 export 'src/render/lod.dart' show LodLevel;
 export 'src/components/widget_component.dart' show WidgetComponent, WidgetInput;
 export 'src/instanced_mesh.dart' show InstancedMesh;
 export 'src/light.dart'
-    show DirectionalLight, Lighting, ShadowCascade, ShadowCasterFaces;
+    show
+        DirectionalLight,
+        Lighting,
+        PointLight,
+        ShadowCascade,
+        ShadowCasterFaces,
+        SpotLight;
 export 'src/render/custom_render_pass.dart'
     show CustomRenderPass, RenderInput, RenderPassContext, RenderStage;
 export 'src/render/object_filter.dart' show NodeFilter;

--- a/packages/flutter_scene/lib/src/components/point_light_component.dart
+++ b/packages/flutter_scene/lib/src/components/point_light_component.dart
@@ -1,0 +1,40 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/light.dart';
+
+/// An engine [Component] that places a [PointLight] in the scene.
+///
+/// While the owning node is part of a live scene, the component registers its
+/// light with the scene's render layer so the renderer can find it, and
+/// unregisters it when the node leaves the scene.
+///
+/// The light's world position is the owning node's world-space translation,
+/// so moving the node moves the light.
+/// {@category Scene graph}
+class PointLightComponent extends Component {
+  /// Creates a component that lights the scene with [light].
+  PointLightComponent(this.light);
+
+  /// The light this component contributes.
+  PointLight light;
+
+  @override
+  void onMount() {
+    node.internalRenderScene?.addPointLight(this);
+  }
+
+  @override
+  void onUnmount() {
+    // Guard on attachment, not mount state: Component.unmount clears the
+    // mounted flag before invoking onUnmount, and the owning node's render
+    // scene is still reachable during teardown (mirrors MeshComponent).
+    if (isAttached) {
+      node.internalRenderScene?.removePointLight(this);
+    }
+  }
+
+  /// The light's world-space position: the owning node's world-space
+  /// translation.
+  Vector3 get worldPosition => node.globalTransform.getTranslation();
+}

--- a/packages/flutter_scene/lib/src/components/spot_light_component.dart
+++ b/packages/flutter_scene/lib/src/components/spot_light_component.dart
@@ -1,0 +1,48 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/light.dart';
+
+/// An engine [Component] that places a [SpotLight] in the scene.
+///
+/// While the owning node is part of a live scene, the component registers its
+/// light with the scene's render layer so the renderer can find it, and
+/// unregisters it when the node leaves the scene.
+///
+/// The light's world position is the owning node's world-space translation,
+/// and its aim is the node's world-space rotation applied to the light's
+/// local [SpotLight.direction], so re-orienting the node aims the cone.
+/// {@category Scene graph}
+class SpotLightComponent extends Component {
+  /// Creates a component that lights the scene with [light].
+  SpotLightComponent(this.light);
+
+  /// The light this component contributes. Its [SpotLight.direction] is read
+  /// in the owning node's local space; [worldDirection] is the world result.
+  SpotLight light;
+
+  @override
+  void onMount() {
+    node.internalRenderScene?.addSpotLight(this);
+  }
+
+  @override
+  void onUnmount() {
+    // Guard on attachment, not mount state (mirrors MeshComponent): the
+    // render scene is still reachable during teardown after the mounted flag
+    // is cleared.
+    if (isAttached) {
+      node.internalRenderScene?.removeSpotLight(this);
+    }
+  }
+
+  /// The light's world-space position: the owning node's world-space
+  /// translation.
+  Vector3 get worldPosition => node.globalTransform.getTranslation();
+
+  /// The cone's world-space aim: the owning node's world-space rotation
+  /// applied to the light's local [SpotLight.direction]. Need not be unit
+  /// length (the shader normalizes it).
+  Vector3 get worldDirection =>
+      node.globalTransform.getRotation() * light.direction;
+}

--- a/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
@@ -16,6 +16,8 @@ import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/components/environment_volume_component.dart';
 import 'package:flutter_scene/src/components/mesh_component.dart';
+import 'package:flutter_scene/src/components/point_light_component.dart';
+import 'package:flutter_scene/src/components/spot_light_component.dart';
 import 'package:flutter_scene/src/environment_settings.dart';
 import 'package:flutter_scene/src/fscene/id.dart';
 import 'package:flutter_scene/src/fscene/property_value.dart';
@@ -41,6 +43,8 @@ void registerBuiltinComponentCodecs(FsceneComponentRegistry registry) {
     ..register(ParticleEmitterCodec())
     ..register(MeshCodec())
     ..register(DirectionalLightCodec())
+    ..register(PointLightCodec())
+    ..register(SpotLightCodec())
     ..register(CameraCodec())
     ..register(EnvironmentVolumeCodec());
 }
@@ -669,6 +673,140 @@ class DirectionalLightCodec extends ComponentCodec {
           p,
           'shadowNormalBias',
           numberDefault('shadowNormalBias'),
+        ),
+      ),
+    );
+  }
+}
+
+/// Codec for [PointLightComponent].
+class PointLightCodec extends ComponentCodec {
+  @override
+  String get type => 'pointLight';
+
+  static final List<ComponentPropertyDef> _schema = [
+    ComponentPropertyDef(
+      'color',
+      ComponentPropertyKind.vec3,
+      Vec3Value(Vector3(1, 1, 1)),
+      doc: 'Linear RGB light color.',
+      read: (c) => Vec3Value((c as PointLightComponent).light.color.clone()),
+    ),
+    ComponentPropertyDef(
+      'intensity',
+      ComponentPropertyKind.number,
+      const DoubleValue(1.0),
+      doc: 'Light brightness (radiance at unit distance).',
+      min: 0,
+      read: (c) => DoubleValue((c as PointLightComponent).light.intensity),
+    ),
+    ComponentPropertyDef(
+      'range',
+      ComponentPropertyKind.number,
+      const DoubleValue(0.0),
+      doc: 'Distance the light reaches, or 0 for infinite range.',
+      min: 0,
+      read: (c) => DoubleValue((c as PointLightComponent).light.range),
+    ),
+  ];
+
+  @override
+  List<ComponentPropertyDef> get propertySchema => _schema;
+
+  @override
+  bool claims(Component component) => component is PointLightComponent;
+
+  @override
+  Component realize(ComponentSpec spec, RealizeContext context) {
+    final p = spec.properties;
+    return PointLightComponent(
+      PointLight(
+        color: readVec3(p, 'color', vec3Default('color')),
+        intensity: readDouble(p, 'intensity', numberDefault('intensity')),
+        range: readDouble(p, 'range', numberDefault('range')),
+      ),
+    );
+  }
+}
+
+/// Codec for [SpotLightComponent].
+class SpotLightCodec extends ComponentCodec {
+  @override
+  String get type => 'spotLight';
+
+  static final List<ComponentPropertyDef> _schema = [
+    ComponentPropertyDef(
+      'direction',
+      ComponentPropertyKind.vec3,
+      Vec3Value(Vector3(0, -1, 0)),
+      doc: 'Cone aim in the node\'s local space.',
+      read: (c) => Vec3Value((c as SpotLightComponent).light.direction.clone()),
+    ),
+    ComponentPropertyDef(
+      'color',
+      ComponentPropertyKind.vec3,
+      Vec3Value(Vector3(1, 1, 1)),
+      doc: 'Linear RGB light color.',
+      read: (c) => Vec3Value((c as SpotLightComponent).light.color.clone()),
+    ),
+    ComponentPropertyDef(
+      'intensity',
+      ComponentPropertyKind.number,
+      const DoubleValue(1.0),
+      doc: 'Light brightness (radiance at unit distance).',
+      min: 0,
+      read: (c) => DoubleValue((c as SpotLightComponent).light.intensity),
+    ),
+    ComponentPropertyDef(
+      'range',
+      ComponentPropertyKind.number,
+      const DoubleValue(0.0),
+      doc: 'Distance the light reaches, or 0 for infinite range.',
+      min: 0,
+      read: (c) => DoubleValue((c as SpotLightComponent).light.range),
+    ),
+    ComponentPropertyDef(
+      'innerConeAngle',
+      ComponentPropertyKind.number,
+      const DoubleValue(0.0),
+      doc: 'Half-angle (radians) of the full-brightness inner cone.',
+      min: 0,
+      read: (c) => DoubleValue((c as SpotLightComponent).light.innerConeAngle),
+    ),
+    ComponentPropertyDef(
+      'outerConeAngle',
+      ComponentPropertyKind.number,
+      const DoubleValue(0.7853981633974483),
+      doc: 'Half-angle (radians) at which the cone falls to zero.',
+      min: 0,
+      read: (c) => DoubleValue((c as SpotLightComponent).light.outerConeAngle),
+    ),
+  ];
+
+  @override
+  List<ComponentPropertyDef> get propertySchema => _schema;
+
+  @override
+  bool claims(Component component) => component is SpotLightComponent;
+
+  @override
+  Component realize(ComponentSpec spec, RealizeContext context) {
+    final p = spec.properties;
+    return SpotLightComponent(
+      SpotLight(
+        direction: readVec3(p, 'direction', vec3Default('direction')),
+        color: readVec3(p, 'color', vec3Default('color')),
+        intensity: readDouble(p, 'intensity', numberDefault('intensity')),
+        range: readDouble(p, 'range', numberDefault('range')),
+        innerConeAngle: readDouble(
+          p,
+          'innerConeAngle',
+          numberDefault('innerConeAngle'),
+        ),
+        outerConeAngle: readDouble(
+          p,
+          'outerConeAngle',
+          numberDefault('outerConeAngle'),
         ),
       ),
     );

--- a/packages/flutter_scene/lib/src/importer/src/gltf/parser.dart
+++ b/packages/flutter_scene/lib/src/importer/src/gltf/parser.dart
@@ -3,6 +3,9 @@ import 'package:vector_math/vector_math.dart';
 import 'types.dart';
 
 GltfDocument parseGltfJson(Map<String, Object?> json) {
+  // KHR_lights_punctual declares its lights at the document's extensions.
+  final docExtensions = json['extensions'] as Map?;
+  final punctual = docExtensions?['KHR_lights_punctual'] as Map?;
   return GltfDocument(
     scene: json['scene'] as int?,
     scenes: _list(json['scenes'], _parseScene),
@@ -17,6 +20,26 @@ GltfDocument parseGltfJson(Map<String, Object?> json) {
     samplers: _list(json['samplers'], _parseSampler),
     skins: _list(json['skins'], _parseSkin),
     animations: _list(json['animations'], _parseAnimation),
+    lights: _list(punctual?['lights'], _parsePunctualLight),
+  );
+}
+
+GltfPunctualLight _parsePunctualLight(Map<String, Object?> j) {
+  Vector3? color;
+  if (j['color'] is List) {
+    final c = (j['color'] as List).cast<num>();
+    color = Vector3(c[0].toDouble(), c[1].toDouble(), c[2].toDouble());
+  }
+  final spot = j['spot'] as Map?;
+  return GltfPunctualLight(
+    name: j['name'] as String?,
+    type: j['type'] as String? ?? 'point',
+    color: color,
+    intensity: (j['intensity'] as num?)?.toDouble() ?? 1.0,
+    range: (j['range'] as num?)?.toDouble(),
+    innerConeAngle: (spot?['innerConeAngle'] as num?)?.toDouble() ?? 0.0,
+    outerConeAngle:
+        (spot?['outerConeAngle'] as num?)?.toDouble() ?? 0.7853981633974483,
   );
 }
 
@@ -61,10 +84,13 @@ GltfNode _parseNode(Map<String, Object?> j) {
     final s = (j['scale'] as List).cast<num>();
     scale = Vector3(s[0].toDouble(), s[1].toDouble(), s[2].toDouble());
   }
+  final nodeExtensions = j['extensions'] as Map?;
+  final punctual = nodeExtensions?['KHR_lights_punctual'] as Map?;
   return GltfNode(
     name: j['name'] as String?,
     mesh: j['mesh'] as int?,
     skin: j['skin'] as int?,
+    light: punctual?['light'] as int?,
     children: ((j['children'] as List?) ?? const []).cast<int>(),
     matrix: matrix,
     translation: translation,

--- a/packages/flutter_scene/lib/src/importer/src/gltf/types.dart
+++ b/packages/flutter_scene/lib/src/importer/src/gltf/types.dart
@@ -19,6 +19,7 @@ class GltfDocument {
     this.samplers = const [],
     this.skins = const [],
     this.animations = const [],
+    this.lights = const [],
   });
 
   final int? scene;
@@ -34,6 +35,36 @@ class GltfDocument {
   final List<GltfSampler> samplers;
   final List<GltfSkin> skins;
   final List<GltfAnimation> animations;
+
+  /// Punctual lights declared by the `KHR_lights_punctual` extension, indexed
+  /// by [GltfNode.light]. Empty when the extension is absent.
+  final List<GltfPunctualLight> lights;
+}
+
+/// A `KHR_lights_punctual` light definition. Fields match the extension spec.
+/// [innerConeAngle]/[outerConeAngle] are only meaningful for `spot` lights.
+class GltfPunctualLight {
+  GltfPunctualLight({
+    this.name,
+    required this.type,
+    Vector3? color,
+    this.intensity = 1.0,
+    this.range,
+    this.innerConeAngle = 0.0,
+    this.outerConeAngle = 0.7853981633974483, // pi / 4
+  }) : color = color ?? Vector3(1.0, 1.0, 1.0);
+
+  final String? name;
+
+  /// One of `directional`, `point`, or `spot`.
+  final String type;
+  final Vector3 color;
+  final double intensity;
+
+  /// Distance cutoff, or null for infinite range (point and spot only).
+  final double? range;
+  final double innerConeAngle;
+  final double outerConeAngle;
 }
 
 class GltfScene {
@@ -47,6 +78,7 @@ class GltfNode {
     this.name,
     this.mesh,
     this.skin,
+    this.light,
     this.children = const [],
     this.matrix,
     this.translation,
@@ -57,6 +89,9 @@ class GltfNode {
   final String? name;
   final int? mesh;
   final int? skin;
+
+  /// Index into [GltfDocument.lights] (`KHR_lights_punctual`), or null.
+  final int? light;
   final List<int> children;
 
   /// If [matrix] is set, [translation]/[rotation]/[scale] are ignored.

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -519,6 +519,10 @@ class Lighting {
     this.punctualParamsCount = 0,
     this.punctualIndexWidth = 0,
     this.punctualIndexHeight = 0,
+    this.spotShadowCount = 0,
+    this.spotShadowDepthBias = 0.0,
+    this.spotShadowNormalBias = 0.0,
+    this.spotShadowSoftness = 0.0,
     this.shadowMap,
     this.cascades = const [],
     this.ssaoMap,
@@ -579,6 +583,16 @@ class Lighting {
   /// normalization.
   final int punctualIndexWidth;
   final int punctualIndexHeight;
+
+  /// Number of shadow-casting spots this frame; their tiles follow the
+  /// directional cascades in [shadowMap] and their matrices ride in
+  /// [punctualParamsTexture]. Zero disables spot shadow sampling.
+  final int spotShadowCount;
+
+  /// Shared spot-shadow sampling parameters.
+  final double spotShadowDepthBias;
+  final double spotShadowNormalBias;
+  final double spotShadowSoftness;
 
   /// The cascaded shadow map atlas (a depth-in-`.r` texture holding the
   /// cascade tiles as a horizontal strip) for [directionalLight], or

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -452,8 +452,11 @@ class Lighting {
     Matrix3? environmentTransform,
     this.directionalLight,
     this.directionalLightDirection,
-    this.punctualLightTexture,
-    this.punctualLightCount = 0,
+    this.punctualParamsTexture,
+    this.punctualIndexTexture,
+    this.punctualParamsCount = 0,
+    this.punctualIndexWidth = 0,
+    this.punctualIndexHeight = 0,
     this.shadowMap,
     this.cascades = const [],
     this.ssaoMap,
@@ -494,16 +497,26 @@ class Lighting {
   /// consumers fall back to [DirectionalLight.direction] in that case.
   final Vector3? directionalLightDirection;
 
-  /// The per-frame data texture holding the additional analytic lights (point
-  /// and spot lights, plus any directional lights past the first shadowed
-  /// one), or null when there are none. Each light occupies a row of RGBA32F
-  /// texels; the shader loops over the first [punctualLightCount] rows. Built
-  /// by `PunctualLightBuffer` and shared across every lit draw this frame.
-  final gpu.Texture? punctualLightTexture;
+  /// The per-frame parameters texture holding every additional analytic light
+  /// (point and spot lights, plus any directional lights past the first
+  /// shadowed one), one per RGBA32F row, or null when there are none. Built by
+  /// `PunctualLightBuffer` and shared across every lit draw this frame; a draw
+  /// reads only the rows its per-object index slice selects.
+  final gpu.Texture? punctualParamsTexture;
 
-  /// The number of valid light rows in [punctualLightTexture]. Zero leaves the
-  /// texture unread (only [directionalLight] and the ambient term contribute).
-  final int punctualLightCount;
+  /// The per-frame light-index texture: each item's
+  /// `[lightListOffset, +lightListCount)` slice indexes into
+  /// [punctualParamsTexture]. Null when no item is reached by any light.
+  final gpu.Texture? punctualIndexTexture;
+
+  /// Number of light rows in [punctualParamsTexture]. Zero leaves punctual
+  /// lighting off (only [directionalLight] and the ambient term contribute).
+  final int punctualParamsCount;
+
+  /// Dimensions of [punctualIndexTexture], for the shader's fetch-coordinate
+  /// normalization.
+  final int punctualIndexWidth;
+  final int punctualIndexHeight;
 
   /// The cascaded shadow map atlas (a depth-in-`.r` texture holding the
   /// cascade tiles as a horizontal strip) for [directionalLight], or

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -389,6 +389,7 @@ class SpotLight {
     this.shadowDepthBias = 0.001,
     this.shadowNormalBias = 0.03,
     this.shadowSoftness = 1.0,
+    this.shadowCasterFaces = ShadowCasterFaces.front,
   }) : color = color ?? Vector3(1.0, 1.0, 1.0),
        direction = direction ?? Vector3(0.0, -1.0, 0.0);
 
@@ -437,6 +438,12 @@ class SpotLight {
   /// Radius, in shadow-map texels, of the soft-shadow PCF kernel. `0` gives a
   /// hard edge.
   double shadowSoftness;
+
+  /// Which faces are rendered into the shadow map. [ShadowCasterFaces.back]
+  /// (second-depth) removes the shadow detaching from a solid caster's base
+  /// (peter-panning) by recording the far side; [ShadowCasterFaces.front] is
+  /// the general default.
+  ShadowCasterFaces shadowCasterFaces;
 
   /// The world -> clip matrix that renders and samples this spot's perspective
   /// shadow map, for a light at [worldPosition] aimed along [worldDirection]

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -321,6 +321,92 @@ class DirectionalLight {
   }
 }
 
+/// A light that radiates from a single world-space point equally in every
+/// direction, its influence falling off with distance.
+///
+/// Attach one to the scene by adding a `PointLightComponent` to a node; the
+/// light's world position is the node's world-space translation, so moving
+/// the node moves the light. The analytic contribution is layered on top of
+/// the image-based-lighting ambient term, the same as [DirectionalLight].
+///
+/// Point lights do not cast shadows in this release.
+/// {@category Lighting and environment}
+class PointLight {
+  /// Creates a [PointLight].
+  ///
+  /// [color] is the light's linear RGB; [intensity] scales it and is the
+  /// radiance at unit distance (point lights fall off with the inverse
+  /// square of distance, so useful values are often larger than a
+  /// [DirectionalLight]'s). [range] is the world-space distance at which the
+  /// influence reaches zero; `0` (the default) means infinite range (pure
+  /// inverse-square falloff).
+  PointLight({Vector3? color, this.intensity = 1.0, this.range = 0.0})
+    : color = color ?? Vector3(1.0, 1.0, 1.0);
+
+  /// Linear RGB color of the light.
+  Vector3 color;
+
+  /// Scalar multiplier applied to [color]; the radiance at unit distance.
+  double intensity;
+
+  /// World-space distance at which the light's influence smoothly reaches
+  /// zero. `0` means infinite range (pure inverse-square falloff, clamped
+  /// near the source).
+  double range;
+}
+
+/// A light that radiates from a world-space point within a cone, combining a
+/// [PointLight]'s distance falloff with an angular falloff between an inner
+/// and outer cone.
+///
+/// Attach one by adding a `SpotLightComponent` to a node; the light's world
+/// position is the node's world translation and its aim is the node's
+/// world-space rotation applied to [direction]. The analytic contribution is
+/// layered on top of the image-based-lighting ambient term.
+///
+/// Spot lights do not cast shadows in this release.
+/// {@category Lighting and environment}
+class SpotLight {
+  /// Creates a [SpotLight].
+  ///
+  /// [direction] is the cone's aim in the owning node's local space (rotated
+  /// to world by the node's transform). [innerConeAngle] and [outerConeAngle]
+  /// are half-angles in radians: the cone is full brightness within
+  /// [innerConeAngle] of the axis and falls to zero at [outerConeAngle].
+  /// Both must satisfy `0 <= inner < outer < pi/2`.
+  SpotLight({
+    Vector3? color,
+    this.intensity = 1.0,
+    this.range = 0.0,
+    Vector3? direction,
+    this.innerConeAngle = 0.0,
+    this.outerConeAngle = math.pi / 4.0,
+  }) : color = color ?? Vector3(1.0, 1.0, 1.0),
+       direction = direction ?? Vector3(0.0, -1.0, 0.0);
+
+  /// Linear RGB color of the light.
+  Vector3 color;
+
+  /// Scalar multiplier applied to [color]; the radiance at unit distance.
+  double intensity;
+
+  /// World-space distance at which the light's influence smoothly reaches
+  /// zero. `0` means infinite range (pure inverse-square falloff).
+  double range;
+
+  /// The cone's aim, in the owning node's local space. Need not be unit
+  /// length. Rotated to world by the node's transform.
+  Vector3 direction;
+
+  /// Half-angle of the inner cone, in radians. Within this angle of the
+  /// axis the light is at full brightness.
+  double innerConeAngle;
+
+  /// Half-angle of the outer cone, in radians. Between [innerConeAngle] and
+  /// this the light falls off to zero; past it the light contributes nothing.
+  double outerConeAngle;
+}
+
 /// One cascade of a cascaded shadow map, produced by
 /// [DirectionalLight.computeCascades].
 ///
@@ -366,6 +452,8 @@ class Lighting {
     Matrix3? environmentTransform,
     this.directionalLight,
     this.directionalLightDirection,
+    this.punctualLightTexture,
+    this.punctualLightCount = 0,
     this.shadowMap,
     this.cascades = const [],
     this.ssaoMap,
@@ -405,6 +493,17 @@ class Lighting {
   /// the light node's transform. Null when there is no directional light;
   /// consumers fall back to [DirectionalLight.direction] in that case.
   final Vector3? directionalLightDirection;
+
+  /// The per-frame data texture holding the additional analytic lights (point
+  /// and spot lights, plus any directional lights past the first shadowed
+  /// one), or null when there are none. Each light occupies a row of RGBA32F
+  /// texels; the shader loops over the first [punctualLightCount] rows. Built
+  /// by `PunctualLightBuffer` and shared across every lit draw this frame.
+  final gpu.Texture? punctualLightTexture;
+
+  /// The number of valid light rows in [punctualLightTexture]. Zero leaves the
+  /// texture unread (only [directionalLight] and the ambient term contribute).
+  final int punctualLightCount;
 
   /// The cascaded shadow map atlas (a depth-in-`.r` texture holding the
   /// cascade tiles as a horizontal strip) for [directionalLight], or

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -386,8 +386,8 @@ class SpotLight {
     this.castsShadow = false,
     this.shadowMapResolution = 1024,
     this.shadowNear = 0.1,
-    this.shadowDepthBias = 0.001,
-    this.shadowNormalBias = 0.03,
+    this.shadowDepthBias = 0.0,
+    this.shadowNormalBias = 0.1,
     this.shadowSoftness = 1.0,
     this.shadowCasterFaces = ShadowCasterFaces.front,
   }) : color = color ?? Vector3(1.0, 1.0, 1.0),
@@ -428,11 +428,16 @@ class SpotLight {
   double shadowNear;
 
   /// Clip-space depth bias subtracted from the receiver before the shadow
-  /// test, to keep lit surfaces from shadowing themselves.
+  /// test. Defaults to `0`: a constant clip-space bias is badly behaved in a
+  /// perspective shadow (tiny near the light, large far away, which detaches
+  /// the shadow from a caster's base), so the normal-offset bias below does
+  /// the work instead. Raise it only to fight grazing-angle self-shadow acne.
   double shadowDepthBias;
 
   /// World-space offset along the surface normal applied to the receiver
-  /// before the shadow lookup ("normal-offset shadows").
+  /// before the shadow lookup ("normal-offset shadows"). This is the main
+  /// acne/peter-panning control for a spot; being world-space it scales with
+  /// the scene, so very small scenes may want a smaller value.
   double shadowNormalBias;
 
   /// Radius, in shadow-map texels, of the soft-shadow PCF kernel. `0` gives a

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -329,7 +329,7 @@ class DirectionalLight {
 /// the node moves the light. The analytic contribution is layered on top of
 /// the image-based-lighting ambient term, the same as [DirectionalLight].
 ///
-/// Point lights do not cast shadows in this release.
+/// Point lights do not cast shadows.
 /// {@category Lighting and environment}
 class PointLight {
   /// Creates a [PointLight].

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -364,7 +364,9 @@ class PointLight {
 /// world-space rotation applied to [direction]. The analytic contribution is
 /// layered on top of the image-based-lighting ambient term.
 ///
-/// Spot lights do not cast shadows in this release.
+/// When [castsShadow] is true and the scene's spot-shadow budget has room, the
+/// renderer renders the spot's cone into a perspective shadow map and the light
+/// is occluded by geometry between it and the surface.
 /// {@category Lighting and environment}
 class SpotLight {
   /// Creates a [SpotLight].
@@ -381,6 +383,12 @@ class SpotLight {
     Vector3? direction,
     this.innerConeAngle = 0.0,
     this.outerConeAngle = math.pi / 4.0,
+    this.castsShadow = false,
+    this.shadowMapResolution = 1024,
+    this.shadowNear = 0.1,
+    this.shadowDepthBias = 0.001,
+    this.shadowNormalBias = 0.03,
+    this.shadowSoftness = 1.0,
   }) : color = color ?? Vector3(1.0, 1.0, 1.0),
        direction = direction ?? Vector3(0.0, -1.0, 0.0);
 
@@ -405,6 +413,60 @@ class SpotLight {
   /// Half-angle of the outer cone, in radians. Between [innerConeAngle] and
   /// this the light falls off to zero; past it the light contributes nothing.
   double outerConeAngle;
+
+  /// Whether this spot casts a shadow. When true, the renderer renders the
+  /// cone into a perspective shadow map if the scene's spot-shadow budget has
+  /// room (shadow-casting spots are limited; the rest shade unshadowed).
+  bool castsShadow;
+
+  /// Pixel resolution of this spot's (square) shadow map tile.
+  int shadowMapResolution;
+
+  /// Near clip distance of the shadow frustum. Geometry closer to the light
+  /// than this does not occlude.
+  double shadowNear;
+
+  /// Clip-space depth bias subtracted from the receiver before the shadow
+  /// test, to keep lit surfaces from shadowing themselves.
+  double shadowDepthBias;
+
+  /// World-space offset along the surface normal applied to the receiver
+  /// before the shadow lookup ("normal-offset shadows").
+  double shadowNormalBias;
+
+  /// Radius, in shadow-map texels, of the soft-shadow PCF kernel. `0` gives a
+  /// hard edge.
+  double shadowSoftness;
+
+  /// The world -> clip matrix that renders and samples this spot's perspective
+  /// shadow map, for a light at [worldPosition] aimed along [worldDirection]
+  /// (both from the owning node's transform). The frustum is the cone, a
+  /// vertical field of view of twice [outerConeAngle] (with a small margin) and
+  /// a square aspect, out to [range] (or a default when the range is infinite).
+  Matrix4 shadowViewProjection(Vector3 worldPosition, Vector3 worldDirection) {
+    final length = worldDirection.length;
+    final dir = length == 0.0
+        ? Vector3(0.0, -1.0, 0.0)
+        : worldDirection / length;
+    final up = dir.y.abs() > 0.99
+        ? Vector3(0.0, 0.0, 1.0)
+        : Vector3(0.0, 1.0, 0.0);
+    final view = DirectionalLight._lookAt(
+      worldPosition,
+      worldPosition + dir,
+      up,
+    );
+    final far = range > 0.0 ? range : 100.0;
+    // A small margin past the outer cone so its lit edge sits inside the
+    // frustum rather than on its clipped border.
+    final fovY = math.min(2.0 * outerConeAngle * 1.05, math.pi * 0.98);
+    final projection = PerspectiveProjection(
+      fovRadiansY: fovY,
+      near: shadowNear,
+      far: far,
+    ).getProjectionMatrix(1.0);
+    return projection * view;
+  }
 }
 
 /// One cascade of a cascaded shadow map, produced by

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -115,6 +115,9 @@ class EngineLightingUniforms {
         ? lighting.environmentBlend.clamp(0.0, 1.0)
         : 0.0;
     fragInfo[161] = light?.shadowAmbientStrength.clamp(0.0, 1.0) ?? 0.0;
+    // radiance_blend.z [162]: the number of additional analytic lights in the
+    // punctual_lights data texture. The fragment loops over this many rows.
+    fragInfo[162] = lighting.punctualLightCount.toDouble();
   }
 
   /// Packs the `FogInfo` block (6 vec4s / 24 floats, see `shaders/fog.glsl`)
@@ -282,6 +285,20 @@ class EngineLightingUniforms {
     // cross-fade is active the primary is bound here too (a valid no-op, since
     // frag_info.radiance_blend.x is 0 and the shader never reads it).
     _bindSecondaryRadiance(pass, shader, lighting.environmentMapB ?? env);
+    // The additional analytic lights (point/spot/extra directional) as an
+    // RGBA32F data texture, point-sampled (each texel is packed light data).
+    // A white placeholder is bound when there are none; the shader never reads
+    // it because frag_info punctual_light_count is 0.
+    pass.bindTexture(
+      shader.getUniformSlot('punctual_lights'),
+      Material.whitePlaceholder(lighting.punctualLightTexture),
+      sampler: gpu.SamplerOptions(
+        minFilter: gpu.MinMagFilter.nearest,
+        magFilter: gpu.MinMagFilter.nearest,
+        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+      ),
+    );
     // Screen-space ambient occlusion. Bilinear so a half-resolution
     // occlusion buffer upsamples smoothly; a white placeholder makes the
     // sample a no-op when occlusion is off. The shader gates it on

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -123,6 +123,13 @@ class EngineLightingUniforms {
     fragInfo[8] = lighting.punctualParamsCount.toDouble();
     fragInfo[9] = lighting.punctualIndexWidth.toDouble();
     fragInfo[10] = lighting.punctualIndexHeight.toDouble();
+    // spot_shadow_params [12..15] (more of the unused SH region): the shared
+    // spot-shadow parameters. count 0 disables spot shadow sampling; the shader
+    // also uses count to size the shared shadow atlas (cascades + spot tiles).
+    fragInfo[12] = lighting.spotShadowCount.toDouble();
+    fragInfo[13] = lighting.spotShadowDepthBias;
+    fragInfo[14] = lighting.spotShadowNormalBias;
+    fragInfo[15] = lighting.spotShadowSoftness;
   }
 
   /// Packs the `FogInfo` block (6 vec4s / 24 floats, see `shaders/fog.glsl`)

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -193,6 +193,53 @@ class EngineLightingUniforms {
     return gpu.BufferView(buffer, offsetInBytes: 0, lengthInBytes: 16);
   }
 
+  // The engine lighting samplers are frame-invariant, so their options are
+  // shared rather than allocated per draw (this binding path runs for every lit
+  // draw, so at high draw counts the per-draw allocation churn is real).
+  static final gpu.SamplerOptions _radianceMipSampler = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.linear,
+    magFilter: gpu.MinMagFilter.linear,
+    mipFilter: gpu.MipFilter.linear,
+    widthAddressMode: gpu.SamplerAddressMode.repeat,
+    heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  );
+  static final gpu.SamplerOptions _radianceAtlasSampler = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.linear,
+    magFilter: gpu.MinMagFilter.linear,
+    mipFilter: gpu.MipFilter.nearest,
+    widthAddressMode: gpu.SamplerAddressMode.repeat,
+    heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  );
+  static final gpu.SamplerOptions _cubeSampler = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.linear,
+    magFilter: gpu.MinMagFilter.linear,
+    mipFilter: gpu.MipFilter.linear,
+    widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+    heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  );
+  static final gpu.SamplerOptions _clampLinearSampler = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.linear,
+    magFilter: gpu.MinMagFilter.linear,
+    widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+    heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  );
+  static final gpu.SamplerOptions _nearestSampler = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.nearest,
+    magFilter: gpu.MinMagFilter.nearest,
+  );
+  static final gpu.SamplerOptions _nearestClampSampler = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.nearest,
+    magFilter: gpu.MinMagFilter.nearest,
+    widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+    heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  );
+
+  // Selects the mip-vs-atlas radiance sampler for a prefiltered radiance
+  // texture's layout (the mip layout needs a linear mip filter for textureLod;
+  // the single-level band atlas is inert under either).
+  static gpu.SamplerOptions _radianceSampler(bool mipLayout) =>
+      mipLayout ? _radianceMipSampler : _radianceAtlasSampler;
+
   /// Binds the prefiltered radiance sampler plus the `RadianceLayoutInfo`
   /// block that tells `SamplePrefilteredRadiance` which layout the bound
   /// texture uses. Every engine site that binds `prefiltered_radiance`
@@ -211,26 +258,14 @@ class EngineLightingUniforms {
     pass.bindTexture(
       shader.getUniformSlot('prefiltered_radiance'),
       env.prefilteredRadianceTexture,
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-        mipFilter: mipLayout ? gpu.MipFilter.linear : gpu.MipFilter.nearest,
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
+      sampler: _radianceSampler(mipLayout),
     );
     // Radiance cubemap (real on the cube layout, a dummy otherwise). Mip-linear
     // for the roughness textureLod; clamp the faces.
     pass.bindTexture(
       shader.getUniformSlot('prefiltered_radiance_cube'),
       env.prefilteredRadianceCube,
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-        mipFilter: gpu.MipFilter.linear,
-        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
+      sampler: _cubeSampler,
     );
     pass.bindUniform(
       shader.getUniformSlot('RadianceLayoutInfo'),
@@ -250,12 +285,7 @@ class EngineLightingUniforms {
     pass.bindTexture(
       shader.getUniformSlot('brdf_lut'),
       Material.getBrdfLutTexture(),
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
+      sampler: _clampLinearSampler,
     );
     pass.bindTexture(
       shader.getUniformSlot('shadow_map'),
@@ -264,22 +294,14 @@ class EngineLightingUniforms {
       // textures without GL_OES_texture_float_linear, making linear filtering
       // incomplete. The shader already performs PCF explicitly, so nearest is
       // the portable choice.
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.nearest,
-        magFilter: gpu.MinMagFilter.nearest,
-      ),
+      sampler: _nearestSampler,
     );
     // Diffuse irradiance SH: a 9x1 coefficient texture, point-sampled (each
     // texel is one coefficient). Sampled in EvaluateDiffuseSH.
     pass.bindTexture(
       shader.getUniformSlot('sh_coefficients'),
       env.diffuseShTexture,
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.nearest,
-        magFilter: gpu.MinMagFilter.nearest,
-        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
+      sampler: _nearestClampSampler,
     );
     // The secondary cross-fade environment (the *_b samplers). When no
     // cross-fade is active the primary is bound here too (a valid no-op, since
@@ -292,12 +314,7 @@ class EngineLightingUniforms {
     pass.bindTexture(
       shader.getUniformSlot('punctual_lights'),
       Material.whitePlaceholder(lighting.punctualLightTexture),
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.nearest,
-        magFilter: gpu.MinMagFilter.nearest,
-        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
+      sampler: _nearestClampSampler,
     );
     // Screen-space ambient occlusion. Bilinear so a half-resolution
     // occlusion buffer upsamples smoothly; a white placeholder makes the
@@ -306,12 +323,7 @@ class EngineLightingUniforms {
     pass.bindTexture(
       shader.getUniformSlot('ssao_texture'),
       Material.whitePlaceholder(lighting.ssaoMap),
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
+      sampler: _clampLinearSampler,
     );
   }
 
@@ -329,24 +341,12 @@ class EngineLightingUniforms {
     pass.bindTexture(
       shader.getUniformSlot('prefiltered_radiance_b'),
       env.prefilteredRadianceTexture,
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-        mipFilter: mipLayout ? gpu.MipFilter.linear : gpu.MipFilter.nearest,
-        widthAddressMode: gpu.SamplerAddressMode.repeat,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
+      sampler: _radianceSampler(mipLayout),
     );
     pass.bindTexture(
       shader.getUniformSlot('prefiltered_radiance_cube_b'),
       env.prefilteredRadianceCube,
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.linear,
-        magFilter: gpu.MinMagFilter.linear,
-        mipFilter: gpu.MipFilter.linear,
-        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
+      sampler: _cubeSampler,
     );
   }
 

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -115,9 +115,14 @@ class EngineLightingUniforms {
         ? lighting.environmentBlend.clamp(0.0, 1.0)
         : 0.0;
     fragInfo[161] = light?.shadowAmbientStrength.clamp(0.0, 1.0) ?? 0.0;
-    // radiance_blend.z [162]: the number of additional analytic lights in the
-    // punctual_lights data texture. The fragment loops over this many rows.
-    fragInfo[162] = lighting.punctualLightCount.toDouble();
+    // punctual_dims [8..10] (the first unused diffuse-SH vec4 slot): the
+    // dimensions the shader needs to normalize its punctual-light fetches.
+    // x: parameters-texture row count (all scene lights). y/z: the light-index
+    // texture width/height. These are frame-constant. The per-object slice
+    // (radiance_blend.z count, .w offset) is written per draw by the material.
+    fragInfo[8] = lighting.punctualParamsCount.toDouble();
+    fragInfo[9] = lighting.punctualIndexWidth.toDouble();
+    fragInfo[10] = lighting.punctualIndexHeight.toDouble();
   }
 
   /// Packs the `FogInfo` block (6 vec4s / 24 floats, see `shaders/fog.glsl`)
@@ -307,13 +312,19 @@ class EngineLightingUniforms {
     // cross-fade is active the primary is bound here too (a valid no-op, since
     // frag_info.radiance_blend.x is 0 and the shader never reads it).
     _bindSecondaryRadiance(pass, shader, lighting.environmentMapB ?? env);
-    // The additional analytic lights (point/spot/extra directional) as an
-    // RGBA32F data texture, point-sampled (each texel is packed light data).
-    // A white placeholder is bound when there are none; the shader never reads
-    // it because frag_info punctual_light_count is 0.
+    // Punctual light parameters (all scene lights) and the per-object light
+    // index buffer, both RGBA32F data textures, point-sampled (each texel is
+    // packed data). White placeholders are bound when there are no lights or no
+    // reached items; the shader never reads them because the per-object count is
+    // 0.
     pass.bindTexture(
       shader.getUniformSlot('punctual_lights'),
-      Material.whitePlaceholder(lighting.punctualLightTexture),
+      Material.whitePlaceholder(lighting.punctualParamsTexture),
+      sampler: _nearestClampSampler,
+    );
+    pass.bindTexture(
+      shader.getUniformSlot('punctual_index'),
+      Material.whitePlaceholder(lighting.punctualIndexTexture),
       sampler: _nearestClampSampler,
     );
     // Screen-space ambient occlusion. Bilinear so a half-resolution

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -172,6 +172,16 @@ abstract class Material {
   @internal
   double lodFade = 1.0;
 
+  /// The owning render item's punctual-light slice, set by the encoder right
+  /// before [bind] and written into `FragInfo.radiance_blend.zw`. The lit
+  /// materials loop the `[lightListOffset, +lightListCount)` range of the
+  /// per-frame light-index buffer, so each item shades only the lights that
+  /// reach it. Both default to 0 (no punctual lights).
+  @internal
+  int lightListOffset = 0;
+  @internal
+  int lightListCount = 0;
+
   gpu.Shader? _fragmentShader;
   String? _fragmentShaderName;
 

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -211,6 +211,10 @@ class PhysicallyBasedMaterial extends Material {
     fragInfo[138] = specularAntiAliasingVariance;
     fragInfo[139] = specularAntiAliasingThreshold;
     fragInfo[EngineLightingUniforms.fadeIndex] = lodFade;
+    // radiance_blend.zw [162]/[163]: this item's punctual-light slice
+    // (count, offset) into the per-frame light-index buffer.
+    fragInfo[162] = lightListCount.toDouble();
+    fragInfo[163] = lightListOffset.toDouble();
     pass.bindUniform(
       fragmentShader.getUniformSlot("FragInfo"),
       transientsBuffer.emplace(ByteData.sublistView(fragInfo)),

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -120,6 +120,10 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
       final env = environment ?? lighting.environmentMap;
       final fragInfo = Float32List(EngineLightingUniforms.fragInfoFloatCount);
       EngineLightingUniforms.packInto(fragInfo, lighting, env);
+      // radiance_blend.zw [162]/[163]: this item's punctual-light slice
+      // (count, offset) into the per-frame light-index buffer.
+      fragInfo[162] = lightListCount.toDouble();
+      fragInfo[163] = lightListOffset.toDouble();
       pass.bindUniform(
         fragmentShader.getUniformSlot('FragInfo'),
         transientsBuffer.emplace(ByteData.sublistView(fragInfo)),

--- a/packages/flutter_scene/lib/src/render/bvh.dart
+++ b/packages/flutter_scene/lib/src/render/bvh.dart
@@ -44,6 +44,30 @@ class Bvh {
     _query(node.right, frustum, visit);
   }
 
+  /// Calls [visit] once for every item whose world AABB intersects [box].
+  ///
+  /// Used to scatter a light's influence volume onto the items it can reach,
+  /// so each item collects only the lights near it.
+  void queryAabb(Aabb3 box, void Function(RenderItem) visit) {
+    _queryAabb(_root, box, visit);
+  }
+
+  static void _queryAabb(
+    _BvhNode? node,
+    Aabb3 box,
+    void Function(RenderItem) visit,
+  ) {
+    if (node == null) return;
+    if (!node.bounds.intersectsWithAabb3(box)) return;
+    final item = node.item;
+    if (item != null) {
+      visit(item);
+      return;
+    }
+    _queryAabb(node.left, box, visit);
+    _queryAabb(node.right, box, visit);
+  }
+
   /// Recomputes every node's AABB from the leaves' current
   /// [RenderItem.worldBounds] without changing the tree topology.
   ///

--- a/packages/flutter_scene/lib/src/render/light_culling.dart
+++ b/packages/flutter_scene/lib/src/render/light_culling.dart
@@ -1,0 +1,102 @@
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/render/bvh.dart';
+import 'package:flutter_scene/src/render/render_scene.dart';
+
+/// A punctual light reduced to what culling needs: its row [index] in the
+/// shared light-parameter buffer and its world-space influence [bounds].
+///
+/// A null [bounds] means infinite influence (a directional light, or a point or
+/// spot light with no range), so the light reaches every item and is never
+/// culled.
+class CullableLight {
+  const CullableLight(this.index, this.bounds);
+
+  final int index;
+  final Aabb3? bounds;
+}
+
+/// The world-space AABB a point or spot light at [worldPosition] with [range]
+/// can influence, or null when [range] is not positive (infinite influence).
+///
+/// A spot light is bounded by the same sphere as a point light of its range; a
+/// tighter cone bound is a future refinement.
+Aabb3? lightInfluenceBounds(Vector3 worldPosition, double range) {
+  if (range <= 0.0) return null;
+  final r = Vector3.all(range);
+  return Aabb3.minMax(worldPosition - r, worldPosition + r);
+}
+
+/// The result of a cull: the flattened light-index buffer (each item's slice is
+/// `[offset, offset + count)`, written onto the items) and whether any item had
+/// more lights than [maxPerItem] and dropped the excess.
+class LightCullResult {
+  const LightCullResult(this.indices, this.overflowed);
+
+  final List<int> indices;
+  final bool overflowed;
+}
+
+/// Assigns each item in [items] the punctual [lights] that reach it, writing
+/// [RenderItem.lightListOffset]/[RenderItem.lightListCount] onto each and
+/// returning the flattened index buffer the light-index texture is built from.
+///
+/// Infinite-influence lights reach every item. Ranged lights are scattered onto
+/// the items their influence AABB overlaps using [bvh] (which holds the bounded
+/// items); unbounded items (no [RenderItem.worldBounds]) cannot be culled, so
+/// they conservatively receive every light. Each item's list is capped at
+/// [maxPerItem]; the excess is dropped and flagged in the result.
+LightCullResult assignLightsToItems({
+  required List<RenderItem> items,
+  required Bvh bvh,
+  required List<CullableLight> lights,
+  required int maxPerItem,
+}) {
+  for (final item in items) {
+    item.lightScratch.clear();
+  }
+
+  final infinite = <int>[
+    for (final light in lights)
+      if (light.bounds == null) light.index,
+  ];
+  final unbounded = <RenderItem>[
+    for (final item in items)
+      if (item.worldBounds == null) item,
+  ];
+
+  // Infinite-influence lights reach every item.
+  if (infinite.isNotEmpty) {
+    for (final item in items) {
+      item.lightScratch.addAll(infinite);
+    }
+  }
+
+  // Ranged lights: scatter onto bounded items via the BVH, and onto the (few)
+  // unbounded items unconditionally since they cannot be culled.
+  for (final light in lights) {
+    final bounds = light.bounds;
+    if (bounds == null) continue;
+    bvh.queryAabb(bounds, (item) => item.lightScratch.add(light.index));
+    for (final item in unbounded) {
+      item.lightScratch.add(light.index);
+    }
+  }
+
+  final flat = <int>[];
+  var overflowed = false;
+  for (final item in items) {
+    final scratch = item.lightScratch;
+    var count = scratch.length;
+    if (count > maxPerItem) {
+      count = maxPerItem;
+      overflowed = true;
+    }
+    item.lightListOffset = flat.length;
+    item.lightListCount = count;
+    for (var i = 0; i < count; i++) {
+      flat.add(scratch[i]);
+    }
+  }
+  return LightCullResult(flat, overflowed);
+}

--- a/packages/flutter_scene/lib/src/render/punctual_lights.dart
+++ b/packages/flutter_scene/lib/src/render/punctual_lights.dart
@@ -33,10 +33,10 @@ const int kMaxPunctualLights = 16;
 //   col 2: direction.xyz, spot angular scale
 //   col 3: spot angular offset, shadow slot (-1 = none), unused, unused
 //   col 4-7: world -> spot-clip matrix for a shadow-casting spot (else unused)
-// The shader reads these by computed UV, sidestepping the GLSL-ES-1.00 ban on
-// dynamically indexing a uniform array (see punctual_lights_design.md). The
-// spot shadow matrix rides here rather than in its own texture so no extra
-// sampler is needed (the lit shader is at the backend sampler limit).
+// The shader reads these by computed UV, sidestepping the GLSL ES 1.00 ban on
+// dynamically indexing a uniform array in a fragment shader. The spot shadow
+// matrix rides here rather than in its own texture so no extra sampler is
+// needed (the lit shader is at the backend's sampler limit).
 const int _texelsPerLight = 8;
 const int _floatsPerLight = _texelsPerLight * 4;
 

--- a/packages/flutter_scene/lib/src/render/punctual_lights.dart
+++ b/packages/flutter_scene/lib/src/render/punctual_lights.dart
@@ -17,8 +17,10 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 /// notes/rendering/punctual_lights_design.md) makes it unlimited via froxel
 /// clustering, so a fragment loops only its screen-region's lights with no
 /// per-draw light state (better for batching than per-object lists, whose CPU
-/// cost grows with draw count). A shader permutation for the no-light case was
-/// considered and rejected for scale. TODO(#188474): when Flutter GPU exposes
+/// cost grows with draw count), as a high-end tier; constrained mobile stays a
+/// small-`MAX` direct loop. A per-object shader permutation for the no-light case
+/// is rejected (pipeline thrash); a coarse per-frame/capability-tier one is a
+/// measured low-end option only. TODO(#188474): when Flutter GPU exposes
 /// storage buffers/compute, a capability-gated higher-tier variant can read a
 /// storage buffer with a real dynamic loop (no cap, no data-texture packing) and
 /// move light-to-region assignment to a compute pass, with this the base-tier

--- a/packages/flutter_scene/lib/src/render/punctual_lights.dart
+++ b/packages/flutter_scene/lib/src/render/punctual_lights.dart
@@ -11,6 +11,16 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 /// directional) shaded per frame. Must match `MAX_PUNCTUAL_LIGHTS` in
 /// `shaders/material_lighting.glsl`; the fragment loop is a constant-bounded
 /// unroll over this count, so it is a compile-time constant in both places.
+///
+/// TODO(lighting): this is a hard *global* cap and the shaded set is shared by
+/// every fragment. Per-object culling via the render BVH turns it into a
+/// per-object budget with an unbounded scene total (see the near-term revision
+/// in notes/rendering/punctual_lights_design.md), and a punctual on/off shader
+/// permutation makes the no-light case cost nothing. TODO(#188474): when Flutter
+/// GPU exposes storage buffers/compute, a higher-tier variant can read a storage
+/// buffer with a real dynamic loop (no cap, no data-texture packing) and move
+/// light-to-region assignment to a compute pass, with this remaining the
+/// base-tier fallback.
 const int kMaxPunctualLights = 16;
 
 // Each light is one row of the data texture, four RGBA32F texels wide:

--- a/packages/flutter_scene/lib/src/render/punctual_lights.dart
+++ b/packages/flutter_scene/lib/src/render/punctual_lights.dart
@@ -1,0 +1,183 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
+import 'package:flutter_scene/src/components/directional_light_component.dart';
+import 'package:flutter_scene/src/components/point_light_component.dart';
+import 'package:flutter_scene/src/components/spot_light_component.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+
+/// The maximum number of additional analytic lights (point + spot + extra
+/// directional) shaded per frame. Must match `MAX_PUNCTUAL_LIGHTS` in
+/// `shaders/material_lighting.glsl`; the fragment loop is a constant-bounded
+/// unroll over this count, so it is a compile-time constant in both places.
+const int kMaxPunctualLights = 16;
+
+// Each light is one row of the data texture, four RGBA32F texels wide:
+//   col 0: position.xyz, type   (0 directional, 1 point, 2 spot)
+//   col 1: color.rgb * intensity, inverse range (0 = infinite)
+//   col 2: direction.xyz, spot angular scale
+//   col 3: spot angular offset, (unused)
+// The shader reads these by computed UV, sidestepping the GLSL-ES-1.00 ban on
+// dynamically indexing a uniform array (see punctual_lights_design.md).
+const int _texelsPerLight = 4;
+const int _floatsPerLight = _texelsPerLight * 4;
+
+const double _typeDirectional = 0.0;
+const double _typePoint = 1.0;
+const double _typeSpot = 2.0;
+
+/// The result of building a frame's punctual light buffer: the data texture and
+/// the number of valid light rows in it.
+class PunctualLighting {
+  const PunctualLighting(this.texture, this.count);
+
+  /// An empty result (no additional lights this frame).
+  const PunctualLighting.empty() : texture = null, count = 0;
+
+  /// The RGBA32F data texture, or null when [count] is zero.
+  final gpu.Texture? texture;
+
+  /// The number of valid light rows in [texture].
+  final int count;
+}
+
+/// Builds the per-frame data texture that carries the scene's additional
+/// analytic lights (point and spot lights, plus directional lights past the
+/// first, which the shadowed `FragInfo` path owns) to every lit draw.
+///
+/// One instance lives on the `Scene` and is rebuilt once per frame. It keeps a
+/// small ring of textures so a frame still in flight is never overwritten
+/// (mirrors the skinning joints texture).
+class PunctualLightBuffer {
+  static const int _ringSize = 3;
+  final List<gpu.Texture?> _ring = List<gpu.Texture?>.filled(_ringSize, null);
+  int _cursor = 0;
+
+  // Warns once (debug only) when the scene has more lights than fit.
+  bool _warnedOverflow = false;
+
+  /// Packs [directionals] (skipping the first, the shadowed directional the
+  /// `FragInfo` path already shades), [points], and [spots] into a data
+  /// texture. Returns [PunctualLighting.empty] when there are no additional
+  /// lights, so a scene with only a single directional light allocates nothing
+  /// and renders exactly as before.
+  PunctualLighting build({
+    required List<DirectionalLightComponent> directionals,
+    required List<PointLightComponent> points,
+    required List<SpotLightComponent> spots,
+  }) {
+    final (floats, count) = packLights(
+      directionals: directionals,
+      points: points,
+      spots: spots,
+    );
+    if (count == 0) {
+      return const PunctualLighting.empty();
+    }
+
+    assert(() {
+      final total =
+          (directionals.isEmpty ? 0 : directionals.length - 1) +
+          points.length +
+          spots.length;
+      if (total > kMaxPunctualLights && !_warnedOverflow) {
+        _warnedOverflow = true;
+        debugPrint(
+          'flutter_scene: $total additional lights exceed the '
+          '$kMaxPunctualLights-light limit; the extras are not shaded.',
+        );
+      }
+      return true;
+    }());
+
+    _cursor = (_cursor + 1) % _ringSize;
+    final texture = _ring[_cursor] ??= gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      _texelsPerLight,
+      kMaxPunctualLights,
+      format: gpu.PixelFormat.r32g32b32a32Float,
+    );
+    texture.overwrite(floats.buffer.asByteData());
+    return PunctualLighting(texture, count);
+  }
+
+  /// Packs the additional analytic lights into the RGBA32F float buffer the
+  /// data texture is uploaded from, returning the buffer and the number of
+  /// light rows written (capped at [kMaxPunctualLights]). Pure and
+  /// GPU-independent so the texel layout, falloff, and cone math can be unit
+  /// tested; [build] wraps it with the texture upload.
+  static (Float32List, int) packLights({
+    required List<DirectionalLightComponent> directionals,
+    required List<PointLightComponent> points,
+    required List<SpotLightComponent> spots,
+  }) {
+    final floats = Float32List(kMaxPunctualLights * _floatsPerLight);
+    var count = 0;
+
+    // Directional lights past the first: the first is shaded (with shadows) by
+    // the FragInfo path, the rest fold in here as attenuation-free entries.
+    for (
+      var i = 1;
+      i < directionals.length && count < kMaxPunctualLights;
+      i++
+    ) {
+      final component = directionals[i];
+      final light = component.light;
+      final base = count * _floatsPerLight;
+      floats[base + 3] = _typeDirectional;
+      final dir = component.worldDirection;
+      floats[base + 8] = dir.x;
+      floats[base + 9] = dir.y;
+      floats[base + 10] = dir.z;
+      floats[base + 4] = light.color.x * light.intensity;
+      floats[base + 5] = light.color.y * light.intensity;
+      floats[base + 6] = light.color.z * light.intensity;
+      count++;
+    }
+
+    for (final component in points) {
+      if (count >= kMaxPunctualLights) break;
+      final light = component.light;
+      final base = count * _floatsPerLight;
+      final position = component.worldPosition;
+      floats[base + 0] = position.x;
+      floats[base + 1] = position.y;
+      floats[base + 2] = position.z;
+      floats[base + 3] = _typePoint;
+      floats[base + 4] = light.color.x * light.intensity;
+      floats[base + 5] = light.color.y * light.intensity;
+      floats[base + 6] = light.color.z * light.intensity;
+      floats[base + 7] = light.range > 0.0 ? 1.0 / light.range : 0.0;
+      count++;
+    }
+
+    for (final component in spots) {
+      if (count >= kMaxPunctualLights) break;
+      final light = component.light;
+      final base = count * _floatsPerLight;
+      final position = component.worldPosition;
+      final direction = component.worldDirection;
+      floats[base + 0] = position.x;
+      floats[base + 1] = position.y;
+      floats[base + 2] = position.z;
+      floats[base + 3] = _typeSpot;
+      floats[base + 4] = light.color.x * light.intensity;
+      floats[base + 5] = light.color.y * light.intensity;
+      floats[base + 6] = light.color.z * light.intensity;
+      floats[base + 7] = light.range > 0.0 ? 1.0 / light.range : 0.0;
+      floats[base + 8] = direction.x;
+      floats[base + 9] = direction.y;
+      floats[base + 10] = direction.z;
+      // Precompute the cone scale/offset so the shader is a scale-add-clamp.
+      final cosInner = math.cos(light.innerConeAngle);
+      final cosOuter = math.cos(light.outerConeAngle);
+      final scale = 1.0 / math.max(cosInner - cosOuter, 1e-4);
+      floats[base + 11] = scale;
+      floats[base + 12] = -cosOuter * scale;
+      count++;
+    }
+
+    return (floats, count);
+  }
+}

--- a/packages/flutter_scene/lib/src/render/punctual_lights.dart
+++ b/packages/flutter_scene/lib/src/render/punctual_lights.dart
@@ -13,14 +13,16 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 /// unroll over this count, so it is a compile-time constant in both places.
 ///
 /// TODO(lighting): this is a hard *global* cap and the shaded set is shared by
-/// every fragment. Per-object culling via the render BVH turns it into a
-/// per-object budget with an unbounded scene total (see the near-term revision
-/// in notes/rendering/punctual_lights_design.md), and a punctual on/off shader
-/// permutation makes the no-light case cost nothing. TODO(#188474): when Flutter
-/// GPU exposes storage buffers/compute, a higher-tier variant can read a storage
-/// buffer with a real dynamic loop (no cap, no data-texture packing) and move
-/// light-to-region assignment to a compute pass, with this remaining the
-/// base-tier fallback.
+/// every fragment. The scale-first path (see the near-term revision in
+/// notes/rendering/punctual_lights_design.md) makes it unlimited via froxel
+/// clustering, so a fragment loops only its screen-region's lights with no
+/// per-draw light state (better for batching than per-object lists, whose CPU
+/// cost grows with draw count). A shader permutation for the no-light case was
+/// considered and rejected for scale. TODO(#188474): when Flutter GPU exposes
+/// storage buffers/compute, a capability-gated higher-tier variant can read a
+/// storage buffer with a real dynamic loop (no cap, no data-texture packing) and
+/// move light-to-region assignment to a compute pass, with this the base-tier
+/// fallback.
 const int kMaxPunctualLights = 16;
 
 // Each light is one row of the data texture, four RGBA32F texels wide:

--- a/packages/flutter_scene/lib/src/render/punctual_lights.dart
+++ b/packages/flutter_scene/lib/src/render/punctual_lights.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/render/bvh.dart';
 import 'package:flutter_scene/src/render/light_culling.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
+import 'package:flutter_scene/src/render/spot_shadow.dart';
 
 /// The maximum number of punctual lights that can shade a single item. The
 /// scene may hold any number of lights; per-object culling gives each item only
@@ -25,15 +26,18 @@ import 'package:flutter_scene/src/render/render_scene.dart';
 /// data-texture path here as the base-tier fallback.
 const int kMaxPunctualLights = 16;
 
-// A punctual light is one row of the parameters texture, four RGBA32F texels
+// A punctual light is one row of the parameters texture, eight RGBA32F texels
 // wide:
 //   col 0: position.xyz, type   (0 directional, 1 point, 2 spot)
 //   col 1: color.rgb * intensity, inverse range (0 = infinite)
 //   col 2: direction.xyz, spot angular scale
-//   col 3: spot angular offset, (unused)
+//   col 3: spot angular offset, shadow slot (-1 = none), unused, unused
+//   col 4-7: world -> spot-clip matrix for a shadow-casting spot (else unused)
 // The shader reads these by computed UV, sidestepping the GLSL-ES-1.00 ban on
-// dynamically indexing a uniform array (see punctual_lights_design.md).
-const int _texelsPerLight = 4;
+// dynamically indexing a uniform array (see punctual_lights_design.md). The
+// spot shadow matrix rides here rather than in its own texture so no extra
+// sampler is needed (the lit shader is at the backend sampler limit).
+const int _texelsPerLight = 8;
 const int _floatsPerLight = _texelsPerLight * 4;
 
 // The per-object light-index buffer is packed into a 2D texture at most this
@@ -55,6 +59,10 @@ class PunctualLighting {
     required this.paramsCount,
     required this.indexWidth,
     required this.indexHeight,
+    this.spotShadowCount = 0,
+    this.spotShadowDepthBias = 0.0,
+    this.spotShadowNormalBias = 0.0,
+    this.spotShadowSoftness = 0.0,
   });
 
   /// An empty result (no punctual lights this frame).
@@ -63,7 +71,11 @@ class PunctualLighting {
       indexTexture = null,
       paramsCount = 0,
       indexWidth = 0,
-      indexHeight = 0;
+      indexHeight = 0,
+      spotShadowCount = 0,
+      spotShadowDepthBias = 0.0,
+      spotShadowNormalBias = 0.0,
+      spotShadowSoftness = 0.0;
 
   /// All scene lights, one per row (RGBA32F, `paramsCount` rows), or null when
   /// there are none.
@@ -80,6 +92,16 @@ class PunctualLighting {
   /// Dimensions of [indexTexture], for the shader's fetch-coordinate math.
   final int indexWidth;
   final int indexHeight;
+
+  /// Number of shadow-casting spots this frame (their tiles follow the
+  /// directional cascades in the shared shadow atlas, and their matrices ride
+  /// in the params texture). Zero disables spot shadow sampling.
+  final int spotShadowCount;
+
+  /// Shared spot-shadow sampling parameters (from the first caster).
+  final double spotShadowDepthBias;
+  final double spotShadowNormalBias;
+  final double spotShadowSoftness;
 }
 
 // A ring of exactly-sized host-visible RGBA32F textures, so a frame in flight is
@@ -141,11 +163,30 @@ class PunctualLightBuffer {
     required List<SpotLightComponent> spots,
     required List<RenderItem> items,
     required Bvh bvh,
+    SpotShadowFrame? spotShadows,
   }) {
     final packed = _packLights(directionals, points, spots);
     final count = packed.count;
     if (count == 0) {
       return const PunctualLighting.empty();
+    }
+
+    // Stamp each shadow-casting spot's slot (texel 3.y) and world -> spot-clip
+    // matrix (texels 4-7) into its parameters row, so the shader can sample the
+    // right shared-atlas tile without a separate matrices texture.
+    if (spotShadows != null) {
+      final spotRowStart = math.max(0, directionals.length - 1) + points.length;
+      for (var si = 0; si < spots.length; si++) {
+        final slot = spotShadows.slotOf(spots[si]);
+        if (slot < 0) continue;
+        final base = (spotRowStart + si) * _floatsPerLight;
+        packed.params[base + 13] = slot.toDouble();
+        packed.params.setRange(
+          base + 16,
+          base + 32,
+          spotShadows.matrices[slot].storage,
+        );
+      }
     }
 
     final cull = assignLightsToItems(
@@ -169,6 +210,8 @@ class PunctualLightBuffer {
     final paramsTexture = _paramsRing.acquire(_texelsPerLight, count);
     paramsTexture.overwrite(packed.params.buffer.asByteData());
 
+    final spotCount = spotShadows?.matrices.length ?? 0;
+
     final indexLength = cull.indices.length;
     if (indexLength == 0) {
       // Every item was culled out (lights exist but reach nothing this frame).
@@ -178,6 +221,10 @@ class PunctualLightBuffer {
         paramsCount: count,
         indexWidth: 0,
         indexHeight: 0,
+        spotShadowCount: spotCount,
+        spotShadowDepthBias: spotShadows?.depthBias ?? 0.0,
+        spotShadowNormalBias: spotShadows?.normalBias ?? 0.0,
+        spotShadowSoftness: spotShadows?.softness ?? 0.0,
       );
     }
 
@@ -197,6 +244,10 @@ class PunctualLightBuffer {
       paramsCount: count,
       indexWidth: indexWidth,
       indexHeight: indexHeight,
+      spotShadowCount: spotCount,
+      spotShadowDepthBias: spotShadows?.depthBias ?? 0.0,
+      spotShadowNormalBias: spotShadows?.normalBias ?? 0.0,
+      spotShadowSoftness: spotShadows?.softness ?? 0.0,
     );
   }
 
@@ -284,6 +335,9 @@ class PunctualLightBuffer {
       final scale = 1.0 / math.max(cosInner - cosOuter, 1e-4);
       floats[base + 11] = scale;
       floats[base + 12] = -cosOuter * scale;
+      // Shadow slot (texel 3.y); -1 = no shadow. build() stamps the slot and
+      // matrix for shadow-casting spots.
+      floats[base + 13] = -1.0;
       cullables.add(
         CullableLight(row, lightInfluenceBounds(position, light.range)),
       );

--- a/packages/flutter_scene/lib/src/render/punctual_lights.dart
+++ b/packages/flutter_scene/lib/src/render/punctual_lights.dart
@@ -6,28 +6,27 @@ import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/components/point_light_component.dart';
 import 'package:flutter_scene/src/components/spot_light_component.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/render/bvh.dart';
+import 'package:flutter_scene/src/render/light_culling.dart';
+import 'package:flutter_scene/src/render/render_scene.dart';
 
-/// The maximum number of additional analytic lights (point + spot + extra
-/// directional) shaded per frame. Must match `MAX_PUNCTUAL_LIGHTS` in
-/// `shaders/material_lighting.glsl`; the fragment loop is a constant-bounded
-/// unroll over this count, so it is a compile-time constant in both places.
+/// The maximum number of punctual lights that can shade a single item. The
+/// scene may hold any number of lights; per-object culling gives each item only
+/// the lights that reach it, and the fragment loops that slice. Must match
+/// `MAX_PUNCTUAL_LIGHTS` in `shaders/material_lighting.glsl` (the fragment loop
+/// bound is a compile-time constant under GLSL ES 1.00), so this is a per-object
+/// budget, not a global cap.
 ///
-/// TODO(lighting): this is a hard *global* cap and the shaded set is shared by
-/// every fragment. The scale-first path (see the near-term revision in
-/// notes/rendering/punctual_lights_design.md) makes it unlimited via froxel
-/// clustering, so a fragment loops only its screen-region's lights with no
-/// per-draw light state (better for batching than per-object lists, whose CPU
-/// cost grows with draw count), as a high-end tier; constrained mobile stays a
-/// small-`MAX` direct loop. A per-object shader permutation for the no-light case
-/// is rejected (pipeline thrash); a coarse per-frame/capability-tier one is a
-/// measured low-end option only. TODO(#188474): when Flutter GPU exposes
-/// storage buffers/compute, a capability-gated higher-tier variant can read a
-/// storage buffer with a real dynamic loop (no cap, no data-texture packing) and
-/// move light-to-region assignment to a compute pass, with this the base-tier
-/// fallback.
+/// TODO(lighting): for the massive-scale tier, froxel clustering replaces the
+/// per-object lists (no per-draw light state, CPU cost independent of draw
+/// count); constrained mobile keeps this direct loop. TODO(#188474): with
+/// Flutter GPU storage buffers/compute, a higher-tier variant can read a storage
+/// buffer with a real dynamic loop and assign lights in a compute pass, with the
+/// data-texture path here as the base-tier fallback.
 const int kMaxPunctualLights = 16;
 
-// Each light is one row of the data texture, four RGBA32F texels wide:
+// A punctual light is one row of the parameters texture, four RGBA32F texels
+// wide:
 //   col 0: position.xyz, type   (0 directional, 1 point, 2 spot)
 //   col 1: color.rgb * intensity, inverse range (0 = infinite)
 //   col 2: direction.xyz, spot angular scale
@@ -37,108 +36,202 @@ const int kMaxPunctualLights = 16;
 const int _texelsPerLight = 4;
 const int _floatsPerLight = _texelsPerLight * 4;
 
+// The per-object light-index buffer is packed into a 2D texture at most this
+// many texels wide (each texel one light index in .r), so a large scene's
+// index buffer stays within the max texture width; the height grows instead.
+const int _indexTexMaxWidth = 2048;
+
 const double _typeDirectional = 0.0;
 const double _typePoint = 1.0;
 const double _typeSpot = 2.0;
 
-/// The result of building a frame's punctual light buffer: the data texture and
-/// the number of valid light rows in it.
+/// The GPU-side punctual lighting for a frame: the parameters texture holding
+/// every scene light, the per-object light-index texture, and their dimensions
+/// (needed by the shader to normalize its fetch coordinates).
 class PunctualLighting {
-  const PunctualLighting(this.texture, this.count);
+  const PunctualLighting({
+    required this.paramsTexture,
+    required this.indexTexture,
+    required this.paramsCount,
+    required this.indexWidth,
+    required this.indexHeight,
+  });
 
-  /// An empty result (no additional lights this frame).
-  const PunctualLighting.empty() : texture = null, count = 0;
+  /// An empty result (no punctual lights this frame).
+  const PunctualLighting.empty()
+    : paramsTexture = null,
+      indexTexture = null,
+      paramsCount = 0,
+      indexWidth = 0,
+      indexHeight = 0;
 
-  /// The RGBA32F data texture, or null when [count] is zero.
-  final gpu.Texture? texture;
+  /// All scene lights, one per row (RGBA32F, `paramsCount` rows), or null when
+  /// there are none.
+  final gpu.Texture? paramsTexture;
 
-  /// The number of valid light rows in [texture].
-  final int count;
+  /// The flattened per-object light-index buffer (each item's
+  /// `[lightListOffset, +lightListCount)` slice indexes into [paramsTexture]),
+  /// or null when no item is reached by any light.
+  final gpu.Texture? indexTexture;
+
+  /// Number of light rows in [paramsTexture].
+  final int paramsCount;
+
+  /// Dimensions of [indexTexture], for the shader's fetch-coordinate math.
+  final int indexWidth;
+  final int indexHeight;
 }
 
-/// Builds the per-frame data texture that carries the scene's additional
-/// analytic lights (point and spot lights, plus directional lights past the
-/// first, which the shadowed `FragInfo` path owns) to every lit draw.
-///
-/// One instance lives on the `Scene` and is rebuilt once per frame. It keeps a
-/// small ring of textures so a frame still in flight is never overwritten
-/// (mirrors the skinning joints texture).
-class PunctualLightBuffer {
-  static const int _ringSize = 3;
-  final List<gpu.Texture?> _ring = List<gpu.Texture?>.filled(_ringSize, null);
+// A ring of exactly-sized host-visible RGBA32F textures, so a frame in flight is
+// never overwritten. Reallocates when the requested size changes (mirrors the
+// skinning joints texture); steady light counts reuse the ring.
+class _TextureRing {
+  static const int _size = 3;
+  final List<gpu.Texture?> _ring = List<gpu.Texture?>.filled(_size, null);
   int _cursor = 0;
+  int _width = 0;
+  int _height = 0;
 
-  // Warns once (debug only) when the scene has more lights than fit.
+  gpu.Texture acquire(int width, int height) {
+    if (width != _width || height != _height) {
+      _ring.fillRange(0, _size, null);
+      _width = width;
+      _height = height;
+    }
+    _cursor = (_cursor + 1) % _size;
+    return _ring[_cursor] ??= gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      width,
+      height,
+      format: gpu.PixelFormat.r32g32b32a32Float,
+    );
+  }
+}
+
+/// The packed light parameters plus the culling inputs derived from them.
+class _PackedLights {
+  _PackedLights(this.params, this.count, this.cullables);
+
+  final Float32List params;
+  final int count;
+  final List<CullableLight> cullables;
+}
+
+/// Builds the per-frame punctual lighting: the parameters texture holding every
+/// point, spot, and extra-directional light in the scene, and the per-object
+/// light-index texture produced by culling those lights against the items.
+///
+/// One instance lives on the `Scene` and is rebuilt once per frame (the
+/// light-object assignment is view-independent).
+class PunctualLightBuffer {
+  final _TextureRing _paramsRing = _TextureRing();
+  final _TextureRing _indexRing = _TextureRing();
+
   bool _warnedOverflow = false;
 
-  /// Packs [directionals] (skipping the first, the shadowed directional the
-  /// `FragInfo` path already shades), [points], and [spots] into a data
-  /// texture. Returns [PunctualLighting.empty] when there are no additional
-  /// lights, so a scene with only a single directional light allocates nothing
-  /// and renders exactly as before.
+  /// Packs the scene's [directionals] (skipping the first, the shadowed
+  /// directional the `FragInfo` path already shades), [points], and [spots]
+  /// into the parameters buffer, culls them against [items] using [bvh], and
+  /// uploads both the parameters and per-object index textures. Returns
+  /// [PunctualLighting.empty] when there are no punctual lights, so a scene with
+  /// only a single directional light allocates nothing and renders as before.
   PunctualLighting build({
     required List<DirectionalLightComponent> directionals,
     required List<PointLightComponent> points,
     required List<SpotLightComponent> spots,
+    required List<RenderItem> items,
+    required Bvh bvh,
   }) {
-    final (floats, count) = packLights(
-      directionals: directionals,
-      points: points,
-      spots: spots,
-    );
+    final packed = _packLights(directionals, points, spots);
+    final count = packed.count;
     if (count == 0) {
       return const PunctualLighting.empty();
     }
 
+    final cull = assignLightsToItems(
+      items: items,
+      bvh: bvh,
+      lights: packed.cullables,
+      maxPerItem: kMaxPunctualLights,
+    );
+
     assert(() {
-      final total =
-          (directionals.isEmpty ? 0 : directionals.length - 1) +
-          points.length +
-          spots.length;
-      if (total > kMaxPunctualLights && !_warnedOverflow) {
+      if (cull.overflowed && !_warnedOverflow) {
         _warnedOverflow = true;
         debugPrint(
-          'flutter_scene: $total additional lights exceed the '
-          '$kMaxPunctualLights-light limit; the extras are not shaded.',
+          'flutter_scene: an object is reached by more than $kMaxPunctualLights '
+          'punctual lights; the excess is not shaded.',
         );
       }
       return true;
     }());
 
-    _cursor = (_cursor + 1) % _ringSize;
-    final texture = _ring[_cursor] ??= gpu.gpuContext.createTexture(
-      gpu.StorageMode.hostVisible,
-      _texelsPerLight,
-      kMaxPunctualLights,
-      format: gpu.PixelFormat.r32g32b32a32Float,
+    final paramsTexture = _paramsRing.acquire(_texelsPerLight, count);
+    paramsTexture.overwrite(packed.params.buffer.asByteData());
+
+    final indexLength = cull.indices.length;
+    if (indexLength == 0) {
+      // Every item was culled out (lights exist but reach nothing this frame).
+      return PunctualLighting(
+        paramsTexture: paramsTexture,
+        indexTexture: null,
+        paramsCount: count,
+        indexWidth: 0,
+        indexHeight: 0,
+      );
+    }
+
+    final indexWidth = math.min(indexLength, _indexTexMaxWidth);
+    final indexHeight = (indexLength + indexWidth - 1) ~/ indexWidth;
+    // RGBA32F; the light index rides in .r, the rest is unread padding.
+    final indexData = Float32List(indexWidth * indexHeight * 4);
+    for (var i = 0; i < indexLength; i++) {
+      indexData[i * 4] = cull.indices[i].toDouble();
+    }
+    final indexTexture = _indexRing.acquire(indexWidth, indexHeight);
+    indexTexture.overwrite(indexData.buffer.asByteData());
+
+    return PunctualLighting(
+      paramsTexture: paramsTexture,
+      indexTexture: indexTexture,
+      paramsCount: count,
+      indexWidth: indexWidth,
+      indexHeight: indexHeight,
     );
-    texture.overwrite(floats.buffer.asByteData());
-    return PunctualLighting(texture, count);
   }
 
-  /// Packs the additional analytic lights into the RGBA32F float buffer the
-  /// data texture is uploaded from, returning the buffer and the number of
-  /// light rows written (capped at [kMaxPunctualLights]). Pure and
-  /// GPU-independent so the texel layout, falloff, and cone math can be unit
-  /// tested; [build] wraps it with the texture upload.
+  /// Packs the additional analytic lights into the parameters buffer, returning
+  /// it and the light count. Pure and GPU-independent so the texel layout,
+  /// falloff, and cone math can be unit tested; [build] wraps it with culling
+  /// and the texture uploads.
+  @visibleForTesting
   static (Float32List, int) packLights({
     required List<DirectionalLightComponent> directionals,
     required List<PointLightComponent> points,
     required List<SpotLightComponent> spots,
   }) {
-    final floats = Float32List(kMaxPunctualLights * _floatsPerLight);
-    var count = 0;
+    final packed = _packLights(directionals, points, spots);
+    return (packed.params, packed.count);
+  }
+
+  static _PackedLights _packLights(
+    List<DirectionalLightComponent> directionals,
+    List<PointLightComponent> points,
+    List<SpotLightComponent> spots,
+  ) {
+    final count =
+        math.max(0, directionals.length - 1) + points.length + spots.length;
+    final floats = Float32List(count * _floatsPerLight);
+    final cullables = <CullableLight>[];
+    var row = 0;
 
     // Directional lights past the first: the first is shaded (with shadows) by
-    // the FragInfo path, the rest fold in here as attenuation-free entries.
-    for (
-      var i = 1;
-      i < directionals.length && count < kMaxPunctualLights;
-      i++
-    ) {
+    // the FragInfo path, the rest fold in here as attenuation-free entries with
+    // infinite influence (they reach every item).
+    for (var i = 1; i < directionals.length; i++) {
       final component = directionals[i];
       final light = component.light;
-      final base = count * _floatsPerLight;
+      final base = row * _floatsPerLight;
       floats[base + 3] = _typeDirectional;
       final dir = component.worldDirection;
       floats[base + 8] = dir.x;
@@ -147,13 +240,13 @@ class PunctualLightBuffer {
       floats[base + 4] = light.color.x * light.intensity;
       floats[base + 5] = light.color.y * light.intensity;
       floats[base + 6] = light.color.z * light.intensity;
-      count++;
+      cullables.add(CullableLight(row, null));
+      row++;
     }
 
     for (final component in points) {
-      if (count >= kMaxPunctualLights) break;
       final light = component.light;
-      final base = count * _floatsPerLight;
+      final base = row * _floatsPerLight;
       final position = component.worldPosition;
       floats[base + 0] = position.x;
       floats[base + 1] = position.y;
@@ -163,13 +256,15 @@ class PunctualLightBuffer {
       floats[base + 5] = light.color.y * light.intensity;
       floats[base + 6] = light.color.z * light.intensity;
       floats[base + 7] = light.range > 0.0 ? 1.0 / light.range : 0.0;
-      count++;
+      cullables.add(
+        CullableLight(row, lightInfluenceBounds(position, light.range)),
+      );
+      row++;
     }
 
     for (final component in spots) {
-      if (count >= kMaxPunctualLights) break;
       final light = component.light;
-      final base = count * _floatsPerLight;
+      final base = row * _floatsPerLight;
       final position = component.worldPosition;
       final direction = component.worldDirection;
       floats[base + 0] = position.x;
@@ -189,9 +284,12 @@ class PunctualLightBuffer {
       final scale = 1.0 / math.max(cosInner - cosOuter, 1e-4);
       floats[base + 11] = scale;
       floats[base + 12] = -cosOuter * scale;
-      count++;
+      cullables.add(
+        CullableLight(row, lightInfluenceBounds(position, light.range)),
+      );
+      row++;
     }
 
-    return (floats, count);
+    return _PackedLights(floats, count, cullables);
   }
 }

--- a/packages/flutter_scene/lib/src/render/render_scene.dart
+++ b/packages/flutter_scene/lib/src/render/render_scene.dart
@@ -64,6 +64,18 @@ class RenderItem {
   /// World-space transform, refreshed each frame from the owning node.
   final Matrix4 worldTransform = Matrix4.identity();
 
+  /// Start index of this item's punctual-light list in the shared per-frame
+  /// light-index buffer, and how many lights follow. Refreshed each frame by
+  /// the light culler; the shader loops that slice so a fragment only shades
+  /// the lights that reach this item. `count` 0 means no punctual lights.
+  int lightListOffset = 0;
+  int lightListCount = 0;
+
+  /// Scratch accumulator the light culler appends this item's light indices to
+  /// before flattening them into the shared buffer. Reused across frames to
+  /// avoid per-item allocation; cleared at the start of each cull.
+  final List<int> lightScratch = [];
+
   /// The owning node's highlight color (linear RGBA), or null when the node
   /// is not highlighted. Refreshed each frame; the selection-outline pass
   /// draws only highlighted items, using this as the mask color.

--- a/packages/flutter_scene/lib/src/render/render_scene.dart
+++ b/packages/flutter_scene/lib/src/render/render_scene.dart
@@ -5,6 +5,8 @@ import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/components/camera_component.dart';
 import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/components/environment_volume_component.dart';
+import 'package:flutter_scene/src/components/point_light_component.dart';
+import 'package:flutter_scene/src/components/spot_light_component.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/render/bvh.dart';
@@ -176,6 +178,36 @@ class RenderScene {
   /// Unregisters [light]. Called when its owning node unmounts.
   void removeDirectionalLight(DirectionalLightComponent light) {
     directionalLights.remove(light);
+  }
+
+  /// The point lights contributed by mounted [PointLightComponent]s, in
+  /// registration order. Collected into the per-frame punctual light buffer.
+  final List<PointLightComponent> pointLights = [];
+
+  /// Registers [light] as an active point light. Called by a
+  /// [PointLightComponent] when its owning node mounts.
+  void addPointLight(PointLightComponent light) {
+    pointLights.add(light);
+  }
+
+  /// Unregisters [light]. Called when its owning node unmounts.
+  void removePointLight(PointLightComponent light) {
+    pointLights.remove(light);
+  }
+
+  /// The spot lights contributed by mounted [SpotLightComponent]s, in
+  /// registration order. Collected into the per-frame punctual light buffer.
+  final List<SpotLightComponent> spotLights = [];
+
+  /// Registers [light] as an active spot light. Called by a
+  /// [SpotLightComponent] when its owning node mounts.
+  void addSpotLight(SpotLightComponent light) {
+    spotLights.add(light);
+  }
+
+  /// Unregisters [light]. Called when its owning node unmounts.
+  void removeSpotLight(SpotLightComponent light) {
+    spotLights.remove(light);
   }
 
   /// The environment volumes contributed by mounted

--- a/packages/flutter_scene/lib/src/render/render_scene.dart
+++ b/packages/flutter_scene/lib/src/render/render_scene.dart
@@ -264,6 +264,12 @@ class RenderScene {
       cameraOverride ?? (cameras.isEmpty ? null : cameras.first.toCamera());
 
   Bvh _bvh = Bvh.build([]);
+
+  /// The spatial structure over the bounded items, current after
+  /// [rebuildIfDirty]. Used by the light culler to scatter each light onto the
+  /// items it reaches.
+  Bvh get bvh => _bvh;
+
   final List<RenderItem> _alwaysVisible = [];
 
   // The BVH needs a full rebuild: an item was added or removed, or an

--- a/packages/flutter_scene/lib/src/render/scene_pass.dart
+++ b/packages/flutter_scene/lib/src/render/scene_pass.dart
@@ -156,6 +156,13 @@ class ScenePass extends RenderGraphPass {
       punctualParamsCount: _punctualLighting.paramsCount,
       punctualIndexWidth: _punctualLighting.indexWidth,
       punctualIndexHeight: _punctualLighting.indexHeight,
+      // Spot shadows share the atlas, so only sample them when it was produced.
+      spotShadowCount: shadowMap == null
+          ? 0
+          : _punctualLighting.spotShadowCount,
+      spotShadowDepthBias: _punctualLighting.spotShadowDepthBias,
+      spotShadowNormalBias: _punctualLighting.spotShadowNormalBias,
+      spotShadowSoftness: _punctualLighting.spotShadowSoftness,
       shadowMap: shadowMap,
       cascades: shadowMap == null ? const [] : _cascades,
       ssaoMap: ssaoMap,

--- a/packages/flutter_scene/lib/src/render/scene_pass.dart
+++ b/packages/flutter_scene/lib/src/render/scene_pass.dart
@@ -43,6 +43,8 @@ class ScenePass extends RenderGraphPass {
     required bool enableMsaa,
     DirectionalLight? directionalLight,
     Vector3? directionalLightDirection,
+    gpu.Texture? punctualLightTexture,
+    int punctualLightCount = 0,
     List<ShadowCascade> cascades = const [],
     double specularOcclusionMode = 0.0,
     int layerMask = kRenderLayerAll,
@@ -60,6 +62,8 @@ class ScenePass extends RenderGraphPass {
        _enableMsaa = enableMsaa,
        _directionalLight = directionalLight,
        _directionalLightDirection = directionalLightDirection,
+       _punctualLightTexture = punctualLightTexture,
+       _punctualLightCount = punctualLightCount,
        _cascades = cascades,
        _specularOcclusionMode = specularOcclusionMode,
        _fog = fog;
@@ -76,6 +80,8 @@ class ScenePass extends RenderGraphPass {
   final bool _enableMsaa;
   final DirectionalLight? _directionalLight;
   final Vector3? _directionalLightDirection;
+  final gpu.Texture? _punctualLightTexture;
+  final int _punctualLightCount;
   final int _layerMask;
   final List<ShadowCascade> _cascades;
   final double _specularOcclusionMode;
@@ -147,6 +153,8 @@ class ScenePass extends RenderGraphPass {
       environmentTransform: _environmentTransform,
       directionalLight: _directionalLight,
       directionalLightDirection: _directionalLightDirection,
+      punctualLightTexture: _punctualLightTexture,
+      punctualLightCount: _punctualLightCount,
       shadowMap: shadowMap,
       cascades: shadowMap == null ? const [] : _cascades,
       ssaoMap: ssaoMap,

--- a/packages/flutter_scene/lib/src/render/scene_pass.dart
+++ b/packages/flutter_scene/lib/src/render/scene_pass.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/fog.dart';
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/environment.dart';
+import 'package:flutter_scene/src/render/punctual_lights.dart';
 import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/render/render_layers.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
@@ -43,8 +44,7 @@ class ScenePass extends RenderGraphPass {
     required bool enableMsaa,
     DirectionalLight? directionalLight,
     Vector3? directionalLightDirection,
-    gpu.Texture? punctualLightTexture,
-    int punctualLightCount = 0,
+    PunctualLighting punctualLighting = const PunctualLighting.empty(),
     List<ShadowCascade> cascades = const [],
     double specularOcclusionMode = 0.0,
     int layerMask = kRenderLayerAll,
@@ -62,8 +62,7 @@ class ScenePass extends RenderGraphPass {
        _enableMsaa = enableMsaa,
        _directionalLight = directionalLight,
        _directionalLightDirection = directionalLightDirection,
-       _punctualLightTexture = punctualLightTexture,
-       _punctualLightCount = punctualLightCount,
+       _punctualLighting = punctualLighting,
        _cascades = cascades,
        _specularOcclusionMode = specularOcclusionMode,
        _fog = fog;
@@ -80,8 +79,7 @@ class ScenePass extends RenderGraphPass {
   final bool _enableMsaa;
   final DirectionalLight? _directionalLight;
   final Vector3? _directionalLightDirection;
-  final gpu.Texture? _punctualLightTexture;
-  final int _punctualLightCount;
+  final PunctualLighting _punctualLighting;
   final int _layerMask;
   final List<ShadowCascade> _cascades;
   final double _specularOcclusionMode;
@@ -153,8 +151,11 @@ class ScenePass extends RenderGraphPass {
       environmentTransform: _environmentTransform,
       directionalLight: _directionalLight,
       directionalLightDirection: _directionalLightDirection,
-      punctualLightTexture: _punctualLightTexture,
-      punctualLightCount: _punctualLightCount,
+      punctualParamsTexture: _punctualLighting.paramsTexture,
+      punctualIndexTexture: _punctualLighting.indexTexture,
+      punctualParamsCount: _punctualLighting.paramsCount,
+      punctualIndexWidth: _punctualLighting.indexWidth,
+      punctualIndexHeight: _punctualLighting.indexHeight,
       shadowMap: shadowMap,
       cascades: shadowMap == null ? const [] : _cascades,
       ssaoMap: ssaoMap,

--- a/packages/flutter_scene/lib/src/render/shadow_pass.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_pass.dart
@@ -136,11 +136,7 @@ class ShadowPass extends RenderGraphPass {
     final spots = _spotShadows;
     if (spots != null) {
       for (var s = 0; s < spots.matrices.length; s++) {
-        renderTile(
-          _cascades.length + s,
-          spots.matrices[s],
-          ShadowCasterFaces.front,
-        );
+        renderTile(_cascades.length + s, spots.matrices[s], spots.casterFaces);
       }
     }
 

--- a/packages/flutter_scene/lib/src/render/shadow_pass.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_pass.dart
@@ -8,10 +8,11 @@ import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/render/shadow_encoder.dart';
 import 'package:flutter_scene/src/render/frame_transients.dart';
+import 'package:flutter_scene/src/render/spot_shadow.dart';
 
-/// Render-graph blackboard key under which [ShadowPass] publishes the
-/// directional shadow map atlas (a depth-in-`.r` fp32 texture). The
-/// downstream scene pass reads it from here.
+/// Render-graph blackboard key under which [ShadowPass] publishes the shadow
+/// map atlas (a depth-in-`.r` fp32 texture). The downstream scene pass reads it
+/// from here.
 const String kShadowMapBlackboardKey = 'directional_shadow_map';
 
 /// Render-graph blackboard key under which [ShadowPass] publishes the packed
@@ -20,33 +21,38 @@ const String kShadowMapBlackboardKey = 'directional_shadow_map';
 /// light color). A depth-aware custom pass reads it to sample the shadow map.
 const String kShadowUniformBlackboardKey = 'shadow_uniform';
 
-/// Renders the scene's depth from a directional light into a cascaded
-/// shadow map atlas and publishes it on the render-graph blackboard.
+/// Renders the scene's depth into one shared shadow map atlas and publishes it
+/// on the render-graph blackboard: the directional light's cascades first, then
+/// each shadow-casting spot's cone.
 ///
-/// The atlas is one fp32 color texture holding the cascade tiles as a
-/// horizontal strip, each [tileResolution] square; window-space depth
-/// goes in the red channel (a transient depth attachment backs the
-/// depth test). It is cleared to 1.0 so texels no caster covers read as
-/// "lit". Each cascade renders into its own tile through a viewport.
+/// The atlas is one fp32 color texture holding the tiles as a horizontal strip,
+/// each [tileResolution] square (cascade tiles `0..cascades.length`, then spot
+/// tiles); window-space depth goes in the red channel (a transient depth
+/// attachment backs the depth test). It is cleared to 1.0 so texels no caster
+/// covers read as "lit". Sharing one atlas keeps every shadow type on a single
+/// sampler in the lit shader.
 class ShadowPass extends RenderGraphPass {
   ShadowPass({
     required RenderScene renderScene,
-    required List<ShadowCascade> cascades,
     required int tileResolution,
-    required ShadowCasterFaces casterFaces,
     required Vector3 cameraPosition,
+    List<ShadowCascade> cascades = const [],
+    ShadowCasterFaces casterFaces = ShadowCasterFaces.front,
+    SpotShadowFrame? spotShadows,
     ByteData? shadowUniform,
   }) : _renderScene = renderScene,
        _cascades = cascades,
        _tileResolution = tileResolution,
        _casterFaces = casterFaces,
        _cameraPosition = cameraPosition,
+       _spotShadows = spotShadows,
        _shadowUniform = shadowUniform;
 
   final RenderScene _renderScene;
   final List<ShadowCascade> _cascades;
   final int _tileResolution;
   final ShadowCasterFaces _casterFaces;
+  final SpotShadowFrame? _spotShadows;
 
   // The packed PostShadowInfo block, published for depth-aware custom passes.
   final ByteData? _shadowUniform;
@@ -61,7 +67,9 @@ class ShadowPass extends RenderGraphPass {
 
   @override
   void execute(RenderGraphContext context) {
-    final atlasWidth = _tileResolution * _cascades.length;
+    final spotCount = _spotShadows?.matrices.length ?? 0;
+    final totalTiles = _cascades.length + spotCount;
+    final atlasWidth = _tileResolution * totalTiles;
     // fp32 (not fp16): the far cascade's orthographic depth range spans
     // hundreds of world units, and fp16's ~11-bit mantissa quantizes
     // window-space depth into steps coarser than the shadow depth bias.
@@ -99,13 +107,13 @@ class ShadowPass extends RenderGraphPass {
     final commandBuffer = gpu.gpuContext.createCommandBuffer();
     final renderPass = commandBuffer.createRenderPass(target);
 
-    // Each cascade renders into its own tile of the strip. The viewport
-    // restricts rasterization to the tile; the shared depth attachment
-    // is cleared once for the whole atlas.
-    for (var c = 0; c < _cascades.length; c++) {
+    // Each tile renders into its own slot of the strip. The viewport restricts
+    // rasterization to the tile; the shared depth attachment is cleared once for
+    // the whole atlas. Renders a tile from a light-space matrix.
+    void renderTile(int tile, Matrix4 matrix, ShadowCasterFaces faces) {
       renderPass.setViewport(
         gpu.Viewport(
-          x: c * _tileResolution,
+          x: tile * _tileResolution,
           y: 0,
           width: _tileResolution,
           height: _tileResolution,
@@ -114,11 +122,26 @@ class ShadowPass extends RenderGraphPass {
       final encoder = ShadowEncoder(
         renderPass,
         context.transientsBuffer,
-        _cascades[c].lightSpaceMatrix,
+        matrix,
         _cameraPosition,
-        _casterFaces,
+        faces,
       );
       _renderScene.cull(encoder.frustum, encoder.submit);
+    }
+
+    // Cascade tiles first (0..cascades.length), then the spot cones.
+    for (var c = 0; c < _cascades.length; c++) {
+      renderTile(c, _cascades[c].lightSpaceMatrix, _casterFaces);
+    }
+    final spots = _spotShadows;
+    if (spots != null) {
+      for (var s = 0; s < spots.matrices.length; s++) {
+        renderTile(
+          _cascades.length + s,
+          spots.matrices[s],
+          ShadowCasterFaces.front,
+        );
+      }
     }
 
     rendererSubmissions.submit(commandBuffer);

--- a/packages/flutter_scene/lib/src/render/spot_shadow.dart
+++ b/packages/flutter_scene/lib/src/render/spot_shadow.dart
@@ -1,6 +1,7 @@
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/components/spot_light_component.dart';
+import 'package:flutter_scene/src/light.dart' show ShadowCasterFaces;
 
 /// The most spot lights that can cast a shadow at once. Each takes a tile in
 /// the shared shadow atlas and a perspective depth pass, so the count is
@@ -20,6 +21,7 @@ class SpotShadowFrame {
     required this.depthBias,
     required this.normalBias,
     required this.softness,
+    required this.casterFaces,
   });
 
   /// The shadow-casting spot components, index = slot.
@@ -32,6 +34,7 @@ class SpotShadowFrame {
   final double depthBias;
   final double normalBias;
   final double softness;
+  final ShadowCasterFaces casterFaces;
 
   /// The slot assigned to [component] (its atlas tile and matrix), or -1 when
   /// it is not a shadow caster this frame.
@@ -64,5 +67,6 @@ SpotShadowFrame? collectSpotShadows(List<SpotLightComponent> spots) {
     depthBias: first.shadowDepthBias,
     normalBias: first.shadowNormalBias,
     softness: first.shadowSoftness,
+    casterFaces: first.shadowCasterFaces,
   );
 }

--- a/packages/flutter_scene/lib/src/render/spot_shadow.dart
+++ b/packages/flutter_scene/lib/src/render/spot_shadow.dart
@@ -1,26 +1,16 @@
-import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/components/spot_light_component.dart';
-import 'package:flutter_scene/src/light.dart' show ShadowCasterFaces;
-import 'package:flutter_scene/src/render/render_graph.dart';
-import 'package:flutter_scene/src/render/render_scene.dart';
-import 'package:flutter_scene/src/render/shadow_encoder.dart';
 
 /// The most spot lights that can cast a shadow at once. Each takes a tile in
-/// the spot-shadow atlas and a perspective depth pass, so the count is capped;
-/// spots past the budget shade unshadowed. Kept small deliberately (shadowed
-/// local lights are expensive, especially on mobile).
+/// the shared shadow atlas and a perspective depth pass, so the count is
+/// capped; spots past the budget shade unshadowed. Kept small deliberately
+/// (shadowed local lights are expensive, especially on mobile).
 const int kMaxSpotShadows = 4;
 
-/// Render-graph blackboard key under which [SpotShadowPass] publishes the
-/// spot-shadow atlas (a depth-in-`.r` fp32 texture, one tile per shadow-casting
-/// spot). The scene pass reads it from here.
-const String kSpotShadowMapBlackboardKey = 'spot_shadow_map';
-
 /// The shadow-casting spots selected for a frame, in slot order (a spot's slot
-/// is its index here, matching its atlas tile and matrix row). All tiles share
-/// one resolution and bias, taken from the first caster (per-spot shadow
+/// is its index here, matching its shadow atlas tile and its matrix). All tiles
+/// share one resolution and bias, taken from the first caster (per-spot shadow
 /// parameters are a future refinement).
 class SpotShadowFrame {
   SpotShadowFrame({
@@ -43,8 +33,8 @@ class SpotShadowFrame {
   final double normalBias;
   final double softness;
 
-  /// The slot assigned to [component] (its atlas tile and matrix row), or -1
-  /// when it is not a shadow caster this frame.
+  /// The slot assigned to [component] (its atlas tile and matrix), or -1 when
+  /// it is not a shadow caster this frame.
   int slotOf(SpotLightComponent component) => casters.indexOf(component);
 }
 
@@ -75,80 +65,4 @@ SpotShadowFrame? collectSpotShadows(List<SpotLightComponent> spots) {
     normalBias: first.shadowNormalBias,
     softness: first.shadowSoftness,
   );
-}
-
-/// Renders each shadow-casting spot's depth into a tile of the spot-shadow
-/// atlas (one square [SpotShadowFrame.tileResolution] tile per caster, laid out
-/// as a horizontal strip) and publishes it on the blackboard. Mirrors the
-/// directional `ShadowPass`, reusing [ShadowEncoder] with the spot's
-/// perspective matrix in place of an orthographic cascade matrix.
-class SpotShadowPass extends RenderGraphPass {
-  SpotShadowPass({
-    required RenderScene renderScene,
-    required SpotShadowFrame frame,
-    required Vector3 cameraPosition,
-  }) : _renderScene = renderScene,
-       _frame = frame,
-       _cameraPosition = cameraPosition;
-
-  final RenderScene _renderScene;
-  final SpotShadowFrame _frame;
-  final Vector3 _cameraPosition;
-
-  @override
-  String get name => 'SpotShadowPass';
-
-  @override
-  void execute(RenderGraphContext context) {
-    final tile = _frame.tileResolution;
-    final atlasWidth = tile * _frame.matrices.length;
-    final color = context.texturePool.acquire(
-      TransientTextureDescriptor.color(
-        width: atlasWidth,
-        height: tile,
-        format: gpu.PixelFormat.r32g32b32a32Float,
-        debugName: 'spot_shadow_map',
-      ),
-    );
-    final depth = context.texturePool.acquire(
-      TransientTextureDescriptor.depth(
-        width: atlasWidth,
-        height: tile,
-        format: gpu.gpuContext.defaultDepthStencilFormat,
-        debugName: 'spot_shadow_map_depth',
-      ),
-    );
-    final target = gpu.RenderTarget.singleColor(
-      gpu.ColorAttachment(
-        texture: color,
-        // White = depth 1.0 in .r, so texels no caster covers read as lit.
-        clearValue: Vector4(1.0, 1.0, 1.0, 1.0),
-      ),
-      depthStencilAttachment: gpu.DepthStencilAttachment(
-        texture: depth,
-        depthClearValue: 1.0,
-      ),
-    );
-    final commandBuffer = gpu.gpuContext.createCommandBuffer();
-    final renderPass = commandBuffer.createRenderPass(target);
-
-    for (var slot = 0; slot < _frame.matrices.length; slot++) {
-      renderPass.setViewport(
-        gpu.Viewport(x: slot * tile, y: 0, width: tile, height: tile),
-      );
-      final encoder = ShadowEncoder(
-        renderPass,
-        context.transientsBuffer,
-        _frame.matrices[slot],
-        _cameraPosition,
-        // Front faces cast (general-purpose); a spot lights closed and open
-        // meshes alike, so keep the default rather than second-depth.
-        ShadowCasterFaces.front,
-      );
-      _renderScene.cull(encoder.frustum, encoder.submit);
-    }
-
-    commandBuffer.submit();
-    context.blackboard.set(kSpotShadowMapBlackboardKey, color);
-  }
 }

--- a/packages/flutter_scene/lib/src/render/spot_shadow.dart
+++ b/packages/flutter_scene/lib/src/render/spot_shadow.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:vector_math/vector_math.dart';
+
+import 'package:flutter_scene/src/components/spot_light_component.dart';
+import 'package:flutter_scene/src/light.dart' show ShadowCasterFaces;
+import 'package:flutter_scene/src/render/render_graph.dart';
+import 'package:flutter_scene/src/render/render_scene.dart';
+import 'package:flutter_scene/src/render/shadow_encoder.dart';
+
+/// The most spot lights that can cast a shadow at once. Each takes a tile in
+/// the spot-shadow atlas and a perspective depth pass, so the count is capped;
+/// spots past the budget shade unshadowed. Kept small deliberately (shadowed
+/// local lights are expensive, especially on mobile).
+const int kMaxSpotShadows = 4;
+
+/// Render-graph blackboard key under which [SpotShadowPass] publishes the
+/// spot-shadow atlas (a depth-in-`.r` fp32 texture, one tile per shadow-casting
+/// spot). The scene pass reads it from here.
+const String kSpotShadowMapBlackboardKey = 'spot_shadow_map';
+
+/// The shadow-casting spots selected for a frame, in slot order (a spot's slot
+/// is its index here, matching its atlas tile and matrix row). All tiles share
+/// one resolution and bias, taken from the first caster (per-spot shadow
+/// parameters are a future refinement).
+class SpotShadowFrame {
+  SpotShadowFrame({
+    required this.casters,
+    required this.matrices,
+    required this.tileResolution,
+    required this.depthBias,
+    required this.normalBias,
+    required this.softness,
+  });
+
+  /// The shadow-casting spot components, index = slot.
+  final List<SpotLightComponent> casters;
+
+  /// World -> spot-clip matrix per caster (parallel to [casters]).
+  final List<Matrix4> matrices;
+
+  final int tileResolution;
+  final double depthBias;
+  final double normalBias;
+  final double softness;
+
+  /// The slot assigned to [component] (its atlas tile and matrix row), or -1
+  /// when it is not a shadow caster this frame.
+  int slotOf(SpotLightComponent component) => casters.indexOf(component);
+}
+
+/// Selects up to [kMaxSpotShadows] shadow-casting spots from [spots] and
+/// computes their world -> spot-clip matrices, or null when none cast a shadow.
+SpotShadowFrame? collectSpotShadows(List<SpotLightComponent> spots) {
+  final casters = <SpotLightComponent>[];
+  for (final spot in spots) {
+    if (!spot.light.castsShadow) continue;
+    casters.add(spot);
+    if (casters.length >= kMaxSpotShadows) break;
+  }
+  if (casters.isEmpty) return null;
+
+  final matrices = [
+    for (final caster in casters)
+      caster.light.shadowViewProjection(
+        caster.worldPosition,
+        caster.worldDirection,
+      ),
+  ];
+  final first = casters.first.light;
+  return SpotShadowFrame(
+    casters: casters,
+    matrices: matrices,
+    tileResolution: first.shadowMapResolution,
+    depthBias: first.shadowDepthBias,
+    normalBias: first.shadowNormalBias,
+    softness: first.shadowSoftness,
+  );
+}
+
+/// Renders each shadow-casting spot's depth into a tile of the spot-shadow
+/// atlas (one square [SpotShadowFrame.tileResolution] tile per caster, laid out
+/// as a horizontal strip) and publishes it on the blackboard. Mirrors the
+/// directional `ShadowPass`, reusing [ShadowEncoder] with the spot's
+/// perspective matrix in place of an orthographic cascade matrix.
+class SpotShadowPass extends RenderGraphPass {
+  SpotShadowPass({
+    required RenderScene renderScene,
+    required SpotShadowFrame frame,
+    required Vector3 cameraPosition,
+  }) : _renderScene = renderScene,
+       _frame = frame,
+       _cameraPosition = cameraPosition;
+
+  final RenderScene _renderScene;
+  final SpotShadowFrame _frame;
+  final Vector3 _cameraPosition;
+
+  @override
+  String get name => 'SpotShadowPass';
+
+  @override
+  void execute(RenderGraphContext context) {
+    final tile = _frame.tileResolution;
+    final atlasWidth = tile * _frame.matrices.length;
+    final color = context.texturePool.acquire(
+      TransientTextureDescriptor.color(
+        width: atlasWidth,
+        height: tile,
+        format: gpu.PixelFormat.r32g32b32a32Float,
+        debugName: 'spot_shadow_map',
+      ),
+    );
+    final depth = context.texturePool.acquire(
+      TransientTextureDescriptor.depth(
+        width: atlasWidth,
+        height: tile,
+        format: gpu.gpuContext.defaultDepthStencilFormat,
+        debugName: 'spot_shadow_map_depth',
+      ),
+    );
+    final target = gpu.RenderTarget.singleColor(
+      gpu.ColorAttachment(
+        texture: color,
+        // White = depth 1.0 in .r, so texels no caster covers read as lit.
+        clearValue: Vector4(1.0, 1.0, 1.0, 1.0),
+      ),
+      depthStencilAttachment: gpu.DepthStencilAttachment(
+        texture: depth,
+        depthClearValue: 1.0,
+      ),
+    );
+    final commandBuffer = gpu.gpuContext.createCommandBuffer();
+    final renderPass = commandBuffer.createRenderPass(target);
+
+    for (var slot = 0; slot < _frame.matrices.length; slot++) {
+      renderPass.setViewport(
+        gpu.Viewport(x: slot * tile, y: 0, width: tile, height: tile),
+      );
+      final encoder = ShadowEncoder(
+        renderPass,
+        context.transientsBuffer,
+        _frame.matrices[slot],
+        _cameraPosition,
+        // Front faces cast (general-purpose); a spot lights closed and open
+        // meshes alike, so keep the default rather than second-depth.
+        ShadowCasterFaces.front,
+      );
+      _renderScene.cull(encoder.frustum, encoder.submit);
+    }
+
+    commandBuffer.submit();
+    context.blackboard.set(kSpotShadowMapBlackboardKey, color);
+  }
+}

--- a/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
@@ -4,6 +4,11 @@ import 'package:flutter/foundation.dart';
 import 'package:vector_math/vector_math.dart';
 import 'package:flutter_scene/src/importer/gltf.dart';
 
+import '../components/component.dart';
+import '../components/directional_light_component.dart';
+import '../components/point_light_component.dart';
+import '../components/spot_light_component.dart';
+import '../light.dart';
 import '../material/unlit_material.dart';
 import '../mesh.dart';
 import '../node.dart';
@@ -229,11 +234,63 @@ void _populateNode({
     }
   }
 
+  final lightIndex = gltfNode.light;
+  if (lightIndex != null && lightIndex >= 0 && lightIndex < doc.lights.length) {
+    final component = _buildLightComponent(doc.lights[lightIndex]);
+    if (component != null) {
+      engineNode.addComponent(component);
+    }
+  }
+
   for (final childIndex in gltfNode.children) {
     if (childIndex < 0 || childIndex >= engineNodes.length) {
       throw Exception('glTF node child index $childIndex out of range');
     }
     engineNode.add(engineNodes[childIndex]);
+  }
+}
+
+// Builds the engine light component for a KHR_lights_punctual light, or null
+// for an unsupported type. glTF lights emit along the node's local -Z axis, so
+// directional and spot lights take that as their local direction (the node
+// transform, and the scene-root handedness flip, then aim them in world space).
+//
+// TODO(lighting): glTF point/spot intensity is candela and directional is lux;
+// flutter_scene uses an artistic multiplier, so the value is carried through
+// unconverted. Map photometric units to the engine's exposure if physical
+// intensities are needed.
+Component? _buildLightComponent(GltfPunctualLight light) {
+  switch (light.type) {
+    case 'directional':
+      return DirectionalLightComponent(
+        DirectionalLight(
+          direction: Vector3(0.0, 0.0, -1.0),
+          color: light.color.clone(),
+          intensity: light.intensity,
+        ),
+      );
+    case 'point':
+      return PointLightComponent(
+        PointLight(
+          color: light.color.clone(),
+          intensity: light.intensity,
+          range: light.range ?? 0.0,
+        ),
+      );
+    case 'spot':
+      return SpotLightComponent(
+        SpotLight(
+          direction: Vector3(0.0, 0.0, -1.0),
+          color: light.color.clone(),
+          intensity: light.intensity,
+          range: light.range ?? 0.0,
+          innerConeAngle: light.innerConeAngle,
+          outerConeAngle: light.outerConeAngle,
+        ),
+      );
+    default:
+      debugPrint('Skipping unsupported KHR_lights_punctual type ${light.type}');
+      return null;
   }
 }
 

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -918,6 +918,8 @@ base class Scene implements SceneGraph {
       directionals: renderScene.directionalLights,
       points: renderScene.pointLights,
       spots: renderScene.spotLights,
+      items: renderScene.items,
+      bvh: renderScene.bvh,
     );
 
     // Texture-target views render first so screen views (and the HUD)
@@ -1202,8 +1204,7 @@ base class Scene implements SceneGraph {
         enableMsaa: enableMsaa,
         directionalLight: light,
         directionalLightDirection: lightDirection,
-        punctualLightTexture: punctualLighting.texture,
-        punctualLightCount: punctualLighting.count,
+        punctualLighting: punctualLighting,
         cascades: cascades,
         specularOcclusionMode: ambientOcclusion.specularMode.index.toDouble(),
         layerMask: view.layerMask,

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -31,6 +31,7 @@ import 'render/post_effect_pass.dart';
 import 'render/render_graph.dart';
 import 'render/render_scene.dart';
 import 'render/punctual_lights.dart';
+import 'render/spot_shadow.dart';
 import 'render/instance_packing.dart';
 import 'render/scene_pass.dart';
 import 'render/ssr_pass.dart';
@@ -911,6 +912,9 @@ base class Scene implements SceneGraph {
         ? null
         : renderScene.directionalLights.first;
 
+    // Select this frame's shadow-casting spots (view-independent).
+    final spotShadowFrame = collectSpotShadows(renderScene.spotLights);
+
     // The additional analytic lights (point, spot, and directional lights past
     // the first) are view-independent, so build their shared data texture once
     // per frame here rather than per view.
@@ -920,6 +924,7 @@ base class Scene implements SceneGraph {
       spots: renderScene.spotLights,
       items: renderScene.items,
       bvh: renderScene.bvh,
+      spotShadows: spotShadowFrame,
     );
 
     // Texture-target views render first so screen views (and the HUD)
@@ -948,6 +953,7 @@ base class Scene implements SceneGraph {
         transientsBuffer: transientsBuffer,
         lightComponent: lightComponent,
         punctualLighting: punctualLighting,
+        spotShadowFrame: spotShadowFrame,
       );
       target.markUpdated(now);
     }
@@ -977,6 +983,7 @@ base class Scene implements SceneGraph {
         transientsBuffer: transientsBuffer,
         lightComponent: lightComponent,
         punctualLighting: punctualLighting,
+        spotShadowFrame: spotShadowFrame,
       );
     }
 
@@ -1017,6 +1024,7 @@ base class Scene implements SceneGraph {
     required gpu.HostBuffer transientsBuffer,
     required DirectionalLightComponent? lightComponent,
     required PunctualLighting punctualLighting,
+    required SpotShadowFrame? spotShadowFrame,
   }) {
     // Allocate the offscreen render target at physical-pixel resolution so
     // the rasterized 3D content matches Flutter's framebuffer density.
@@ -1047,6 +1055,7 @@ base class Scene implements SceneGraph {
       transientsBuffer: transientsBuffer,
       lightComponent: lightComponent,
       punctualLighting: punctualLighting,
+      spotShadowFrame: spotShadowFrame,
     );
 
     final image = swapchainColor.asImage();
@@ -1069,6 +1078,7 @@ base class Scene implements SceneGraph {
     required gpu.HostBuffer transientsBuffer,
     required DirectionalLightComponent? lightComponent,
     required PunctualLighting punctualLighting,
+    required SpotShadowFrame? spotShadowFrame,
   }) {
     final camera = view.camera;
     final effectiveAa = _resolveAntiAliasingMode(
@@ -1109,19 +1119,31 @@ base class Scene implements SceneGraph {
     if (wantGodRays) customInputs.addAll(_godRaysPass.inputs);
 
     final graph = RenderGraph();
-    if (cascades.isNotEmpty) {
+    // Directional cascades and shadow-casting spots share one atlas (and so one
+    // sampler in the lit shader). All tiles use one resolution, the directional
+    // light's when it casts, otherwise the spots'.
+    if (cascades.isNotEmpty || spotShadowFrame != null) {
       graph.addPass(
         ShadowPass(
           renderScene: renderScene,
           cascades: cascades,
-          tileResolution: light!.shadowMapResolution,
-          casterFaces: light.shadowCasterFaces,
+          tileResolution: cascades.isNotEmpty
+              ? light!.shadowMapResolution
+              : spotShadowFrame!.tileResolution,
+          casterFaces: cascades.isNotEmpty
+              ? light!.shadowCasterFaces
+              : ShadowCasterFaces.front,
           cameraPosition: camera.position,
-          shadowUniform: customInputs.contains(RenderInput.shadowMap)
+          spotShadows: spotShadowFrame,
+          // PostShadowInfo describes the directional cascades, so publish it
+          // only when they exist (a spot-only atlas has no directional light).
+          shadowUniform:
+              cascades.isNotEmpty &&
+                  customInputs.contains(RenderInput.shadowMap)
               ? packPostShadowInfo(
                   cascades,
-                  lightDirection ?? light.direction,
-                  light.color * light.intensity,
+                  lightDirection ?? light!.direction,
+                  light!.color * light.intensity,
                 )
               : null,
         ),

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -30,6 +30,7 @@ import 'render/fxaa_pass.dart';
 import 'render/post_effect_pass.dart';
 import 'render/render_graph.dart';
 import 'render/render_scene.dart';
+import 'render/punctual_lights.dart';
 import 'render/instance_packing.dart';
 import 'render/scene_pass.dart';
 import 'render/ssr_pass.dart';
@@ -356,6 +357,10 @@ base class Scene implements SceneGraph {
   /// Kept in sync by the node graph as mesh-bearing nodes are added and
   /// removed. Engine-internal; not part of the stable public API.
   final RenderScene renderScene = RenderScene();
+
+  // Builds the per-frame data texture carrying the scene's point, spot, and
+  // extra directional lights. Rebuilt once per frame in [render].
+  final PunctualLightBuffer _punctualLightBuffer = PunctualLightBuffer();
 
   /// The scene's primary camera.
   ///
@@ -906,6 +911,15 @@ base class Scene implements SceneGraph {
         ? null
         : renderScene.directionalLights.first;
 
+    // The additional analytic lights (point, spot, and directional lights past
+    // the first) are view-independent, so build their shared data texture once
+    // per frame here rather than per view.
+    final punctualLighting = _punctualLightBuffer.build(
+      directionals: renderScene.directionalLights,
+      points: renderScene.pointLights,
+      spots: renderScene.spotLights,
+    );
+
     // Texture-target views render first so screen views (and the HUD)
     // composite this frame's captures, the simple form of the
     // produce-before-consume rule.
@@ -931,6 +945,7 @@ base class Scene implements SceneGraph {
         environmentMap: environmentMap,
         transientsBuffer: transientsBuffer,
         lightComponent: lightComponent,
+        punctualLighting: punctualLighting,
       );
       target.markUpdated(now);
     }
@@ -959,6 +974,7 @@ base class Scene implements SceneGraph {
         environmentMap: environmentMap,
         transientsBuffer: transientsBuffer,
         lightComponent: lightComponent,
+        punctualLighting: punctualLighting,
       );
     }
 
@@ -998,6 +1014,7 @@ base class Scene implements SceneGraph {
     required EnvironmentMap environmentMap,
     required gpu.HostBuffer transientsBuffer,
     required DirectionalLightComponent? lightComponent,
+    required PunctualLighting punctualLighting,
   }) {
     // Allocate the offscreen render target at physical-pixel resolution so
     // the rasterized 3D content matches Flutter's framebuffer density.
@@ -1027,6 +1044,7 @@ base class Scene implements SceneGraph {
       environmentMap: environmentMap,
       transientsBuffer: transientsBuffer,
       lightComponent: lightComponent,
+      punctualLighting: punctualLighting,
     );
 
     final image = swapchainColor.asImage();
@@ -1048,6 +1066,7 @@ base class Scene implements SceneGraph {
     required EnvironmentMap environmentMap,
     required gpu.HostBuffer transientsBuffer,
     required DirectionalLightComponent? lightComponent,
+    required PunctualLighting punctualLighting,
   }) {
     final camera = view.camera;
     final effectiveAa = _resolveAntiAliasingMode(
@@ -1183,6 +1202,8 @@ base class Scene implements SceneGraph {
         enableMsaa: enableMsaa,
         directionalLight: light,
         directionalLightDirection: lightDirection,
+        punctualLightTexture: punctualLighting.texture,
+        punctualLightCount: punctualLighting.count,
         cascades: cascades,
         specularOcclusionMode: ambientOcclusion.specularMode.index.toDouble(),
         layerMask: view.layerMask,

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -49,6 +49,8 @@ base class _TranslucentRecord {
     this.pipeline,
     this.depth,
     this.windingFlipped,
+    this.lightListOffset,
+    this.lightListCount,
   );
   final Matrix4 worldTransform;
   final Geometry geometry;
@@ -57,6 +59,9 @@ base class _TranslucentRecord {
   final gpu.RenderPipeline pipeline;
   final double depth;
   final bool windingFlipped;
+  // The owning item's punctual-light slice, captured at submit time.
+  final int lightListOffset;
+  final int lightListCount;
 }
 
 /// Render pipelines keyed by their (vertex shader, fragment shader, vertex
@@ -270,6 +275,8 @@ base class SceneEncoder {
             pipeline,
             _depthOf(worldTransform),
             item.windingFlipped != (instanceTransform.determinant() < 0),
+            item.lightListOffset,
+            item.lightListCount,
           ),
         );
       }
@@ -283,6 +290,8 @@ base class SceneEncoder {
           pipeline,
           _depthOf(item.worldTransform),
           item.windingFlipped,
+          item.lightListOffset,
+          item.lightListCount,
         ),
       );
     }
@@ -466,6 +475,8 @@ base class SceneEncoder {
     });
     for (final record in _opaqueRecords) {
       final item = record.item;
+      record.material.lightListOffset = item.lightListOffset;
+      record.material.lightListCount = item.lightListCount;
       final instances = item.instanceTransforms;
       if (instances != null) {
         _encodeInstanced(
@@ -506,6 +517,8 @@ base class SceneEncoder {
       ),
     );
     for (final record in _translucentRecords) {
+      record.material.lightListOffset = record.lightListOffset;
+      record.material.lightListCount = record.lightListCount;
       _encode(
         record.pipeline,
         record.worldTransform,

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -8,11 +8,11 @@
 uniform FragInfo {
   vec4 color;
   vec4 emissive_factor;
-  // Diffuse irradiance L2 spherical-harmonic coefficients (xyz = RGB,
-  // w unused). The cosine convolution (A_l band factors) and the 1/pi
-  // Lambertian term are already folded in, so evaluating the polynomial
-  // yields E(n)/pi, ready to multiply by the diffuse albedo.
-  vec4 diffuse_sh0;
+  // Punctual light texture dimensions, for normalizing the shader's fetch
+  // coordinates. x: parameters-texture row count (all scene lights). y/z:
+  // light-index texture width/height. (Reuses the first of the once-diffuse-SH
+  // slots, which are unused now that SH is sampled from sh_coefficients.)
+  vec4 punctual_dims;
   vec4 diffuse_sh1;
   vec4 diffuse_sh2;
   vec4 diffuse_sh3;
@@ -130,3 +130,9 @@ uniform sampler2D ssao_texture;
 //   2: direction.xyz, spot angular scale
 //   3: spot angular offset, unused, unused, unused
 uniform sampler2D punctual_lights;
+// The per-object light-index buffer: a 2D RGBA32F texture whose texels (row
+// major, index in .r) are light rows into punctual_lights. Each object shades
+// the slice [radiance_blend.w, radiance_blend.w + radiance_blend.z). Read by
+// computed UV (punctual_dims.yz give its width/height). A white placeholder is
+// bound and never read when the per-object count is 0.
+uniform sampler2D punctual_index;

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -13,7 +13,12 @@ uniform FragInfo {
   // light-index texture width/height. (Reuses the first of the once-diffuse-SH
   // slots, which are unused now that SH is sampled from sh_coefficients.)
   vec4 punctual_dims;
-  vec4 diffuse_sh1;
+  // Spot-shadow parameters (more of the unused SH region). x: shadow-casting
+  // spot count (0 disables spot shadows; their atlas tiles follow the
+  // directional cascades, and their matrices ride in the params texture).
+  // y: clip-space depth bias. z: world-space normal bias. w: PCF softness in
+  // texels.
+  vec4 spot_shadow_params;
   vec4 diffuse_sh2;
   vec4 diffuse_sh3;
   vec4 diffuse_sh4;

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -90,8 +90,11 @@ uniform FragInfo {
   // toward the secondary environment (the *_b samplers), 0 samples only the
   // primary. y: shadow-ambient strength, how much the cast shadow also darkens
   // the IBL ambient (0 leaves the ambient physical, 1 darkens it as much as the
-  // direct light). zw reserved. Both environments share RadianceLayoutInfo (the
-  // layout is a per-backend choice, not per-environment).
+  // direct light). z: the number of additional analytic lights packed into the
+  // punctual_lights data texture (point, spot, and directional lights past the
+  // first shadowed one); the material loops over this many. w reserved. Both
+  // environments share RadianceLayoutInfo (the layout is a per-backend choice,
+  // not per-environment).
   vec4 radiance_blend;
 }
 frag_info;
@@ -117,3 +120,13 @@ uniform sampler2D sh_coefficients_b;
 // placeholder is bound when occlusion is disabled, so the sample is a
 // no-op; frag_info.ssao_params.x gates it regardless.
 uniform sampler2D ssao_texture;
+// The additional analytic lights (point, spot, and directional lights past the
+// first) as an RGBA32F data texture: one light per row, four texels wide. Read
+// by computed UV (not a dynamically-indexed uniform array, which GLSL ES 1.00
+// forbids in a fragment shader). frag_info.radiance_blend.z is the row count; a
+// white placeholder is bound and never read when it is zero. Column layout:
+//   0: position.xyz, type (0 directional, 1 point, 2 spot)
+//   1: color.rgb * intensity, inverse range (0 = infinite)
+//   2: direction.xyz, spot angular scale
+//   3: spot angular offset, unused, unused, unused
+uniform sampler2D punctual_lights;

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -418,13 +418,14 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // active count ends it early. Rows are fetched by computed UV, so no uniform
   // array is dynamically indexed.
   //
-  // TODO(lighting): gate this block, the punctual_lights sampler, and the count
-  // read behind an `#ifdef FS_PUNCTUAL_LIGHTS` and compile a base variant
-  // without it, so a lit material used in a scene with no point/spot lights (the
-  // standard PBR shader and every custom-lit .fmat) is byte-identical to the
-  // pre-punctual shader and binds no light sampler. The engine selects the
-  // +punctual variant per draw only when the object is reached by a light. See
-  // notes/rendering/punctual_lights_design.md (near-term revision).
+  // TODO(lighting): this stays a single uniform-gated loop on purpose (a shader
+  // permutation was considered and rejected: it multiplies pipeline variants and
+  // fights draw-call batching at scale, and the unentered loop is already ~free
+  // under uniform control flow). To make it unlimited without per-fragment cost
+  // growing, feed it a per-region light subset from froxel clustering and loop
+  // that range instead of the global set; and hoist the frame-constant lighting
+  // bindings to per-pass so no light sampler is bound per draw. See
+  // notes/rendering/punctual_lights_design.md (near-term revision, scale-first).
   int punctual_count = int(frag_info.radiance_blend.z);
   for (int i = 0; i < MAX_PUNCTUAL_LIGHTS; i++) {
     if (i >= punctual_count) {

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -417,6 +417,14 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // this release. The loop bound is the compile-time MAX_PUNCTUAL_LIGHTS; the
   // active count ends it early. Rows are fetched by computed UV, so no uniform
   // array is dynamically indexed.
+  //
+  // TODO(lighting): gate this block, the punctual_lights sampler, and the count
+  // read behind an `#ifdef FS_PUNCTUAL_LIGHTS` and compile a base variant
+  // without it, so a lit material used in a scene with no point/spot lights (the
+  // standard PBR shader and every custom-lit .fmat) is byte-identical to the
+  // pre-punctual shader and binds no light sampler. The engine selects the
+  // +punctual variant per draw only when the object is reached by a light. See
+  // notes/rendering/punctual_lights_design.md (near-term revision).
   int punctual_count = int(frag_info.radiance_blend.z);
   for (int i = 0; i < MAX_PUNCTUAL_LIGHTS; i++) {
     if (i >= punctual_count) {

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -198,6 +198,50 @@ float ComputeSpecularOcclusion(float n_dot_v, float occlusion,
       0.0, 1.0);
 }
 
+// The number of additional analytic lights (point, spot, and directional
+// lights past the first) the loop below can shade in one draw. Must match
+// kMaxPunctualLights in lib/src/render/punctual_lights.dart. The loop is
+// unrolled to this constant bound because GLSL ES 1.00 requires a compile-time
+// loop bound; the active count (frag_info.radiance_blend.z) ends it early.
+#define MAX_PUNCTUAL_LIGHTS 16
+
+// Reads column `col` (0..3) of light `light_index`'s row from the
+// punctual_lights data texture. Fetched by computed UV rather than a
+// dynamically-indexed uniform array, which a GLSL ES 1.00 fragment shader may
+// not do (see punctual_lights_design.md). The texture is 4 texels wide and
+// MAX_PUNCTUAL_LIGHTS rows tall.
+vec4 FetchPunctualTexel(int light_index, int col) {
+  vec2 uv = vec2((float(col) + 0.5) * 0.25,
+                 (float(light_index) + 0.5) / float(MAX_PUNCTUAL_LIGHTS));
+  return texture(punctual_lights, uv);
+}
+
+// One analytic light's Cook-Torrance contribution. `light_vector` points from
+// the surface toward the light (unit length); `radiance` is the light color
+// premultiplied by intensity and any distance/cone attenuation. Returns the
+// linear direct term; the caller multiplies in any shadow visibility. Shared by
+// the directional light and every punctual light so the BRDF lives in one place.
+vec3 EvaluateAnalyticLight(vec3 light_vector, vec3 radiance, vec3 normal,
+                           vec3 camera_normal, vec3 albedo, float metallic,
+                           float roughness, vec3 reflectance, float n_dot_v) {
+  float n_dot_l = max(dot(normal, light_vector), 0.0);
+  if (n_dot_l <= 0.0) {
+    return vec3(0.0);
+  }
+  vec3 half_vector = normalize(light_vector + camera_normal);
+  float n_dot_v_safe = max(n_dot_v, 1e-4);
+  float distribution = DistributionGGX(normal, half_vector, roughness);
+  float visibility =
+      VisibilitySmithGGXCorrelated(n_dot_v_safe, n_dot_l, roughness);
+  vec3 specular_fresnel =
+      FresnelSchlick(max(dot(half_vector, camera_normal), 0.0), reflectance);
+  // `visibility` already folds in 1 / (4 * NoL * NoV).
+  vec3 specular = distribution * visibility * specular_fresnel;
+  vec3 diffuse =
+      (vec3(1.0) - specular_fresnel) * (1.0 - metallic) * albedo * (1.0 / kPi);
+  return (diffuse + specular) * radiance * n_dot_l;
+}
+
 // Lights a surface described by `material` and returns the final fragment
 // color (linear HDR, premultiplied by alpha). This is the engine-owned half of
 // the material contract; a material's Surface() function fills `material` and
@@ -321,12 +365,10 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // Sun direction and how squarely this surface faces it. `facing` ramps from
   // 0 (at or past the terminator) to 1 (sun-facing) over a small band, so the
   // sun's influence falls off smoothly rather than at a hard line.
-  float n_dot_l = 0.0;
   float geometric_n_dot_l = 0.0;
   vec3 light_vector = vec3(0.0);
   if (frag_info.has_directional_light > 0.5) {
     light_vector = -normalize(frag_info.directional_light_direction.xyz);
-    n_dot_l = dot(normal, light_vector);
     geometric_n_dot_l = dot(GetWorldNormal(), light_vector);
   }
   // Whether the surface faces the sun is a geometric property, so gate the
@@ -359,22 +401,59 @@ vec4 EvaluateLighting(MaterialInputs material) {
       ambient_shadow;
 
   // Analytic directional light (Cook-Torrance, layered on top of the IBL
-  // ambient term).
+  // ambient term). The shadowed first directional light shades here; its shadow
+  // visibility multiplies the whole term.
   vec3 direct = vec3(0.0);
-  if (frag_info.has_directional_light > 0.5 && n_dot_l > 0.0) {
-    vec3 half_vector = normalize(light_vector + camera_normal);
-    float n_dot_v_safe = max(n_dot_v, 1e-4);
-    float distribution = DistributionGGX(normal, half_vector, roughness);
-    float visibility =
-        VisibilitySmithGGXCorrelated(n_dot_v_safe, n_dot_l, roughness);
-    vec3 specular_fresnel =
-        FresnelSchlick(max(dot(half_vector, camera_normal), 0.0), reflectance);
-    // `visibility` already folds in 1 / (4 * NoL * NoV).
-    vec3 specular = distribution * visibility * specular_fresnel;
-    vec3 diffuse = (vec3(1.0) - specular_fresnel) * (1.0 - metallic) *
-                   albedo * (1.0 / kPi);
-    direct = (diffuse + specular) * frag_info.directional_light_color.rgb *
-             n_dot_l * shadow;
+  if (frag_info.has_directional_light > 0.5) {
+    direct = EvaluateAnalyticLight(light_vector,
+                                   frag_info.directional_light_color.rgb, normal,
+                                   camera_normal, albedo, metallic, roughness,
+                                   reflectance, n_dot_v) *
+             shadow;
+  }
+
+  // Additional analytic lights (point, spot, and directional lights past the
+  // first) from the punctual_lights data texture. None of them cast shadows in
+  // this release. The loop bound is the compile-time MAX_PUNCTUAL_LIGHTS; the
+  // active count ends it early. Rows are fetched by computed UV, so no uniform
+  // array is dynamically indexed.
+  int punctual_count = int(frag_info.radiance_blend.z);
+  for (int i = 0; i < MAX_PUNCTUAL_LIGHTS; i++) {
+    if (i >= punctual_count) {
+      break;
+    }
+    vec4 l0 = FetchPunctualTexel(i, 0); // position.xyz, type
+    vec4 l1 = FetchPunctualTexel(i, 1); // color.rgb, inverse range
+    float type = l0.w;
+    vec3 radiance = l1.rgb;
+    vec3 punctual_light_vector;
+    if (type < 0.5) {
+      // Directional: the travel direction is in texel 2; no attenuation.
+      punctual_light_vector = -normalize(FetchPunctualTexel(i, 2).xyz);
+    } else {
+      vec3 to_light = l0.xyz - v_position;
+      float dist_sq = dot(to_light, to_light);
+      punctual_light_vector = to_light * inversesqrt(max(dist_sq, 1e-8));
+      // Windowed inverse-square distance falloff (Frostbite/Karis): with an
+      // inverse range of 0 (infinite range) the window is 1 and this is a pure
+      // inverse square, clamped near the source.
+      float inv_range = l1.w;
+      float factor = dist_sq * inv_range * inv_range;
+      float window = clamp(1.0 - factor * factor, 0.0, 1.0);
+      radiance *= (window * window) / max(dist_sq, 1e-4);
+      if (type > 1.5) {
+        // Spot cone: a squared linear ramp on the cosine between the inner and
+        // outer cone, using the precomputed scale (texel 2 w) and offset.
+        vec4 l2 = FetchPunctualTexel(i, 2); // direction.xyz, angular scale
+        float spot_offset = FetchPunctualTexel(i, 3).x;
+        float cd = dot(normalize(l2.xyz), -punctual_light_vector);
+        float cone = clamp(cd * l2.w + spot_offset, 0.0, 1.0);
+        radiance *= cone * cone;
+      }
+    }
+    direct += EvaluateAnalyticLight(punctual_light_vector, radiance, normal,
+                                    camera_normal, albedo, metallic, roughness,
+                                    reflectance, n_dot_v);
   }
 
   vec3 emissive = material.emissive;

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -206,14 +206,25 @@ float ComputeSpecularOcclusion(float n_dot_v, float occlusion,
 #define MAX_PUNCTUAL_LIGHTS 16
 
 // Reads column `col` (0..3) of light `light_index`'s row from the
-// punctual_lights data texture. Fetched by computed UV rather than a
-// dynamically-indexed uniform array, which a GLSL ES 1.00 fragment shader may
-// not do (see punctual_lights_design.md). The texture is 4 texels wide and
-// MAX_PUNCTUAL_LIGHTS rows tall.
+// punctual_lights parameters texture (4 texels wide, punctual_dims.x rows
+// tall). Fetched by computed UV rather than a dynamically-indexed uniform
+// array, which a GLSL ES 1.00 fragment shader may not do (see
+// punctual_lights_design.md).
 vec4 FetchPunctualTexel(int light_index, int col) {
   vec2 uv = vec2((float(col) + 0.5) * 0.25,
-                 (float(light_index) + 0.5) / float(MAX_PUNCTUAL_LIGHTS));
+                 (float(light_index) + 0.5) / frag_info.punctual_dims.x);
   return texture(punctual_lights, uv);
+}
+
+// Reads entry `j` of the per-object light-index buffer, returning the light row
+// it points at. The buffer is a 2D texture (index in .r); `j` is decomposed to
+// a texel with the width/height in punctual_dims.yz.
+float FetchPunctualIndex(int j) {
+  float width = frag_info.punctual_dims.y;
+  float fj = float(j);
+  vec2 uv = vec2((mod(fj, width) + 0.5) / width,
+                 (floor(fj / width) + 0.5) / frag_info.punctual_dims.z);
+  return texture(punctual_index, uv).r;
 }
 
 // One analytic light's Cook-Torrance contribution. `light_vector` points from
@@ -413,34 +424,41 @@ vec4 EvaluateLighting(MaterialInputs material) {
   }
 
   // Additional analytic lights (point, spot, and directional lights past the
-  // first) from the punctual_lights data texture. None of them cast shadows in
-  // this release. The loop bound is the compile-time MAX_PUNCTUAL_LIGHTS; the
-  // active count ends it early. Rows are fetched by computed UV, so no uniform
+  // first). None cast shadows in this release. The scene may hold any number of
+  // lights; per-object culling gives this object a contiguous slice of the
+  // light-index buffer, and the loop shades only that slice. The loop bound is
+  // the compile-time per-object budget MAX_PUNCTUAL_LIGHTS; the object's count
+  // ends it early. Every fetch is a computed-UV texture read, so no uniform
   // array is dynamically indexed.
   //
-  // TODO(lighting): this stays a single uniform-gated loop. A per-draw (per-object)
-  // punctual on/off permutation is rejected: it varies the pipeline within a frame
-  // and defeats material-sorted batching, worst on tile GPUs. A coarse
-  // (per-frame-global / capability-tier) permutation that compiles the loop out for
-  // sun/IBL-only scenes is a possible low-end win, but only if the never-entered
-  // loop is measured to cost occupancy on real hardware; do the free wins first
-  // (hoist frame-constant lighting bindings to per-pass so no light sampler binds
-  // per draw). To make it unlimited without per-fragment cost growing, feed a
-  // per-region subset from froxel clustering (a high-end tier) and loop that range.
-  // See notes/rendering/punctual_lights_design.md (near-term revision).
-  int punctual_count = int(frag_info.radiance_blend.z);
+  // TODO(lighting): this stays a single uniform-gated loop. A per-draw
+  // (per-object) punctual on/off permutation is rejected: it varies the pipeline
+  // within a frame and defeats material-sorted batching, worst on tile GPUs. A
+  // coarse (per-frame-global / capability-tier) permutation that compiles the
+  // loop out for sun/IBL-only scenes is a possible low-end win, but only if the
+  // never-entered loop is measured to cost occupancy on real hardware. Froxel
+  // clustering is the high-end tier (no per-draw light state). See
+  // notes/rendering/punctual_lights_design.md.
+  // punctual_dims.x is the parameters-texture row count; 0 means the scene has
+  // no punctual lights this frame, so ignore any stale per-object count (and
+  // never divide by the zero texture height in the fetch helpers).
+  int punctual_count =
+      frag_info.punctual_dims.x < 0.5 ? 0 : int(frag_info.radiance_blend.z);
+  int punctual_offset = int(frag_info.radiance_blend.w);
   for (int i = 0; i < MAX_PUNCTUAL_LIGHTS; i++) {
     if (i >= punctual_count) {
       break;
     }
-    vec4 l0 = FetchPunctualTexel(i, 0); // position.xyz, type
-    vec4 l1 = FetchPunctualTexel(i, 1); // color.rgb, inverse range
+    // Resolve this slot to a light row through the per-object index buffer.
+    int light_row = int(FetchPunctualIndex(punctual_offset + i) + 0.5);
+    vec4 l0 = FetchPunctualTexel(light_row, 0); // position.xyz, type
+    vec4 l1 = FetchPunctualTexel(light_row, 1); // color.rgb, inverse range
     float type = l0.w;
     vec3 radiance = l1.rgb;
     vec3 punctual_light_vector;
     if (type < 0.5) {
       // Directional: the travel direction is in texel 2; no attenuation.
-      punctual_light_vector = -normalize(FetchPunctualTexel(i, 2).xyz);
+      punctual_light_vector = -normalize(FetchPunctualTexel(light_row, 2).xyz);
     } else {
       vec3 to_light = l0.xyz - v_position;
       float dist_sq = dot(to_light, to_light);
@@ -455,8 +473,8 @@ vec4 EvaluateLighting(MaterialInputs material) {
       if (type > 1.5) {
         // Spot cone: a squared linear ramp on the cosine between the inner and
         // outer cone, using the precomputed scale (texel 2 w) and offset.
-        vec4 l2 = FetchPunctualTexel(i, 2); // direction.xyz, angular scale
-        float spot_offset = FetchPunctualTexel(i, 3).x;
+        vec4 l2 = FetchPunctualTexel(light_row, 2); // direction.xyz, angular scale
+        float spot_offset = FetchPunctualTexel(light_row, 3).x;
         float cd = dot(normalize(l2.xyz), -punctual_light_vector);
         float cone = clamp(cd * l2.w + spot_offset, 0.0, 1.0);
         radiance *= cone * cone;

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -256,11 +256,27 @@ vec3 EvaluateAnalyticLight(vec3 light_vector, vec3 radiance, vec3 normal,
   return (diffuse + specular) * radiance * n_dot_l;
 }
 
+// One shadow comparison tap for a spot: places the in-tile `uv` in the spot's
+// atlas tile (`tile` of `total`, stored top-down so V is flipped) and returns 1
+// lit / 0 shadowed. `uv` is clamped into the tile so the kernel never reads a
+// neighbouring tile (the atlas is nearest-sampled, so there is no bilinear
+// bleed once it stays in-tile).
+float SpotShadowTap(vec2 uv, float tile, float total, float receiver) {
+  vec2 atlas_uv = vec2((tile + clamp(uv.x, 0.0, 1.0)) / total,
+                       1.0 - clamp(uv.y, 0.0, 1.0));
+  return receiver <= texture(shadow_map, atlas_uv).r ? 1.0 : 0.0;
+}
+
+// Number of ring taps around the center for the spot-shadow PCF.
+#define SPOT_PCF_RING 8
+
 // Spot-shadow visibility (1 lit .. 0 shadowed) for the shadow-casting spot in
 // row `light_row`, slot `slot`. Its world -> spot-clip matrix rides in the
 // light's own params row (texels 4-7); its shadow tile follows the directional
-// cascades in the shared atlas. Fragments outside the spot frustum read as lit
-// (the cone attenuation already zeroed them).
+// cascades in the shared atlas. A center tap plus a per-fragment-rotated ring
+// (radius from spot_shadow_params.w, the softness) gives a soft penumbra; a
+// softness of 0 collapses the kernel to a hard edge. Fragments outside the spot
+// frustum read as lit (the cone attenuation already zeroed them).
 float SampleSpotShadow(int light_row, int slot, vec3 world_pos, vec3 normal) {
   mat4 m = mat4(FetchPunctualTexel(light_row, 4), FetchPunctualTexel(light_row, 5),
                 FetchPunctualTexel(light_row, 6), FetchPunctualTexel(light_row, 7));
@@ -277,11 +293,21 @@ float SampleSpotShadow(int light_row, int slot, vec3 world_pos, vec3 normal) {
   float total = frag_info.shadow_cascade_count + frag_info.spot_shadow_params.x;
   float tile = frag_info.shadow_cascade_count + float(slot);
   float receiver = proj.z - frag_info.spot_shadow_params.y;
-  // Shared atlas: place uv in this spot's tile (after the cascades); stored
-  // top-down, so flip V (matches the cascade sampling).
-  vec2 atlas_uv = vec2((tile + uv.x) / total, 1.0 - uv.y);
-  float caster = texture(shadow_map, atlas_uv).r;
-  return receiver <= caster ? 1.0 : 0.0;
+  // Penumbra radius in tile-UV (resolution-independent). softness 0 = hard.
+  float radius = frag_info.spot_shadow_params.w * 0.004;
+
+  float lit = SpotShadowTap(uv, tile, total, receiver);
+  // A per-fragment rotation hides the ring pattern as a smooth edge.
+  float noise = fract(
+      52.9829189 *
+      fract(dot(gl_FragCoord.xy, vec2(0.06711056, 0.00583715))));
+  float base = noise * 6.28318530718;
+  for (int i = 0; i < SPOT_PCF_RING; i++) {
+    float a = base + float(i) * (6.28318530718 / float(SPOT_PCF_RING));
+    vec2 offset = vec2(cos(a), sin(a)) * radius;
+    lit += SpotShadowTap(uv + offset, tile, total, receiver);
+  }
+  return lit / float(SPOT_PCF_RING + 1);
 }
 
 // Lights a surface described by `material` and returns the final fragment

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -207,11 +207,10 @@ float ComputeSpecularOcclusion(float n_dot_v, float occlusion,
 // loop bound; the active count (frag_info.radiance_blend.z) ends it early.
 #define MAX_PUNCTUAL_LIGHTS 16
 
-// Reads column `col` (0..3) of light `light_index`'s row from the
-// punctual_lights parameters texture (4 texels wide, punctual_dims.x rows
+// Reads column `col` (0..7) of light `light_index`'s row from the
+// punctual_lights parameters texture (8 texels wide, punctual_dims.x rows
 // tall). Fetched by computed UV rather than a dynamically-indexed uniform
-// array, which a GLSL ES 1.00 fragment shader may not do (see
-// punctual_lights_design.md).
+// array, which a GLSL ES 1.00 fragment shader may not do.
 vec4 FetchPunctualTexel(int light_index, int col) {
   // 8 texels per light row: 0.0625 = 0.5 / 8 centers the first column.
   vec2 uv = vec2((float(col) + 0.5) * 0.125,
@@ -481,7 +480,7 @@ vec4 EvaluateLighting(MaterialInputs material) {
   }
 
   // Additional analytic lights (point, spot, and directional lights past the
-  // first). None cast shadows in this release. The scene may hold any number of
+  // first); point lights do not cast shadows. The scene may hold any number of
   // lights; per-object culling gives this object a contiguous slice of the
   // light-index buffer, and the loop shades only that slice. The loop bound is
   // the compile-time per-object budget MAX_PUNCTUAL_LIGHTS; the object's count
@@ -494,8 +493,7 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // coarse (per-frame-global / capability-tier) permutation that compiles the
   // loop out for sun/IBL-only scenes is a possible low-end win, but only if the
   // never-entered loop is measured to cost occupancy on real hardware. Froxel
-  // clustering is the high-end tier (no per-draw light state). See
-  // notes/rendering/punctual_lights_design.md.
+  // clustering is the high-end tier (no per-draw light state).
   // punctual_dims.x is the parameters-texture row count; 0 means the scene has
   // no punctual lights this frame, so ignore any stale per-object count (and
   // never divide by the zero texture height in the fetch helpers).
@@ -520,9 +518,9 @@ vec4 EvaluateLighting(MaterialInputs material) {
       vec3 to_light = l0.xyz - v_position;
       float dist_sq = dot(to_light, to_light);
       punctual_light_vector = to_light * inversesqrt(max(dist_sq, 1e-8));
-      // Windowed inverse-square distance falloff (Frostbite/Karis): with an
-      // inverse range of 0 (infinite range) the window is 1 and this is a pure
-      // inverse square, clamped near the source.
+      // Windowed inverse-square distance falloff: with an inverse range of 0
+      // (infinite range) the window is 1 and this is a pure inverse square,
+      // clamped near the source.
       float inv_range = l1.w;
       float factor = dist_sq * inv_range * inv_range;
       float window = clamp(1.0 - factor * factor, 0.0, 1.0);

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -418,14 +418,16 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // active count ends it early. Rows are fetched by computed UV, so no uniform
   // array is dynamically indexed.
   //
-  // TODO(lighting): this stays a single uniform-gated loop on purpose (a shader
-  // permutation was considered and rejected: it multiplies pipeline variants and
-  // fights draw-call batching at scale, and the unentered loop is already ~free
-  // under uniform control flow). To make it unlimited without per-fragment cost
-  // growing, feed it a per-region light subset from froxel clustering and loop
-  // that range instead of the global set; and hoist the frame-constant lighting
-  // bindings to per-pass so no light sampler is bound per draw. See
-  // notes/rendering/punctual_lights_design.md (near-term revision, scale-first).
+  // TODO(lighting): this stays a single uniform-gated loop. A per-draw (per-object)
+  // punctual on/off permutation is rejected: it varies the pipeline within a frame
+  // and defeats material-sorted batching, worst on tile GPUs. A coarse
+  // (per-frame-global / capability-tier) permutation that compiles the loop out for
+  // sun/IBL-only scenes is a possible low-end win, but only if the never-entered
+  // loop is measured to cost occupancy on real hardware; do the free wins first
+  // (hoist frame-constant lighting bindings to per-pass so no light sampler binds
+  // per draw). To make it unlimited without per-fragment cost growing, feed a
+  // per-region subset from froxel clustering (a high-end tier) and loop that range.
+  // See notes/rendering/punctual_lights_design.md (near-term revision).
   int punctual_count = int(frag_info.radiance_blend.z);
   for (int i = 0; i < MAX_PUNCTUAL_LIGHTS; i++) {
     if (i >= punctual_count) {

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -89,7 +89,9 @@ float SampleCascade(int cascade, int count, mat4 cascade_matrix, float box,
   // World-space penumbra -> this cascade's UV space, floored at a texel.
   float radius =
       max(frag_info.shadow_softness / box, frag_info.shadow_texel_size);
-  float inv_count = 1.0 / float(count);
+  // The atlas also holds spot-shadow tiles after the cascades, so normalize the
+  // atlas-x by the total tile count. Spot count 0 leaves this at 1 / cascades.
+  float inv_count = 1.0 / (float(count) + frag_info.spot_shadow_params.x);
 
   // A per-fragment rotation hides the 16-tap pattern as a smooth edge.
   float noise = fract(
@@ -211,7 +213,8 @@ float ComputeSpecularOcclusion(float n_dot_v, float occlusion,
 // array, which a GLSL ES 1.00 fragment shader may not do (see
 // punctual_lights_design.md).
 vec4 FetchPunctualTexel(int light_index, int col) {
-  vec2 uv = vec2((float(col) + 0.5) * 0.25,
+  // 8 texels per light row: 0.0625 = 0.5 / 8 centers the first column.
+  vec2 uv = vec2((float(col) + 0.5) * 0.125,
                  (float(light_index) + 0.5) / frag_info.punctual_dims.x);
   return texture(punctual_lights, uv);
 }
@@ -251,6 +254,34 @@ vec3 EvaluateAnalyticLight(vec3 light_vector, vec3 radiance, vec3 normal,
   vec3 diffuse =
       (vec3(1.0) - specular_fresnel) * (1.0 - metallic) * albedo * (1.0 / kPi);
   return (diffuse + specular) * radiance * n_dot_l;
+}
+
+// Spot-shadow visibility (1 lit .. 0 shadowed) for the shadow-casting spot in
+// row `light_row`, slot `slot`. Its world -> spot-clip matrix rides in the
+// light's own params row (texels 4-7); its shadow tile follows the directional
+// cascades in the shared atlas. Fragments outside the spot frustum read as lit
+// (the cone attenuation already zeroed them).
+float SampleSpotShadow(int light_row, int slot, vec3 world_pos, vec3 normal) {
+  mat4 m = mat4(FetchPunctualTexel(light_row, 4), FetchPunctualTexel(light_row, 5),
+                FetchPunctualTexel(light_row, 6), FetchPunctualTexel(light_row, 7));
+  vec4 clip = m * vec4(world_pos + normal * frag_info.spot_shadow_params.z, 1.0);
+  if (clip.w <= 0.0) {
+    return 1.0;
+  }
+  vec3 proj = clip.xyz / clip.w;
+  vec2 uv = proj.xy * 0.5 + 0.5;
+  if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0 || proj.z < 0.0 ||
+      proj.z > 1.0) {
+    return 1.0;
+  }
+  float total = frag_info.shadow_cascade_count + frag_info.spot_shadow_params.x;
+  float tile = frag_info.shadow_cascade_count + float(slot);
+  float receiver = proj.z - frag_info.spot_shadow_params.y;
+  // Shared atlas: place uv in this spot's tile (after the cascades); stored
+  // top-down, so flip V (matches the cascade sampling).
+  vec2 atlas_uv = vec2((tile + uv.x) / total, 1.0 - uv.y);
+  float caster = texture(shadow_map, atlas_uv).r;
+  return receiver <= caster ? 1.0 : 0.0;
 }
 
 // Lights a surface described by `material` and returns the final fragment
@@ -474,10 +505,16 @@ vec4 EvaluateLighting(MaterialInputs material) {
         // Spot cone: a squared linear ramp on the cosine between the inner and
         // outer cone, using the precomputed scale (texel 2 w) and offset.
         vec4 l2 = FetchPunctualTexel(light_row, 2); // direction.xyz, angular scale
-        float spot_offset = FetchPunctualTexel(light_row, 3).x;
+        vec4 l3 = FetchPunctualTexel(light_row, 3); // spot offset, shadow slot
         float cd = dot(normalize(l2.xyz), -punctual_light_vector);
-        float cone = clamp(cd * l2.w + spot_offset, 0.0, 1.0);
+        float cone = clamp(cd * l2.w + l3.x, 0.0, 1.0);
         radiance *= cone * cone;
+        // Spot shadow, when this spot has a slot in the shared atlas. Gate on
+        // the geometric normal (the shadow is a geometric property).
+        if (l3.y > -0.5 && frag_info.spot_shadow_params.x > 0.5) {
+          radiance *= SampleSpotShadow(
+              light_row, int(l3.y + 0.5), v_position, GetWorldNormal());
+        }
       }
     }
     direct += EvaluateAnalyticLight(punctual_light_vector, radiance, normal,

--- a/packages/flutter_scene/test/bvh_test.dart
+++ b/packages/flutter_scene/test/bvh_test.dart
@@ -125,6 +125,30 @@ void main() {
       );
       expect(hits, {mover}, reason: 'the moved item is found at its new spot');
     });
+
+    test('queryAabb agrees with a brute-force overlap test', () {
+      final items = [for (int i = 0; i < 8; i++) _itemAt(i * 4.0)];
+      final bvh = Bvh.build(items);
+      // Overlaps the items at x = 4, 8, 12 (each a unit box), none others.
+      final box = Aabb3.minMax(Vector3(3, -1, -1), Vector3(13, 1, 1));
+
+      final expected = items
+          .where((i) => i.worldBounds!.intersectsWithAabb3(box))
+          .toSet();
+      expect(expected.length, 3);
+
+      final hits = <RenderItem>{};
+      bvh.queryAabb(box, hits.add);
+      expect(hits, expected);
+    });
+
+    test('queryAabb on an empty BVH yields nothing', () {
+      final hits = <RenderItem>[];
+      Bvh.build(
+        [],
+      ).queryAabb(Aabb3.minMax(Vector3.zero(), Vector3.all(1)), hits.add);
+      expect(hits, isEmpty);
+    });
   });
 
   group('RenderScene.cull', () {

--- a/packages/flutter_scene/test/fscene/component_schema_test.dart
+++ b/packages/flutter_scene/test/fscene/component_schema_test.dart
@@ -23,14 +23,28 @@ void main() {
   final registry = defaultComponentRegistry();
 
   test('the registry exposes the built-in component types', () {
-    expect(registry.types, containsAll(['mesh', 'directionalLight', 'camera']));
+    expect(
+      registry.types,
+      containsAll([
+        'mesh',
+        'directionalLight',
+        'pointLight',
+        'spotLight',
+        'camera',
+      ]),
+    );
   });
 
   // For codecs that derive serialize from their schema, realizing an empty
   // spec and serializing must reproduce exactly the schema's keys (in order)
   // and default values. This locks schema, realize defaults, and serialize
   // together so none can drift.
-  for (final type in ['directionalLight', 'camera']) {
+  for (final type in [
+    'directionalLight',
+    'pointLight',
+    'spotLight',
+    'camera',
+  ]) {
     test('$type schema, realize defaults, and serialize agree', () {
       final codec = registry.codecFor(type)!;
       final doc = SceneDocument();

--- a/packages/flutter_scene/test/light_culling_test.dart
+++ b/packages/flutter_scene/test/light_culling_test.dart
@@ -1,0 +1,153 @@
+// Covers assignLightsToItems: ranged lights reach only the items their
+// influence AABB overlaps (scattered through the BVH), infinite-influence
+// lights reach every item, unbounded items receive every light, and each
+// item's list is capped at maxPerItem with the excess flagged.
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/render/bvh.dart';
+import 'package:flutter_scene/src/render/light_culling.dart';
+import 'package:flutter_scene/src/render/render_scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+class _StubGeometry extends Geometry {
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Matrix4 modelTransform,
+    Matrix4 cameraTransform,
+    Vector3 cameraPosition, {
+    gpu.Shader? shaderOverride,
+  }) => throw UnsupportedError('stub');
+}
+
+class _StubMaterial extends Material {
+  @override
+  void bind(gpu.RenderPass pass, gpu.HostBuffer transientsBuffer, Lighting l) =>
+      throw UnsupportedError('stub');
+}
+
+RenderItem _itemAt(double x) =>
+    RenderItem(geometry: _StubGeometry(), material: _StubMaterial())
+      ..worldBounds = Aabb3.minMax(
+        Vector3(x - 0.5, -0.5, -0.5),
+        Vector3(x + 0.5, 0.5, 0.5),
+      );
+
+RenderItem _unboundedItem() =>
+    RenderItem(geometry: _StubGeometry(), material: _StubMaterial());
+
+void main() {
+  test('a ranged light reaches only the items it overlaps', () {
+    final near = _itemAt(0);
+    final far = _itemAt(10);
+    final items = [near, far];
+    final bvh = Bvh.build(items);
+
+    // Range 1.5 at the origin: AABB [-1.5, 1.5], overlaps `near`, not `far`.
+    final light = CullableLight(0, lightInfluenceBounds(Vector3.zero(), 1.5));
+    final result = assignLightsToItems(
+      items: items,
+      bvh: bvh,
+      lights: [light],
+      maxPerItem: 16,
+    );
+
+    expect(near.lightListCount, 1);
+    expect(near.lightListOffset, 0);
+    expect(far.lightListCount, 0);
+    expect(result.indices, [0]);
+    expect(result.overflowed, isFalse);
+    // The far item's slice is empty.
+    expect(
+      result.indices.sublist(
+        far.lightListOffset,
+        far.lightListOffset + far.lightListCount,
+      ),
+      isEmpty,
+    );
+  });
+
+  test('an infinite-influence light reaches every item', () {
+    final a = _itemAt(0);
+    final b = _itemAt(100);
+    final items = [a, b];
+    final result = assignLightsToItems(
+      items: items,
+      bvh: Bvh.build(items),
+      lights: [const CullableLight(7, null)], // null bounds = infinite
+      maxPerItem: 16,
+    );
+    expect(a.lightListCount, 1);
+    expect(b.lightListCount, 1);
+    expect(result.indices, [7, 7]);
+  });
+
+  test('lightInfluenceBounds is null for a non-positive range', () {
+    expect(lightInfluenceBounds(Vector3.zero(), 0.0), isNull);
+    expect(lightInfluenceBounds(Vector3.zero(), -1.0), isNull);
+    expect(lightInfluenceBounds(Vector3.zero(), 2.0), isNotNull);
+  });
+
+  test('an unbounded item receives every light', () {
+    final bounded = _itemAt(0);
+    final unbounded = _unboundedItem();
+    final items = [bounded, unbounded];
+    // Only the bounded item is in the BVH (mirrors RenderScene.rebuildIfDirty).
+    final bvh = Bvh.build([bounded]);
+
+    // A ranged light far from the bounded item plus an infinite one.
+    final ranged = CullableLight(
+      1,
+      lightInfluenceBounds(Vector3(500, 0, 0), 1.0),
+    );
+    final result = assignLightsToItems(
+      items: items,
+      bvh: bvh,
+      lights: [ranged, const CullableLight(2, null)],
+      maxPerItem: 16,
+    );
+
+    // The bounded item is out of the ranged light's reach: infinite only.
+    expect(bounded.lightListCount, 1);
+    // The unbounded item cannot be culled: it gets both.
+    expect(unbounded.lightListCount, 2);
+    expect(result.overflowed, isFalse);
+  });
+
+  test('a per-item list is capped at maxPerItem and flags overflow', () {
+    final item = _itemAt(0);
+    final items = [item];
+    // Five infinite lights, cap of 3.
+    final result = assignLightsToItems(
+      items: items,
+      bvh: Bvh.build(items),
+      lights: [for (var i = 0; i < 5; i++) CullableLight(i, null)],
+      maxPerItem: 3,
+    );
+    expect(item.lightListCount, 3);
+    expect(result.indices, [0, 1, 2]);
+    expect(result.overflowed, isTrue);
+  });
+
+  test('offsets pack items back to back', () {
+    final a = _itemAt(0);
+    final b = _itemAt(0); // same spot, both overlap the light
+    final items = [a, b];
+    final bvh = Bvh.build(items);
+    final light = CullableLight(4, lightInfluenceBounds(Vector3.zero(), 1.0));
+    final result = assignLightsToItems(
+      items: items,
+      bvh: bvh,
+      lights: [light],
+      maxPerItem: 16,
+    );
+    expect(a.lightListOffset, 0);
+    expect(a.lightListCount, 1);
+    expect(b.lightListOffset, 1);
+    expect(b.lightListCount, 1);
+    expect(result.indices, [4, 4]);
+  });
+}

--- a/packages/flutter_scene/test/light_test.dart
+++ b/packages/flutter_scene/test/light_test.dart
@@ -80,4 +80,44 @@ void main() {
       }
     });
   });
+
+  group('SpotLight.shadowViewProjection', () {
+    // A spot at the origin aiming straight down, a 30-degree outer cone,
+    // reaching 10 units.
+    final light = SpotLight(outerConeAngle: pi / 6, range: 10.0);
+    final matrix = light.shadowViewProjection(
+      Vector3.zero(),
+      Vector3(0, -1, 0),
+    );
+
+    Vector3 project(Vector3 world) {
+      final clip = matrix * Vector4(world.x, world.y, world.z, 1.0) as Vector4;
+      return Vector3(clip.x / clip.w, clip.y / clip.w, clip.z / clip.w);
+    }
+
+    test('a point on the axis within range projects to the tile center', () {
+      final ndc = project(Vector3(0, -5, 0));
+      expect(ndc.x, closeTo(0.0, 1e-5));
+      expect(ndc.y, closeTo(0.0, 1e-5));
+      expect(ndc.z, greaterThan(0.0));
+      expect(ndc.z, lessThan(1.0));
+    });
+
+    test('a point well outside the cone falls outside the tile', () {
+      // ~63 degrees off the axis, far past the 30-degree cone.
+      final ndc = project(Vector3(10, -5, 0));
+      expect(ndc.x.abs() > 1.0 || ndc.y.abs() > 1.0, isTrue);
+    });
+
+    test('a point past the range is clipped beyond the far plane', () {
+      final ndc = project(Vector3(0, -20, 0));
+      expect(ndc.z, greaterThan(1.0));
+    });
+
+    test('depth increases with distance from the light', () {
+      final near = project(Vector3(0, -2, 0)).z;
+      final far = project(Vector3(0, -9, 0)).z;
+      expect(far, greaterThan(near));
+    });
+  });
 }

--- a/packages/flutter_scene/test/punctual_lights_import_test.dart
+++ b/packages/flutter_scene/test/punctual_lights_import_test.dart
@@ -1,0 +1,98 @@
+// Covers parsing the KHR_lights_punctual extension into the GltfDocument: the
+// document-level lights array and the per-node light index, for directional,
+// point, and spot lights.
+
+import 'dart:math' as math;
+
+import 'package:flutter_scene/src/importer/gltf.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('parses KHR_lights_punctual lights and node references', () {
+    final doc = parseGltfJson(<String, Object?>{
+      'extensions': {
+        'KHR_lights_punctual': {
+          'lights': [
+            {
+              'type': 'directional',
+              'color': [1.0, 0.9, 0.8],
+              'intensity': 2.0,
+            },
+            {'type': 'point', 'intensity': 5.0, 'range': 12.0},
+            {
+              'type': 'spot',
+              'intensity': 8.0,
+              'spot': {'innerConeAngle': 0.1, 'outerConeAngle': 0.5},
+            },
+          ],
+        },
+      },
+      'nodes': [
+        {
+          'name': 'sun',
+          'extensions': {
+            'KHR_lights_punctual': {'light': 0},
+          },
+        },
+        {
+          'name': 'lamp',
+          'extensions': {
+            'KHR_lights_punctual': {'light': 1},
+          },
+        },
+        {'name': 'nolight'},
+      ],
+    });
+
+    expect(doc.lights, hasLength(3));
+
+    final directional = doc.lights[0];
+    expect(directional.type, 'directional');
+    // Color is stored as a float32 Vector3, so compare loosely.
+    expect(directional.color.x, closeTo(1.0, 1e-6));
+    expect(directional.color.z, closeTo(0.8, 1e-6));
+    expect(directional.intensity, 2.0);
+    expect(directional.range, isNull);
+
+    final point = doc.lights[1];
+    expect(point.type, 'point');
+    expect(point.intensity, 5.0);
+    expect(point.range, 12.0);
+    // Color defaults to white when omitted.
+    expect(point.color.x, 1.0);
+
+    final spot = doc.lights[2];
+    expect(spot.type, 'spot');
+    expect(spot.innerConeAngle, closeTo(0.1, 1e-9));
+    expect(spot.outerConeAngle, closeTo(0.5, 1e-9));
+
+    // Node light references.
+    expect(doc.nodes[0].light, 0);
+    expect(doc.nodes[1].light, 1);
+    expect(doc.nodes[2].light, isNull);
+  });
+
+  test('a spot light without a spot block uses the default cone', () {
+    final doc = parseGltfJson(<String, Object?>{
+      'extensions': {
+        'KHR_lights_punctual': {
+          'lights': [
+            {'type': 'spot'},
+          ],
+        },
+      },
+    });
+    expect(doc.lights.single.outerConeAngle, closeTo(math.pi / 4, 1e-9));
+    expect(doc.lights.single.innerConeAngle, 0.0);
+  });
+
+  test('a document without the extension has no lights', () {
+    final doc = parseGltfJson(<String, Object?>{
+      'nodes': [
+        {'name': 'a'},
+      ],
+    });
+    expect(doc.lights, isEmpty);
+    expect(doc.nodes.single.light, isNull);
+  });
+}

--- a/packages/flutter_scene/test/punctual_lights_test.dart
+++ b/packages/flutter_scene/test/punctual_lights_test.dart
@@ -1,0 +1,153 @@
+// Covers PunctualLightBuffer.packLights: the data-texture texel layout (which
+// must match FetchPunctualTexel's column reads in material_lighting.glsl), the
+// color-times-intensity premultiply, the inverse-range encoding, the spot cone
+// scale/offset, and that the first directional light is skipped (it is shaded
+// with shadows by the FragInfo path, so only the extras are packed here).
+
+import 'dart:math' as math;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/render/punctual_lights.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+// Floats per light row (4 RGBA32F texels). Kept local to the test so a change
+// to the layout has to be reflected here on purpose.
+const int _floatsPerLight = 16;
+
+PointLightComponent _pointAt(Vector3 position, PointLight light) {
+  final node = Node(localTransform: Matrix4.translation(position));
+  final component = PointLightComponent(light);
+  node.addComponent(component);
+  return component;
+}
+
+SpotLightComponent _spotAt(Vector3 position, SpotLight light) {
+  final node = Node(localTransform: Matrix4.translation(position));
+  final component = SpotLightComponent(light);
+  node.addComponent(component);
+  return component;
+}
+
+DirectionalLightComponent _directional(DirectionalLight light) {
+  final node = Node();
+  final component = DirectionalLightComponent(light);
+  node.addComponent(component);
+  return component;
+}
+
+void main() {
+  group('PunctualLightBuffer.packLights', () {
+    test('packs a point light into row 0 with premultiplied color', () {
+      final (floats, count) = PunctualLightBuffer.packLights(
+        directionals: const [],
+        points: [
+          _pointAt(
+            Vector3(1.0, 2.0, 3.0),
+            PointLight(
+              color: Vector3(0.5, 0.6, 0.7),
+              intensity: 2.0,
+              range: 10,
+            ),
+          ),
+        ],
+        spots: const [],
+      );
+      expect(count, 1);
+      // Texel 0: position.xyz, type (1 = point).
+      expect(floats[0], 1.0);
+      expect(floats[1], 2.0);
+      expect(floats[2], 3.0);
+      expect(floats[3], 1.0);
+      // Texel 1: color * intensity, inverse range.
+      expect(floats[4], closeTo(1.0, 1e-6));
+      expect(floats[5], closeTo(1.2, 1e-6));
+      expect(floats[6], closeTo(1.4, 1e-6));
+      expect(floats[7], closeTo(0.1, 1e-6));
+    });
+
+    test('an infinite-range point light encodes inverse range 0', () {
+      final (floats, _) = PunctualLightBuffer.packLights(
+        directionals: const [],
+        points: [_pointAt(Vector3.zero(), PointLight())],
+        spots: const [],
+      );
+      expect(floats[7], 0.0);
+    });
+
+    test('packs a spot light with the precomputed cone scale and offset', () {
+      final (floats, count) = PunctualLightBuffer.packLights(
+        directionals: const [],
+        points: const [],
+        spots: [
+          _spotAt(
+            Vector3(4.0, 0.0, 0.0),
+            SpotLight(
+              direction: Vector3(0.0, -1.0, 0.0),
+              innerConeAngle: 0.0,
+              outerConeAngle: math.pi / 4.0,
+            ),
+          ),
+        ],
+      );
+      expect(count, 1);
+      // Texel 0: position + type (2 = spot).
+      expect(floats[0], 4.0);
+      expect(floats[3], 2.0);
+      // Texel 2: direction + angular scale.
+      expect(floats[8], closeTo(0.0, 1e-6));
+      expect(floats[9], closeTo(-1.0, 1e-6));
+      expect(floats[10], closeTo(0.0, 1e-6));
+      final cosOuter = math.cos(math.pi / 4.0);
+      final scale = 1.0 / (1.0 - cosOuter); // cos(inner=0) = 1
+      expect(floats[11], closeTo(scale, 1e-6));
+      // Texel 3: angular offset.
+      expect(floats[12], closeTo(-cosOuter * scale, 1e-6));
+    });
+
+    test('skips the first directional light and packs the rest as type 0', () {
+      final (floats, count) = PunctualLightBuffer.packLights(
+        directionals: [
+          _directional(DirectionalLight()), // shaded by the FragInfo path
+          _directional(
+            DirectionalLight(
+              direction: Vector3(0.0, 0.0, -1.0),
+              color: Vector3(1.0, 1.0, 1.0),
+              intensity: 3.0,
+            ),
+          ),
+        ],
+        points: const [],
+        spots: const [],
+      );
+      expect(count, 1);
+      // Type 0 (directional), color premultiplied, travel direction in texel 2.
+      expect(floats[3], 0.0);
+      expect(floats[4], closeTo(3.0, 1e-6));
+      expect(floats[8], closeTo(0.0, 1e-6));
+      expect(floats[10], closeTo(-1.0, 1e-6));
+    });
+
+    test('a lone directional light packs nothing', () {
+      final (_, count) = PunctualLightBuffer.packLights(
+        directionals: [_directional(DirectionalLight())],
+        points: const [],
+        spots: const [],
+      );
+      expect(count, 0);
+    });
+
+    test('point and spot lights share the row order', () {
+      final (floats, count) = PunctualLightBuffer.packLights(
+        directionals: const [],
+        points: [_pointAt(Vector3(1.0, 0.0, 0.0), PointLight())],
+        spots: [_spotAt(Vector3(0.0, 5.0, 0.0), SpotLight())],
+      );
+      expect(count, 2);
+      // Row 0 is the point light, row 1 the spot.
+      expect(floats[3], 1.0);
+      expect(floats[_floatsPerLight + 3], 2.0);
+      expect(floats[_floatsPerLight + 1], 5.0);
+    });
+  });
+}

--- a/packages/flutter_scene/test/punctual_lights_test.dart
+++ b/packages/flutter_scene/test/punctual_lights_test.dart
@@ -11,9 +11,9 @@ import 'package:flutter_scene/src/render/punctual_lights.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart';
 
-// Floats per light row (4 RGBA32F texels). Kept local to the test so a change
+// Floats per light row (8 RGBA32F texels). Kept local to the test so a change
 // to the layout has to be reflected here on purpose.
-const int _floatsPerLight = 16;
+const int _floatsPerLight = 32;
 
 PointLightComponent _pointAt(Vector3 position, PointLight light) {
   final node = Node(localTransform: Matrix4.translation(position));

--- a/packages/flutter_scene/test/spot_shadow_test.dart
+++ b/packages/flutter_scene/test/spot_shadow_test.dart
@@ -1,0 +1,68 @@
+// Covers collectSpotShadows: only shadow-casting spots are selected, the count
+// is capped at kMaxSpotShadows, a matrix is computed per caster, and slotOf
+// reports each caster's slot (or -1 for a non-caster).
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/render/spot_shadow.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+SpotLightComponent _spot({required bool castsShadow, Vector3? at}) {
+  final node = Node(localTransform: Matrix4.translation(at ?? Vector3.zero()));
+  final component = SpotLightComponent(
+    SpotLight(range: 10.0, castsShadow: castsShadow),
+  );
+  node.addComponent(component);
+  return component;
+}
+
+void main() {
+  test('no shadow casters yields null', () {
+    final frame = collectSpotShadows([
+      _spot(castsShadow: false),
+      _spot(castsShadow: false),
+    ]);
+    expect(frame, isNull);
+  });
+
+  test('selects only casters and computes a matrix each', () {
+    final a = _spot(castsShadow: true, at: Vector3(0, 5, 0));
+    final b = _spot(castsShadow: false);
+    final c = _spot(castsShadow: true, at: Vector3(3, 5, 0));
+    final frame = collectSpotShadows([a, b, c])!;
+
+    expect(frame.casters, [a, c]);
+    expect(frame.matrices, hasLength(2));
+    expect(frame.slotOf(a), 0);
+    expect(frame.slotOf(c), 1);
+    expect(frame.slotOf(b), -1);
+  });
+
+  test('caps the number of shadow casters at kMaxSpotShadows', () {
+    final spots = [
+      for (var i = 0; i < kMaxSpotShadows + 3; i++)
+        _spot(castsShadow: true, at: Vector3(i.toDouble(), 5, 0)),
+    ];
+    final frame = collectSpotShadows(spots)!;
+    expect(frame.casters, hasLength(kMaxSpotShadows));
+    expect(frame.matrices, hasLength(kMaxSpotShadows));
+    // The spots past the budget are not casters this frame.
+    expect(frame.slotOf(spots.last), -1);
+  });
+
+  test('shares tile resolution and bias from the first caster', () {
+    final node = Node();
+    final component = SpotLightComponent(
+      SpotLight(
+        castsShadow: true,
+        range: 10,
+        shadowMapResolution: 512,
+        shadowDepthBias: 0.007,
+      ),
+    );
+    node.addComponent(component);
+    final frame = collectSpotShadows([component])!;
+    expect(frame.tileResolution, 512);
+    expect(frame.depthBias, closeTo(0.007, 1e-9));
+  });
+}


### PR DESCRIPTION
Adds point and spot lights alongside the existing directional light, shades any number of them in a scene, and casts perspective shadow maps from spot lights.

Point and spot lights attach to a node through `PointLightComponent` and `SpotLightComponent`, taking their world position (and, for spots, aim) from the node transform. They use a range-windowed inverse-square falloff, and spots add a cone falloff between an inner and outer angle. More than one directional light now shades as well. The glTF runtime importer reads the `KHR_lights_punctual` extension, and the `.fscene` format gains `pointLight` and `spotLight` component codecs, so authored lights round-trip.

The scene may hold an unlimited number of lights. Each frame the lights pack into a parameters texture and are culled against the render items through the existing BVH, so a fragment only shades the lights that reach its object. The per-object budget stays bounded while the scene total is unbounded, and all light data is read from textures by computed UV, because a fragment shader cannot dynamically index a uniform array under GLSL ES 1.00.

Shadow-casting spot lights render their cone into a perspective tile of the directional shadow atlas, so every shadow type shares one sampler (the lit shader is already at the backend's sampler limit). Shadow-casting spots are hard-capped, their edges soften with a rotated PCF kernel, and they default to a normal-offset bias because a constant clip-space depth bias is badly behaved in a perspective shadow.

Two example scenes are included, a grid of many culled point lights and an adjustable spot-shadow scene.

Verified locally on Metal (macOS); this touches shaders, the shadow atlas layout, a light-parameter texture stride change, and PCF loops, so the CI smoke matrix exercises the GLES, Vulkan, and WebGL2 backends.
