### PR TITLE
Speed up draw calls on the web backend

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 0.19.0
 
+* Large speedup for many-draw scenes on the web backend. Per-draw uniform
+  data was written into one shared GL buffer between draws that read it,
+  which forces the browser's GL implementation to copy ("ghost") the buffer
+  on every write; a scene with ~100 draw calls spent most of its frame time
+  there, in the browser's GPU process. Per-draw uniforms now go into small
+  pooled buffers written once per frame cycle (105-draw test scene, Apple
+  M3 Max Chrome, 35 fps to a 120 fps display cap). Vertex-attribute state is
+  also cached in vertex-array objects per (pipeline, geometry, index buffer)
+  instead of being re-specified every draw, and redundant per-draw texture
+  sampler-state calls are skipped.
+
 * Ambient occlusion and screen-space reflections no longer sample the wrong
   depth for double-sided (`culling: none`) materials. The depth prepass they
   read culled every material back-face regardless of its own mode, so a

--- a/packages/flutter_scene/lib/src/gpu/web/buffer.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/buffer.dart
@@ -147,81 +147,76 @@ base class HostBuffer {
   static const int kDefaultBlockLengthInBytes = 1024000;
   static const int _kFrameCount = 4;
 
+  /// Pooled emplacement size classes. Each emplacement gets its own small GL
+  /// buffer, written exactly once and then only read until its frame slot
+  /// comes around again. Writing into a buffer that in-flight draws already
+  /// read forces the browser's GL implementation to ghost (copy) the buffer
+  /// per write, which dominated per-draw cost out of all proportion to the
+  /// bytes moved; one-write-per-cycle buffers never ghost.
+  static const List<int> _kPoolClassSizes = [512, 4096];
+
   HostBuffer._initialize(
     this._gpuContext, {
     this.blockLengthInBytes = HostBuffer.kDefaultBlockLengthInBytes,
   }) {
-    for (int i = 0; i < frameCount; i++) {
-      _buffers.add([_allocateNewBlock(blockLengthInBytes)]);
+    for (var frame = 0; frame < _kFrameCount; frame++) {
+      _pools.add([for (final _ in _kPoolClassSizes) <DeviceBuffer>[]]);
+      _cursors.add(List<int>.filled(_kPoolClassSizes.length, 0));
     }
   }
 
   final GpuContext _gpuContext;
+
+  /// Retained for API compatibility with flutter_gpu's HostBuffer; the web
+  /// backend pools per-emplacement buffers instead of bump-allocating blocks.
   final int blockLengthInBytes;
 
   int get frameCount => _kFrameCount;
 
   int _frameCursor = 0;
-  int _bufferCursor = 0;
-  int _offsetCursor = 0;
-  final List<List<DeviceBuffer>> _buffers = [];
+
+  /// Pooled emplacement buffers: [frame][sizeClass] -> buffers, reused in
+  /// order each time their frame slot comes around.
+  final List<List<List<DeviceBuffer>>> _pools = [];
+  final List<List<int>> _cursors = [];
 
   DeviceBuffer _allocateNewBlock(int length) =>
       _gpuContext.createDeviceBuffer(StorageMode.hostVisible, length);
 
-  BufferView _allocateEmplacement(ByteData bytes) {
-    if (bytes.lengthInBytes > blockLengthInBytes) {
-      return BufferView(
-        _allocateNewBlock(bytes.lengthInBytes),
-        offsetInBytes: 0,
-        lengthInBytes: bytes.lengthInBytes,
-      );
-    }
-
-    final alignment = _gpuContext.minimumUniformByteAlignment;
-    int padding = alignment - (_offsetCursor % alignment);
-    padding %= alignment;
-    if (_offsetCursor + padding + bytes.lengthInBytes > blockLengthInBytes) {
-      final buffer = _allocateNewBlock(blockLengthInBytes);
-      _buffers[_frameCursor].add(buffer);
-      _bufferCursor++;
-      _offsetCursor = bytes.lengthInBytes;
-      return BufferView(
-        buffer,
-        offsetInBytes: 0,
-        lengthInBytes: bytes.lengthInBytes,
-      );
-    }
-
-    _offsetCursor += padding;
-    final view = BufferView(
-      _buffers[_frameCursor][_bufferCursor],
-      offsetInBytes: _offsetCursor,
-      lengthInBytes: bytes.lengthInBytes,
-    );
-    _offsetCursor += bytes.lengthInBytes;
-    return view;
-  }
-
   /// Append byte data and return a view at the resulting GPU offset.
   BufferView emplace(ByteData bytes) {
-    final view = _allocateEmplacement(bytes);
-    if (!view.buffer.overwrite(
-      bytes,
-      destinationOffsetInBytes: view.offsetInBytes,
-    )) {
-      throw Exception(
-        'HostBuffer emplace failed at offset ${view.offsetInBytes}',
-      );
+    final length = bytes.lengthInBytes;
+    for (var sizeClass = 0; sizeClass < _kPoolClassSizes.length; sizeClass++) {
+      if (length > _kPoolClassSizes[sizeClass]) continue;
+      final pool = _pools[_frameCursor][sizeClass];
+      final cursor = _cursors[_frameCursor][sizeClass]++;
+      final DeviceBuffer buffer;
+      if (cursor < pool.length) {
+        buffer = pool[cursor];
+      } else {
+        buffer = _allocateNewBlock(_kPoolClassSizes[sizeClass]);
+        pool.add(buffer);
+      }
+      if (!buffer.overwrite(bytes)) {
+        throw Exception('HostBuffer emplace failed');
+      }
+      return BufferView(buffer, offsetInBytes: 0, lengthInBytes: length);
     }
-    return view;
+    // Oversize emplacement: a dedicated buffer of its own.
+    final buffer = _allocateNewBlock(length);
+    if (!buffer.overwrite(bytes)) {
+      throw Exception('HostBuffer emplace failed');
+    }
+    return BufferView(buffer, offsetInBytes: 0, lengthInBytes: length);
   }
 
   /// Advance the frame cursor; subsequent [emplace] calls reuse the next
   /// frame's buffers.
   void reset() {
     _frameCursor = (_frameCursor + 1) % frameCount;
-    _bufferCursor = 0;
-    _offsetCursor = 0;
+    final cursors = _cursors[_frameCursor];
+    for (var i = 0; i < cursors.length; i++) {
+      cursors[i] = 0;
+    }
   }
 }

--- a/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/gpu_context.dart
@@ -42,6 +42,12 @@ base class GpuContext {
   late final web.OffscreenCanvas _canvas;
   late final web.WebGL2RenderingContext _gl;
 
+  /// Cached vertex-array objects keyed by (pipeline, vertex streams, index
+  /// buffer), in least-recently-used order; see RenderPass._applyVertexState.
+  static const int _kMaxCachedVaos = 512;
+  final Map<String, web.WebGLVertexArrayObject> _vaoCache =
+      <String, web.WebGLVertexArrayObject>{};
+
   int _maxSupportedAnisotropy = 1;
 
   /// The device's maximum supported anisotropy (1 when the extension is

--- a/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
@@ -671,36 +671,55 @@ base class RenderPass {
     gl.activeTexture(web.WebGL2RenderingContext.TEXTURE0 + unit);
     gl.bindTexture(target, texture.glTexture);
     if (sampler != null) {
-      gl.texParameteri(
-        target,
-        web.WebGL2RenderingContext.TEXTURE_MIN_FILTER,
-        _glMinFilter(sampler, texture),
-      );
-      gl.texParameteri(
-        target,
-        web.WebGL2RenderingContext.TEXTURE_MAG_FILTER,
-        sampler.magFilter == MinMagFilter.nearest
-            ? web.WebGL2RenderingContext.NEAREST
-            : web.WebGL2RenderingContext.LINEAR,
-      );
-      gl.texParameteri(
-        target,
-        web.WebGL2RenderingContext.TEXTURE_WRAP_S,
-        _glAddressMode(sampler.widthAddressMode),
-      );
-      gl.texParameteri(
-        target,
-        web.WebGL2RenderingContext.TEXTURE_WRAP_T,
-        _glAddressMode(sampler.heightAddressMode),
-      );
+      // Sampler parameters are per-texture-object GL state; skip the ones
+      // already applied to this texture. Per-draw texParameteri calls are
+      // validated in the browser's GPU process and add up across draws.
+      final minFilter = _glMinFilter(sampler, texture);
+      if (texture._lastMinFilter != minFilter) {
+        texture._lastMinFilter = minFilter;
+        gl.texParameteri(
+          target,
+          web.WebGL2RenderingContext.TEXTURE_MIN_FILTER,
+          minFilter,
+        );
+      }
+      final magFilter = sampler.magFilter == MinMagFilter.nearest
+          ? web.WebGL2RenderingContext.NEAREST
+          : web.WebGL2RenderingContext.LINEAR;
+      if (texture._lastMagFilter != magFilter) {
+        texture._lastMagFilter = magFilter;
+        gl.texParameteri(
+          target,
+          web.WebGL2RenderingContext.TEXTURE_MAG_FILTER,
+          magFilter,
+        );
+      }
+      final wrapS = _glAddressMode(sampler.widthAddressMode);
+      if (texture._lastWrapS != wrapS) {
+        texture._lastWrapS = wrapS;
+        gl.texParameteri(
+          target,
+          web.WebGL2RenderingContext.TEXTURE_WRAP_S,
+          wrapS,
+        );
+      }
+      final wrapT = _glAddressMode(sampler.heightAddressMode);
+      if (texture._lastWrapT != wrapT) {
+        texture._lastWrapT = wrapT;
+        gl.texParameteri(
+          target,
+          web.WebGL2RenderingContext.TEXTURE_WRAP_T,
+          wrapT,
+        );
+      }
       final maxAniso = _gpuContext.maxSupportedAnisotropy;
       if (sampler.maxAnisotropy > 1 && maxAniso > 1) {
         // EXT_texture_filter_anisotropic: TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE.
-        gl.texParameterf(
-          target,
-          0x84FE,
-          sampler.maxAnisotropy.clamp(1, maxAniso).toDouble(),
-        );
+        final anisotropy = sampler.maxAnisotropy.clamp(1, maxAniso).toDouble();
+        if (texture._lastAnisotropy != anisotropy) {
+          texture._lastAnisotropy = anisotropy;
+          gl.texParameterf(target, 0x84FE, anisotropy);
+        }
       }
     }
   }

--- a/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/render_pass.dart
@@ -190,6 +190,11 @@ base class RenderPass {
 
   RenderPipeline? _boundPipeline;
   web.WebGLVertexArrayObject? _vao;
+
+  /// Vertex-stream bindings recorded since the last [clearBindings], applied
+  /// through the VAO cache when the draw is issued: (view, slot, whether the
+  /// stream is instance-rate).
+  final List<(BufferView, int, bool)> _pendingVertexBindings = [];
   PrimitiveType _primitiveType = PrimitiveType.triangle;
   BufferView? _inlineVertexBufferView;
 
@@ -365,7 +370,6 @@ base class RenderPass {
   }
 
   void bindVertexBuffer(BufferView bufferView, {int slot = 0}) {
-    final gl = _gpuContext._gl;
     final pipeline = _boundPipeline;
     if (pipeline == null) {
       throw StateError('bindVertexBuffer called before bindPipeline');
@@ -380,13 +384,16 @@ base class RenderPass {
       );
     }
 
-    _ensureVao();
-    bufferView.buffer._bindForTarget(web.WebGL2RenderingContext.ARRAY_BUFFER);
+    if (layout == null && pipeline.vertexShader.vertexInputs.isEmpty) {
+      // Inline pipeline (no reflected attributes): configured at draw time
+      // from the vertex count; not part of the cached-VAO path.
+      _inlineVertexBufferView = bufferView;
+      return;
+    }
+    _inlineVertexBufferView = null;
 
+    var instanceRate = false;
     if (layout != null) {
-      // Explicit layout: the buffer's slot describes its stride, step mode,
-      // and named attributes; the shader's reflection only supplies the
-      // attribute locations.
       if (slot < 0 || slot >= layout.buffers.length) {
         throw RangeError.value(
           slot,
@@ -394,7 +401,24 @@ base class RenderPass {
           'Pipeline VertexLayout declares ${layout.buffers.length} buffers',
         );
       }
-      _inlineVertexBufferView = null;
+      instanceRate = layout.buffers[slot].stepMode == VertexStepMode.instance;
+    }
+    // Deferred: applied (through the VAO cache) when the draw is issued.
+    _pendingVertexBindings.add((bufferView, slot, instanceRate));
+  }
+
+  /// Applies one recorded vertex-stream binding to the currently bound VAO:
+  /// binds the stream's GL buffer and points/enables its attributes.
+  void _applyVertexBinding(BufferView bufferView, int slot) {
+    final gl = _gpuContext._gl;
+    final pipeline = _boundPipeline!;
+    bufferView.buffer._bindForTarget(web.WebGL2RenderingContext.ARRAY_BUFFER);
+
+    final layout = pipeline.vertexLayout;
+    if (layout != null) {
+      // Explicit layout: the buffer's slot describes its stride, step mode,
+      // and named attributes; the shader's reflection only supplies the
+      // attribute locations.
       final buffer = layout.buffers[slot];
       final divisor = buffer.stepMode == VertexStepMode.instance ? 1 : 0;
       for (final attribute in buffer.attributes) {
@@ -426,35 +450,98 @@ base class RenderPass {
     }
 
     final inputs = pipeline.vertexShader.vertexInputs;
-    if (inputs.isEmpty) {
-      _inlineVertexBufferView = bufferView;
+    final stride = pipeline.vertexShader.vertexStride;
+    for (final input in inputs) {
+      gl.enableVertexAttribArray(input.location);
+      gl.vertexAttribPointer(
+        input.location,
+        input.componentCount,
+        web.WebGL2RenderingContext.FLOAT,
+        false,
+        stride,
+        bufferView.offsetInBytes + input.offsetInBytes,
+      );
+      // Divisor state lives in the VAO and may be left over from an
+      // instanced layout; reset it for vertex-rate inputs.
+      gl.vertexAttribDivisor(input.location, 0);
+    }
+  }
+
+  /// Binds the vertex (and, when [needsIndex] is set, index) state for the
+  /// draw being issued, through a cached VAO.
+  ///
+  /// Vertex-attribute specification is the dominant per-draw GL traffic, and
+  /// on the web every GL call is validated in the browser's GPU process, so
+  /// re-specifying stable geometry streams per draw is expensive out of all
+  /// proportion to the Dart-side cost. Geometry streams are stable per
+  /// (pipeline, buffers, offsets), so their full attribute state is captured
+  /// in a VAO once and re-bound with a single call thereafter.
+  ///
+  /// Instance-rate streams are excluded from the cache key and re-pointed on
+  /// the bound VAO every draw: they ride the per-frame bump allocator, so
+  /// their offset changes per draw and every instanced draw re-points them
+  /// anyway.
+  void _applyVertexState({required bool needsIndex}) {
+    if (_inlineVertexBufferView != null) {
+      _ensureVao();
+      return;
+    }
+    final gl = _gpuContext._gl;
+    final pipeline = _boundPipeline!;
+    final key = StringBuffer()..write(identityHashCode(pipeline));
+    for (final (view, slot, instanceRate) in _pendingVertexBindings) {
+      if (instanceRate) continue;
+      key
+        ..write('|')
+        ..write(identityHashCode(view.buffer))
+        ..write(':')
+        ..write(view.offsetInBytes)
+        ..write(':')
+        ..write(slot);
+    }
+    final indexView = needsIndex ? _indexBufferView : null;
+    if (indexView != null) {
+      key
+        ..write('#')
+        ..write(identityHashCode(indexView.buffer))
+        ..write(':')
+        ..write(indexView.offsetInBytes);
+    }
+    final cacheKey = key.toString();
+    final cache = _gpuContext._vaoCache;
+    // Remove-and-reinsert keeps the map in least-recently-used order.
+    var vao = cache.remove(cacheKey);
+    if (vao != null) {
+      cache[cacheKey] = vao;
+      gl.bindVertexArray(vao);
     } else {
-      _inlineVertexBufferView = null;
-      final stride = pipeline.vertexShader.vertexStride;
-      for (final input in inputs) {
-        gl.enableVertexAttribArray(input.location);
-        gl.vertexAttribPointer(
-          input.location,
-          input.componentCount,
-          web.WebGL2RenderingContext.FLOAT,
-          false,
-          stride,
-          bufferView.offsetInBytes + input.offsetInBytes,
-        );
-        // Divisor state lives in the VAO and may be left over from an
-        // instanced layout; reset it for vertex-rate inputs.
-        gl.vertexAttribDivisor(input.location, 0);
+      vao = gl.createVertexArray();
+      if (vao == null) {
+        throw StateError('Failed to create WebGL vertex array');
       }
+      gl.bindVertexArray(vao);
+      for (final (view, slot, instanceRate) in _pendingVertexBindings) {
+        if (instanceRate) continue;
+        _applyVertexBinding(view, slot);
+      }
+      // ELEMENT_ARRAY_BUFFER binding is VAO state; capture it with the rest.
+      indexView?.buffer._bindForTarget(
+        web.WebGL2RenderingContext.ELEMENT_ARRAY_BUFFER,
+      );
+      cache[cacheKey] = vao;
+      if (cache.length > GpuContext._kMaxCachedVaos) {
+        final oldest = cache.keys.first;
+        gl.deleteVertexArray(cache.remove(oldest)!);
+      }
+    }
+    for (final (view, slot, instanceRate) in _pendingVertexBindings) {
+      if (instanceRate) _applyVertexBinding(view, slot);
     }
   }
 
   void bindIndexBuffer(BufferView bufferView, IndexType indexType) {
-    // ELEMENT_ARRAY_BUFFER binding is captured in VAO state, so the VAO must
-    // be bound first.
-    _ensureVao();
-    bufferView.buffer._bindForTarget(
-      web.WebGL2RenderingContext.ELEMENT_ARRAY_BUFFER,
-    );
+    // Deferred: ELEMENT_ARRAY_BUFFER binding is VAO state, applied (through
+    // the VAO cache) when the draw is issued.
     _indexBufferView = bufferView;
     _indexType = indexType;
   }
@@ -664,6 +751,7 @@ base class RenderPass {
     }
     _inlineVertexBufferView = null;
     _indexBufferView = null;
+    _pendingVertexBindings.clear();
   }
 
   void setColorBlendEnable(bool enable, {int colorAttachmentIndex = 0}) {
@@ -855,6 +943,7 @@ base class RenderPass {
       throw StateError('draw called before bindPipeline');
     }
     if (vertexCount == 0 || instanceCount == 0) return;
+    _applyVertexState(needsIndex: false);
     _configureInlineVertexBuffer(vertexCount);
     if (instanceCount != 1) {
       gl.drawArraysInstanced(
@@ -881,6 +970,7 @@ base class RenderPass {
     if (indexView == null) {
       throw StateError('drawIndexed called before bindIndexBuffer');
     }
+    _applyVertexState(needsIndex: true);
     final glIndexType = _indexType == IndexType.int16
         ? web.WebGL2RenderingContext.UNSIGNED_SHORT
         : web.WebGL2RenderingContext.UNSIGNED_INT;

--- a/packages/flutter_scene/lib/src/gpu/web/texture.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/texture.dart
@@ -201,6 +201,15 @@ base class Texture {
   final bool enableShaderWriteUsage;
   final int mipLevelCount;
 
+  // Sampler state last applied to this texture (GL sampler parameters are
+  // per-texture-object state). Lets RenderPass.bindTexture skip redundant
+  // texParameteri calls, which otherwise dominate per-draw GL traffic.
+  int _lastMinFilter = -1;
+  int _lastMagFilter = -1;
+  int _lastWrapS = -1;
+  int _lastWrapT = -1;
+  double _lastAnisotropy = -1;
+
   late final _GlFormat _glFormat;
   web.WebGLTexture? _texture;
   web.WebGLRenderbuffer? _renderbuffer;


### PR DESCRIPTION
Draw calls on the web backend were far more expensive than they should be. A 105-draw scene rendered at 35 fps in Chrome on an Apple M3 Max while the same scene merged into 2 draws hit the 120 fps display cap, and profiling put the entire Dart-side render (encoder, uniform packing, GL bindings, present) at about 2 ms per frame, so the cost lived in the browser's GPU process.

The dominant cause was buffer ghosting. Per-draw uniform data was bump-allocated into one shared GL buffer and uploaded with bufferSubData between the draws that read it, and writing a buffer that in-flight draws already read forces the browser's GL implementation to copy the whole buffer per write, roughly 600 times per frame in that scene. HostBuffer emplacements now come from small pooled buffers in two size classes, each written exactly once and then only read until its slot in the existing four-frame ring comes around again, so no write ever touches a buffer with pending reads. Confirmed by first testing with a fresh GL buffer per emplacement, which jumped the same scene from 35 fps to over 100 before the pooled version made it a steady 120.

Two smaller reductions in per-draw GL traffic ride along. Vertex-attribute state is captured once per (pipeline, geometry streams, index buffer) in a cached VAO and re-bound with one call per draw instead of re-specifying every attribute (instance-rate streams ride the bump allocator, so they are excluded from the cache key and re-pointed each draw), and texture sampler parameters are only set when they differ from the texture's last-applied state. Together these cut per-draw GL calls from roughly thirty to a handful.

All changes are inside the web shim; the renderer issues identical commands on every backend. `flutter analyze` is clean, all 760 tests pass, and the docs site's full demo set (models, skinned animation, custom materials with vertex stages, SSR, widget surfaces) renders correctly on the rebuilt shim.
