### PR TITLE
Add a Materialize example and keep declared .fmat resources bindable

### DIFF
--- a/examples/flutter_app/assets/materialize_glass.fmat
+++ b/examples/flutter_app/assets/materialize_glass.fmat
@@ -1,14 +1,15 @@
 // Glass-shard stage of the Materialize example. Rendered over an unwelded
 // triangle soup where every triangle carries flat outward normals plus two
 // custom attributes, its centroid (tri_centroid) and a per-triangle random
-// seed (tri_seed). As the glass front sweeps up past a triangle's centroid,
-// the shard flies in from a scattered pose (pushed out along its face
-// normal with a seeded tumble) and seats onto the surface.
+// seed (tri_seed). As the glass front sweeps past a triangle's centroid the
+// shard flies in from a world-space direction, fading in at a distance and
+// easing along an s-curve (accelerate, then decelerate into a soft landing),
+// then sits on the surface glowing until the opaque shell phases over it.
 //
-// The Vertex() hook cannot see the instance model matrix, and the shard
-// math has to rotate about the centroid in object space, so the node's
-// world transform is passed in as the model_matrix parameter and the hook
-// writes world outputs through it itself.
+// The Vertex() hook cannot see the instance model matrix, and the tumble has
+// to rotate about the centroid in object space, so the node's world transform
+// is passed in as the model_matrix parameter and the hook writes world
+// outputs through it itself.
 
 material {
   name: "MaterializeGlass",
@@ -18,18 +19,28 @@ material {
 
   parameters: [
     { type: mat4, name: model_matrix },
-    // Object-space sweep fronts, driven from Dart each tick.
-    { type: float, name: glass_y, default: 10.0 },
-    { type: float, name: solid_y, default: -10.0 },
-    // Height of the assembly band; a shard goes from fully scattered to
-    // seated while the glass front crosses this span above its centroid.
+    { type: vec3, name: sweep_dir, default: [0.0, 1.0, 0.0] },
+    // Sweep fronts (object-space sweep coordinates), driven per tick.
+    { type: float, name: glass_front, default: 10.0 },
+    { type: float, name: solid_front, default: -10.0 },
+    // Sweep span a shard's flight occupies; the shard leaves its scattered
+    // pose when the glass front reaches its centroid and lands when the
+    // front has advanced this far past it.
     { type: float, name: band, default: 0.35 },
-    // How far shards sit out along their face normal when scattered.
-    { type: float, name: scatter, hint: range(0, 3, 0.01), default: 0.8 },
+    // World-space direction the shards come from, and how far out they start.
+    { type: vec3, name: fly_dir, default: [0.35, 1.0, -0.3] },
+    { type: float, name: fly_distance, default: 1.2 },
+    // Portion of the flight over which a shard fades in from nothing.
+    { type: float, name: fade_portion, hint: range(0.01, 1, 0.01), default: 0.35 },
+    // How long (in flight-band units past landing) the landing glow lasts.
+    { type: float, name: cool_span, hint: range(0.05, 4, 0.05), default: 1.5 },
+    // Tumble rotation amount while in flight.
+    { type: float, name: tumble, hint: range(0, 3, 0.01), default: 1.0 },
     { type: float, name: time, default: 0.0 },
+    // rgb tints the glass; a is its base translucency.
     { type: vec4, name: glass_color, hint: source_color, default: [0.5, 0.85, 1.0, 0.16] },
-    { type: vec3, name: heat_color, hint: source_color, default: [0.3, 0.9, 1.0] },
-    { type: float, name: heat_strength, hint: range(0, 20, 0.1), default: 5.0 },
+    { type: vec3, name: glow_color, hint: source_color, default: [0.3, 0.9, 1.0] },
+    { type: float, name: glow_strength, hint: range(0, 30, 0.1), default: 6.0 },
   ],
 
   attributes: [
@@ -38,35 +49,42 @@ material {
   ],
 
   varyings: [
-    { type: float, name: assemble },
-    { type: float, name: centroid_y },
+    { type: float, name: flight_a },
+    { type: float, name: seat_g },
+    { type: float, name: sweep_c },
   ],
 }
 
 vertex {
   void Vertex(inout VertexInputs vertex) {
-    centroid_y = tri_centroid.y;
+    float cs = dot(tri_centroid, material_params.sweep_dir);
+    sweep_c = cs;
 
-    // 0 scattered, 1 seated. Eased so shards decelerate as they arrive.
-    float a = clamp(
-        (material_params.glass_y - tri_centroid.y) /
-            max(material_params.band, 1e-4),
-        0.0, 1.0);
-    a = smoothstep(0.0, 1.0, a);
-    assemble = a;
+    // Raw flight progress: 0 scattered, 1 seated, keeps counting past 1 so
+    // the fragment stage knows how long the shard has been down.
+    float t = (material_params.glass_front - cs) /
+        max(material_params.band, 1e-4);
+    float a = clamp(t, 0.0, 1.0);
+    flight_a = a;
+    seat_g = max(t - 1.0, 0.0);
 
-    float s = 1.0 - a;
+    // Smootherstep easing: the shard accelerates away from its start, then
+    // decelerates and lands softly (zero velocity at both ends).
+    float ease = a * a * a * (a * (a * 6.0 - 15.0) + 10.0);
+    float s = 1.0 - ease;
+
+    // Seeded tumble about the centroid, unwinding to zero as it lands.
     vec3 rel = vertex.position - tri_centroid;
     vec3 n = vertex.normal;
-
-    // Seeded tumble about the centroid, with a slow wobble while afloat.
     vec3 axis = normalize(
-        vec3(sin(tri_seed * 3.1), cos(tri_seed * 5.7), sin(tri_seed * 7.3)) +
+        vec3(sin(tri_seed * 19.3), cos(tri_seed * 35.7), sin(tri_seed * 45.9)) +
         vec3(0.0, 0.001, 0.0));
     float wobble =
         sin(material_params.time * (1.0 + fract(tri_seed) * 1.5) +
             tri_seed * 40.0) * 0.4;
-    float angle = s * ((fract(tri_seed * 7.61) - 0.5) * 8.0 + wobble);
+    float angle = s * (material_params.tumble *
+                           (fract(tri_seed * 7.61) - 0.5) * 8.0 +
+                       wobble);
     float ca = cos(angle);
     float sa = sin(angle);
     vec3 rel_rot =
@@ -74,17 +92,18 @@ vertex {
     vec3 n_rot =
         n * ca + cross(axis, n) * sa + axis * dot(axis, n) * (1.0 - ca);
 
-    // Outward flight along the face normal plus a gentle drift.
-    float dist =
-        s * s * material_params.scatter * (0.6 + 0.8 * fract(tri_seed * 13.37));
-    vec3 drift = n * dist +
-        vec3(sin(tri_seed * 21.0 + material_params.time * 0.7), 0.35,
-             cos(tri_seed * 17.0 + material_params.time * 0.7)) *
-            (0.12 * s);
+    vec3 obj = tri_centroid + rel_rot;
+    vec3 world = (material_params.model_matrix * vec4(obj, 1.0)).xyz;
 
-    vec3 obj = tri_centroid + rel_rot + drift;
-    vertex.world_position =
-        (material_params.model_matrix * vec4(obj, 1.0)).xyz;
+    // World-space flight in from fly_dir, with a little per-shard spread so
+    // the swarm does not arrive as a rigid sheet.
+    vec3 fdir = normalize(material_params.fly_dir + vec3(0.0, 1e-4, 0.0));
+    vec3 spread = vec3(sin(tri_seed * 21.0), sin(tri_seed * 33.0),
+                       cos(tri_seed * 17.0)) * 0.25;
+    world += (fdir + spread) *
+        (material_params.fly_distance * (0.75 + 0.5 * fract(tri_seed * 13.37)) * s);
+
+    vertex.world_position = world;
     vertex.world_normal =
         normalize(mat3(material_params.model_matrix) * n_rot);
   }
@@ -92,18 +111,18 @@ vertex {
 
 fragment {
   void Surface(inout MaterialInputs material) {
-    // Pop in as soon as the shard starts flying, hand off to the opaque
+    // Fade in over the first part of the flight, hand off to the opaque
     // shell once the solid front passes the centroid.
-    float visible = smoothstep(0.0, 0.15, assemble);
+    float appear = smoothstep(0.0, material_params.fade_portion, flight_a);
     float takeover =
-        smoothstep(material_params.solid_y - 0.02, material_params.solid_y,
-                   centroid_y);
+        smoothstep(material_params.solid_front - 0.02,
+                   material_params.solid_front, sweep_c);
 
     vec3 n = GetWorldNormal();
     vec3 v = GetViewDirection();
     float fresnel = pow(1.0 - abs(dot(n, v)), 3.0);
     float alpha = mix(material_params.glass_color.a, 0.9, fresnel);
-    alpha *= visible * takeover;
+    alpha *= appear * takeover;
     if (alpha <= 0.003) {
       discard;
     }
@@ -112,11 +131,14 @@ fragment {
     material.metallic = 0.0;
     material.roughness = 0.06;
 
-    // Shards run hot mid-flight and cool off as they seat.
-    float heat = assemble * (1.0 - assemble) * 4.0;
-    material.emissive =
-        material_params.heat_color * (heat * material_params.heat_strength *
-                                      (0.35 + 0.65 * fresnel));
+    // Landing glow: ignites as the shard arrives and cools off while it sits
+    // on the surface, still visible when the shell phases over it.
+    float ignite = smoothstep(0.6, 1.0, flight_a);
+    float cool = 1.0 - smoothstep(0.0, max(material_params.cool_span, 1e-3),
+                                  seat_g);
+    material.emissive = material_params.glow_color *
+        (material_params.glow_strength * ignite * cool *
+         (0.35 + 0.65 * fresnel));
     PrepareMaterial(material);
   }
 }

--- a/examples/flutter_app/assets/materialize_glass.fmat
+++ b/examples/flutter_app/assets/materialize_glass.fmat
@@ -1,0 +1,122 @@
+// Glass-shard stage of the Materialize example. Rendered over an unwelded
+// triangle soup where every triangle carries flat outward normals plus two
+// custom attributes, its centroid (tri_centroid) and a per-triangle random
+// seed (tri_seed). As the glass front sweeps up past a triangle's centroid,
+// the shard flies in from a scattered pose (pushed out along its face
+// normal with a seeded tumble) and seats onto the surface.
+//
+// The Vertex() hook cannot see the instance model matrix, and the shard
+// math has to rotate about the centroid in object space, so the node's
+// world transform is passed in as the model_matrix parameter and the hook
+// writes world outputs through it itself.
+
+material {
+  name: "MaterializeGlass",
+  shading_model: lit,
+  blending: alpha,
+  culling: none,
+
+  parameters: [
+    { type: mat4, name: model_matrix },
+    // Object-space sweep fronts, driven from Dart each tick.
+    { type: float, name: glass_y, default: 10.0 },
+    { type: float, name: solid_y, default: -10.0 },
+    // Height of the assembly band; a shard goes from fully scattered to
+    // seated while the glass front crosses this span above its centroid.
+    { type: float, name: band, default: 0.35 },
+    // How far shards sit out along their face normal when scattered.
+    { type: float, name: scatter, hint: range(0, 3, 0.01), default: 0.8 },
+    { type: float, name: time, default: 0.0 },
+    { type: vec4, name: glass_color, hint: source_color, default: [0.5, 0.85, 1.0, 0.16] },
+    { type: vec3, name: heat_color, hint: source_color, default: [0.3, 0.9, 1.0] },
+    { type: float, name: heat_strength, hint: range(0, 20, 0.1), default: 5.0 },
+  ],
+
+  attributes: [
+    { type: vec3, name: tri_centroid },
+    { type: float, name: tri_seed },
+  ],
+
+  varyings: [
+    { type: float, name: assemble },
+    { type: float, name: centroid_y },
+  ],
+}
+
+vertex {
+  void Vertex(inout VertexInputs vertex) {
+    centroid_y = tri_centroid.y;
+
+    // 0 scattered, 1 seated. Eased so shards decelerate as they arrive.
+    float a = clamp(
+        (material_params.glass_y - tri_centroid.y) /
+            max(material_params.band, 1e-4),
+        0.0, 1.0);
+    a = smoothstep(0.0, 1.0, a);
+    assemble = a;
+
+    float s = 1.0 - a;
+    vec3 rel = vertex.position - tri_centroid;
+    vec3 n = vertex.normal;
+
+    // Seeded tumble about the centroid, with a slow wobble while afloat.
+    vec3 axis = normalize(
+        vec3(sin(tri_seed * 3.1), cos(tri_seed * 5.7), sin(tri_seed * 7.3)) +
+        vec3(0.0, 0.001, 0.0));
+    float wobble =
+        sin(material_params.time * (1.0 + fract(tri_seed) * 1.5) +
+            tri_seed * 40.0) * 0.4;
+    float angle = s * ((fract(tri_seed * 7.61) - 0.5) * 8.0 + wobble);
+    float ca = cos(angle);
+    float sa = sin(angle);
+    vec3 rel_rot =
+        rel * ca + cross(axis, rel) * sa + axis * dot(axis, rel) * (1.0 - ca);
+    vec3 n_rot =
+        n * ca + cross(axis, n) * sa + axis * dot(axis, n) * (1.0 - ca);
+
+    // Outward flight along the face normal plus a gentle drift.
+    float dist =
+        s * s * material_params.scatter * (0.6 + 0.8 * fract(tri_seed * 13.37));
+    vec3 drift = n * dist +
+        vec3(sin(tri_seed * 21.0 + material_params.time * 0.7), 0.35,
+             cos(tri_seed * 17.0 + material_params.time * 0.7)) *
+            (0.12 * s);
+
+    vec3 obj = tri_centroid + rel_rot + drift;
+    vertex.world_position =
+        (material_params.model_matrix * vec4(obj, 1.0)).xyz;
+    vertex.world_normal =
+        normalize(mat3(material_params.model_matrix) * n_rot);
+  }
+}
+
+fragment {
+  void Surface(inout MaterialInputs material) {
+    // Pop in as soon as the shard starts flying, hand off to the opaque
+    // shell once the solid front passes the centroid.
+    float visible = smoothstep(0.0, 0.15, assemble);
+    float takeover =
+        smoothstep(material_params.solid_y - 0.02, material_params.solid_y,
+                   centroid_y);
+
+    vec3 n = GetWorldNormal();
+    vec3 v = GetViewDirection();
+    float fresnel = pow(1.0 - abs(dot(n, v)), 3.0);
+    float alpha = mix(material_params.glass_color.a, 0.9, fresnel);
+    alpha *= visible * takeover;
+    if (alpha <= 0.003) {
+      discard;
+    }
+
+    material.base_color = vec4(material_params.glass_color.rgb, alpha);
+    material.metallic = 0.0;
+    material.roughness = 0.06;
+
+    // Shards run hot mid-flight and cool off as they seat.
+    float heat = assemble * (1.0 - assemble) * 4.0;
+    material.emissive =
+        material_params.heat_color * (heat * material_params.heat_strength *
+                                      (0.35 + 0.65 * fresnel));
+    PrepareMaterial(material);
+  }
+}

--- a/examples/flutter_app/assets/materialize_glass.fmat
+++ b/examples/flutter_app/assets/materialize_glass.fmat
@@ -2,9 +2,14 @@
 // triangle soup where every triangle carries flat outward normals plus two
 // custom attributes, its centroid (tri_centroid) and a per-triangle random
 // seed (tri_seed). As the glass front sweeps past a triangle's centroid the
-// shard flies in from a world-space direction, fading in at a distance and
-// easing along an s-curve (accelerate, then decelerate into a soft landing),
-// then sits on the surface glowing until the opaque shell phases over it.
+// shard flies in from its scattered pose, fading in at a distance and easing
+// along an s-curve (accelerate, then decelerate into a soft landing), then
+// sits on the surface glowing until the opaque shell phases over it.
+//
+// The scattered pose composes four offsets, a shared bias direction
+// (fly_dir * fly_distance), a radial push away from the model's center
+// (center_distance), a push along the shard's own face normal
+// (normal_distance), and a seeded random jitter.
 //
 // The Vertex() hook cannot see the instance model matrix, and the tumble has
 // to rotate about the centroid in object space, so the node's world transform
@@ -19,28 +24,35 @@ material {
 
   parameters: [
     { type: mat4, name: model_matrix },
-    { type: vec3, name: sweep_dir, default: [0.0, 1.0, 0.0] },
-    // Sweep fronts (object-space sweep coordinates), driven per tick.
+    // World-space center of the whole model, driven per tick.
+    { type: vec3, name: model_center, default: [0.0, 0.0, 0.0] },
+    // Sweep fronts (world-space heights), driven per tick.
     { type: float, name: glass_front, default: 10.0 },
     { type: float, name: solid_front, default: -10.0 },
-    // Sweep span a shard's flight occupies; the shard leaves its scattered
+    // Height span a shard's flight occupies; the shard leaves its scattered
     // pose when the glass front reaches its centroid and lands when the
     // front has advanced this far past it.
     { type: float, name: band, default: 0.35 },
-    // World-space direction the shards come from, and how far out they start.
-    { type: vec3, name: fly_dir, default: [0.35, 1.0, -0.3] },
-    { type: float, name: fly_distance, default: 1.2 },
+    // Scatter pose controls (world-space distances).
+    { type: vec3, name: fly_dir, default: [0.0, -1.0, 0.0] },
+    { type: float, name: fly_distance, default: 1.4 },
+    { type: float, name: center_distance, default: 0.0 },
+    { type: float, name: normal_distance, default: 0.0 },
+    { type: float, name: jitter, default: 0.15 },
     // Portion of the flight over which a shard fades in from nothing.
-    { type: float, name: fade_portion, hint: range(0.01, 1, 0.01), default: 0.35 },
+    { type: float, name: fade_portion, hint: range(0.01, 1, 0.01), default: 0.64 },
     // How long (in flight-band units past landing) the landing glow lasts.
-    { type: float, name: cool_span, hint: range(0.05, 4, 0.05), default: 1.5 },
+    { type: float, name: cool_span, hint: range(0.05, 4, 0.05), default: 0.33 },
     // Tumble rotation amount while in flight.
-    { type: float, name: tumble, hint: range(0, 3, 0.01), default: 1.0 },
+    { type: float, name: tumble, hint: range(0, 3, 0.01), default: 2.3 },
     { type: float, name: time, default: 0.0 },
     // rgb tints the glass; a is its base translucency.
-    { type: vec4, name: glass_color, hint: source_color, default: [0.5, 0.85, 1.0, 0.16] },
-    { type: vec3, name: glow_color, hint: source_color, default: [0.3, 0.9, 1.0] },
-    { type: float, name: glow_strength, hint: range(0, 30, 0.1), default: 6.0 },
+    { type: vec4, name: glass_color, hint: source_color, default: [0.5, 0.85, 1.0, 0.69] },
+    { type: vec3, name: glow_color, hint: source_color, default: [1.0, 1.0, 0.6] },
+    { type: float, name: glow_strength, hint: range(0, 30, 0.1), default: 22.0 },
+    // Boundary noise, shared with the wireframe and shell stages.
+    { type: vec3, name: noise_scale, default: [8.0, 8.0, 8.0] },
+    { type: float, name: noise_amp, default: 0.0 },
   ],
 
   attributes: [
@@ -51,18 +63,17 @@ material {
   varyings: [
     { type: float, name: flight_a },
     { type: float, name: seat_g },
-    { type: float, name: sweep_c },
   ],
 }
 
 vertex {
   void Vertex(inout VertexInputs vertex) {
-    float cs = dot(tri_centroid, material_params.sweep_dir);
-    sweep_c = cs;
+    // World-space height of the shard's centroid drives its timing.
+    float wc = (material_params.model_matrix * vec4(tri_centroid, 1.0)).y;
 
     // Raw flight progress: 0 scattered, 1 seated, keeps counting past 1 so
     // the fragment stage knows how long the shard has been down.
-    float t = (material_params.glass_front - cs) /
+    float t = (material_params.glass_front - wc) /
         max(material_params.band, 1e-4);
     float a = clamp(t, 0.0, 1.0);
     flight_a = a;
@@ -92,35 +103,69 @@ vertex {
     vec3 n_rot =
         n * ca + cross(axis, n) * sa + axis * dot(axis, n) * (1.0 - ca);
 
-    vec3 obj = tri_centroid + rel_rot;
-    vec3 world = (material_params.model_matrix * vec4(obj, 1.0)).xyz;
+    vec3 seated =
+        (material_params.model_matrix * vec4(tri_centroid + rel_rot, 1.0)).xyz;
 
-    // World-space flight in from fly_dir, with a little per-shard spread so
-    // the swarm does not arrive as a rigid sheet.
+    // Compose the scattered pose (all world space): shared bias direction,
+    // radial push from the model center, a push along the shard's own face
+    // normal, and seeded random jitter.
     vec3 fdir = normalize(material_params.fly_dir + vec3(0.0, 1e-4, 0.0));
-    vec3 spread = vec3(sin(tri_seed * 21.0), sin(tri_seed * 33.0),
-                       cos(tri_seed * 17.0)) * 0.25;
-    world += (fdir + spread) *
-        (material_params.fly_distance * (0.75 + 0.5 * fract(tri_seed * 13.37)) * s);
+    vec3 radial = seated - material_params.model_center;
+    float rlen = length(radial);
+    radial = rlen > 1e-5 ? radial / rlen : vec3(0.0, 1.0, 0.0);
+    vec3 n_world = normalize(mat3(material_params.model_matrix) * n);
+    vec3 jdir = normalize(vec3(sin(tri_seed * 61.0), sin(tri_seed * 47.0 + 2.0),
+                               cos(tri_seed * 53.0)));
+    vec3 offset = fdir * material_params.fly_distance +
+        radial * material_params.center_distance +
+        n_world * material_params.normal_distance +
+        jdir * (material_params.jitter * (0.5 + fract(tri_seed * 9.19)));
 
-    vertex.world_position = world;
+    vertex.world_position = seated + offset * s;
     vertex.world_normal =
         normalize(mat3(material_params.model_matrix) * n_rot);
   }
 }
 
 fragment {
-  void Surface(inout MaterialInputs material) {
-    // Fade in over the first part of the flight, hand off to the opaque
-    // shell once the solid front passes the centroid.
-    float appear = smoothstep(0.0, material_params.fade_portion, flight_a);
-    float takeover =
-        smoothstep(material_params.solid_front - 0.02,
-                   material_params.solid_front, sweep_c);
+  // Hash-based gradient noise; wobbles the takeover boundary with the same
+  // function (and inputs) as the shell's reveal so they line up exactly.
+  vec3 NoiseHash(vec3 p) {
+    p = vec3(dot(p, vec3(127.1, 311.7, 74.7)),
+             dot(p, vec3(269.5, 183.3, 246.1)),
+             dot(p, vec3(113.5, 271.9, 124.6)));
+    return fract(sin(p) * 43758.5453123) * 2.0 - 1.0;
+  }
 
-    vec3 n = GetWorldNormal();
+  float SeamNoise(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    vec3 u = f * f * (3.0 - 2.0 * f);
+    float n000 = dot(NoiseHash(i), f);
+    float n100 = dot(NoiseHash(i + vec3(1.0, 0.0, 0.0)), f - vec3(1.0, 0.0, 0.0));
+    float n010 = dot(NoiseHash(i + vec3(0.0, 1.0, 0.0)), f - vec3(0.0, 1.0, 0.0));
+    float n110 = dot(NoiseHash(i + vec3(1.0, 1.0, 0.0)), f - vec3(1.0, 1.0, 0.0));
+    float n001 = dot(NoiseHash(i + vec3(0.0, 0.0, 1.0)), f - vec3(0.0, 0.0, 1.0));
+    float n101 = dot(NoiseHash(i + vec3(1.0, 0.0, 1.0)), f - vec3(1.0, 0.0, 1.0));
+    float n011 = dot(NoiseHash(i + vec3(0.0, 1.0, 1.0)), f - vec3(0.0, 1.0, 1.0));
+    float n111 = dot(NoiseHash(i + vec3(1.0, 1.0, 1.0)), f - vec3(1.0, 1.0, 1.0));
+    return mix(
+        mix(mix(n000, n100, u.x), mix(n010, n110, u.x), u.y),
+        mix(mix(n001, n101, u.x), mix(n011, n111, u.x), u.y), u.z);
+  }
+
+  void Surface(inout MaterialInputs material) {
+    // Fade in over the first part of the flight; hand off to the opaque
+    // shell along the same noisy boundary its reveal uses.
+    float appear = smoothstep(0.0, material_params.fade_portion, flight_a);
+    float n = SeamNoise(GetWorldPosition() * material_params.noise_scale) *
+        material_params.noise_amp;
+    float front = material_params.solid_front + n;
+    float takeover = smoothstep(front - 0.01, front, GetWorldPosition().y);
+
+    vec3 nrm = GetWorldNormal();
     vec3 v = GetViewDirection();
-    float fresnel = pow(1.0 - abs(dot(n, v)), 3.0);
+    float fresnel = pow(1.0 - abs(dot(nrm, v)), 3.0);
     float alpha = mix(material_params.glass_color.a, 0.9, fresnel);
     alpha *= appear * takeover;
     if (alpha <= 0.003) {

--- a/examples/flutter_app/assets/materialize_shell.fmat
+++ b/examples/flutter_app/assets/materialize_shell.fmat
@@ -4,10 +4,15 @@
 // parameters and the factor uniforms copied from the imported material,
 // so below the seam it shades like the standard PBR material.
 //
-// TODO(materialize-shadows): the depth/shadow variant runs no Surface(),
-// so with a shadow-casting key light this pass casts the full helmet's
-// shadow before the reveal finishes. Discard-aware depth variants in the
-// fmat pipeline would fix it.
+// The reveal front is a world-space height wobbled by a gradient noise (the
+// same function and inputs the wireframe and glass stages use, so all three
+// boundaries line up); the seam stays line-like but turns amorphous and
+// curvy as the noise amount rises.
+//
+// TODO(materialize-shadows): the depth/shadow pass runs no Surface(), so
+// with a shadow-casting key light this pass casts the full helmet's shadow
+// before the reveal finishes. Discard-aware depth variants in the fmat
+// pipeline would fix it.
 
 material {
   name: "MaterializeShell",
@@ -15,13 +20,15 @@ material {
   blending: opaque,
 
   parameters: [
-    { type: vec3, name: sweep_dir, default: [0.0, 1.0, 0.0] },
-    // Reveal front (an object-space sweep coordinate), driven per tick.
+    // Reveal front (a world-space height), driven per tick.
     { type: float, name: solid_front, default: 10.0 },
     // Height of the emissive seam band under the front.
     { type: float, name: seam_width, default: 0.06 },
     { type: vec4, name: seam_color, hint: source_color, default: [0.3, 0.9, 1.0, 1.0] },
     { type: float, name: seam_strength, hint: range(0, 40, 0.1), default: 16.0 },
+    // Boundary noise, per-dimension scale plus amount.
+    { type: vec3, name: noise_scale, default: [8.0, 8.0, 8.0] },
+    { type: float, name: noise_amp, default: 0.0 },
 
     // Standard PBR inputs mirrored from the imported material.
     { type: vec4, name: base_color_factor, default: [1.0, 1.0, 1.0, 1.0] },
@@ -36,21 +43,42 @@ material {
     { type: sampler2d, name: occlusion_texture, hint: default_white },
     { type: sampler2d, name: emissive_texture, hint: default_black },
   ],
-
-  varyings: [
-    { type: float, name: sweep_s },
-  ],
-}
-
-vertex {
-  void Vertex(inout VertexInputs vertex) {
-    sweep_s = dot(vertex.position, material_params.sweep_dir);
-  }
 }
 
 fragment {
+  // Hash-based gradient noise; wobbles the reveal boundary. The wireframe
+  // and glass stages use the same function and inputs so their boundaries
+  // line up with this one.
+  vec3 NoiseHash(vec3 p) {
+    p = vec3(dot(p, vec3(127.1, 311.7, 74.7)),
+             dot(p, vec3(269.5, 183.3, 246.1)),
+             dot(p, vec3(113.5, 271.9, 124.6)));
+    return fract(sin(p) * 43758.5453123) * 2.0 - 1.0;
+  }
+
+  float SeamNoise(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    vec3 u = f * f * (3.0 - 2.0 * f);
+    float n000 = dot(NoiseHash(i), f);
+    float n100 = dot(NoiseHash(i + vec3(1.0, 0.0, 0.0)), f - vec3(1.0, 0.0, 0.0));
+    float n010 = dot(NoiseHash(i + vec3(0.0, 1.0, 0.0)), f - vec3(0.0, 1.0, 0.0));
+    float n110 = dot(NoiseHash(i + vec3(1.0, 1.0, 0.0)), f - vec3(1.0, 1.0, 0.0));
+    float n001 = dot(NoiseHash(i + vec3(0.0, 0.0, 1.0)), f - vec3(0.0, 0.0, 1.0));
+    float n101 = dot(NoiseHash(i + vec3(1.0, 0.0, 1.0)), f - vec3(1.0, 0.0, 1.0));
+    float n011 = dot(NoiseHash(i + vec3(0.0, 1.0, 1.0)), f - vec3(0.0, 1.0, 1.0));
+    float n111 = dot(NoiseHash(i + vec3(1.0, 1.0, 1.0)), f - vec3(1.0, 1.0, 1.0));
+    return mix(
+        mix(mix(n000, n100, u.x), mix(n010, n110, u.x), u.y),
+        mix(mix(n001, n101, u.x), mix(n011, n111, u.x), u.y), u.z);
+  }
+
   void Surface(inout MaterialInputs material) {
-    if (sweep_s > material_params.solid_front) {
+    vec3 world = GetWorldPosition();
+    float n = SeamNoise(world * material_params.noise_scale) *
+        material_params.noise_amp;
+    float front = material_params.solid_front + n;
+    if (world.y > front) {
       discard;
     }
 
@@ -78,7 +106,7 @@ fragment {
         material_params.emissive_factor;
 
     // The laser seam, a hot emissive band right under the reveal front.
-    float d = material_params.solid_front - sweep_s;
+    float d = front - world.y;
     float seam =
         1.0 - smoothstep(0.0, max(material_params.seam_width, 1e-4), d);
     material.emissive +=

--- a/examples/flutter_app/assets/materialize_shell.fmat
+++ b/examples/flutter_app/assets/materialize_shell.fmat
@@ -1,0 +1,89 @@
+// Final stage of the Materialize example, the real PBR surface revealing
+// itself bottom-to-top behind a glowing seam. Applied to the original
+// imported geometry with the model's own textures re-bound as sampler
+// parameters and the factor uniforms copied from the imported material,
+// so below the seam it shades like the standard PBR material.
+//
+// TODO(materialize-shadows): the depth/shadow variant runs no Surface(),
+// so with a shadow-casting key light this pass casts the full helmet's
+// shadow before the reveal finishes. Discard-aware depth variants in the
+// fmat pipeline would fix it.
+
+material {
+  name: "MaterializeShell",
+  shading_model: lit,
+  blending: opaque,
+
+  parameters: [
+    // Object-space reveal front, driven from Dart each tick.
+    { type: float, name: solid_y, default: 10.0 },
+    // Height of the emissive seam band under the front.
+    { type: float, name: seam_width, default: 0.06 },
+    { type: vec4, name: seam_color, hint: source_color, default: [0.3, 0.9, 1.0, 1.0] },
+    { type: float, name: seam_strength, hint: range(0, 40, 0.1), default: 16.0 },
+
+    // Standard PBR inputs mirrored from the imported material.
+    { type: vec4, name: base_color_factor, default: [1.0, 1.0, 1.0, 1.0] },
+    { type: float, name: metallic_factor, hint: range(0, 1, 0.01), default: 1.0 },
+    { type: float, name: roughness_factor, hint: range(0, 1, 0.01), default: 1.0 },
+    { type: vec3, name: emissive_factor, default: [0.0, 0.0, 0.0] },
+    { type: float, name: normal_scale, hint: range(0, 2, 0.01), default: 1.0 },
+    { type: float, name: occlusion_strength, hint: range(0, 1, 0.01), default: 1.0 },
+    { type: sampler2d, name: base_color_texture, hint: default_white },
+    { type: sampler2d, name: metallic_roughness_texture, hint: default_white },
+    { type: sampler2d, name: normal_texture, hint: default_normal },
+    { type: sampler2d, name: occlusion_texture, hint: default_white },
+    { type: sampler2d, name: emissive_texture, hint: default_black },
+  ],
+
+  varyings: [
+    { type: float, name: object_y },
+  ],
+}
+
+vertex {
+  void Vertex(inout VertexInputs vertex) {
+    object_y = vertex.position.y;
+  }
+}
+
+fragment {
+  void Surface(inout MaterialInputs material) {
+    if (object_y > material_params.solid_y) {
+      discard;
+    }
+
+    vec2 uv = GetUV0();
+
+    vec4 base = texture(base_color_texture, uv);
+    material.base_color = vec4(
+        SRGBToLinear(base.rgb) * material_params.base_color_factor.rgb, 1.0);
+
+    // PerturbNormal wants the non-normalized view vector.
+    material.normal = PerturbNormal(normal_texture, GetWorldNormal(),
+                                    v_viewvector, uv,
+                                    material_params.normal_scale);
+
+    vec4 mr = texture(metallic_roughness_texture, uv);
+    material.metallic = clamp(mr.b * material_params.metallic_factor, 0.0, 1.0);
+    material.roughness = clamp(mr.g * material_params.roughness_factor,
+                               0.05, 1.0);
+
+    float occlusion = texture(occlusion_texture, uv).r;
+    material.occlusion =
+        1.0 - (1.0 - occlusion) * material_params.occlusion_strength;
+
+    material.emissive = SRGBToLinear(texture(emissive_texture, uv).rgb) *
+        material_params.emissive_factor;
+
+    // The laser seam, a hot emissive band right under the reveal front.
+    float d = material_params.solid_y - object_y;
+    float seam =
+        1.0 - smoothstep(0.0, max(material_params.seam_width, 1e-4), d);
+    material.emissive +=
+        material_params.seam_color.rgb * (seam * seam *
+                                          material_params.seam_strength);
+
+    PrepareMaterial(material);
+  }
+}

--- a/examples/flutter_app/assets/materialize_shell.fmat
+++ b/examples/flutter_app/assets/materialize_shell.fmat
@@ -15,8 +15,9 @@ material {
   blending: opaque,
 
   parameters: [
-    // Object-space reveal front, driven from Dart each tick.
-    { type: float, name: solid_y, default: 10.0 },
+    { type: vec3, name: sweep_dir, default: [0.0, 1.0, 0.0] },
+    // Reveal front (an object-space sweep coordinate), driven per tick.
+    { type: float, name: solid_front, default: 10.0 },
     // Height of the emissive seam band under the front.
     { type: float, name: seam_width, default: 0.06 },
     { type: vec4, name: seam_color, hint: source_color, default: [0.3, 0.9, 1.0, 1.0] },
@@ -37,19 +38,19 @@ material {
   ],
 
   varyings: [
-    { type: float, name: object_y },
+    { type: float, name: sweep_s },
   ],
 }
 
 vertex {
   void Vertex(inout VertexInputs vertex) {
-    object_y = vertex.position.y;
+    sweep_s = dot(vertex.position, material_params.sweep_dir);
   }
 }
 
 fragment {
   void Surface(inout MaterialInputs material) {
-    if (object_y > material_params.solid_y) {
+    if (sweep_s > material_params.solid_front) {
       discard;
     }
 
@@ -77,7 +78,7 @@ fragment {
         material_params.emissive_factor;
 
     // The laser seam, a hot emissive band right under the reveal front.
-    float d = material_params.solid_y - object_y;
+    float d = material_params.solid_front - sweep_s;
     float seam =
         1.0 - smoothstep(0.0, max(material_params.seam_width, 1e-4), d);
     material.emissive +=

--- a/examples/flutter_app/assets/materialize_wireframe.fmat
+++ b/examples/flutter_app/assets/materialize_wireframe.fmat
@@ -1,36 +1,70 @@
-// Wireframe stage of the Materialize example. Rendered over line-list
-// geometry built from the model's unique triangle edges. Lines fade in
-// below the wire front with a hot leading edge, and fade back out once
-// the solid front passes (the opaque surface has taken over by then).
+// Wireframe stage of the Materialize example. Rendered over ribbon geometry,
+// one view-facing quad per unique mesh edge (native line primitives are a
+// fixed one pixel, so thickness is built from triangles). Each vertex carries
+// the opposite edge endpoint and a side sign; the vertex stage expands the
+// quad perpendicular to both the edge and the view direction.
+//
+// All gating compares a sweep coordinate (dot(position, sweep_dir), object
+// space) against fronts driven from Dart, so the reveal travels along the
+// model's up axis regardless of how the source asset is oriented.
 
 material {
   name: "MaterializeWireframe",
   shading_model: unlit,
   blending: alpha,
+  culling: none,
 
   parameters: [
-    // Object-space sweep fronts, driven from Dart each tick.
-    { type: float, name: wire_y, default: 10.0 },
-    { type: float, name: solid_y, default: -10.0 },
+    { type: mat4, name: model_matrix },
+    { type: vec3, name: sweep_dir, default: [0.0, 1.0, 0.0] },
+    // Sweep fronts (object-space sweep coordinates), driven per tick.
+    { type: float, name: wire_front, default: 10.0 },
+    { type: float, name: solid_front, default: -10.0 },
     // Height of the fade band around each front.
     { type: float, name: band, default: 0.08 },
-    // Push lines slightly outward along the vertex normal so they sit
-    // above the shell surface instead of z-fighting it.
+    // World-space ribbon width.
+    { type: float, name: thickness, default: 0.004 },
+    // Push the ribbon off the surface along the vertex normal so it does not
+    // z-fight the shell.
     { type: float, name: inflate, default: 0.004 },
     { type: vec4, name: wire_color, hint: source_color, default: [0.25, 0.85, 1.0, 0.85] },
-    { type: float, name: glow_strength, hint: range(0, 20, 0.1), default: 8.0 },
+    { type: float, name: glow_strength, hint: range(0, 30, 0.1), default: 8.0 },
+  ],
+
+  attributes: [
+    { type: vec3, name: edge_other },
+    { type: float, name: edge_side },
   ],
 
   varyings: [
-    { type: float, name: object_y },
+    { type: float, name: sweep_s },
   ],
 }
 
 vertex {
   void Vertex(inout VertexInputs vertex) {
-    object_y = vertex.position.y;
-    vertex.world_position +=
-        normalize(vertex.world_normal) * material_params.inflate;
+    sweep_s = dot(vertex.position, material_params.sweep_dir);
+
+    // Inflate both endpoints along this vertex's normal (the endpoints of an
+    // edge have nearly parallel normals, so sharing one is fine).
+    vec3 p = vertex.position + vertex.normal * material_params.inflate;
+    vec3 o = edge_other + vertex.normal * material_params.inflate;
+
+    vec3 world_p = (material_params.model_matrix * vec4(p, 1.0)).xyz;
+    vec3 world_o = (material_params.model_matrix * vec4(o, 1.0)).xyz;
+
+    // Expand perpendicular to the edge and the view direction so the ribbon
+    // always faces the camera.
+    vec3 dir = world_o - world_p;
+    vec3 view = vertex.camera_position - world_p;
+    vec3 perp = cross(dir, view);
+    float len = length(perp);
+    perp = len > 1e-6 ? perp / len : vec3(0.0);
+
+    vertex.world_position =
+        world_p + perp * (material_params.thickness * 0.5 * edge_side);
+    vertex.world_normal =
+        normalize(mat3(material_params.model_matrix) * vertex.normal);
   }
 }
 
@@ -39,12 +73,12 @@ fragment {
     float band = max(material_params.band, 1e-4);
     // 1 below the wire front, easing to 0 above it.
     float reveal = 1.0 -
-        smoothstep(material_params.wire_y - band, material_params.wire_y,
-                   object_y);
-    // 0 below the solid front (opaque surface owns that region now).
+        smoothstep(material_params.wire_front - band,
+                   material_params.wire_front, sweep_s);
+    // 0 below the solid front (the opaque surface owns that region now).
     float takeover =
-        smoothstep(material_params.solid_y - band,
-                   material_params.solid_y + band, object_y);
+        smoothstep(material_params.solid_front - band,
+                   material_params.solid_front + band, sweep_s);
     float alpha = reveal * takeover * material_params.wire_color.a;
     if (alpha <= 0.003) {
       discard;
@@ -52,7 +86,8 @@ fragment {
 
     // Hot pulse at the leading edge.
     float edge = 1.0 -
-        clamp(abs(object_y - material_params.wire_y) / (band * 2.0), 0.0, 1.0);
+        clamp(abs(sweep_s - material_params.wire_front) / (band * 2.0),
+              0.0, 1.0);
     vec3 color = material_params.wire_color.rgb *
         (1.0 + material_params.glow_strength * edge * edge);
 

--- a/examples/flutter_app/assets/materialize_wireframe.fmat
+++ b/examples/flutter_app/assets/materialize_wireframe.fmat
@@ -4,9 +4,9 @@
 // the opposite edge endpoint and a side sign; the vertex stage expands the
 // quad perpendicular to both the edge and the view direction.
 //
-// All gating compares a sweep coordinate (dot(position, sweep_dir), object
-// space) against fronts driven from Dart, so the reveal travels along the
-// model's up axis regardless of how the source asset is oriented.
+// All gating compares world-space height against fronts driven from Dart
+// (the model only spins about the world up axis, so height is stable), with
+// a shared gradient noise wobbling the boundary so the sweep reads organic.
 
 material {
   name: "MaterializeWireframe",
@@ -16,8 +16,7 @@ material {
 
   parameters: [
     { type: mat4, name: model_matrix },
-    { type: vec3, name: sweep_dir, default: [0.0, 1.0, 0.0] },
-    // Sweep fronts (object-space sweep coordinates), driven per tick.
+    // Sweep fronts (world-space heights), driven per tick.
     { type: float, name: wire_front, default: 10.0 },
     { type: float, name: solid_front, default: -10.0 },
     // Height of the fade band around each front.
@@ -29,6 +28,9 @@ material {
     { type: float, name: inflate, default: 0.004 },
     { type: vec4, name: wire_color, hint: source_color, default: [0.25, 0.85, 1.0, 0.85] },
     { type: float, name: glow_strength, hint: range(0, 30, 0.1), default: 8.0 },
+    // Boundary noise, shared with the glass and shell stages.
+    { type: vec3, name: noise_scale, default: [8.0, 8.0, 8.0] },
+    { type: float, name: noise_amp, default: 0.0 },
   ],
 
   attributes: [
@@ -37,14 +39,12 @@ material {
   ],
 
   varyings: [
-    { type: float, name: sweep_s },
+    { type: float, name: world_h },
   ],
 }
 
 vertex {
   void Vertex(inout VertexInputs vertex) {
-    sweep_s = dot(vertex.position, material_params.sweep_dir);
-
     // Inflate both endpoints along this vertex's normal (the endpoints of an
     // edge have nearly parallel normals, so sharing one is fine).
     vec3 p = vertex.position + vertex.normal * material_params.inflate;
@@ -52,6 +52,7 @@ vertex {
 
     vec3 world_p = (material_params.model_matrix * vec4(p, 1.0)).xyz;
     vec3 world_o = (material_params.model_matrix * vec4(o, 1.0)).xyz;
+    world_h = world_p.y;
 
     // Expand perpendicular to the edge and the view direction so the ribbon
     // always faces the camera.
@@ -69,25 +70,51 @@ vertex {
 }
 
 fragment {
+  // Hash-based gradient noise; wobbles the sweep boundaries. The same
+  // function (and inputs) gate the glass and shell stages so their
+  // boundaries line up.
+  vec3 NoiseHash(vec3 p) {
+    p = vec3(dot(p, vec3(127.1, 311.7, 74.7)),
+             dot(p, vec3(269.5, 183.3, 246.1)),
+             dot(p, vec3(113.5, 271.9, 124.6)));
+    return fract(sin(p) * 43758.5453123) * 2.0 - 1.0;
+  }
+
+  float SeamNoise(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    vec3 u = f * f * (3.0 - 2.0 * f);
+    float n000 = dot(NoiseHash(i), f);
+    float n100 = dot(NoiseHash(i + vec3(1.0, 0.0, 0.0)), f - vec3(1.0, 0.0, 0.0));
+    float n010 = dot(NoiseHash(i + vec3(0.0, 1.0, 0.0)), f - vec3(0.0, 1.0, 0.0));
+    float n110 = dot(NoiseHash(i + vec3(1.0, 1.0, 0.0)), f - vec3(1.0, 1.0, 0.0));
+    float n001 = dot(NoiseHash(i + vec3(0.0, 0.0, 1.0)), f - vec3(0.0, 0.0, 1.0));
+    float n101 = dot(NoiseHash(i + vec3(1.0, 0.0, 1.0)), f - vec3(1.0, 0.0, 1.0));
+    float n011 = dot(NoiseHash(i + vec3(0.0, 1.0, 1.0)), f - vec3(0.0, 1.0, 1.0));
+    float n111 = dot(NoiseHash(i + vec3(1.0, 1.0, 1.0)), f - vec3(1.0, 1.0, 1.0));
+    return mix(
+        mix(mix(n000, n100, u.x), mix(n010, n110, u.x), u.y),
+        mix(mix(n001, n101, u.x), mix(n011, n111, u.x), u.y), u.z);
+  }
+
   void Surface(inout MaterialInputs material) {
     float band = max(material_params.band, 1e-4);
+    float n = SeamNoise(GetWorldPosition() * material_params.noise_scale) *
+        material_params.noise_amp;
+    float wire_front = material_params.wire_front + n;
+    float solid_front = material_params.solid_front + n;
+
     // 1 below the wire front, easing to 0 above it.
-    float reveal = 1.0 -
-        smoothstep(material_params.wire_front - band,
-                   material_params.wire_front, sweep_s);
+    float reveal = 1.0 - smoothstep(wire_front - band, wire_front, world_h);
     // 0 below the solid front (the opaque surface owns that region now).
-    float takeover =
-        smoothstep(material_params.solid_front - band,
-                   material_params.solid_front + band, sweep_s);
+    float takeover = smoothstep(solid_front - band, solid_front + band, world_h);
     float alpha = reveal * takeover * material_params.wire_color.a;
     if (alpha <= 0.003) {
       discard;
     }
 
     // Hot pulse at the leading edge.
-    float edge = 1.0 -
-        clamp(abs(sweep_s - material_params.wire_front) / (band * 2.0),
-              0.0, 1.0);
+    float edge = 1.0 - clamp(abs(world_h - wire_front) / (band * 2.0), 0.0, 1.0);
     vec3 color = material_params.wire_color.rgb *
         (1.0 + material_params.glow_strength * edge * edge);
 

--- a/examples/flutter_app/assets/materialize_wireframe.fmat
+++ b/examples/flutter_app/assets/materialize_wireframe.fmat
@@ -1,0 +1,62 @@
+// Wireframe stage of the Materialize example. Rendered over line-list
+// geometry built from the model's unique triangle edges. Lines fade in
+// below the wire front with a hot leading edge, and fade back out once
+// the solid front passes (the opaque surface has taken over by then).
+
+material {
+  name: "MaterializeWireframe",
+  shading_model: unlit,
+  blending: alpha,
+
+  parameters: [
+    // Object-space sweep fronts, driven from Dart each tick.
+    { type: float, name: wire_y, default: 10.0 },
+    { type: float, name: solid_y, default: -10.0 },
+    // Height of the fade band around each front.
+    { type: float, name: band, default: 0.08 },
+    // Push lines slightly outward along the vertex normal so they sit
+    // above the shell surface instead of z-fighting it.
+    { type: float, name: inflate, default: 0.004 },
+    { type: vec4, name: wire_color, hint: source_color, default: [0.25, 0.85, 1.0, 0.85] },
+    { type: float, name: glow_strength, hint: range(0, 20, 0.1), default: 8.0 },
+  ],
+
+  varyings: [
+    { type: float, name: object_y },
+  ],
+}
+
+vertex {
+  void Vertex(inout VertexInputs vertex) {
+    object_y = vertex.position.y;
+    vertex.world_position +=
+        normalize(vertex.world_normal) * material_params.inflate;
+  }
+}
+
+fragment {
+  void Surface(inout MaterialInputs material) {
+    float band = max(material_params.band, 1e-4);
+    // 1 below the wire front, easing to 0 above it.
+    float reveal = 1.0 -
+        smoothstep(material_params.wire_y - band, material_params.wire_y,
+                   object_y);
+    // 0 below the solid front (opaque surface owns that region now).
+    float takeover =
+        smoothstep(material_params.solid_y - band,
+                   material_params.solid_y + band, object_y);
+    float alpha = reveal * takeover * material_params.wire_color.a;
+    if (alpha <= 0.003) {
+      discard;
+    }
+
+    // Hot pulse at the leading edge.
+    float edge = 1.0 -
+        clamp(abs(object_y - material_params.wire_y) / (band * 2.0), 0.0, 1.0);
+    vec3 color = material_params.wire_color.rgb *
+        (1.0 + material_params.glow_strength * edge * edge);
+
+    material.base_color = vec4(color, alpha);
+    PrepareMaterial(material);
+  }
+}

--- a/examples/flutter_app/lib/example_materialize.dart
+++ b/examples/flutter_app/lib/example_materialize.dart
@@ -5,22 +5,27 @@
 //      edges, unlit translucent .fmat with a glowing sweep front).
 //   2. Glass triangles fly in and assemble over it (unwelded triangle soup
 //      with flat outward normals; per-triangle centroid + seed attributes let
-//      the vertex stage fly each shard in from a settable world direction,
-//      fading in at a distance and easing along an s-curve into a soft
-//      landing, then glowing on the surface until the shell phases over it).
+//      the vertex stage fly each shard in from a composable scattered pose,
+//      a bias direction, a radial push from the model center, a push along
+//      the face normal, and seeded jitter, fading in at a distance and
+//      easing along an s-curve into a soft landing, then glowing on the
+//      surface until the shell phases over it).
 //   3. The real PBR surface reveals itself behind a hot emissive seam (the
 //      original geometry with a .fmat that replicates standard PBR sampling,
 //      re-binding the model's own textures, and discards above the front).
 //
 // A single eased progress value drives three staggered sweep fronts. All
-// gating compares dot(position, sweep_dir) in object space, where sweep_dir
-// is the model's up axis mapped into mesh space at load, so the reveal
-// travels bottom-to-top regardless of how the source asset is oriented.
+// gating compares world-space height (the model only spins about the world
+// up axis, so height is stable), wobbled by a shared gradient noise so the
+// boundaries read organic; the same noise inputs gate all three stages so
+// their boundaries line up. Every mesh node and every primitive of the
+// imported model is incorporated (wire/glass geometry per node, a shell
+// material per primitive).
 //
 // Every look/timing input lives in _MaterializeSettings, editable from the
 // side panel; the print button dumps the current values to the console.
 //
-// The example reads the imported primitive's retained CPU vertex data back
+// The example reads the imported primitives' retained CPU vertex data back
 // through the internal cpuMeshData accessor to derive the wire and soup
 // geometry; in-repo example apps may reach into internals, so the lints are
 // waived for the whole file (same waiver as example_shapes.dart).
@@ -46,8 +51,9 @@ const int _kHelmetSizeBytes = 3773916;
 // Sweep overshoot below/above the model so every fade band fully clears.
 const double _kSweepPad = 0.15;
 
-/// Every tunable of the effect. Lengths are fractions of the model's height
-/// along the sweep axis; the print button dumps the current values.
+/// Every tunable of the effect. Lengths are fractions of the model's height;
+/// noise scales are cycles per model height. The print button dumps the
+/// current values.
 class _MaterializeSettings {
   // Wireframe.
   double wireThickness = 0.006;
@@ -62,6 +68,9 @@ class _MaterializeSettings {
   double glassGlowStrength = 22.0;
   vm.Vector3 flyDir = vm.Vector3(0.0, -1.0, 0.0);
   double flyDistance = 1.4;
+  double centerDistance = 0.0;
+  double normalDistance = 0.0;
+  double jitter = 0.15;
   double fadePortion = 0.64;
   double coolSpan = 0.33;
   double tumble = 2.3;
@@ -71,6 +80,10 @@ class _MaterializeSettings {
   double seamWidth = 0.23;
   vm.Vector3 seamColor = vm.Vector3(0.3, 0.9, 1.0);
   double seamStrength = 28.6;
+
+  // Boundary noise, shared by all three stages.
+  vm.Vector3 noiseScale = vm.Vector3(8.0, 8.0, 8.0);
+  double noiseAmp = 0.06;
 
   // Timing.
   double duration = 7.0;
@@ -94,6 +107,9 @@ glassGlowColor: ${v3(glassGlowColor)}
 glassGlowStrength: ${f(glassGlowStrength)}
 flyDir: ${v3(flyDir)}
 flyDistance: ${f(flyDistance)}
+centerDistance: ${f(centerDistance)}
+normalDistance: ${f(normalDistance)}
+jitter: ${f(jitter)}
 fadePortion: ${f(fadePortion)}
 coolSpan: ${f(coolSpan)}
 tumble: ${f(tumble)}
@@ -101,6 +117,8 @@ glassBand: ${f(glassBand)}
 seamWidth: ${f(seamWidth)}
 seamColor: ${v3(seamColor)}
 seamStrength: ${f(seamStrength)}
+noiseScale: ${v3(noiseScale)}
+noiseAmp: ${f(noiseAmp)}
 duration: ${f(duration)}
 lagWireToGlass: ${f(lagWireToGlass)}
 lagGlassToSolid: ${f(lagGlassToSolid)}
@@ -124,19 +142,21 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
   Object? _error;
   int _downloaded = 0;
 
-  PreprocessedMaterial? _wireMaterial;
-  PreprocessedMaterial? _glassMaterial;
-  PreprocessedMaterial? _shellMaterial;
+  // One shell material per imported primitive (each carries that primitive's
+  // textures), and one wire/glass pass per mesh node (each carries that
+  // node's world transform).
+  final List<PreprocessedMaterial> _shellMaterials = [];
+  final List<(Node, PreprocessedMaterial)> _wirePasses = [];
+  final List<(Node, PreprocessedMaterial)> _glassPasses = [];
 
   final Node _spin = Node(name: 'materialize_spin');
-  Node? _wireNode;
-  Node? _glassNode;
 
-  // The model's up axis in mesh-object space, and the vertex extent along it.
-  vm.Vector3 _sweepDir = vm.Vector3(0, 1, 0);
-  double _sweepMin = 0;
-  double _sweepMax = 1;
-  double get _sweepRange => math.max(_sweepMax - _sweepMin, 1e-3);
+  // World-space vertical extent of the whole model (all nodes, all
+  // primitives), and its center, scanned at load with the spin at identity.
+  double _minH = 0;
+  double _maxH = 1;
+  final vm.Vector3 _center = vm.Vector3.zero();
+  double get _range => math.max(_maxH - _minH, 1e-3);
 
   vm.Vector3 _cameraPosition = vm.Vector3(0, 0, -3);
   vm.Vector3 _cameraTarget = vm.Vector3.zero();
@@ -154,10 +174,6 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
 
   Future<void> _load() async {
     try {
-      final wire = await loadFmatMaterial('assets/materialize_wireframe.fmat');
-      final glass = await loadFmatMaterial('assets/materialize_glass.fmat');
-      final shell = await loadFmatMaterial('assets/materialize_shell.fmat');
-
       final bytes = await fetchResource(
         _kHelmetUrl,
         expectedSize: _kHelmetSizeBytes,
@@ -169,74 +185,104 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
       final helmet = await Node.fromGlbBytes(bytes);
       if (!mounted) return;
 
-      final meshNode = _findMeshNode(helmet);
-      if (meshNode == null) {
+      final meshNodes = <Node>[];
+      _collectMeshNodes(helmet, meshNodes);
+      if (meshNodes.isEmpty) {
         throw StateError('No mesh found in the downloaded model.');
       }
-      final primitive = meshNode.mesh!.primitives.first;
-      final source = _extractTriangleMesh(primitive.geometry);
 
-      // The source asset's mesh space is not necessarily y-up (the glTF node
-      // hierarchy carries a rotation), so map the model's world up axis into
-      // mesh space and sweep along that.
-      final inverse = vm.Matrix4.copy(meshNode.globalTransform)..invert();
-      _sweepDir = inverse.getRotation().transform(vm.Vector3(0, 1, 0))
-        ..normalize();
-      _sweepMin = double.infinity;
-      _sweepMax = double.negativeInfinity;
-      for (var v = 0; v < source.positions.length; v += 3) {
-        final s =
-            source.positions[v] * _sweepDir.x +
-            source.positions[v + 1] * _sweepDir.y +
-            source.positions[v + 2] * _sweepDir.z;
-        if (s < _sweepMin) _sweepMin = s;
-        if (s > _sweepMax) _sweepMax = s;
+      // World-space AABB across every node and primitive, for the sweep
+      // extent and the camera framing.
+      var minX = double.infinity, minY = double.infinity;
+      var minZ = double.infinity;
+      var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+      var maxZ = double.negativeInfinity;
+      var primitiveCount = 0;
+      var triangleCount = 0;
+      final scratch = vm.Vector3.zero();
+
+      for (final meshNode in meshNodes) {
+        final world = meshNode.globalTransform;
+        final parts = <_TriangleMesh>[];
+        for (final primitive in meshNode.mesh!.primitives) {
+          final source = _extractTriangleMesh(primitive.geometry);
+          parts.add(source);
+          primitiveCount++;
+          triangleCount += source.indices.length ~/ 3;
+          for (var v = 0; v < source.positions.length; v += 3) {
+            scratch.setValues(
+              source.positions[v],
+              source.positions[v + 1],
+              source.positions[v + 2],
+            );
+            world.transform3(scratch);
+            if (scratch.x < minX) minX = scratch.x;
+            if (scratch.y < minY) minY = scratch.y;
+            if (scratch.z < minZ) minZ = scratch.z;
+            if (scratch.x > maxX) maxX = scratch.x;
+            if (scratch.y > maxY) maxY = scratch.y;
+            if (scratch.z > maxZ) maxZ = scratch.z;
+          }
+
+          // Stage 3: this primitive keeps its geometry but shades through the
+          // reveal material, mirroring its own imported textures/factors.
+          final shell = await loadFmatMaterial('assets/materialize_shell.fmat');
+          _bindShellInputs(shell, primitive.material);
+          primitive.material = shell;
+          _shellMaterials.add(shell);
+        }
+
+        final source = _mergeTriangleMeshes(parts);
+
+        // Stage 1: view-facing ribbon quads over this node's unique edges.
+        final wire = await loadFmatMaterial(
+          'assets/materialize_wireframe.fmat',
+        );
+        final wireNode = Node(
+          name: 'materialize_wire',
+          mesh: Mesh(_buildWireGeometry(source), wire),
+        );
+        meshNode.add(wireNode);
+        _wirePasses.add((wireNode, wire));
+
+        // Stage 2: this node's unwelded shard soup.
+        final glass = await loadFmatMaterial('assets/materialize_glass.fmat');
+        final glassNode = Node(
+          name: 'materialize_glass',
+          mesh: Mesh(_buildGlassGeometry(source), glass),
+        );
+        meshNode.add(glassNode);
+        _glassPasses.add((glassNode, glass));
       }
-
-      // Stage 3: the original geometry, shading like the imported PBR
-      // material but clipped to the reveal front with an emissive seam.
-      _bindShellInputs(shell, primitive.material);
-      primitive.material = shell;
-
-      // Stage 1: view-facing ribbon quads over the mesh's unique edges.
-      final wireNode = Node(
-        name: 'materialize_wire',
-        mesh: Mesh(_buildWireGeometry(source), wire),
+      debugPrint(
+        'Materialize: ${meshNodes.length} mesh node(s), '
+        '$primitiveCount primitive(s), $triangleCount triangles',
       );
-      meshNode.add(wireNode);
 
-      // Stage 2: the unwelded shard soup with flat normals and per-triangle
-      // centroid/seed attributes.
-      final glassNode = Node(
-        name: 'materialize_glass',
-        mesh: Mesh(_buildGlassGeometry(source), glass),
+      _minH = minY;
+      _maxH = maxY;
+      _center.setValues(
+        (minX + maxX) / 2,
+        (minY + maxY) / 2,
+        (minZ + maxZ) / 2,
       );
-      meshNode.add(glassNode);
+      final radius = math.max(
+        vm.Vector3(maxX - minX, maxY - minY, maxZ - minZ).length * 0.5,
+        0.1,
+      );
 
       _spin.add(helmet);
       scene.add(_spin);
 
       // Frame the camera. After the importer's scene-root Z flip glTF
       // models face -Z, so the camera sits on the -Z side.
-      final bounds = primitive.geometry.localBounds;
-      final center = bounds == null
-          ? vm.Vector3.zero()
-          : vm.Vector3.copy(bounds.center);
-      final radius = bounds == null
-          ? 1.0
-          : math.max((bounds.max - bounds.min).length * 0.5, 0.1);
-      _cameraTarget = center;
+      _cameraTarget = vm.Vector3.copy(_center);
       _cameraPosition = vm.Vector3(
-        center.x + radius * 0.4,
-        center.y + radius * 0.5,
-        center.z - radius * 2.6,
+        _center.x + radius * 0.4,
+        _center.y + radius * 0.5,
+        _center.z - radius * 2.6,
       );
 
-      _wireMaterial = wire;
-      _glassMaterial = glass;
-      _shellMaterial = shell;
-      _wireNode = wireNode;
-      _glassNode = glassNode;
       _applySettings();
       _applyProgress(0);
       setState(() => _ready = true);
@@ -246,16 +292,14 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
     }
   }
 
-  Node? _findMeshNode(Node node) {
+  void _collectMeshNodes(Node node, List<Node> out) {
     final mesh = node.mesh;
     if (mesh != null && mesh.primitives.isNotEmpty) {
-      return node;
+      out.add(node);
     }
     for (final child in node.children) {
-      final found = _findMeshNode(child);
-      if (found != null) return found;
+      _collectMeshNodes(child, out);
     }
-    return null;
   }
 
   /// Copies the imported material's textures and factors into the shell
@@ -310,9 +354,47 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
       normals[v * 3 + 1] = floats[base + 4];
       normals[v * 3 + 2] = floats[base + 5];
     }
+    // Note sublistView range args count the SOURCE's elements (bytes for a
+    // ByteData), so no end bound is passed; the buffer holds exactly
+    // indexCount elements.
     final List<int> indices = data.indexType == gpu.IndexType.int32
-        ? Uint32List.sublistView(indexData, 0, data.indexCount)
-        : Uint16List.sublistView(indexData, 0, data.indexCount);
+        ? Uint32List.sublistView(indexData)
+        : Uint16List.sublistView(indexData);
+    return _TriangleMesh(positions, normals, indices);
+  }
+
+  /// Concatenates per-primitive triangle meshes (same node space) into one,
+  /// rebasing the indices.
+  _TriangleMesh _mergeTriangleMeshes(List<_TriangleMesh> parts) {
+    if (parts.length == 1) return parts.first;
+    var vertexCount = 0;
+    var indexCount = 0;
+    for (final part in parts) {
+      vertexCount += part.positions.length ~/ 3;
+      indexCount += part.indices.length;
+    }
+    final positions = Float32List(vertexCount * 3);
+    final normals = Float32List(vertexCount * 3);
+    final indices = List<int>.filled(indexCount, 0);
+    var vertexBase = 0;
+    var indexBase = 0;
+    for (final part in parts) {
+      positions.setRange(
+        vertexBase * 3,
+        vertexBase * 3 + part.positions.length,
+        part.positions,
+      );
+      normals.setRange(
+        vertexBase * 3,
+        vertexBase * 3 + part.normals.length,
+        part.normals,
+      );
+      for (var i = 0; i < part.indices.length; i++) {
+        indices[indexBase + i] = part.indices[i] + vertexBase;
+      }
+      vertexBase += part.positions.length ~/ 3;
+      indexBase += part.indices.length;
+    }
     return _TriangleMesh(positions, normals, indices);
   }
 
@@ -461,89 +543,102 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
   }
 
   /// Writes every look setting into the materials (scaled to the model's
-  /// height along the sweep axis where the setting is a fraction).
+  /// world height where the setting is a fraction).
   void _applySettings() {
-    final wire = _wireMaterial;
-    final glass = _glassMaterial;
-    final shell = _shellMaterial;
-    if (wire == null || glass == null || shell == null) return;
+    if (_shellMaterials.isEmpty) return;
     final s = _settings;
-    final range = _sweepRange;
+    final range = _range;
+    final noiseScale = s.noiseScale / range;
+    final noiseAmp = s.noiseAmp * range;
 
-    wire.parameters
-      ..setVec3('sweep_dir', _sweepDir)
-      ..setFloat('band', range * 0.06)
-      ..setFloat('thickness', range * s.wireThickness)
-      ..setFloat('inflate', range * 0.004)
-      ..setVec4(
-        'wire_color',
-        vm.Vector4(s.wireColor.x, s.wireColor.y, s.wireColor.z, s.wireAlpha),
-      )
-      ..setFloat('glow_strength', s.wireGlow);
+    for (final (_, wire) in _wirePasses) {
+      wire.parameters
+        ..setFloat('band', range * 0.06)
+        ..setFloat('thickness', range * s.wireThickness)
+        ..setFloat('inflate', range * 0.004)
+        ..setVec4(
+          'wire_color',
+          vm.Vector4(s.wireColor.x, s.wireColor.y, s.wireColor.z, s.wireAlpha),
+        )
+        ..setFloat('glow_strength', s.wireGlow)
+        ..setVec3('noise_scale', noiseScale)
+        ..setFloat('noise_amp', noiseAmp);
+    }
 
-    glass.parameters
-      ..setVec3('sweep_dir', _sweepDir)
-      ..setFloat('band', range * s.glassBand)
-      ..setVec3('fly_dir', s.flyDir)
-      ..setFloat('fly_distance', range * s.flyDistance)
-      ..setFloat('fade_portion', s.fadePortion)
-      ..setFloat('cool_span', s.coolSpan)
-      ..setFloat('tumble', s.tumble)
-      ..setVec4(
-        'glass_color',
-        vm.Vector4(s.glassTint.x, s.glassTint.y, s.glassTint.z, s.glassAlpha),
-      )
-      ..setVec3('glow_color', s.glassGlowColor)
-      ..setFloat('glow_strength', s.glassGlowStrength);
+    for (final (_, glass) in _glassPasses) {
+      glass.parameters
+        ..setFloat('band', range * s.glassBand)
+        ..setVec3('fly_dir', s.flyDir)
+        ..setFloat('fly_distance', range * s.flyDistance)
+        ..setFloat('center_distance', range * s.centerDistance)
+        ..setFloat('normal_distance', range * s.normalDistance)
+        ..setFloat('jitter', range * s.jitter)
+        ..setFloat('fade_portion', s.fadePortion)
+        ..setFloat('cool_span', s.coolSpan)
+        ..setFloat('tumble', s.tumble)
+        ..setVec4(
+          'glass_color',
+          vm.Vector4(s.glassTint.x, s.glassTint.y, s.glassTint.z, s.glassAlpha),
+        )
+        ..setVec3('glow_color', s.glassGlowColor)
+        ..setFloat('glow_strength', s.glassGlowStrength)
+        ..setVec3('noise_scale', noiseScale)
+        ..setFloat('noise_amp', noiseAmp);
+    }
 
-    shell.parameters
-      ..setVec3('sweep_dir', _sweepDir)
-      ..setFloat('seam_width', range * s.seamWidth)
-      ..setVec4(
-        'seam_color',
-        vm.Vector4(s.seamColor.x, s.seamColor.y, s.seamColor.z, 1.0),
-      )
-      ..setFloat('seam_strength', s.seamStrength);
+    for (final shell in _shellMaterials) {
+      shell.parameters
+        ..setFloat('seam_width', range * s.seamWidth)
+        ..setVec4(
+          'seam_color',
+          vm.Vector4(s.seamColor.x, s.seamColor.y, s.seamColor.z, 1.0),
+        )
+        ..setFloat('seam_strength', s.seamStrength)
+        ..setVec3('noise_scale', noiseScale)
+        ..setFloat('noise_amp', noiseAmp);
+    }
   }
 
   /// Maps eased progress to the three staggered sweep fronts and writes them
   /// (plus the animated inputs) into the materials.
   void _applyProgress(double elapsedSeconds) {
-    final wire = _wireMaterial;
-    final glass = _glassMaterial;
-    final shell = _shellMaterial;
-    final wireNode = _wireNode;
-    final glassNode = _glassNode;
-    if (wire == null ||
-        glass == null ||
-        shell == null ||
-        wireNode == null ||
-        glassNode == null) {
-      return;
-    }
+    if (_shellMaterials.isEmpty) return;
     final s = _settings;
     final p = _t.clamp(0.0, 1.0);
     final eased = p * p * (3 - 2 * p);
 
-    const start = -_kSweepPad;
-    final end = 1.0 + s.lagWireToGlass + s.lagGlassToSolid + _kSweepPad;
+    // Pad past the noise amplitude so the wobbled boundaries fully clear.
+    final pad = _kSweepPad + s.noiseAmp;
+    final start = -pad;
+    final end = 1.0 + s.lagWireToGlass + s.lagGlassToSolid + pad;
     final wireN = start + eased * (end - start);
-    double front(double n) => _sweepMin + n * _sweepRange;
+    double front(double n) => _minH + n * _range;
 
     final wireFront = front(wireN);
     final glassFront = front(wireN - s.lagWireToGlass);
     final solidFront = front(wireN - s.lagWireToGlass - s.lagGlassToSolid);
 
-    wire.parameters
-      ..setFloat('wire_front', wireFront)
-      ..setFloat('solid_front', solidFront)
-      ..setMat4('model_matrix', wireNode.globalTransform);
-    glass.parameters
-      ..setFloat('glass_front', glassFront)
-      ..setFloat('solid_front', solidFront)
-      ..setFloat('time', elapsedSeconds)
-      ..setMat4('model_matrix', glassNode.globalTransform);
-    shell.parameters.setFloat('solid_front', solidFront);
+    // The model center, spun along with the model, for the radial scatter.
+    final center = vm.Vector3.copy(_center);
+    _spin.globalTransform.transform3(center);
+
+    for (final (node, wire) in _wirePasses) {
+      wire.parameters
+        ..setFloat('wire_front', wireFront)
+        ..setFloat('solid_front', solidFront)
+        ..setMat4('model_matrix', node.globalTransform);
+    }
+    for (final (node, glass) in _glassPasses) {
+      glass.parameters
+        ..setFloat('glass_front', glassFront)
+        ..setFloat('solid_front', solidFront)
+        ..setFloat('time', elapsedSeconds)
+        ..setVec3('model_center', center)
+        ..setMat4('model_matrix', node.globalTransform);
+    }
+    for (final shell in _shellMaterials) {
+      shell.parameters.setFloat('solid_front', solidFront);
+    }
   }
 
   @override
@@ -615,8 +710,15 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
             showSkybox: false,
           ),
         ),
-        Positioned(top: 8, right: 8, bottom: 8, child: _settingsPanel()),
-        Positioned(top: 8, left: 8, child: _playbackBar()),
+        // The panel starts below the debug banner and the global settings
+        // buttons in the top-right corner.
+        Positioned(top: 72, right: 8, bottom: 8, child: _settingsPanel()),
+        Positioned(
+          top: 8,
+          left: 0,
+          right: 0,
+          child: Center(child: _playbackBar()),
+        ),
       ],
     );
   }
@@ -765,9 +867,30 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
                     _slider(
                       'Fly distance',
                       _settings.flyDistance,
-                      0.1,
+                      0.0,
                       4.0,
                       (v) => _settings.flyDistance = v,
+                    ),
+                    _slider(
+                      'From center',
+                      _settings.centerDistance,
+                      0.0,
+                      3.0,
+                      (v) => _settings.centerDistance = v,
+                    ),
+                    _slider(
+                      'Off normal',
+                      _settings.normalDistance,
+                      0.0,
+                      2.0,
+                      (v) => _settings.normalDistance = v,
+                    ),
+                    _slider(
+                      'Jitter',
+                      _settings.jitter,
+                      0.0,
+                      1.0,
+                      (v) => _settings.jitter = v,
                     ),
                     _slider(
                       'Fade portion',
@@ -817,6 +940,34 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
                       0.0,
                       40.0,
                       (v) => _settings.seamStrength = v,
+                    ),
+                    _slider(
+                      'Noise scale X',
+                      _settings.noiseScale.x,
+                      0.5,
+                      30.0,
+                      (v) => _settings.noiseScale.x = v,
+                    ),
+                    _slider(
+                      'Noise scale Y',
+                      _settings.noiseScale.y,
+                      0.5,
+                      30.0,
+                      (v) => _settings.noiseScale.y = v,
+                    ),
+                    _slider(
+                      'Noise scale Z',
+                      _settings.noiseScale.z,
+                      0.5,
+                      30.0,
+                      (v) => _settings.noiseScale.z = v,
+                    ),
+                    _slider(
+                      'Noise amount',
+                      _settings.noiseAmp,
+                      0.0,
+                      0.3,
+                      (v) => _settings.noiseAmp = v,
                     ),
                   ]),
                   _section('Timing', [

--- a/examples/flutter_app/lib/example_materialize.dart
+++ b/examples/flutter_app/lib/example_materialize.dart
@@ -22,8 +22,10 @@
 // imported model is incorporated (wire/glass geometry per node, a shell
 // material per primitive).
 //
-// Every look/timing input lives in _MaterializeSettings, editable from the
-// side panel; the print button dumps the current values to the console.
+// Every look/timing input lives in MaterializeSettings (see
+// materialize_settings.dart, which also holds the side panel and the
+// playback bar); the panel's print button dumps the current values to the
+// console.
 //
 // The example reads the imported primitives' retained CPU vertex data back
 // through the internal cpuMeshData accessor to derive the wire and soup
@@ -42,6 +44,7 @@ import 'package:vector_math/vector_math.dart' as vm;
 import 'environment_menu.dart' show EnvironmentSelector, fetchResource;
 import 'example_settings.dart';
 import 'lighting_panel.dart';
+import 'materialize_settings.dart';
 
 const String _kHelmetUrl =
     'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/'
@@ -50,81 +53,6 @@ const int _kHelmetSizeBytes = 3773916;
 
 // Sweep overshoot below/above the model so every fade band fully clears.
 const double _kSweepPad = 0.15;
-
-/// Every tunable of the effect. Lengths are fractions of the model's height;
-/// noise scales are cycles per model height. The print button dumps the
-/// current values.
-class _MaterializeSettings {
-  // Wireframe.
-  double wireThickness = 0.002;
-  vm.Vector3 wireColor = vm.Vector3(0.16, 0.64, 1.0);
-  double wireAlpha = 0.85;
-  double wireGlow = 27.5;
-
-  // Glass.
-  vm.Vector3 glassTint = vm.Vector3(0.5, 0.85, 1.0);
-  double glassAlpha = 0.2;
-  vm.Vector3 glassGlowColor = vm.Vector3(1.0, 1.0, 0.6);
-  double glassGlowStrength = 1.9;
-  vm.Vector3 flyDir = vm.Vector3(0.0, 1.0, 0.0);
-  double flyDistance = 0.0;
-  double centerDistance = 0.45;
-  double normalDistance = 1.5;
-  double jitter = 0.32;
-  double fadePortion = 0.64;
-  double coolSpan = 0.62;
-  double tumble = 2.3;
-  double glassBand = 0.84;
-
-  // Shell reveal.
-  double seamWidth = 0.12;
-  vm.Vector3 seamColor = vm.Vector3(0.3, 0.9, 1.0);
-  double seamStrength = 40.0;
-
-  // Boundary noise, shared by all three stages.
-  vm.Vector3 noiseScale = vm.Vector3(3.4, 0.5, 3.9);
-  double noiseAmp = 0.11;
-
-  // Timing.
-  double duration = 7.0;
-  double lagWireToGlass = 0.0;
-  double lagGlassToSolid = 1.5;
-
-  String dump() {
-    String v3(vm.Vector3 v) =>
-        '${v.x.toStringAsFixed(3)}, ${v.y.toStringAsFixed(3)}, '
-        '${v.z.toStringAsFixed(3)}';
-    String f(double v) => v.toStringAsFixed(3);
-    return '''
-=== Materialize settings ===
-wireThickness: ${f(wireThickness)}
-wireColor: ${v3(wireColor)}
-wireAlpha: ${f(wireAlpha)}
-wireGlow: ${f(wireGlow)}
-glassTint: ${v3(glassTint)}
-glassAlpha: ${f(glassAlpha)}
-glassGlowColor: ${v3(glassGlowColor)}
-glassGlowStrength: ${f(glassGlowStrength)}
-flyDir: ${v3(flyDir)}
-flyDistance: ${f(flyDistance)}
-centerDistance: ${f(centerDistance)}
-normalDistance: ${f(normalDistance)}
-jitter: ${f(jitter)}
-fadePortion: ${f(fadePortion)}
-coolSpan: ${f(coolSpan)}
-tumble: ${f(tumble)}
-glassBand: ${f(glassBand)}
-seamWidth: ${f(seamWidth)}
-seamColor: ${v3(seamColor)}
-seamStrength: ${f(seamStrength)}
-noiseScale: ${v3(noiseScale)}
-noiseAmp: ${f(noiseAmp)}
-duration: ${f(duration)}
-lagWireToGlass: ${f(lagWireToGlass)}
-lagGlassToSolid: ${f(lagGlassToSolid)}
-============================''';
-  }
-}
 
 class ExampleMaterialize extends StatefulWidget {
   const ExampleMaterialize({super.key});
@@ -135,7 +63,7 @@ class ExampleMaterialize extends StatefulWidget {
 
 class _ExampleMaterializeState extends State<ExampleMaterialize> {
   final Scene scene = Scene();
-  final _MaterializeSettings _settings = _MaterializeSettings();
+  final MaterializeSettings _settings = MaterializeSettings();
   final EnvironmentSelector _environmentSelector = EnvironmentSelector();
 
   bool _ready = false;
@@ -716,410 +644,32 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
         ),
         // The panel starts below the debug banner and the global settings
         // buttons in the top-right corner.
-        Positioned(top: 72, right: 8, bottom: 8, child: _settingsPanel()),
+        Positioned(
+          top: 72,
+          right: 8,
+          bottom: 8,
+          child: MaterializeSettingsPanel(
+            settings: _settings,
+            onChanged: _applySettings,
+          ),
+        ),
         Positioned(
           top: 8,
           left: 0,
           right: 0,
-          child: Center(child: _playbackBar()),
-        ),
-      ],
-    );
-  }
-
-  Widget _playbackBar() {
-    return Card(
-      color: Colors.black54,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            IconButton(
-              icon: Icon(
-                _playing ? Icons.pause : Icons.play_arrow,
-                color: Colors.white,
-              ),
-              onPressed: () => setState(() => _playing = !_playing),
-            ),
-            IconButton(
-              icon: const Icon(Icons.replay, color: Colors.white),
-              onPressed: () => setState(() {
+          child: Center(
+            child: MaterializePlaybackBar(
+              playing: _playing,
+              progress: _t.clamp(0.0, 1.0).toDouble(),
+              onPlayingChanged: (playing) => setState(() => _playing = playing),
+              onRestart: () => setState(() {
                 _t = -0.05;
                 _playing = true;
               }),
-            ),
-            SizedBox(
-              width: 220,
-              child: Slider(
-                value: _t.clamp(0.0, 1.0).toDouble(),
-                onChangeStart: (_) => setState(() => _playing = false),
-                onChanged: (value) => setState(() => _t = value),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _settingsPanel() {
-    return SizedBox(
-      width: 290,
-      child: Card(
-        color: Colors.black54,
-        child: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(12, 8, 4, 0),
-              child: Row(
-                children: [
-                  const Text(
-                    'Effect settings',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const Spacer(),
-                  IconButton(
-                    tooltip: 'Print settings to console',
-                    icon: const Icon(Icons.print, color: Colors.white),
-                    onPressed: () => debugPrint(_settings.dump()),
-                  ),
-                ],
-              ),
-            ),
-            Expanded(
-              child: ListView(
-                padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
-                children: [
-                  _section('Wireframe', [
-                    _slider(
-                      'Thickness',
-                      _settings.wireThickness,
-                      0.001,
-                      0.03,
-                      (v) => _settings.wireThickness = v,
-                    ),
-                    _colorRow(
-                      'Color',
-                      _settings.wireColor,
-                      (v) => _settings.wireColor = v,
-                    ),
-                    _slider(
-                      'Opacity',
-                      _settings.wireAlpha,
-                      0.0,
-                      1.0,
-                      (v) => _settings.wireAlpha = v,
-                    ),
-                    _slider(
-                      'Front glow',
-                      _settings.wireGlow,
-                      0.0,
-                      30.0,
-                      (v) => _settings.wireGlow = v,
-                    ),
-                  ]),
-                  _section('Glass', [
-                    _colorRow(
-                      'Tint',
-                      _settings.glassTint,
-                      (v) => _settings.glassTint = v,
-                    ),
-                    _slider(
-                      'Translucency',
-                      _settings.glassAlpha,
-                      0.0,
-                      1.0,
-                      (v) => _settings.glassAlpha = v,
-                    ),
-                    _colorRow(
-                      'Glow color',
-                      _settings.glassGlowColor,
-                      (v) => _settings.glassGlowColor = v,
-                    ),
-                    _slider(
-                      'Glow intensity',
-                      _settings.glassGlowStrength,
-                      0.0,
-                      30.0,
-                      (v) => _settings.glassGlowStrength = v,
-                    ),
-                    _slider(
-                      'Fly-in X',
-                      _settings.flyDir.x,
-                      -1.0,
-                      1.0,
-                      (v) => _settings.flyDir.x = v,
-                    ),
-                    _slider(
-                      'Fly-in Y',
-                      _settings.flyDir.y,
-                      -1.0,
-                      1.0,
-                      (v) => _settings.flyDir.y = v,
-                    ),
-                    _slider(
-                      'Fly-in Z',
-                      _settings.flyDir.z,
-                      -1.0,
-                      1.0,
-                      (v) => _settings.flyDir.z = v,
-                    ),
-                    _slider(
-                      'Fly distance',
-                      _settings.flyDistance,
-                      0.0,
-                      4.0,
-                      (v) => _settings.flyDistance = v,
-                    ),
-                    _slider(
-                      'From center',
-                      _settings.centerDistance,
-                      0.0,
-                      3.0,
-                      (v) => _settings.centerDistance = v,
-                    ),
-                    _slider(
-                      'Off normal',
-                      _settings.normalDistance,
-                      0.0,
-                      2.0,
-                      (v) => _settings.normalDistance = v,
-                    ),
-                    _slider(
-                      'Jitter',
-                      _settings.jitter,
-                      0.0,
-                      1.0,
-                      (v) => _settings.jitter = v,
-                    ),
-                    _slider(
-                      'Fade portion',
-                      _settings.fadePortion,
-                      0.05,
-                      1.0,
-                      (v) => _settings.fadePortion = v,
-                    ),
-                    _slider(
-                      'Glow cool span',
-                      _settings.coolSpan,
-                      0.05,
-                      4.0,
-                      (v) => _settings.coolSpan = v,
-                    ),
-                    _slider(
-                      'Tumble',
-                      _settings.tumble,
-                      0.0,
-                      3.0,
-                      (v) => _settings.tumble = v,
-                    ),
-                    _slider(
-                      'Assembly band',
-                      _settings.glassBand,
-                      0.05,
-                      1.0,
-                      (v) => _settings.glassBand = v,
-                    ),
-                  ]),
-                  _section('Reveal', [
-                    _slider(
-                      'Seam thickness',
-                      _settings.seamWidth,
-                      0.005,
-                      0.3,
-                      (v) => _settings.seamWidth = v,
-                    ),
-                    _colorRow(
-                      'Seam color',
-                      _settings.seamColor,
-                      (v) => _settings.seamColor = v,
-                    ),
-                    _slider(
-                      'Seam brightness',
-                      _settings.seamStrength,
-                      0.0,
-                      40.0,
-                      (v) => _settings.seamStrength = v,
-                    ),
-                    _slider(
-                      'Noise scale X',
-                      _settings.noiseScale.x,
-                      0.5,
-                      30.0,
-                      (v) => _settings.noiseScale.x = v,
-                    ),
-                    _slider(
-                      'Noise scale Y',
-                      _settings.noiseScale.y,
-                      0.5,
-                      30.0,
-                      (v) => _settings.noiseScale.y = v,
-                    ),
-                    _slider(
-                      'Noise scale Z',
-                      _settings.noiseScale.z,
-                      0.5,
-                      30.0,
-                      (v) => _settings.noiseScale.z = v,
-                    ),
-                    _slider(
-                      'Noise amount',
-                      _settings.noiseAmp,
-                      0.0,
-                      0.3,
-                      (v) => _settings.noiseAmp = v,
-                    ),
-                  ]),
-                  _section('Timing', [
-                    _slider(
-                      'Cycle seconds',
-                      _settings.duration,
-                      3.0,
-                      20.0,
-                      (v) => _settings.duration = v,
-                    ),
-                    _slider(
-                      'Wire to glass lag',
-                      _settings.lagWireToGlass,
-                      0.0,
-                      1.0,
-                      (v) => _settings.lagWireToGlass = v,
-                    ),
-                    _slider(
-                      'Glass to solid lag',
-                      _settings.lagGlassToSolid,
-                      0.0,
-                      1.5,
-                      (v) => _settings.lagGlassToSolid = v,
-                    ),
-                  ]),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _section(String title, List<Widget> children) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.only(top: 8, bottom: 2),
-          child: Text(
-            title,
-            style: const TextStyle(
-              color: Colors.white70,
-              fontWeight: FontWeight.bold,
-              fontSize: 12,
+              onScrub: (value) => setState(() => _t = value),
             ),
           ),
         ),
-        ...children,
-      ],
-    );
-  }
-
-  Widget _slider(
-    String label,
-    double value,
-    double min,
-    double max,
-    void Function(double) apply,
-  ) {
-    return Row(
-      children: [
-        SizedBox(
-          width: 108,
-          child: Text(
-            label,
-            style: const TextStyle(color: Colors.white, fontSize: 11),
-          ),
-        ),
-        Expanded(
-          child: SliderTheme(
-            data: SliderTheme.of(context).copyWith(
-              trackHeight: 2,
-              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
-            ),
-            child: Slider(
-              value: value.clamp(min, max).toDouble(),
-              min: min,
-              max: max,
-              onChanged: (v) => setState(() {
-                apply(v);
-                _applySettings();
-              }),
-            ),
-          ),
-        ),
-        SizedBox(
-          width: 34,
-          child: Text(
-            value.toStringAsFixed(2),
-            style: const TextStyle(color: Colors.white54, fontSize: 10),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _colorRow(
-    String label,
-    vm.Vector3 color,
-    void Function(vm.Vector3) apply,
-  ) {
-    Widget channel(String name, double value, void Function(double) set) {
-      return Expanded(
-        child: SliderTheme(
-          data: SliderTheme.of(context).copyWith(
-            trackHeight: 2,
-            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 5),
-          ),
-          child: Slider(
-            value: value.clamp(0.0, 1.0).toDouble(),
-            onChanged: (v) => setState(() {
-              set(v);
-              apply(color);
-              _applySettings();
-            }),
-          ),
-        ),
-      );
-    }
-
-    return Row(
-      children: [
-        SizedBox(
-          width: 76,
-          child: Text(
-            label,
-            style: const TextStyle(color: Colors.white, fontSize: 11),
-          ),
-        ),
-        Container(
-          width: 14,
-          height: 14,
-          margin: const EdgeInsets.only(right: 4),
-          decoration: BoxDecoration(
-            color: Color.fromARGB(
-              255,
-              (color.x * 255).round(),
-              (color.y * 255).round(),
-              (color.z * 255).round(),
-            ),
-            borderRadius: BorderRadius.circular(3),
-          ),
-        ),
-        channel('R', color.x, (v) => color.x = v),
-        channel('G', color.y, (v) => color.y = v),
-        channel('B', color.z, (v) => color.z = v),
       ],
     );
   }

--- a/examples/flutter_app/lib/example_materialize.dart
+++ b/examples/flutter_app/lib/example_materialize.dart
@@ -57,25 +57,25 @@ class _MaterializeSettings {
 
   // Glass.
   vm.Vector3 glassTint = vm.Vector3(0.5, 0.85, 1.0);
-  double glassAlpha = 0.16;
-  vm.Vector3 glassGlowColor = vm.Vector3(0.3, 0.9, 1.0);
-  double glassGlowStrength = 6.0;
-  vm.Vector3 flyDir = vm.Vector3(0.35, 1.0, -0.3);
-  double flyDistance = 1.2;
-  double fadePortion = 0.35;
-  double coolSpan = 1.5;
-  double tumble = 1.0;
-  double glassBand = 0.3;
+  double glassAlpha = 0.69;
+  vm.Vector3 glassGlowColor = vm.Vector3(1.0, 1.0, 0.6);
+  double glassGlowStrength = 22.0;
+  vm.Vector3 flyDir = vm.Vector3(0.0, -1.0, 0.0);
+  double flyDistance = 1.4;
+  double fadePortion = 0.64;
+  double coolSpan = 0.33;
+  double tumble = 2.3;
+  double glassBand = 0.5;
 
   // Shell reveal.
-  double seamWidth = 0.05;
+  double seamWidth = 0.23;
   vm.Vector3 seamColor = vm.Vector3(0.3, 0.9, 1.0);
-  double seamStrength = 16.0;
+  double seamStrength = 28.6;
 
   // Timing.
-  double duration = 10.0;
-  double lagWireToGlass = 0.25;
-  double lagGlassToSolid = 0.6;
+  double duration = 7.0;
+  double lagWireToGlass = 0.0;
+  double lagGlassToSolid = 1.05;
 
   String dump() {
     String v3(vm.Vector3 v) =>

--- a/examples/flutter_app/lib/example_materialize.dart
+++ b/examples/flutter_app/lib/example_materialize.dart
@@ -1,18 +1,24 @@
-// Materialize showcase. The DamagedHelmet phases into existence bottom-to-top
-// in three stages, each its own draw call over the same model:
-//   1. A wireframe forms (line-list geometry over the mesh's unique edges,
-//      unlit translucent .fmat with a glowing sweep front).
+// Materialize showcase. The DamagedHelmet phases into existence from the
+// bottom of the model to the top in three stages, each its own draw call over
+// the same model:
+//   1. A wireframe forms (view-facing ribbon quads over the mesh's unique
+//      edges, unlit translucent .fmat with a glowing sweep front).
 //   2. Glass triangles fly in and assemble over it (unwelded triangle soup
-//      with flat outward normals; a per-triangle centroid + seed attribute
-//      lets the vertex stage scatter each shard along its face normal with a
-//      seeded tumble and pull it into place).
+//      with flat outward normals; per-triangle centroid + seed attributes let
+//      the vertex stage fly each shard in from a settable world direction,
+//      fading in at a distance and easing along an s-curve into a soft
+//      landing, then glowing on the surface until the shell phases over it).
 //   3. The real PBR surface reveals itself behind a hot emissive seam (the
 //      original geometry with a .fmat that replicates standard PBR sampling,
 //      re-binding the model's own textures, and discards above the front).
 //
-// A single eased progress value drives three object-space front heights
-// (wire leads, glass lags, solid trails), written into the materials each
-// tick, so all gating is a per-fragment compare against vertex.position.y.
+// A single eased progress value drives three staggered sweep fronts. All
+// gating compares dot(position, sweep_dir) in object space, where sweep_dir
+// is the model's up axis mapped into mesh space at load, so the reveal
+// travels bottom-to-top regardless of how the source asset is oriented.
+//
+// Every look/timing input lives in _MaterializeSettings, editable from the
+// side panel; the print button dumps the current values to the console.
 //
 // The example reads the imported primitive's retained CPU vertex data back
 // through the internal cpuMeshData accessor to derive the wire and soup
@@ -28,18 +34,79 @@ import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart' as vm;
 
-import 'environment_menu.dart' show fetchResource;
+import 'environment_menu.dart' show EnvironmentSelector, fetchResource;
 import 'example_settings.dart';
+import 'lighting_panel.dart';
 
 const String _kHelmetUrl =
     'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/'
     'main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb';
 const int _kHelmetSizeBytes = 3773916;
 
-// How far (in normalized model height) each stage trails the one before it.
-const double _kStageLag = 0.35;
 // Sweep overshoot below/above the model so every fade band fully clears.
 const double _kSweepPad = 0.15;
+
+/// Every tunable of the effect. Lengths are fractions of the model's height
+/// along the sweep axis; the print button dumps the current values.
+class _MaterializeSettings {
+  // Wireframe.
+  double wireThickness = 0.006;
+  vm.Vector3 wireColor = vm.Vector3(0.25, 0.85, 1.0);
+  double wireAlpha = 0.85;
+  double wireGlow = 8.0;
+
+  // Glass.
+  vm.Vector3 glassTint = vm.Vector3(0.5, 0.85, 1.0);
+  double glassAlpha = 0.16;
+  vm.Vector3 glassGlowColor = vm.Vector3(0.3, 0.9, 1.0);
+  double glassGlowStrength = 6.0;
+  vm.Vector3 flyDir = vm.Vector3(0.35, 1.0, -0.3);
+  double flyDistance = 1.2;
+  double fadePortion = 0.35;
+  double coolSpan = 1.5;
+  double tumble = 1.0;
+  double glassBand = 0.3;
+
+  // Shell reveal.
+  double seamWidth = 0.05;
+  vm.Vector3 seamColor = vm.Vector3(0.3, 0.9, 1.0);
+  double seamStrength = 16.0;
+
+  // Timing.
+  double duration = 10.0;
+  double lagWireToGlass = 0.25;
+  double lagGlassToSolid = 0.6;
+
+  String dump() {
+    String v3(vm.Vector3 v) =>
+        '${v.x.toStringAsFixed(3)}, ${v.y.toStringAsFixed(3)}, '
+        '${v.z.toStringAsFixed(3)}';
+    String f(double v) => v.toStringAsFixed(3);
+    return '''
+=== Materialize settings ===
+wireThickness: ${f(wireThickness)}
+wireColor: ${v3(wireColor)}
+wireAlpha: ${f(wireAlpha)}
+wireGlow: ${f(wireGlow)}
+glassTint: ${v3(glassTint)}
+glassAlpha: ${f(glassAlpha)}
+glassGlowColor: ${v3(glassGlowColor)}
+glassGlowStrength: ${f(glassGlowStrength)}
+flyDir: ${v3(flyDir)}
+flyDistance: ${f(flyDistance)}
+fadePortion: ${f(fadePortion)}
+coolSpan: ${f(coolSpan)}
+tumble: ${f(tumble)}
+glassBand: ${f(glassBand)}
+seamWidth: ${f(seamWidth)}
+seamColor: ${v3(seamColor)}
+seamStrength: ${f(seamStrength)}
+duration: ${f(duration)}
+lagWireToGlass: ${f(lagWireToGlass)}
+lagGlassToSolid: ${f(lagGlassToSolid)}
+============================''';
+  }
+}
 
 class ExampleMaterialize extends StatefulWidget {
   const ExampleMaterialize({super.key});
@@ -50,6 +117,8 @@ class ExampleMaterialize extends StatefulWidget {
 
 class _ExampleMaterializeState extends State<ExampleMaterialize> {
   final Scene scene = Scene();
+  final _MaterializeSettings _settings = _MaterializeSettings();
+  final EnvironmentSelector _environmentSelector = EnvironmentSelector();
 
   bool _ready = false;
   Object? _error;
@@ -60,12 +129,14 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
   PreprocessedMaterial? _shellMaterial;
 
   final Node _spin = Node(name: 'materialize_spin');
+  Node? _wireNode;
   Node? _glassNode;
 
-  // Object-space vertical extent of the helmet, from the shell geometry's
-  // local bounds. Every sweep front is derived from these.
-  double _minY = 0;
-  double _maxY = 1;
+  // The model's up axis in mesh-object space, and the vertex extent along it.
+  vm.Vector3 _sweepDir = vm.Vector3(0, 1, 0);
+  double _sweepMin = 0;
+  double _sweepMax = 1;
+  double get _sweepRange => math.max(_sweepMax - _sweepMin, 1e-3);
 
   vm.Vector3 _cameraPosition = vm.Vector3(0, 0, -3);
   vm.Vector3 _cameraTarget = vm.Vector3.zero();
@@ -74,7 +145,6 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
   // fully materialized and fully hidden.
   double _t = -0.05;
   bool _playing = true;
-  double _duration = 8.0;
 
   @override
   void initState() {
@@ -106,30 +176,34 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
       final primitive = meshNode.mesh!.primitives.first;
       final source = _extractTriangleMesh(primitive.geometry);
 
-      final bounds = primitive.geometry.localBounds;
-      if (bounds == null) {
-        throw StateError('Imported geometry has no local bounds.');
+      // The source asset's mesh space is not necessarily y-up (the glTF node
+      // hierarchy carries a rotation), so map the model's world up axis into
+      // mesh space and sweep along that.
+      final inverse = vm.Matrix4.copy(meshNode.globalTransform)..invert();
+      _sweepDir = inverse.getRotation().transform(vm.Vector3(0, 1, 0))
+        ..normalize();
+      _sweepMin = double.infinity;
+      _sweepMax = double.negativeInfinity;
+      for (var v = 0; v < source.positions.length; v += 3) {
+        final s =
+            source.positions[v] * _sweepDir.x +
+            source.positions[v + 1] * _sweepDir.y +
+            source.positions[v + 2] * _sweepDir.z;
+        if (s < _sweepMin) _sweepMin = s;
+        if (s > _sweepMax) _sweepMax = s;
       }
-      _minY = bounds.min.y;
-      _maxY = bounds.max.y;
-      final height = math.max(_maxY - _minY, 1e-3);
 
       // Stage 3: the original geometry, shading like the imported PBR
       // material but clipped to the reveal front with an emissive seam.
       _bindShellInputs(shell, primitive.material);
-      shell.parameters.setFloat('seam_width', height * 0.05);
       primitive.material = shell;
 
-      // Stage 1: the unique triangle edges as a line list. Source positions
-      // and normals are reused so the lines can inflate off the surface.
+      // Stage 1: view-facing ribbon quads over the mesh's unique edges.
       final wireNode = Node(
         name: 'materialize_wire',
         mesh: Mesh(_buildWireGeometry(source), wire),
       );
       meshNode.add(wireNode);
-      wire.parameters
-        ..setFloat('band', height * 0.06)
-        ..setFloat('inflate', height * 0.004);
 
       // Stage 2: the unwelded shard soup with flat normals and per-triangle
       // centroid/seed attributes.
@@ -138,17 +212,19 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
         mesh: Mesh(_buildGlassGeometry(source), glass),
       );
       meshNode.add(glassNode);
-      glass.parameters
-        ..setFloat('band', height * 0.30)
-        ..setFloat('scatter', height * 0.8);
 
       _spin.add(helmet);
       scene.add(_spin);
 
       // Frame the camera. After the importer's scene-root Z flip glTF
       // models face -Z, so the camera sits on the -Z side.
-      final center = vm.Vector3.copy(bounds.center);
-      final radius = math.max((bounds.max - bounds.min).length * 0.5, 0.1);
+      final bounds = primitive.geometry.localBounds;
+      final center = bounds == null
+          ? vm.Vector3.zero()
+          : vm.Vector3.copy(bounds.center);
+      final radius = bounds == null
+          ? 1.0
+          : math.max((bounds.max - bounds.min).length * 0.5, 0.1);
       _cameraTarget = center;
       _cameraPosition = vm.Vector3(
         center.x + radius * 0.4,
@@ -159,7 +235,9 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
       _wireMaterial = wire;
       _glassMaterial = glass;
       _shellMaterial = shell;
+      _wireNode = wireNode;
       _glassNode = glassNode;
+      _applySettings();
       _applyProgress(0);
       setState(() => _ready = true);
     } catch (e) {
@@ -238,33 +316,67 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
     return _TriangleMesh(positions, normals, indices);
   }
 
-  /// A line list over the mesh's unique undirected edges. Shared edges are
-  /// deduplicated so the translucent lines do not double-blend.
+  /// A view-facing ribbon quad per unique undirected edge. Each vertex
+  /// carries the opposite endpoint and a side sign; the material's vertex
+  /// stage expands the quad perpendicular to the edge and the view.
   MeshGeometry _buildWireGeometry(_TriangleMesh source) {
     final seen = <int>{};
-    final edges = <int>[];
+    final edgeA = <int>[];
+    final edgeB = <int>[];
     void addEdge(int a, int b) {
       final lo = math.min(a, b);
       final hi = math.max(a, b);
       if (seen.add(lo * 0x100000 + hi)) {
-        edges
-          ..add(lo)
-          ..add(hi);
+        edgeA.add(lo);
+        edgeB.add(hi);
       }
     }
 
-    final indices = source.indices;
-    for (var t = 0; t + 2 < indices.length; t += 3) {
-      addEdge(indices[t], indices[t + 1]);
-      addEdge(indices[t + 1], indices[t + 2]);
-      addEdge(indices[t + 2], indices[t]);
+    final srcIndices = source.indices;
+    for (var t = 0; t + 2 < srcIndices.length; t += 3) {
+      addEdge(srcIndices[t], srcIndices[t + 1]);
+      addEdge(srcIndices[t + 1], srcIndices[t + 2]);
+      addEdge(srcIndices[t + 2], srcIndices[t]);
+    }
+
+    final edgeCount = edgeA.length;
+    final positions = Float32List(edgeCount * 12);
+    final normals = Float32List(edgeCount * 12);
+    final others = Float32List(edgeCount * 12);
+    final sides = Float32List(edgeCount * 4);
+    final indices = List<int>.filled(edgeCount * 6, 0);
+    void writeVec3(Float32List dst, int vertex, Float32List src, int index) {
+      dst[vertex * 3] = src[index * 3];
+      dst[vertex * 3 + 1] = src[index * 3 + 1];
+      dst[vertex * 3 + 2] = src[index * 3 + 2];
+    }
+
+    for (var e = 0; e < edgeCount; e++) {
+      final a = edgeA[e], b = edgeB[e];
+      final base = e * 4;
+      for (var corner = 0; corner < 4; corner++) {
+        final v = base + corner;
+        final atA = corner < 2;
+        writeVec3(positions, v, source.positions, atA ? a : b);
+        writeVec3(normals, v, source.normals, atA ? a : b);
+        writeVec3(others, v, source.positions, atA ? b : a);
+        sides[v] = corner.isEven ? 1.0 : -1.0;
+      }
+      final i = e * 6;
+      indices[i] = base;
+      indices[i + 1] = base + 1;
+      indices[i + 2] = base + 2;
+      indices[i + 3] = base;
+      indices[i + 4] = base + 2;
+      indices[i + 5] = base + 3;
     }
     return MeshGeometry.fromArrays(
-      positions: source.positions,
-      normals: source.normals,
-      indices: edges,
-      primitiveType: gpu.PrimitiveType.line,
-    );
+        positions: positions,
+        normals: normals,
+        indices: indices,
+      )
+      ..setCustomAttribute('edge_other', others, components: 3)
+      ..setCustomAttribute('edge_side', sides, components: 1);
   }
 
   /// The shard soup: every triangle unwelded to three unique vertices with a
@@ -348,41 +460,90 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
       ..setCustomAttribute('tri_seed', seeds, components: 1);
   }
 
-  /// Maps eased progress to the three object-space sweep fronts and writes
-  /// them (plus the animated inputs) into the materials.
+  /// Writes every look setting into the materials (scaled to the model's
+  /// height along the sweep axis where the setting is a fraction).
+  void _applySettings() {
+    final wire = _wireMaterial;
+    final glass = _glassMaterial;
+    final shell = _shellMaterial;
+    if (wire == null || glass == null || shell == null) return;
+    final s = _settings;
+    final range = _sweepRange;
+
+    wire.parameters
+      ..setVec3('sweep_dir', _sweepDir)
+      ..setFloat('band', range * 0.06)
+      ..setFloat('thickness', range * s.wireThickness)
+      ..setFloat('inflate', range * 0.004)
+      ..setVec4(
+        'wire_color',
+        vm.Vector4(s.wireColor.x, s.wireColor.y, s.wireColor.z, s.wireAlpha),
+      )
+      ..setFloat('glow_strength', s.wireGlow);
+
+    glass.parameters
+      ..setVec3('sweep_dir', _sweepDir)
+      ..setFloat('band', range * s.glassBand)
+      ..setVec3('fly_dir', s.flyDir)
+      ..setFloat('fly_distance', range * s.flyDistance)
+      ..setFloat('fade_portion', s.fadePortion)
+      ..setFloat('cool_span', s.coolSpan)
+      ..setFloat('tumble', s.tumble)
+      ..setVec4(
+        'glass_color',
+        vm.Vector4(s.glassTint.x, s.glassTint.y, s.glassTint.z, s.glassAlpha),
+      )
+      ..setVec3('glow_color', s.glassGlowColor)
+      ..setFloat('glow_strength', s.glassGlowStrength);
+
+    shell.parameters
+      ..setVec3('sweep_dir', _sweepDir)
+      ..setFloat('seam_width', range * s.seamWidth)
+      ..setVec4(
+        'seam_color',
+        vm.Vector4(s.seamColor.x, s.seamColor.y, s.seamColor.z, 1.0),
+      )
+      ..setFloat('seam_strength', s.seamStrength);
+  }
+
+  /// Maps eased progress to the three staggered sweep fronts and writes them
+  /// (plus the animated inputs) into the materials.
   void _applyProgress(double elapsedSeconds) {
     final wire = _wireMaterial;
     final glass = _glassMaterial;
     final shell = _shellMaterial;
+    final wireNode = _wireNode;
     final glassNode = _glassNode;
-    if (wire == null || glass == null || shell == null || glassNode == null) {
+    if (wire == null ||
+        glass == null ||
+        shell == null ||
+        wireNode == null ||
+        glassNode == null) {
       return;
     }
+    final s = _settings;
     final p = _t.clamp(0.0, 1.0);
     final eased = p * p * (3 - 2 * p);
-    final height = _maxY - _minY;
 
     const start = -_kSweepPad;
-    const end = 1.0 + 2 * _kStageLag + _kSweepPad;
+    final end = 1.0 + s.lagWireToGlass + s.lagGlassToSolid + _kSweepPad;
     final wireN = start + eased * (end - start);
-    double frontY(double n) => _minY + n * height;
+    double front(double n) => _sweepMin + n * _sweepRange;
 
-    final wireY = frontY(wireN);
-    final glassY = frontY(wireN - _kStageLag);
-    final solidY = frontY(wireN - 2 * _kStageLag);
+    final wireFront = front(wireN);
+    final glassFront = front(wireN - s.lagWireToGlass);
+    final solidFront = front(wireN - s.lagWireToGlass - s.lagGlassToSolid);
 
     wire.parameters
-      ..setFloat('wire_y', wireY)
-      ..setFloat('solid_y', solidY);
+      ..setFloat('wire_front', wireFront)
+      ..setFloat('solid_front', solidFront)
+      ..setMat4('model_matrix', wireNode.globalTransform);
     glass.parameters
-      ..setFloat('glass_y', glassY)
-      ..setFloat('solid_y', solidY)
-      ..setFloat('time', elapsedSeconds);
-    shell.parameters.setFloat('solid_y', solidY);
-
-    // The glass vertex stage does its shard math in object space and needs
-    // the node's world transform to write world outputs itself.
-    glass.parameters.setMat4('model_matrix', glassNode.globalTransform);
+      ..setFloat('glass_front', glassFront)
+      ..setFloat('solid_front', solidFront)
+      ..setFloat('time', elapsedSeconds)
+      ..setMat4('model_matrix', glassNode.globalTransform);
+    shell.parameters.setFloat('solid_front', solidFront);
   }
 
   @override
@@ -424,6 +585,7 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
     }
     return Stack(
       children: [
+        const Positioned.fill(child: ColoredBox(color: Color(0xFF06080C))),
         Positioned.fill(
           child: SceneView(
             scene,
@@ -434,7 +596,7 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
             onTick: (elapsed, deltaSeconds) {
               final seconds = elapsed.inMicroseconds / 1e6;
               if (_playing) {
-                _t += deltaSeconds / _duration;
+                _t += deltaSeconds / _settings.duration;
                 // Hold briefly at both ends, then loop.
                 if (_t > 1.3) _t = -0.08;
               }
@@ -445,55 +607,364 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
           ),
         ),
         Positioned(
-          left: 16,
-          right: 16,
-          bottom: 16,
-          child: Card(
-            color: Colors.black54,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          left: 8,
+          bottom: 8,
+          child: LightingPanel(
+            scene: scene,
+            selector: _environmentSelector,
+            showSkybox: false,
+          ),
+        ),
+        Positioned(top: 8, right: 8, bottom: 8, child: _settingsPanel()),
+        Positioned(top: 8, left: 8, child: _playbackBar()),
+      ],
+    );
+  }
+
+  Widget _playbackBar() {
+    return Card(
+      color: Colors.black54,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: Icon(
+                _playing ? Icons.pause : Icons.play_arrow,
+                color: Colors.white,
+              ),
+              onPressed: () => setState(() => _playing = !_playing),
+            ),
+            IconButton(
+              icon: const Icon(Icons.replay, color: Colors.white),
+              onPressed: () => setState(() {
+                _t = -0.05;
+                _playing = true;
+              }),
+            ),
+            SizedBox(
+              width: 220,
+              child: Slider(
+                value: _t.clamp(0.0, 1.0).toDouble(),
+                onChangeStart: (_) => setState(() => _playing = false),
+                onChanged: (value) => setState(() => _t = value),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _settingsPanel() {
+    return SizedBox(
+      width: 290,
+      child: Card(
+        color: Colors.black54,
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 8, 4, 0),
               child: Row(
                 children: [
-                  IconButton(
-                    icon: Icon(
-                      _playing ? Icons.pause : Icons.play_arrow,
+                  const Text(
+                    'Effect settings',
+                    style: TextStyle(
                       color: Colors.white,
+                      fontWeight: FontWeight.bold,
                     ),
-                    onPressed: () => setState(() => _playing = !_playing),
                   ),
+                  const Spacer(),
                   IconButton(
-                    icon: const Icon(Icons.replay, color: Colors.white),
-                    onPressed: () => setState(() {
-                      _t = -0.05;
-                      _playing = true;
-                    }),
-                  ),
-                  const Text('Progress', style: TextStyle(color: Colors.white)),
-                  Expanded(
-                    child: Slider(
-                      value: _t.clamp(0.0, 1.0).toDouble(),
-                      onChangeStart: (_) => setState(() => _playing = false),
-                      onChanged: (value) => setState(() => _t = value),
-                    ),
-                  ),
-                  Text(
-                    'Cycle ${_duration.toStringAsFixed(0)}s',
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                  SizedBox(
-                    width: 120,
-                    child: Slider(
-                      value: _duration,
-                      min: 3,
-                      max: 16,
-                      onChanged: (value) => setState(() => _duration = value),
-                    ),
+                    tooltip: 'Print settings to console',
+                    icon: const Icon(Icons.print, color: Colors.white),
+                    onPressed: () => debugPrint(_settings.dump()),
                   ),
                 ],
               ),
             ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+                children: [
+                  _section('Wireframe', [
+                    _slider(
+                      'Thickness',
+                      _settings.wireThickness,
+                      0.001,
+                      0.03,
+                      (v) => _settings.wireThickness = v,
+                    ),
+                    _colorRow(
+                      'Color',
+                      _settings.wireColor,
+                      (v) => _settings.wireColor = v,
+                    ),
+                    _slider(
+                      'Opacity',
+                      _settings.wireAlpha,
+                      0.0,
+                      1.0,
+                      (v) => _settings.wireAlpha = v,
+                    ),
+                    _slider(
+                      'Front glow',
+                      _settings.wireGlow,
+                      0.0,
+                      30.0,
+                      (v) => _settings.wireGlow = v,
+                    ),
+                  ]),
+                  _section('Glass', [
+                    _colorRow(
+                      'Tint',
+                      _settings.glassTint,
+                      (v) => _settings.glassTint = v,
+                    ),
+                    _slider(
+                      'Translucency',
+                      _settings.glassAlpha,
+                      0.0,
+                      1.0,
+                      (v) => _settings.glassAlpha = v,
+                    ),
+                    _colorRow(
+                      'Glow color',
+                      _settings.glassGlowColor,
+                      (v) => _settings.glassGlowColor = v,
+                    ),
+                    _slider(
+                      'Glow intensity',
+                      _settings.glassGlowStrength,
+                      0.0,
+                      30.0,
+                      (v) => _settings.glassGlowStrength = v,
+                    ),
+                    _slider(
+                      'Fly-in X',
+                      _settings.flyDir.x,
+                      -1.0,
+                      1.0,
+                      (v) => _settings.flyDir.x = v,
+                    ),
+                    _slider(
+                      'Fly-in Y',
+                      _settings.flyDir.y,
+                      -1.0,
+                      1.0,
+                      (v) => _settings.flyDir.y = v,
+                    ),
+                    _slider(
+                      'Fly-in Z',
+                      _settings.flyDir.z,
+                      -1.0,
+                      1.0,
+                      (v) => _settings.flyDir.z = v,
+                    ),
+                    _slider(
+                      'Fly distance',
+                      _settings.flyDistance,
+                      0.1,
+                      4.0,
+                      (v) => _settings.flyDistance = v,
+                    ),
+                    _slider(
+                      'Fade portion',
+                      _settings.fadePortion,
+                      0.05,
+                      1.0,
+                      (v) => _settings.fadePortion = v,
+                    ),
+                    _slider(
+                      'Glow cool span',
+                      _settings.coolSpan,
+                      0.05,
+                      4.0,
+                      (v) => _settings.coolSpan = v,
+                    ),
+                    _slider(
+                      'Tumble',
+                      _settings.tumble,
+                      0.0,
+                      3.0,
+                      (v) => _settings.tumble = v,
+                    ),
+                    _slider(
+                      'Assembly band',
+                      _settings.glassBand,
+                      0.05,
+                      1.0,
+                      (v) => _settings.glassBand = v,
+                    ),
+                  ]),
+                  _section('Reveal', [
+                    _slider(
+                      'Seam thickness',
+                      _settings.seamWidth,
+                      0.005,
+                      0.3,
+                      (v) => _settings.seamWidth = v,
+                    ),
+                    _colorRow(
+                      'Seam color',
+                      _settings.seamColor,
+                      (v) => _settings.seamColor = v,
+                    ),
+                    _slider(
+                      'Seam brightness',
+                      _settings.seamStrength,
+                      0.0,
+                      40.0,
+                      (v) => _settings.seamStrength = v,
+                    ),
+                  ]),
+                  _section('Timing', [
+                    _slider(
+                      'Cycle seconds',
+                      _settings.duration,
+                      3.0,
+                      20.0,
+                      (v) => _settings.duration = v,
+                    ),
+                    _slider(
+                      'Wire to glass lag',
+                      _settings.lagWireToGlass,
+                      0.0,
+                      1.0,
+                      (v) => _settings.lagWireToGlass = v,
+                    ),
+                    _slider(
+                      'Glass to solid lag',
+                      _settings.lagGlassToSolid,
+                      0.0,
+                      1.5,
+                      (v) => _settings.lagGlassToSolid = v,
+                    ),
+                  ]),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _section(String title, List<Widget> children) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 8, bottom: 2),
+          child: Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white70,
+              fontWeight: FontWeight.bold,
+              fontSize: 12,
+            ),
           ),
         ),
+        ...children,
+      ],
+    );
+  }
+
+  Widget _slider(
+    String label,
+    double value,
+    double min,
+    double max,
+    void Function(double) apply,
+  ) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 108,
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white, fontSize: 11),
+          ),
+        ),
+        Expanded(
+          child: SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              trackHeight: 2,
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+            ),
+            child: Slider(
+              value: value.clamp(min, max).toDouble(),
+              min: min,
+              max: max,
+              onChanged: (v) => setState(() {
+                apply(v);
+                _applySettings();
+              }),
+            ),
+          ),
+        ),
+        SizedBox(
+          width: 34,
+          child: Text(
+            value.toStringAsFixed(2),
+            style: const TextStyle(color: Colors.white54, fontSize: 10),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _colorRow(
+    String label,
+    vm.Vector3 color,
+    void Function(vm.Vector3) apply,
+  ) {
+    Widget channel(String name, double value, void Function(double) set) {
+      return Expanded(
+        child: SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            trackHeight: 2,
+            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 5),
+          ),
+          child: Slider(
+            value: value.clamp(0.0, 1.0).toDouble(),
+            onChanged: (v) => setState(() {
+              set(v);
+              apply(color);
+              _applySettings();
+            }),
+          ),
+        ),
+      );
+    }
+
+    return Row(
+      children: [
+        SizedBox(
+          width: 76,
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white, fontSize: 11),
+          ),
+        ),
+        Container(
+          width: 14,
+          height: 14,
+          margin: const EdgeInsets.only(right: 4),
+          decoration: BoxDecoration(
+            color: Color.fromARGB(
+              255,
+              (color.x * 255).round(),
+              (color.y * 255).round(),
+              (color.z * 255).round(),
+            ),
+            borderRadius: BorderRadius.circular(3),
+          ),
+        ),
+        channel('R', color.x, (v) => color.x = v),
+        channel('G', color.y, (v) => color.y = v),
+        channel('B', color.z, (v) => color.z = v),
       ],
     );
   }

--- a/examples/flutter_app/lib/example_materialize.dart
+++ b/examples/flutter_app/lib/example_materialize.dart
@@ -56,39 +56,39 @@ const double _kSweepPad = 0.15;
 /// current values.
 class _MaterializeSettings {
   // Wireframe.
-  double wireThickness = 0.006;
-  vm.Vector3 wireColor = vm.Vector3(0.25, 0.85, 1.0);
+  double wireThickness = 0.002;
+  vm.Vector3 wireColor = vm.Vector3(0.16, 0.64, 1.0);
   double wireAlpha = 0.85;
-  double wireGlow = 8.0;
+  double wireGlow = 27.5;
 
   // Glass.
   vm.Vector3 glassTint = vm.Vector3(0.5, 0.85, 1.0);
-  double glassAlpha = 0.69;
+  double glassAlpha = 0.2;
   vm.Vector3 glassGlowColor = vm.Vector3(1.0, 1.0, 0.6);
-  double glassGlowStrength = 22.0;
-  vm.Vector3 flyDir = vm.Vector3(0.0, -1.0, 0.0);
-  double flyDistance = 1.4;
-  double centerDistance = 0.0;
-  double normalDistance = 0.0;
-  double jitter = 0.15;
+  double glassGlowStrength = 1.9;
+  vm.Vector3 flyDir = vm.Vector3(0.0, 1.0, 0.0);
+  double flyDistance = 0.0;
+  double centerDistance = 0.45;
+  double normalDistance = 1.5;
+  double jitter = 0.32;
   double fadePortion = 0.64;
-  double coolSpan = 0.33;
+  double coolSpan = 0.62;
   double tumble = 2.3;
-  double glassBand = 0.5;
+  double glassBand = 0.84;
 
   // Shell reveal.
-  double seamWidth = 0.23;
+  double seamWidth = 0.12;
   vm.Vector3 seamColor = vm.Vector3(0.3, 0.9, 1.0);
-  double seamStrength = 28.6;
+  double seamStrength = 40.0;
 
   // Boundary noise, shared by all three stages.
-  vm.Vector3 noiseScale = vm.Vector3(8.0, 8.0, 8.0);
-  double noiseAmp = 0.06;
+  vm.Vector3 noiseScale = vm.Vector3(3.4, 0.5, 3.9);
+  double noiseAmp = 0.11;
 
   // Timing.
   double duration = 7.0;
   double lagWireToGlass = 0.0;
-  double lagGlassToSolid = 1.05;
+  double lagGlassToSolid = 1.5;
 
   String dump() {
     String v3(vm.Vector3 v) =>

--- a/examples/flutter_app/lib/example_materialize.dart
+++ b/examples/flutter_app/lib/example_materialize.dart
@@ -707,7 +707,11 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
           child: LightingPanel(
             scene: scene,
             selector: _environmentSelector,
-            showSkybox: false,
+            initialEnvironmentId: 'helipad',
+            initialSkyBlur: 0.33,
+            initialExposure: 2.03,
+            initialIblIntensity: 1.36,
+            initialRotationDegrees: vm.Vector3(0.0, -80.7, 0.0),
           ),
         ),
         // The panel starts below the debug banner and the global settings

--- a/examples/flutter_app/lib/example_materialize.dart
+++ b/examples/flutter_app/lib/example_materialize.dart
@@ -1,0 +1,508 @@
+// Materialize showcase. The DamagedHelmet phases into existence bottom-to-top
+// in three stages, each its own draw call over the same model:
+//   1. A wireframe forms (line-list geometry over the mesh's unique edges,
+//      unlit translucent .fmat with a glowing sweep front).
+//   2. Glass triangles fly in and assemble over it (unwelded triangle soup
+//      with flat outward normals; a per-triangle centroid + seed attribute
+//      lets the vertex stage scatter each shard along its face normal with a
+//      seeded tumble and pull it into place).
+//   3. The real PBR surface reveals itself behind a hot emissive seam (the
+//      original geometry with a .fmat that replicates standard PBR sampling,
+//      re-binding the model's own textures, and discards above the front).
+//
+// A single eased progress value drives three object-space front heights
+// (wire leads, glass lags, solid trails), written into the materials each
+// tick, so all gating is a per-fragment compare against vertex.position.y.
+//
+// The example reads the imported primitive's retained CPU vertex data back
+// through the internal cpuMeshData accessor to derive the wire and soup
+// geometry; in-repo example apps may reach into internals, so the lints are
+// waived for the whole file (same waiver as example_shapes.dart).
+// ignore_for_file: implementation_imports, invalid_use_of_internal_member
+
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' hide Material;
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'environment_menu.dart' show fetchResource;
+import 'example_settings.dart';
+
+const String _kHelmetUrl =
+    'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/'
+    'main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb';
+const int _kHelmetSizeBytes = 3773916;
+
+// How far (in normalized model height) each stage trails the one before it.
+const double _kStageLag = 0.35;
+// Sweep overshoot below/above the model so every fade band fully clears.
+const double _kSweepPad = 0.15;
+
+class ExampleMaterialize extends StatefulWidget {
+  const ExampleMaterialize({super.key});
+
+  @override
+  State<ExampleMaterialize> createState() => _ExampleMaterializeState();
+}
+
+class _ExampleMaterializeState extends State<ExampleMaterialize> {
+  final Scene scene = Scene();
+
+  bool _ready = false;
+  Object? _error;
+  int _downloaded = 0;
+
+  PreprocessedMaterial? _wireMaterial;
+  PreprocessedMaterial? _glassMaterial;
+  PreprocessedMaterial? _shellMaterial;
+
+  final Node _spin = Node(name: 'materialize_spin');
+  Node? _glassNode;
+
+  // Object-space vertical extent of the helmet, from the shell geometry's
+  // local bounds. Every sweep front is derived from these.
+  double _minY = 0;
+  double _maxY = 1;
+
+  vm.Vector3 _cameraPosition = vm.Vector3(0, 0, -3);
+  vm.Vector3 _cameraTarget = vm.Vector3.zero();
+
+  // Timeline. _t runs past [0, 1] a little so the effect holds briefly when
+  // fully materialized and fully hidden.
+  double _t = -0.05;
+  bool _playing = true;
+  double _duration = 8.0;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final wire = await loadFmatMaterial('assets/materialize_wireframe.fmat');
+      final glass = await loadFmatMaterial('assets/materialize_glass.fmat');
+      final shell = await loadFmatMaterial('assets/materialize_shell.fmat');
+
+      final bytes = await fetchResource(
+        _kHelmetUrl,
+        expectedSize: _kHelmetSizeBytes,
+        onChunk: (chunk) {
+          if (!mounted) return;
+          setState(() => _downloaded += chunk);
+        },
+      );
+      final helmet = await Node.fromGlbBytes(bytes);
+      if (!mounted) return;
+
+      final meshNode = _findMeshNode(helmet);
+      if (meshNode == null) {
+        throw StateError('No mesh found in the downloaded model.');
+      }
+      final primitive = meshNode.mesh!.primitives.first;
+      final source = _extractTriangleMesh(primitive.geometry);
+
+      final bounds = primitive.geometry.localBounds;
+      if (bounds == null) {
+        throw StateError('Imported geometry has no local bounds.');
+      }
+      _minY = bounds.min.y;
+      _maxY = bounds.max.y;
+      final height = math.max(_maxY - _minY, 1e-3);
+
+      // Stage 3: the original geometry, shading like the imported PBR
+      // material but clipped to the reveal front with an emissive seam.
+      _bindShellInputs(shell, primitive.material);
+      shell.parameters.setFloat('seam_width', height * 0.05);
+      primitive.material = shell;
+
+      // Stage 1: the unique triangle edges as a line list. Source positions
+      // and normals are reused so the lines can inflate off the surface.
+      final wireNode = Node(
+        name: 'materialize_wire',
+        mesh: Mesh(_buildWireGeometry(source), wire),
+      );
+      meshNode.add(wireNode);
+      wire.parameters
+        ..setFloat('band', height * 0.06)
+        ..setFloat('inflate', height * 0.004);
+
+      // Stage 2: the unwelded shard soup with flat normals and per-triangle
+      // centroid/seed attributes.
+      final glassNode = Node(
+        name: 'materialize_glass',
+        mesh: Mesh(_buildGlassGeometry(source), glass),
+      );
+      meshNode.add(glassNode);
+      glass.parameters
+        ..setFloat('band', height * 0.30)
+        ..setFloat('scatter', height * 0.8);
+
+      _spin.add(helmet);
+      scene.add(_spin);
+
+      // Frame the camera. After the importer's scene-root Z flip glTF
+      // models face -Z, so the camera sits on the -Z side.
+      final center = vm.Vector3.copy(bounds.center);
+      final radius = math.max((bounds.max - bounds.min).length * 0.5, 0.1);
+      _cameraTarget = center;
+      _cameraPosition = vm.Vector3(
+        center.x + radius * 0.4,
+        center.y + radius * 0.5,
+        center.z - radius * 2.6,
+      );
+
+      _wireMaterial = wire;
+      _glassMaterial = glass;
+      _shellMaterial = shell;
+      _glassNode = glassNode;
+      _applyProgress(0);
+      setState(() => _ready = true);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e);
+    }
+  }
+
+  Node? _findMeshNode(Node node) {
+    final mesh = node.mesh;
+    if (mesh != null && mesh.primitives.isNotEmpty) {
+      return node;
+    }
+    for (final child in node.children) {
+      final found = _findMeshNode(child);
+      if (found != null) return found;
+    }
+    return null;
+  }
+
+  /// Copies the imported material's textures and factors into the shell
+  /// material's mirrored PBR parameters.
+  void _bindShellInputs(PreprocessedMaterial shell, Material imported) {
+    if (imported is! PhysicallyBasedMaterial) return;
+    void bind(String name, TextureSource? source) {
+      final texture = source?.sampledTexture;
+      if (texture == null) return;
+      shell.parameters.setTexture(
+        name,
+        texture,
+        sampler: source!.sampledSampler,
+      );
+    }
+
+    bind('base_color_texture', imported.baseColorTexture);
+    bind('metallic_roughness_texture', imported.metallicRoughnessTexture);
+    bind('normal_texture', imported.normalTexture);
+    bind('occlusion_texture', imported.occlusionTexture);
+    bind('emissive_texture', imported.emissiveTexture);
+    shell.parameters
+      ..setVec4('base_color_factor', imported.baseColorFactor)
+      ..setFloat('metallic_factor', imported.metallicFactor)
+      ..setFloat('roughness_factor', imported.roughnessFactor)
+      ..setVec3('emissive_factor', imported.emissiveFactor.rgb)
+      ..setFloat('normal_scale', imported.normalScale)
+      ..setFloat('occlusion_strength', imported.occlusionStrength);
+  }
+
+  /// Reads positions, normals, and triangle indices back from the imported
+  /// geometry's retained CPU copy (interleaved unskinned layout, 12 floats
+  /// per vertex).
+  _TriangleMesh _extractTriangleMesh(Geometry geometry) {
+    final data = geometry.cpuMeshData;
+    final vertices = data.vertices;
+    final indexData = data.indices;
+    if (vertices == null || indexData == null) {
+      throw StateError('Imported geometry retained no CPU vertex data.');
+    }
+    const stride = 12; // floats per unskinned vertex
+    final floats = Float32List.sublistView(vertices);
+    final vertexCount = data.vertexCount;
+    final positions = Float32List(vertexCount * 3);
+    final normals = Float32List(vertexCount * 3);
+    for (var v = 0; v < vertexCount; v++) {
+      final base = v * stride;
+      positions[v * 3] = floats[base];
+      positions[v * 3 + 1] = floats[base + 1];
+      positions[v * 3 + 2] = floats[base + 2];
+      normals[v * 3] = floats[base + 3];
+      normals[v * 3 + 1] = floats[base + 4];
+      normals[v * 3 + 2] = floats[base + 5];
+    }
+    final List<int> indices = data.indexType == gpu.IndexType.int32
+        ? Uint32List.sublistView(indexData, 0, data.indexCount)
+        : Uint16List.sublistView(indexData, 0, data.indexCount);
+    return _TriangleMesh(positions, normals, indices);
+  }
+
+  /// A line list over the mesh's unique undirected edges. Shared edges are
+  /// deduplicated so the translucent lines do not double-blend.
+  MeshGeometry _buildWireGeometry(_TriangleMesh source) {
+    final seen = <int>{};
+    final edges = <int>[];
+    void addEdge(int a, int b) {
+      final lo = math.min(a, b);
+      final hi = math.max(a, b);
+      if (seen.add(lo * 0x100000 + hi)) {
+        edges
+          ..add(lo)
+          ..add(hi);
+      }
+    }
+
+    final indices = source.indices;
+    for (var t = 0; t + 2 < indices.length; t += 3) {
+      addEdge(indices[t], indices[t + 1]);
+      addEdge(indices[t + 1], indices[t + 2]);
+      addEdge(indices[t + 2], indices[t]);
+    }
+    return MeshGeometry.fromArrays(
+      positions: source.positions,
+      normals: source.normals,
+      indices: edges,
+      primitiveType: gpu.PrimitiveType.line,
+    );
+  }
+
+  /// The shard soup: every triangle unwelded to three unique vertices with a
+  /// flat outward normal, plus the triangle centroid and a random seed as
+  /// custom attributes for the glass material's vertex stage.
+  MeshGeometry _buildGlassGeometry(_TriangleMesh source) {
+    final indices = source.indices;
+    final triangleCount = indices.length ~/ 3;
+    final positions = Float32List(triangleCount * 9);
+    final normals = Float32List(triangleCount * 9);
+    final centroids = Float32List(triangleCount * 9);
+    final seeds = Float32List(triangleCount * 3);
+
+    final p0 = vm.Vector3.zero(),
+        p1 = vm.Vector3.zero(),
+        p2 = vm.Vector3.zero();
+    final smooth = vm.Vector3.zero();
+    var seedState = 0x9e3779b9;
+    for (var t = 0; t < triangleCount; t++) {
+      final i0 = indices[t * 3],
+          i1 = indices[t * 3 + 1],
+          i2 = indices[t * 3 + 2];
+      p0.setValues(
+        source.positions[i0 * 3],
+        source.positions[i0 * 3 + 1],
+        source.positions[i0 * 3 + 2],
+      );
+      p1.setValues(
+        source.positions[i1 * 3],
+        source.positions[i1 * 3 + 1],
+        source.positions[i1 * 3 + 2],
+      );
+      p2.setValues(
+        source.positions[i2 * 3],
+        source.positions[i2 * 3 + 1],
+        source.positions[i2 * 3 + 2],
+      );
+
+      // Flat face normal, sign-checked against the averaged vertex normals
+      // so it always points outward.
+      final flat = (p1 - p0).cross(p2 - p0);
+      if (flat.length2 > 0) flat.normalize();
+      smooth.setValues(
+        source.normals[i0 * 3] +
+            source.normals[i1 * 3] +
+            source.normals[i2 * 3],
+        source.normals[i0 * 3 + 1] +
+            source.normals[i1 * 3 + 1] +
+            source.normals[i2 * 3 + 1],
+        source.normals[i0 * 3 + 2] +
+            source.normals[i1 * 3 + 2] +
+            source.normals[i2 * 3 + 2],
+      );
+      if (flat.dot(smooth) < 0) flat.negate();
+
+      final cx = (p0.x + p1.x + p2.x) / 3;
+      final cy = (p0.y + p1.y + p2.y) / 3;
+      final cz = (p0.z + p1.z + p2.z) / 3;
+
+      // Cheap deterministic per-triangle random in [0, 1).
+      seedState = 0x1fffffff & (seedState * 1103515245 + 12345);
+      final seed = (seedState & 0xffff) / 0x10000;
+
+      for (var v = 0; v < 3; v++) {
+        final src = v == 0 ? p0 : (v == 1 ? p1 : p2);
+        final out = (t * 3 + v) * 3;
+        positions[out] = src.x;
+        positions[out + 1] = src.y;
+        positions[out + 2] = src.z;
+        normals[out] = flat.x;
+        normals[out + 1] = flat.y;
+        normals[out + 2] = flat.z;
+        centroids[out] = cx;
+        centroids[out + 1] = cy;
+        centroids[out + 2] = cz;
+        seeds[t * 3 + v] = seed;
+      }
+    }
+    return MeshGeometry.fromArrays(positions: positions, normals: normals)
+      ..setCustomAttribute('tri_centroid', centroids, components: 3)
+      ..setCustomAttribute('tri_seed', seeds, components: 1);
+  }
+
+  /// Maps eased progress to the three object-space sweep fronts and writes
+  /// them (plus the animated inputs) into the materials.
+  void _applyProgress(double elapsedSeconds) {
+    final wire = _wireMaterial;
+    final glass = _glassMaterial;
+    final shell = _shellMaterial;
+    final glassNode = _glassNode;
+    if (wire == null || glass == null || shell == null || glassNode == null) {
+      return;
+    }
+    final p = _t.clamp(0.0, 1.0);
+    final eased = p * p * (3 - 2 * p);
+    final height = _maxY - _minY;
+
+    const start = -_kSweepPad;
+    const end = 1.0 + 2 * _kStageLag + _kSweepPad;
+    final wireN = start + eased * (end - start);
+    double frontY(double n) => _minY + n * height;
+
+    final wireY = frontY(wireN);
+    final glassY = frontY(wireN - _kStageLag);
+    final solidY = frontY(wireN - 2 * _kStageLag);
+
+    wire.parameters
+      ..setFloat('wire_y', wireY)
+      ..setFloat('solid_y', solidY);
+    glass.parameters
+      ..setFloat('glass_y', glassY)
+      ..setFloat('solid_y', solidY)
+      ..setFloat('time', elapsedSeconds);
+    shell.parameters.setFloat('solid_y', solidY);
+
+    // The glass vertex stage does its shard math in object space and needs
+    // the node's world transform to write world outputs itself.
+    glass.parameters.setMat4('model_matrix', glassNode.globalTransform);
+  }
+
+  @override
+  void dispose() {
+    scene.removeAll();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_error != null) {
+      return Center(
+        child: Text(
+          'Failed to load the model.\n$_error',
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+    if (!_ready) {
+      final fraction = (_downloaded / _kHelmetSizeBytes)
+          .clamp(0.0, 1.0)
+          .toDouble();
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: 240,
+              child: LinearProgressIndicator(value: fraction),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Downloading DamagedHelmet '
+              '(${(_downloaded / (1024 * 1024)).toStringAsFixed(1)} MB)',
+            ),
+          ],
+        ),
+      );
+    }
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: SceneView(
+            scene,
+            camera: PerspectiveCamera(
+              position: _cameraPosition,
+              target: _cameraTarget,
+            ),
+            onTick: (elapsed, deltaSeconds) {
+              final seconds = elapsed.inMicroseconds / 1e6;
+              if (_playing) {
+                _t += deltaSeconds / _duration;
+                // Hold briefly at both ends, then loop.
+                if (_t > 1.3) _t = -0.08;
+              }
+              _spin.localTransform = vm.Matrix4.rotationY(seconds * 0.25);
+              _applyProgress(seconds);
+              exampleSettings.applyTo(scene);
+            },
+          ),
+        ),
+        Positioned(
+          left: 16,
+          right: 16,
+          bottom: 16,
+          child: Card(
+            color: Colors.black54,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: Icon(
+                      _playing ? Icons.pause : Icons.play_arrow,
+                      color: Colors.white,
+                    ),
+                    onPressed: () => setState(() => _playing = !_playing),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.replay, color: Colors.white),
+                    onPressed: () => setState(() {
+                      _t = -0.05;
+                      _playing = true;
+                    }),
+                  ),
+                  const Text('Progress', style: TextStyle(color: Colors.white)),
+                  Expanded(
+                    child: Slider(
+                      value: _t.clamp(0.0, 1.0).toDouble(),
+                      onChangeStart: (_) => setState(() => _playing = false),
+                      onChanged: (value) => setState(() => _t = value),
+                    ),
+                  ),
+                  Text(
+                    'Cycle ${_duration.toStringAsFixed(0)}s',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  SizedBox(
+                    width: 120,
+                    child: Slider(
+                      value: _duration,
+                      min: 3,
+                      max: 16,
+                      onChanged: (value) => setState(() => _duration = value),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TriangleMesh {
+  _TriangleMesh(this.positions, this.normals, this.indices);
+
+  final Float32List positions;
+  final Float32List normals;
+  final List<int> indices;
+}

--- a/examples/flutter_app/lib/example_settings.dart
+++ b/examples/flutter_app/lib/example_settings.dart
@@ -5,11 +5,14 @@ import 'package:flutter_scene/gpu.dart' as gpu;
 import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart';
 
-/// Post-processing settings shared by every example.
+/// The rendering and post-processing settings an example runs with.
 ///
-/// The settings sidebar edits the single [exampleSettings] instance, and
-/// each example copies it onto its own scene with [applyTo] right before
-/// rendering, so one set of controls drives every scene.
+/// Each example gets its own instance (recreated by the app shell whenever
+/// the selection changes, see [resetExampleSettings]), so tuning one scene
+/// never leaks into another and an example can ship its own defaults. The
+/// settings sidebar edits the current [exampleSettings] instance, and each
+/// example copies it onto its own scene with [applyTo] right before
+/// rendering.
 class ExampleSettings {
   /// Color grading shared across the examples.
   final ColorGradingSettings colorGrading = ColorGradingSettings();
@@ -164,8 +167,23 @@ class ExampleSettings {
   }
 }
 
-/// The single shared settings instance used across the example app.
-final ExampleSettings exampleSettings = ExampleSettings();
+/// The settings instance for the currently selected example. Examples read
+/// this in their tick; the app shell replaces it via [resetExampleSettings]
+/// when the selection changes.
+ExampleSettings exampleSettings = ExampleSettings();
+
+// The custom wave effect is loaded once at startup and carried across the
+// per-example instances.
+PostEffect? _waveEffect;
+
+/// Replaces [exampleSettings] with a fresh instance for a newly selected
+/// example, built by [defaults] when the example overrides the stock
+/// defaults, and returns it.
+ExampleSettings resetExampleSettings([ExampleSettings Function()? defaults]) {
+  exampleSettings = (defaults?.call() ?? ExampleSettings())
+    ..waveEffect = _waveEffect;
+  return exampleSettings;
+}
 
 /// Loads the example shader bundle and builds the custom post-processing
 /// effects. Awaited at startup alongside [Scene.initializeStaticResources].
@@ -175,11 +193,12 @@ Future<void> loadExampleEffects() async {
   );
   final waveShader = library?['WaveFragment'];
   if (waveShader != null) {
-    exampleSettings.waveEffect = PostEffect(
+    _waveEffect = PostEffect(
       fragmentShader: waveShader,
       insertion: PostInsertion.beforeTonemap,
       enabled: false,
       useFrameInfo: true,
     );
+    exampleSettings.waveEffect = _waveEffect;
   }
 }

--- a/examples/flutter_app/lib/lighting_panel.dart
+++ b/examples/flutter_app/lib/lighting_panel.dart
@@ -3,6 +3,7 @@
 // environment rotation, applied directly to the scene it is given. Used by
 // the stress tests and the widget-texture example.
 
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -20,6 +21,11 @@ class LightingPanel extends StatefulWidget {
     required this.scene,
     required this.selector,
     this.showSkybox = true,
+    this.initialEnvironmentId,
+    this.initialSkyBlur = 0.0,
+    this.initialExposure = 1.0,
+    this.initialIblIntensity = 1.0,
+    this.initialRotationDegrees,
   });
 
   final Scene scene;
@@ -28,6 +34,21 @@ class LightingPanel extends StatefulWidget {
   /// Whether the skybox starts enabled.
   final bool showSkybox;
 
+  /// The [ExampleEnvironment.id] to select at startup, or null to keep the
+  /// selector's current environment. Loads (from the cache when possible)
+  /// in the background.
+  final String? initialEnvironmentId;
+
+  /// Starting values for the sliders, applied to the scene at startup so an
+  /// example can ship its own lighting defaults.
+  final double initialSkyBlur;
+  final double initialExposure;
+  final double initialIblIntensity;
+
+  /// Starting environment rotation Euler angles in degrees (x, y, z), or
+  /// null for none.
+  final vm.Vector3? initialRotationDegrees;
+
   @override
   State<LightingPanel> createState() => _LightingPanelState();
 }
@@ -35,17 +56,30 @@ class LightingPanel extends StatefulWidget {
 class _LightingPanelState extends State<LightingPanel> {
   late bool _showSkybox = widget.showSkybox;
   final EnvironmentSkySource _skySource = EnvironmentSkySource();
-  double _exposure = 1.0;
-  double _environmentIntensity = 1.0;
-  double _envRotationX = 0.0;
-  double _envRotationY = 0.0;
-  double _envRotationZ = 0.0;
+  late double _exposure = widget.initialExposure;
+  late double _environmentIntensity = widget.initialIblIntensity;
+  late double _envRotationX = widget.initialRotationDegrees?.x ?? 0.0;
+  late double _envRotationY = widget.initialRotationDegrees?.y ?? 0.0;
+  late double _envRotationZ = widget.initialRotationDegrees?.z ?? 0.0;
 
   @override
   void initState() {
     super.initState();
+    _skySource.blurriness = widget.initialSkyBlur;
+    widget.scene.exposure = _exposure;
+    widget.scene.environmentIntensity = _environmentIntensity;
+    _applyEnvironmentRotation();
     _applySkybox();
     widget.selector.addListener(_onSelectorChanged);
+    final environmentId = widget.initialEnvironmentId;
+    if (environmentId != null && widget.selector.active.id != environmentId) {
+      for (final environment in exampleEnvironments) {
+        if (environment.id == environmentId) {
+          unawaited(_selectEnvironment(environment));
+          break;
+        }
+      }
+    }
   }
 
   @override

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -42,6 +42,30 @@ void main() {
   runApp(const MyApp());
 }
 
+/// Per-example overrides of the stock [ExampleSettings] defaults, keyed by
+/// the example's name in the picker. Examples not listed start from the
+/// stock defaults. Every example gets its own fresh instance either way
+/// (see [resetExampleSettings]), so tuning one scene never leaks into
+/// another.
+final Map<String, ExampleSettings Function()> settingsDefaults = {
+  // A cinematic grade for the dark materialize stage: no key light (the
+  // effect's own emissives and the environment carry it), bloom for the hot
+  // seam and shard glows, and a subtle lens treatment.
+  'Materialize (.fmat)': () => ExampleSettings()
+    ..directionalLightEnabled = false
+    ..colorGrading.enabled = true
+    ..colorGrading.brightness = 1.05
+    ..colorGrading.contrast = 1.19
+    ..colorGrading.saturation = 1.16
+    ..colorGrading.temperature = -0.20
+    ..colorGrading.tint = 0.01
+    ..bloom.enabled = true
+    ..bloom.intensity = 0.06
+    ..chromaticAberration.enabled = true
+    ..chromaticAberration.intensity = 0.14
+    ..vignette.enabled = true,
+};
+
 class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
@@ -138,6 +162,7 @@ class _MyAppState extends State<MyApp> {
       'Stress Tests': (context) => const ExampleStressTests(),
     };
     selectedExample = examples.keys.first;
+    resetExampleSettings(settingsDefaults[selectedExample]);
 
     _ready = Future.wait([
       Scene.initializeStaticResources(),
@@ -177,7 +202,13 @@ class _MyAppState extends State<MyApp> {
                     examples: examples.keys.toList(growable: false),
                     selected: selectedExample,
                     onSelected: (next) {
-                      setState(() => selectedExample = next);
+                      setState(() {
+                        selectedExample = next;
+                        // Every example runs on its own settings instance;
+                        // examples listed in settingsDefaults start from
+                        // their own defaults instead of the stock ones.
+                        resetExampleSettings(settingsDefaults[next]);
+                      });
                     },
                   ),
                 ),

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -19,6 +19,7 @@ import 'example_fscene_stream.dart';
 import 'example_instancing.dart';
 import 'example_lod.dart';
 import 'example_logo.dart';
+import 'example_materialize.dart';
 import 'example_nav_route.dart';
 import 'example_physics.dart';
 import 'example_physics_box3d.dart';
@@ -79,6 +80,7 @@ class _MyAppState extends State<MyApp> {
       'Toon': (context) => const ExampleToon(),
       'Toon (.fmat)': (context) => const ExampleToonFmat(),
       'Custom vertices (.fmat)': (context) => const ExampleVertexCurve(),
+      'Materialize (.fmat)': (context) => const ExampleMaterialize(),
       'Custom Skybox': (context) => const ExampleSkybox(),
       'Widget Texture': (context) => const ExampleWidgetTexture(),
       'Render Targets': (context) => const ExampleRenderTarget(),

--- a/examples/flutter_app/lib/materialize_settings.dart
+++ b/examples/flutter_app/lib/materialize_settings.dart
@@ -1,0 +1,524 @@
+// The Materialize example's tunables and control widgets: the settings
+// model (with a console dump for capturing tuned values), the side panel
+// that edits it, and the playback bar. The scene/effect logic lives in
+// example_materialize.dart.
+
+import 'package:flutter/material.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+/// Every tunable of the effect. Lengths are fractions of the model's height;
+/// noise scales are cycles per model height. The print button dumps the
+/// current values.
+class MaterializeSettings {
+  // Wireframe.
+  double wireThickness = 0.002;
+  vm.Vector3 wireColor = vm.Vector3(0.16, 0.64, 1.0);
+  double wireAlpha = 0.85;
+  double wireGlow = 27.5;
+
+  // Glass.
+  vm.Vector3 glassTint = vm.Vector3(0.5, 0.85, 1.0);
+  double glassAlpha = 0.2;
+  vm.Vector3 glassGlowColor = vm.Vector3(1.0, 1.0, 0.6);
+  double glassGlowStrength = 1.9;
+  vm.Vector3 flyDir = vm.Vector3(0.0, 1.0, 0.0);
+  double flyDistance = 0.0;
+  double centerDistance = 0.45;
+  double normalDistance = 1.5;
+  double jitter = 0.32;
+  double fadePortion = 0.64;
+  double coolSpan = 0.62;
+  double tumble = 2.3;
+  double glassBand = 0.84;
+
+  // Shell reveal.
+  double seamWidth = 0.12;
+  vm.Vector3 seamColor = vm.Vector3(0.3, 0.9, 1.0);
+  double seamStrength = 40.0;
+
+  // Boundary noise, shared by all three stages.
+  vm.Vector3 noiseScale = vm.Vector3(3.4, 0.5, 3.9);
+  double noiseAmp = 0.11;
+
+  // Timing.
+  double duration = 7.0;
+  double lagWireToGlass = 0.0;
+  double lagGlassToSolid = 1.5;
+
+  String dump() {
+    String v3(vm.Vector3 v) =>
+        '${v.x.toStringAsFixed(3)}, ${v.y.toStringAsFixed(3)}, '
+        '${v.z.toStringAsFixed(3)}';
+    String f(double v) => v.toStringAsFixed(3);
+    return '''
+=== Materialize settings ===
+wireThickness: ${f(wireThickness)}
+wireColor: ${v3(wireColor)}
+wireAlpha: ${f(wireAlpha)}
+wireGlow: ${f(wireGlow)}
+glassTint: ${v3(glassTint)}
+glassAlpha: ${f(glassAlpha)}
+glassGlowColor: ${v3(glassGlowColor)}
+glassGlowStrength: ${f(glassGlowStrength)}
+flyDir: ${v3(flyDir)}
+flyDistance: ${f(flyDistance)}
+centerDistance: ${f(centerDistance)}
+normalDistance: ${f(normalDistance)}
+jitter: ${f(jitter)}
+fadePortion: ${f(fadePortion)}
+coolSpan: ${f(coolSpan)}
+tumble: ${f(tumble)}
+glassBand: ${f(glassBand)}
+seamWidth: ${f(seamWidth)}
+seamColor: ${v3(seamColor)}
+seamStrength: ${f(seamStrength)}
+noiseScale: ${v3(noiseScale)}
+noiseAmp: ${f(noiseAmp)}
+duration: ${f(duration)}
+lagWireToGlass: ${f(lagWireToGlass)}
+lagGlassToSolid: ${f(lagGlassToSolid)}
+============================''';
+  }
+}
+
+/// The scrollable side panel that edits a [MaterializeSettings], with a
+/// print button that dumps the current values to the console. [onChanged]
+/// fires after any edit so the owner can push the values into its materials.
+class MaterializeSettingsPanel extends StatefulWidget {
+  const MaterializeSettingsPanel({
+    super.key,
+    required this.settings,
+    required this.onChanged,
+  });
+
+  final MaterializeSettings settings;
+  final VoidCallback onChanged;
+
+  @override
+  State<MaterializeSettingsPanel> createState() =>
+      _MaterializeSettingsPanelState();
+}
+
+class _MaterializeSettingsPanelState extends State<MaterializeSettingsPanel> {
+  MaterializeSettings get _settings => widget.settings;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 290,
+      child: Card(
+        color: Colors.black54,
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 8, 4, 0),
+              child: Row(
+                children: [
+                  const Text(
+                    'Effect settings',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const Spacer(),
+                  IconButton(
+                    tooltip: 'Print settings to console',
+                    icon: const Icon(Icons.print, color: Colors.white),
+                    onPressed: () => debugPrint(_settings.dump()),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+                children: [
+                  _section('Wireframe', [
+                    _slider(
+                      'Thickness',
+                      _settings.wireThickness,
+                      0.001,
+                      0.03,
+                      (v) => _settings.wireThickness = v,
+                    ),
+                    _colorRow(
+                      'Color',
+                      _settings.wireColor,
+                      (v) => _settings.wireColor = v,
+                    ),
+                    _slider(
+                      'Opacity',
+                      _settings.wireAlpha,
+                      0.0,
+                      1.0,
+                      (v) => _settings.wireAlpha = v,
+                    ),
+                    _slider(
+                      'Front glow',
+                      _settings.wireGlow,
+                      0.0,
+                      30.0,
+                      (v) => _settings.wireGlow = v,
+                    ),
+                  ]),
+                  _section('Glass', [
+                    _colorRow(
+                      'Tint',
+                      _settings.glassTint,
+                      (v) => _settings.glassTint = v,
+                    ),
+                    _slider(
+                      'Translucency',
+                      _settings.glassAlpha,
+                      0.0,
+                      1.0,
+                      (v) => _settings.glassAlpha = v,
+                    ),
+                    _colorRow(
+                      'Glow color',
+                      _settings.glassGlowColor,
+                      (v) => _settings.glassGlowColor = v,
+                    ),
+                    _slider(
+                      'Glow intensity',
+                      _settings.glassGlowStrength,
+                      0.0,
+                      30.0,
+                      (v) => _settings.glassGlowStrength = v,
+                    ),
+                    _slider(
+                      'Fly-in X',
+                      _settings.flyDir.x,
+                      -1.0,
+                      1.0,
+                      (v) => _settings.flyDir.x = v,
+                    ),
+                    _slider(
+                      'Fly-in Y',
+                      _settings.flyDir.y,
+                      -1.0,
+                      1.0,
+                      (v) => _settings.flyDir.y = v,
+                    ),
+                    _slider(
+                      'Fly-in Z',
+                      _settings.flyDir.z,
+                      -1.0,
+                      1.0,
+                      (v) => _settings.flyDir.z = v,
+                    ),
+                    _slider(
+                      'Fly distance',
+                      _settings.flyDistance,
+                      0.0,
+                      4.0,
+                      (v) => _settings.flyDistance = v,
+                    ),
+                    _slider(
+                      'From center',
+                      _settings.centerDistance,
+                      0.0,
+                      3.0,
+                      (v) => _settings.centerDistance = v,
+                    ),
+                    _slider(
+                      'Off normal',
+                      _settings.normalDistance,
+                      0.0,
+                      2.0,
+                      (v) => _settings.normalDistance = v,
+                    ),
+                    _slider(
+                      'Jitter',
+                      _settings.jitter,
+                      0.0,
+                      1.0,
+                      (v) => _settings.jitter = v,
+                    ),
+                    _slider(
+                      'Fade portion',
+                      _settings.fadePortion,
+                      0.05,
+                      1.0,
+                      (v) => _settings.fadePortion = v,
+                    ),
+                    _slider(
+                      'Glow cool span',
+                      _settings.coolSpan,
+                      0.05,
+                      4.0,
+                      (v) => _settings.coolSpan = v,
+                    ),
+                    _slider(
+                      'Tumble',
+                      _settings.tumble,
+                      0.0,
+                      3.0,
+                      (v) => _settings.tumble = v,
+                    ),
+                    _slider(
+                      'Assembly band',
+                      _settings.glassBand,
+                      0.05,
+                      1.0,
+                      (v) => _settings.glassBand = v,
+                    ),
+                  ]),
+                  _section('Reveal', [
+                    _slider(
+                      'Seam thickness',
+                      _settings.seamWidth,
+                      0.005,
+                      0.3,
+                      (v) => _settings.seamWidth = v,
+                    ),
+                    _colorRow(
+                      'Seam color',
+                      _settings.seamColor,
+                      (v) => _settings.seamColor = v,
+                    ),
+                    _slider(
+                      'Seam brightness',
+                      _settings.seamStrength,
+                      0.0,
+                      40.0,
+                      (v) => _settings.seamStrength = v,
+                    ),
+                    _slider(
+                      'Noise scale X',
+                      _settings.noiseScale.x,
+                      0.5,
+                      30.0,
+                      (v) => _settings.noiseScale.x = v,
+                    ),
+                    _slider(
+                      'Noise scale Y',
+                      _settings.noiseScale.y,
+                      0.5,
+                      30.0,
+                      (v) => _settings.noiseScale.y = v,
+                    ),
+                    _slider(
+                      'Noise scale Z',
+                      _settings.noiseScale.z,
+                      0.5,
+                      30.0,
+                      (v) => _settings.noiseScale.z = v,
+                    ),
+                    _slider(
+                      'Noise amount',
+                      _settings.noiseAmp,
+                      0.0,
+                      0.3,
+                      (v) => _settings.noiseAmp = v,
+                    ),
+                  ]),
+                  _section('Timing', [
+                    _slider(
+                      'Cycle seconds',
+                      _settings.duration,
+                      3.0,
+                      20.0,
+                      (v) => _settings.duration = v,
+                    ),
+                    _slider(
+                      'Wire to glass lag',
+                      _settings.lagWireToGlass,
+                      0.0,
+                      1.0,
+                      (v) => _settings.lagWireToGlass = v,
+                    ),
+                    _slider(
+                      'Glass to solid lag',
+                      _settings.lagGlassToSolid,
+                      0.0,
+                      1.5,
+                      (v) => _settings.lagGlassToSolid = v,
+                    ),
+                  ]),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _section(String title, List<Widget> children) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 8, bottom: 2),
+          child: Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white70,
+              fontWeight: FontWeight.bold,
+              fontSize: 12,
+            ),
+          ),
+        ),
+        ...children,
+      ],
+    );
+  }
+
+  Widget _slider(
+    String label,
+    double value,
+    double min,
+    double max,
+    void Function(double) apply,
+  ) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 108,
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white, fontSize: 11),
+          ),
+        ),
+        Expanded(
+          child: SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              trackHeight: 2,
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+            ),
+            child: Slider(
+              value: value.clamp(min, max).toDouble(),
+              min: min,
+              max: max,
+              onChanged: (v) {
+                setState(() => apply(v));
+                widget.onChanged();
+              },
+            ),
+          ),
+        ),
+        SizedBox(
+          width: 34,
+          child: Text(
+            value.toStringAsFixed(2),
+            style: const TextStyle(color: Colors.white54, fontSize: 10),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _colorRow(
+    String label,
+    vm.Vector3 color,
+    void Function(vm.Vector3) apply,
+  ) {
+    Widget channel(String name, double value, void Function(double) set) {
+      return Expanded(
+        child: SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            trackHeight: 2,
+            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 5),
+          ),
+          child: Slider(
+            value: value.clamp(0.0, 1.0).toDouble(),
+            onChanged: (v) {
+              setState(() {
+                set(v);
+                apply(color);
+              });
+              widget.onChanged();
+            },
+          ),
+        ),
+      );
+    }
+
+    return Row(
+      children: [
+        SizedBox(
+          width: 76,
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white, fontSize: 11),
+          ),
+        ),
+        Container(
+          width: 14,
+          height: 14,
+          margin: const EdgeInsets.only(right: 4),
+          decoration: BoxDecoration(
+            color: Color.fromARGB(
+              255,
+              (color.x * 255).round(),
+              (color.y * 255).round(),
+              (color.z * 255).round(),
+            ),
+            borderRadius: BorderRadius.circular(3),
+          ),
+        ),
+        channel('R', color.x, (v) => color.x = v),
+        channel('G', color.y, (v) => color.y = v),
+        channel('B', color.z, (v) => color.z = v),
+      ],
+    );
+  }
+}
+
+/// The play/pause/replay/scrub bar. The owner keeps the timeline state; the
+/// bar reports edits through the callbacks.
+class MaterializePlaybackBar extends StatelessWidget {
+  const MaterializePlaybackBar({
+    super.key,
+    required this.playing,
+    required this.progress,
+    required this.onPlayingChanged,
+    required this.onRestart,
+    required this.onScrub,
+  });
+
+  final bool playing;
+
+  /// Clamped timeline position in [0, 1].
+  final double progress;
+
+  final ValueChanged<bool> onPlayingChanged;
+  final VoidCallback onRestart;
+  final ValueChanged<double> onScrub;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Colors.black54,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: Icon(
+                playing ? Icons.pause : Icons.play_arrow,
+                color: Colors.white,
+              ),
+              onPressed: () => onPlayingChanged(!playing),
+            ),
+            IconButton(
+              icon: const Icon(Icons.replay, color: Colors.white),
+              onPressed: onRestart,
+            ),
+            SizedBox(
+              width: 220,
+              child: Slider(
+                value: progress,
+                onChangeStart: (_) => onPlayingChanged(false),
+                onChanged: onScrub,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
@@ -131,9 +131,13 @@ String emitFragmentGlsl(FmatMaterial material) {
   sb.writeln('  Surface(material);');
   if (uniforms.isNotEmpty) {
     final first = uniforms.first;
-    final scalar = first.type.glslType == 'float'
-        ? 'material_params.${first.name}'
-        : 'material_params.${first.name}.x';
+    final member = '$kMaterialParamsInstance.${first.name}';
+    final scalar = switch (first.type) {
+      FmatType.float_ => member,
+      FmatType.int_ => 'float($member)',
+      FmatType.mat4 => '$member[0].x',
+      _ => '$member.x',
+    };
     sb.writeln(
       '  material.base_color.r += '
       '$kFragmentKeepAliveInstance.keep_alive.x * $scalar;',

--- a/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
@@ -98,6 +98,7 @@ String emitFragmentGlsl(FmatMaterial material) {
   _writeVaryings(sb, material, 'in');
 
   final uniforms = material.uniformParameters.toList();
+  final samplers = material.samplerParameters.toList();
   if (uniforms.isNotEmpty) {
     sb.writeln('uniform $kMaterialParamsBlock {');
     for (final p in uniforms) {
@@ -106,15 +107,17 @@ String emitFragmentGlsl(FmatMaterial material) {
     sb.writeln('}');
     sb.writeln('$kMaterialParamsInstance;');
     sb.writeln();
-    // Bound to zero by the runtime; main() multiplies a MaterialParams field by
-    // it so the block cannot be optimized out when Surface() reads no parameter
-    // (its uniform slot would then be missing and binding it would crash).
+  }
+  if (uniforms.isNotEmpty || samplers.isNotEmpty) {
+    // Bound to zero by the runtime; main() folds the parameters into a term
+    // multiplied by it so no declared parameter resource can be optimized out
+    // (the runtime binds them all unconditionally, and binding an
+    // optimized-out uniform or sampler is unsafe).
     sb.writeln('uniform $kFragmentKeepAliveBlock { vec4 keep_alive; }');
     sb.writeln('$kFragmentKeepAliveInstance;');
     sb.writeln();
   }
 
-  final samplers = material.samplerParameters.toList();
   for (final p in samplers) {
     sb.writeln('uniform ${p.type.glslType} ${p.name};');
   }
@@ -129,11 +132,11 @@ String emitFragmentGlsl(FmatMaterial material) {
   sb.writeln('void main() {');
   sb.writeln('  MaterialInputs material = InitMaterialInputs();');
   sb.writeln('  Surface(material);');
-  if (uniforms.isNotEmpty) {
+  final keepAlive = _fragmentKeepAliveTerm(material, uniforms, samplers);
+  if (keepAlive != null) {
     sb.writeln(
       '  material.base_color.r += '
-      '$kFragmentKeepAliveInstance.keep_alive.x * '
-      '${_paramsKeepAliveScalar(uniforms.first)};',
+      '$kFragmentKeepAliveInstance.keep_alive.x * $keepAlive;',
     );
   }
   if (lit) {
@@ -163,6 +166,38 @@ String _paramsKeepAliveScalar(FmatParameter p) {
     FmatType.mat4 => '$member[0].x',
     _ => '$member.x',
   };
+}
+
+/// The scalar keep-alive term for a fragment (or sky) shader, or null when
+/// the material declares no parameters (no keep-alive block is emitted then).
+///
+/// Folds in a MaterialParams read plus a zero-multiplied fetch of every
+/// sampler [source] never mentions, so the runtime can bind every declared
+/// parameter resource safely. Samplers the author's code references are
+/// skipped (their real fetch keeps them live and they pay nothing here);
+/// the whole-word check errs toward the extra fetch when unsure.
+String? _fragmentKeepAliveTerm(
+  FmatMaterial material,
+  List<FmatParameter> uniforms,
+  List<FmatParameter> samplers,
+) {
+  if (uniforms.isEmpty && samplers.isEmpty) return null;
+  final terms = <String>[
+    if (uniforms.isNotEmpty) _paramsKeepAliveScalar(uniforms.first),
+    for (final p in samplers)
+      if (!RegExp(
+        '\\b${RegExp.escape(p.name)}\\b',
+      ).hasMatch(material.fragmentSource))
+        p.type == FmatType.samplerCube
+            ? 'texture(${p.name}, vec3(0.0, 0.0, 1.0)).x'
+            : 'texture(${p.name}, vec2(0.0)).x',
+  ];
+  // Every declared resource is already referenced; the block still needs a
+  // live operand of its own so it cannot be folded away.
+  if (terms.isEmpty) {
+    return '$kFragmentKeepAliveInstance.keep_alive.y';
+  }
+  return '(${terms.join(' + ')})';
 }
 
 /// Emits the vertex-shader GLSL for each variant of [material], keyed by the
@@ -267,6 +302,17 @@ String _emitVertexVariant(
   // Custom per-vertex attributes Vertex() reads by name (real inputs in the
   // color variants, zero in the depth variant).
   _writeAttributes(sb, material, isDepth: isDepth);
+  if (material.attributes.isNotEmpty) {
+    // Folded into the zero-bound keep-alive by the body include so an
+    // attribute Vertex() never reads survives compilation; the geometry
+    // supplies its buffer unconditionally and a stripped input breaks
+    // reflection and the pipeline's vertex layout.
+    final terms = material.attributes
+        .map((a) => a.type == FmatType.float_ ? a.name : '${a.name}.x')
+        .join(' + ');
+    sb.writeln('#define MATERIAL_ATTRIBUTES_KEEP_ALIVE ($terms)');
+    sb.writeln();
+  }
 
   // Custom interpolants Vertex() writes by name, read in the fragment stage.
   _writeVaryings(sb, material, 'out');
@@ -296,6 +342,7 @@ String _emitSkyGlsl(FmatMaterial material) {
   sb.writeln();
 
   final uniforms = material.uniformParameters.toList();
+  final samplers = material.samplerParameters.toList();
   if (uniforms.isNotEmpty) {
     sb.writeln('uniform $kMaterialParamsBlock {');
     for (final p in uniforms) {
@@ -305,8 +352,14 @@ String _emitSkyGlsl(FmatMaterial material) {
     sb.writeln('$kMaterialParamsInstance;');
     sb.writeln();
   }
+  if (uniforms.isNotEmpty || samplers.isNotEmpty) {
+    // Same keep-alive as the surface fragment shader; see
+    // _fragmentKeepAliveTerm.
+    sb.writeln('uniform $kFragmentKeepAliveBlock { vec4 keep_alive; }');
+    sb.writeln('$kFragmentKeepAliveInstance;');
+    sb.writeln();
+  }
 
-  final samplers = material.samplerParameters.toList();
   for (final p in samplers) {
     sb.writeln('uniform ${p.type.glslType} ${p.name};');
   }
@@ -337,6 +390,13 @@ String _emitSkyGlsl(FmatMaterial material) {
   sb.writeln('void main() {');
   sb.writeln('  // Linear HDR radiance, premultiplied alpha (opaque sky).');
   sb.writeln('  frag_color = vec4(Sky(normalize(v_ray)), 1.0);');
+  final keepAlive = _fragmentKeepAliveTerm(material, uniforms, samplers);
+  if (keepAlive != null) {
+    sb.writeln(
+      '  frag_color.r += '
+      '$kFragmentKeepAliveInstance.keep_alive.x * $keepAlive;',
+    );
+  }
   sb.writeln('}');
 
   return sb.toString();

--- a/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
@@ -130,17 +130,10 @@ String emitFragmentGlsl(FmatMaterial material) {
   sb.writeln('  MaterialInputs material = InitMaterialInputs();');
   sb.writeln('  Surface(material);');
   if (uniforms.isNotEmpty) {
-    final first = uniforms.first;
-    final member = '$kMaterialParamsInstance.${first.name}';
-    final scalar = switch (first.type) {
-      FmatType.float_ => member,
-      FmatType.int_ => 'float($member)',
-      FmatType.mat4 => '$member[0].x',
-      _ => '$member.x',
-    };
     sb.writeln(
       '  material.base_color.r += '
-      '$kFragmentKeepAliveInstance.keep_alive.x * $scalar;',
+      '$kFragmentKeepAliveInstance.keep_alive.x * '
+      '${_paramsKeepAliveScalar(uniforms.first)};',
     );
   }
   if (lit) {
@@ -155,6 +148,21 @@ String emitFragmentGlsl(FmatMaterial material) {
   sb.writeln('}');
 
   return sb.toString();
+}
+
+/// A scalar GLSL expression reading one component of [p] through the
+/// MaterialParams instance. Both stages fold it into their zero-bound
+/// keep-alive term so the optimizer cannot strip the block when the author's
+/// code reads no parameter (the runtime binds it unconditionally, and binding
+/// an optimized-out block is unsafe).
+String _paramsKeepAliveScalar(FmatParameter p) {
+  final member = '$kMaterialParamsInstance.${p.name}';
+  return switch (p.type) {
+    FmatType.float_ => member,
+    FmatType.int_ => 'float($member)',
+    FmatType.mat4 => '$member[0].x',
+    _ => '$member.x',
+  };
 }
 
 /// Emits the vertex-shader GLSL for each variant of [material], keyed by the
@@ -231,6 +239,15 @@ String _emitVertexVariant(
     }
     sb.writeln('}');
     sb.writeln('$kMaterialParamsInstance;');
+    sb.writeln();
+    // The body include folds this into the zero-bound keep-alive so the block
+    // survives even when Vertex() reads no parameter; the runtime binds it to
+    // both stages unconditionally, and binding an optimized-out block crashes
+    // the Metal backend.
+    sb.writeln(
+      '#define MATERIAL_PARAMS_KEEP_ALIVE '
+      '(${_paramsKeepAliveScalar(uniforms.first)})',
+    );
     sb.writeln();
   }
 

--- a/packages/flutter_scene/lib/src/material/material_parameters.dart
+++ b/packages/flutter_scene/lib/src/material/material_parameters.dart
@@ -399,6 +399,13 @@ class MaterialParameters {
   @internal
   bool get hasUniformBlock => _block.lengthInBytes > 0;
 
+  /// Whether this material declares any parameter at all (the uniform block
+  /// or samplers). Mirrors the emitter's condition for declaring the
+  /// `FragmentKeepAlive` block, so the runtime binds it exactly when the
+  /// generated shader carries it.
+  @internal
+  bool get hasAnyParameters => hasUniformBlock || _samplers.isNotEmpty;
+
   /// Binds only the `MaterialParams` uniform block on [shader] into [pass],
   /// not the sampler parameters. Used to make the block available to the
   /// vertex stage, whose generated shader declares the block but not the

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -151,10 +151,11 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
 
     parameters.bind(pass, fragmentShader, transientsBuffer);
     // Bind the fragment keep-alive block (name matches kFragmentKeepAliveBlock
-    // in the emitter) to zero. The generated fragment references MaterialParams
-    // through it so the block is not optimized out when Surface() reads no
-    // parameter; it is declared only when the material has such a block.
-    if (parameters.hasUniformBlock) {
+    // in the emitter) to zero. The generated fragment references every
+    // declared parameter resource through it (the MaterialParams block and
+    // any unreferenced samplers) so none can be optimized out; the emitter
+    // declares it whenever the material has any parameter.
+    if (parameters.hasAnyParameters) {
       pass.bindUniform(
         fragmentShader.getUniformSlot('FragmentKeepAlive'),
         transientsBuffer.emplace(_zeroKeepAlive),

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -65,6 +65,10 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
   ) {
     // The generated vertex variant declares the same MaterialParams block as
     // the fragment shader, so a parameter reads the same value in both stages.
+    // The variant's keep-alive references the block (see
+    // MATERIAL_PARAMS_KEEP_ALIVE in the emitter) so it survives compilation
+    // even when Vertex() reads no parameter; binding an optimized-out block
+    // crashes the Metal backend.
     parameters.bindUniformBlock(pass, vertexShader, transientsBuffer);
     // Bind the keep-alive block (name must match kVertexKeepAliveBlock in the
     // emitter) to zero: the generated shader multiplies the mesh inputs by it

--- a/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/hot_reload/hot_reloadable_fmat.dart';
 import 'package:flutter_scene/src/material/environment.dart';
@@ -36,6 +38,9 @@ class PreprocessedSky extends ShaderSkySource implements HotReloadableFmat {
   /// The sky's parameters, set by name. See [MaterialParameters].
   final MaterialParameters parameters;
 
+  // 16 zero bytes (a std140 vec4) for the FragmentKeepAlive block.
+  static final ByteData _zeroKeepAlive = ByteData(16);
+
   @override
   void updateFromMetadata(
     gpu.Shader fragmentShader,
@@ -55,6 +60,15 @@ class PreprocessedSky extends ShaderSkySource implements HotReloadableFmat {
     // Parameters (the MaterialParams block plus any declared samplers) carry
     // the sky's inputs; the raw uniform-block path is unused here.
     parameters.bind(pass, fragmentShader, transientsBuffer);
+    // Zero keep-alive, mirroring PreprocessedMaterial; the generated sky
+    // references every declared parameter resource through it so none can be
+    // optimized out.
+    if (parameters.hasAnyParameters) {
+      pass.bindUniform(
+        fragmentShader.getUniformSlot('FragmentKeepAlive'),
+        transientsBuffer.emplace(_zeroKeepAlive),
+      );
+    }
     // A `requires: [environment]` sky samples the scene's prefiltered
     // radiance, bound the same way the standard material binds it.
     if (useEnvironment) {

--- a/packages/flutter_scene/shaders/flutter_scene_skinned_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_skinned_body.glsl
@@ -100,5 +100,11 @@ void main() {
   // runtime binds the block to the vertex stage unconditionally.
   gl_Position.x += vertex_keep_alive.keep_alive.x * MATERIAL_PARAMS_KEEP_ALIVE;
 #endif
+#ifdef MATERIAL_ATTRIBUTES_KEEP_ALIVE
+  // Keep declared custom attributes live even when Vertex() reads none; a
+  // stripped input breaks reflection and the pipeline's vertex layout.
+  gl_Position.x +=
+      vertex_keep_alive.keep_alive.x * MATERIAL_ATTRIBUTES_KEEP_ALIVE;
+#endif
 #endif
 }

--- a/packages/flutter_scene/shaders/flutter_scene_skinned_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_skinned_body.glsl
@@ -95,5 +95,10 @@ void main() {
       vec4(position + normal + vec3(texture_coords, 0.0) + color.xyz +
                joints.xyz + weights.xyz,
            0.0);
+#ifdef MATERIAL_PARAMS_KEEP_ALIVE
+  // Keep MaterialParams live even when Vertex() reads no parameter; the
+  // runtime binds the block to the vertex stage unconditionally.
+  gl_Position.x += vertex_keep_alive.keep_alive.x * MATERIAL_PARAMS_KEEP_ALIVE;
+#endif
 #endif
 }

--- a/packages/flutter_scene/shaders/flutter_scene_unskinned_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_unskinned_body.glsl
@@ -68,5 +68,11 @@ void main() {
   // runtime binds the block to the vertex stage unconditionally.
   gl_Position.x += vertex_keep_alive.keep_alive.x * MATERIAL_PARAMS_KEEP_ALIVE;
 #endif
+#ifdef MATERIAL_ATTRIBUTES_KEEP_ALIVE
+  // Keep declared custom attributes live even when Vertex() reads none; a
+  // stripped input breaks reflection and the pipeline's vertex layout.
+  gl_Position.x +=
+      vertex_keep_alive.keep_alive.x * MATERIAL_ATTRIBUTES_KEEP_ALIVE;
+#endif
 #endif
 }

--- a/packages/flutter_scene/shaders/flutter_scene_unskinned_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_unskinned_body.glsl
@@ -53,9 +53,15 @@ void main() {
 #ifdef HAS_MATERIAL_VERTEX
   // Reference the mesh inputs behind a runtime-zero (see VertexKeepAlive) so a
   // Vertex() hook that fully replaces the outputs cannot let the optimizer
-  // strip a declared attribute, which would break shader reflection. Compiled
-  // only into a .fmat's vertex variants, never the engine's base shaders.
+  // strip a declared attribute, which would break shader reflection. The
+  // instance-rate model_transform columns are included because a hook that
+  // overwrites world_position without reading it leaves them dead too.
+  // Compiled only into a .fmat's vertex variants, never the engine's base
+  // shaders.
   gl_Position += vertex_keep_alive.keep_alive.x *
-      vec4(position + normal + vec3(texture_coords, 0.0) + color.xyz, 0.0);
+      vec4(position + normal + vec3(texture_coords, 0.0) + color.xyz +
+               model_transform_0.xyz + model_transform_1.xyz +
+               model_transform_2.xyz + model_transform_3.xyz,
+           0.0);
 #endif
 }

--- a/packages/flutter_scene/shaders/flutter_scene_unskinned_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_unskinned_body.glsl
@@ -63,5 +63,10 @@ void main() {
                model_transform_0.xyz + model_transform_1.xyz +
                model_transform_2.xyz + model_transform_3.xyz,
            0.0);
+#ifdef MATERIAL_PARAMS_KEEP_ALIVE
+  // Keep MaterialParams live even when Vertex() reads no parameter; the
+  // runtime binds the block to the vertex stage unconditionally.
+  gl_Position.x += vertex_keep_alive.keep_alive.x * MATERIAL_PARAMS_KEEP_ALIVE;
+#endif
 #endif
 }

--- a/packages/flutter_scene/shaders/flutter_scene_unskinned_depth_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_unskinned_depth_body.glsl
@@ -55,8 +55,12 @@ void main() {
   v_color = vec4(0.0);
 
 #ifdef HAS_MATERIAL_VERTEX
-  // Keep the position input live so a hook that replaces world_position cannot
-  // strip it (see VertexKeepAlive). Only position is fetched in the depth pass.
-  gl_Position += vertex_keep_alive.keep_alive.x * vec4(position, 0.0);
+  // Keep the position input and the instance-rate model_transform columns
+  // live so a hook that replaces world_position cannot strip them (see
+  // VertexKeepAlive). Only position is fetched in the depth pass.
+  gl_Position += vertex_keep_alive.keep_alive.x *
+      vec4(position + model_transform_0.xyz + model_transform_1.xyz +
+               model_transform_2.xyz + model_transform_3.xyz,
+           0.0);
 #endif
 }

--- a/packages/flutter_scene/shaders/flutter_scene_unskinned_depth_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_unskinned_depth_body.glsl
@@ -67,5 +67,11 @@ void main() {
   // runtime binds the block to the vertex stage unconditionally.
   gl_Position.x += vertex_keep_alive.keep_alive.x * MATERIAL_PARAMS_KEEP_ALIVE;
 #endif
+#ifdef MATERIAL_ATTRIBUTES_KEEP_ALIVE
+  // Keep declared custom attributes live even when Vertex() reads none; a
+  // stripped input breaks reflection and the pipeline's vertex layout.
+  gl_Position.x +=
+      vertex_keep_alive.keep_alive.x * MATERIAL_ATTRIBUTES_KEEP_ALIVE;
+#endif
 #endif
 }

--- a/packages/flutter_scene/shaders/flutter_scene_unskinned_depth_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_unskinned_depth_body.glsl
@@ -62,5 +62,10 @@ void main() {
       vec4(position + model_transform_0.xyz + model_transform_1.xyz +
                model_transform_2.xyz + model_transform_3.xyz,
            0.0);
+#ifdef MATERIAL_PARAMS_KEEP_ALIVE
+  // Keep MaterialParams live even when Vertex() reads no parameter; the
+  // runtime binds the block to the vertex stage unconditionally.
+  gl_Position.x += vertex_keep_alive.keep_alive.x * MATERIAL_PARAMS_KEEP_ALIVE;
+#endif
 #endif
 }

--- a/packages/flutter_scene/test/fmat_test.dart
+++ b/packages/flutter_scene/test/fmat_test.dart
@@ -206,6 +206,36 @@ fragment {
         ),
       );
     });
+
+    test('vertex variants keep MaterialParams live via the body macro', () {
+      // A Vertex() that reads no parameter must not let the compiler strip
+      // the MaterialParams block from the variant; the runtime binds it to
+      // the vertex stage unconditionally.
+      final c = compileFmat('''
+material {
+  name: "V",
+  shading_model: unlit,
+  parameters: [ { type: float, name: k, default: 1.0 } ],
+  varyings: [ { type: float, name: h } ],
+}
+vertex {
+  void Vertex(inout VertexInputs vertex) {
+    h = vertex.position.y;
+  }
+}
+fragment {
+  void Surface(inout MaterialInputs material) {
+    material.base_color = vec4(h);
+  }
+}
+''');
+      for (final variant in c.vertexGlsl.values) {
+        expect(
+          variant,
+          contains('#define MATERIAL_PARAMS_KEEP_ALIVE (material_params.k)'),
+        );
+      }
+    });
   });
 
   group('sidecar', () {

--- a/packages/flutter_scene/test/fmat_test.dart
+++ b/packages/flutter_scene/test/fmat_test.dart
@@ -156,7 +156,7 @@ fragment {
       );
       expect(
         c.glsl,
-        contains('fragment_keep_alive.keep_alive.x * material_params.k'),
+        contains('fragment_keep_alive.keep_alive.x * (material_params.k)'),
       );
     });
 
@@ -182,7 +182,7 @@ fragment {
         c.glsl,
         contains(
           'fragment_keep_alive.keep_alive.x * '
-          'material_params.transform[0].x',
+          '(material_params.transform[0].x)',
         ),
       );
 
@@ -202,7 +202,7 @@ fragment {
         ci.glsl,
         contains(
           'fragment_keep_alive.keep_alive.x * '
-          'float(material_params.steps)',
+          '(float(material_params.steps))',
         ),
       );
     });
@@ -235,6 +235,132 @@ fragment {
           contains('#define MATERIAL_PARAMS_KEEP_ALIVE (material_params.k)'),
         );
       }
+    });
+
+    test(
+      'vertex variants keep declared attributes live via the body macro',
+      () {
+        // An attribute Vertex() never reads must not be stripped; the geometry
+        // supplies its buffer unconditionally, and a missing input breaks
+        // reflection and the pipeline's vertex layout.
+        final c = compileFmat('''
+material {
+  name: "A",
+  shading_model: unlit,
+  attributes: [
+    { type: float, name: seed },
+    { type: vec3, name: center },
+  ],
+  varyings: [ { type: float, name: h } ],
+}
+vertex {
+  void Vertex(inout VertexInputs vertex) {
+    h = vertex.position.y;
+  }
+}
+fragment {
+  void Surface(inout MaterialInputs material) {
+    material.base_color = vec4(h);
+  }
+}
+''');
+        for (final variant in c.vertexGlsl.values) {
+          expect(
+            variant,
+            contains(
+              '#define MATERIAL_ATTRIBUTES_KEEP_ALIVE (seed + center.x)',
+            ),
+          );
+        }
+      },
+    );
+
+    test('keep-alive fetches samplers the fragment never references', () {
+      // The runtime binds every declared sampler; one the author's code never
+      // samples must not be stripped from the compiled shader.
+      final c = compileFmat('''
+material {
+  name: "S",
+  shading_model: unlit,
+  parameters: [
+    { type: sampler2d, name: used_texture, hint: default_white },
+    { type: sampler2d, name: unused_texture, hint: default_white },
+    { type: samplerCube, name: unused_cube, hint: default_black },
+  ],
+}
+fragment {
+  void Surface(inout MaterialInputs material) {
+    material.base_color = texture(used_texture, GetUV0());
+  }
+}
+''');
+      // No MaterialParams block, but the keep-alive block is still declared
+      // for the sampler fetches.
+      expect(c.glsl, isNot(contains('uniform MaterialParams {')));
+      expect(
+        c.glsl,
+        contains('uniform FragmentKeepAlive { vec4 keep_alive; }'),
+      );
+      expect(c.glsl, contains('texture(unused_texture, vec2(0.0)).x'));
+      expect(c.glsl, contains('texture(unused_cube, vec3(0.0, 0.0, 1.0)).x'));
+      // The sampler the fragment really uses pays no keep-alive fetch.
+      expect(c.glsl, isNot(contains('texture(used_texture, vec2(0.0))')));
+    });
+
+    test(
+      'sampler-only material with all samplers used keeps the block live',
+      () {
+        final c = compileFmat('''
+material {
+  name: "S2",
+  shading_model: unlit,
+  parameters: [
+    { type: sampler2d, name: tex, hint: default_white },
+  ],
+}
+fragment {
+  void Surface(inout MaterialInputs material) {
+    material.base_color = texture(tex, GetUV0());
+  }
+}
+''');
+        expect(
+          c.glsl,
+          contains(
+            'fragment_keep_alive.keep_alive.x * '
+            'fragment_keep_alive.keep_alive.y',
+          ),
+        );
+      },
+    );
+
+    test('sky shaders carry the same parameter keep-alive', () {
+      final c = compileFmat('''
+material {
+  name: "SkyK",
+  parameters: [
+    { type: vec3, name: unused_color, default: [0.0, 0.0, 0.0] },
+    { type: sampler2d, name: unused_texture, hint: default_white },
+  ],
+}
+sky {
+  vec3 Sky(vec3 direction) {
+    return vec3(0.5);
+  }
+}
+''');
+      expect(
+        c.glsl,
+        contains('uniform FragmentKeepAlive { vec4 keep_alive; }'),
+      );
+      expect(
+        c.glsl,
+        contains(
+          'frag_color.r += fragment_keep_alive.keep_alive.x * '
+          '(material_params.unused_color.x + '
+          'texture(unused_texture, vec2(0.0)).x)',
+        ),
+      );
     });
   });
 

--- a/packages/flutter_scene/test/fmat_test.dart
+++ b/packages/flutter_scene/test/fmat_test.dart
@@ -159,6 +159,53 @@ fragment {
         contains('fragment_keep_alive.keep_alive.x * material_params.k'),
       );
     });
+
+    test('keep-alive reads a scalar from mat4 and int leading parameters', () {
+      // The keep-alive multiplies the first MaterialParams member; a plain
+      // `.x` swizzle is invalid GLSL on mat4 and int members.
+      final c = compileFmat('''
+material {
+  name: "M",
+  shading_model: unlit,
+  parameters: [
+    { type: mat4, name: transform },
+    { type: float, name: k, default: 1.0 },
+  ],
+}
+fragment {
+  void Surface(inout MaterialInputs material) {
+    material.base_color = vec4(1.0);
+  }
+}
+''');
+      expect(
+        c.glsl,
+        contains(
+          'fragment_keep_alive.keep_alive.x * '
+          'material_params.transform[0].x',
+        ),
+      );
+
+      final ci = compileFmat('''
+material {
+  name: "I",
+  shading_model: unlit,
+  parameters: [ { type: int, name: steps, default: 3 } ],
+}
+fragment {
+  void Surface(inout MaterialInputs material) {
+    material.base_color = vec4(1.0);
+  }
+}
+''');
+      expect(
+        ci.glsl,
+        contains(
+          'fragment_keep_alive.keep_alive.x * '
+          'float(material_params.steps)',
+        ),
+      );
+    });
   });
 
   group('sidecar', () {


### PR DESCRIPTION
Adds a "Materialize (.fmat)" example page where the DamagedHelmet (downloaded like the stress tests) phases into existence from the bottom of the model to the top in three draw calls over the same model. A glowing wireframe forms first (view-facing ribbon quads built over the mesh's unique edges, with a thickness control), then glass shards fly in and assemble (an unwelded triangle soup with flat outward normals and per-triangle centroid/seed attributes; each shard's scattered pose composes a bias direction, a radial push from the model center, a push along its face normal, and seeded jitter, and it eases in along an s-curve with a soft landing, glowing on the surface until it is phased over), then the real PBR surface reveals itself behind a hot emissive seam (the original geometry with its own textures re-bound into a clipping material). All three boundaries are wobbled by a shared gradient noise with per-dimension scale controls so the seam stays line-like but reads amorphous. A side panel exposes the look and timing of every stage with a print button that dumps the current values, and the shared lighting panel is embedded.

The example app also gains per-example settings instances (tuning one scene no longer leaks into the others) with a registry for per-scene defaults, and the lighting panel accepts startup values so a scene can open with its intended environment. The Materialize page uses both for a dark, cinematic setup.

Building the example flushed out five latent bugs in the .fmat pipeline, all one family. The shader compiler strips declared resources the author's code never reads, reflection still lists them, and the runtime binds them unconditionally, so the failures ranged from cryptic build errors to native crashes in the Metal backend. Each is fixed by keeping the resource genuinely live in the emitted GLSL, since the runtime cannot detect the strip:

- The fragment keep-alive emitted invalid GLSL when the leading material parameter is a `mat4` (or `int`).
- A `Vertex()` hook that fully replaces `world_position` let the instance-rate `model_transform` attributes strip, breaking reflection and vertex binding.
- A `Vertex()` hook that reads no parameter let the `MaterialParams` block strip from the vertex variant, and the unconditional vertex-stage bind crashed the Metal backend at draw.
- A declared custom attribute `Vertex()` never reads failed shader-bundle reflection at build time.
- A declared sampler the fragment never samples crashed the Metal backend at draw. Unreferenced samplers now get a zero-multiplied keep-alive fetch (samplers the author's code uses pay nothing extra), sampler-only materials keep the keep-alive block live through a self-reference, and sky shaders carry the same protection.

All 805 tests pass, including new emitter regression tests for each case, and the example is verified on Metal.
