### PR TITLE
Replace per-frame HostBuffer transients with a completion-aware arena

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,15 +1,38 @@
 ## 0.19.0
 
+* Per-frame transient GPU data (uniform blocks, instance transforms) now
+  rides an engine-owned, completion-aware arena allocator instead of
+  `package:flutter_gpu`'s `HostBuffer`. Emplacements stage CPU-side and
+  upload in a single write per block just before each command buffer
+  submission; a block is never written again while in-flight frames may
+  read it, and pooled memory grows with actual GPU queue depth and shrinks
+  back afterward. This removes a redundant 4x internal buffer ring, fixes
+  whole-frame aborts when a frame emplaces more than ~1MB of transients (a
+  `HostBuffer` block-boundary bug), and collapses per-draw GPU buffer
+  writes into a handful of block uploads per frame.
+
+* BREAKING: the custom-pass and material/geometry `bind` surfaces take a
+  `TransientWriter` (newly exported) where they previously took a
+  `gpu.HostBuffer`, and `RenderPassContext.transientsBuffer` changes type
+  accordingly. Call sites that only called `emplace` need no changes
+  beyond the parameter type.
+
 * Large speedup for many-draw scenes on the web backend. Per-draw uniform
   data was written into one shared GL buffer between draws that read it,
   which forces the browser's GL implementation to copy ("ghost") the buffer
   on every write; a scene with ~100 draw calls spent most of its frame time
-  there, in the browser's GPU process. Per-draw uniforms now go into small
-  pooled buffers written once per frame cycle (105-draw test scene, Apple
-  M3 Max Chrome, 35 fps to a 120 fps display cap). Vertex-attribute state is
-  also cached in vertex-array objects per (pipeline, geometry, index buffer)
-  instead of being re-specified every draw, and redundant per-draw texture
-  sampler-state calls are skipped.
+  there, in the browser's GPU process. Transient data is now written exactly
+  once per buffer before the draws that read it (see the arena entry above;
+  105-draw test scene, Apple M3 Max Chrome, 35 fps to a 120 fps display
+  cap). Vertex-attribute state is also cached in vertex-array objects per
+  (pipeline, geometry, index buffer) instead of being re-specified every
+  draw, and redundant per-draw texture sampler-state calls are skipped.
+
+* The web shim's `HostBuffer` is a faithful port of flutter_gpu's block bump
+  allocator again (with a corrected length-aware block-rollover bounds
+  check), keeping the shim a drop-in flutter_gpu replacement for consumers
+  that use it directly; the engine itself no longer allocates through
+  `HostBuffer` on any backend.
 
 * Ambient occlusion and screen-space reflections no longer sample the wrong
   depth for double-sided (`culling: none`) materials. The depth prepass they

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -9,7 +9,11 @@
   back afterward. This removes a redundant 4x internal buffer ring, fixes
   whole-frame aborts when a frame emplaces more than ~1MB of transients (a
   `HostBuffer` block-boundary bug), and collapses per-draw GPU buffer
-  writes into a handful of block uploads per frame.
+  writes into a handful of block uploads per frame. On the WebGL2 backend,
+  where GL commands execute during pass encoding (so a bound buffer can
+  never be written again without the browser ghosting it), the same arena
+  interface is backed by per-emplacement pooled buffers with identical
+  completion-gated recycling and shrink behavior.
 
 * BREAKING: the custom-pass and material/geometry `bind` surfaces take a
   `TransientWriter` (newly exported) where they previously took a

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -109,6 +109,7 @@ export 'src/light.dart'
         SpotLight;
 export 'src/render/custom_render_pass.dart'
     show CustomRenderPass, RenderInput, RenderPassContext, RenderStage;
+export 'src/render/frame_transients.dart' show TransientWriter;
 export 'src/render/object_filter.dart' show NodeFilter;
 export 'src/render/render_layers.dart'
     show kRenderLayerAll, kRenderLayerDefault;

--- a/packages/flutter_scene/lib/src/geometry/billboard_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/billboard_geometry.dart
@@ -6,8 +6,8 @@ import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
-import 'package:flutter_scene/src/render/instance_packing.dart';
 import 'package:flutter_scene/src/shaders.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// How a billboard quad orients itself toward the camera.
 /// {@category Geometry}
@@ -179,7 +179,7 @@ class BillboardGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     vm.Matrix4 modelTransform,
     vm.Matrix4 cameraTransform,
     vm.Vector3 cameraPosition, {
@@ -197,10 +197,7 @@ class BillboardGeometry extends Geometry {
         0,
         _instanceCount * floatsPerInstance,
       );
-      pass.bindVertexBuffer(
-        instanceTransformBuffers.emplace(liveBytes),
-        slot: 1,
-      );
+      pass.bindVertexBuffer(instanceTransients.emplace(liveBytes), slot: 1);
     }
 
     final frameInfo = Float32List(44);

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/importer/constants.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'package:flutter_scene/src/shaders.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// Vertex (and optional index) data along with the vertex shader used to
 /// transform it.
@@ -490,7 +491,7 @@ abstract class Geometry {
   /// place its uniform blocks at different binding points.
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     vm.Matrix4 modelTransform,
     vm.Matrix4 cameraTransform,
     vm.Vector3 cameraPosition, {
@@ -761,7 +762,7 @@ class UnskinnedGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     vm.Matrix4 modelTransform,
     vm.Matrix4 cameraTransform,
     vm.Vector3 cameraPosition, {
@@ -814,7 +815,7 @@ class SkinnedGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     vm.Matrix4 modelTransform,
     vm.Matrix4 cameraTransform,
     vm.Vector3 cameraPosition, {
@@ -1089,7 +1090,7 @@ final VertexLayoutDescriptor kUnskinnedSoADepthLayout = VertexLayoutDescriptor(
 @internal
 void bindUnskinnedFrameInfo(
   gpu.RenderPass pass,
-  gpu.HostBuffer transientsBuffer,
+  TransientWriter transientsBuffer,
   gpu.Shader shader,
   vm.Matrix4 cameraTransform,
   vm.Vector3 cameraPosition,

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -694,7 +694,7 @@ class _RingBufferStream {
   /// Tightly packed bytes for one vertex of this attribute.
   final int bytesPerVertex;
 
-  // Matches `gpu.HostBuffer`'s frame count, the number of frames the engine
+  // Matches `TransientWriter`'s frame count, the number of frames the engine
   // cycles transient buffers through.
   static const int _ringDepth = 4;
 

--- a/packages/flutter_scene/lib/src/gpu/web/buffer.dart
+++ b/packages/flutter_scene/lib/src/gpu/web/buffer.dart
@@ -143,80 +143,107 @@ base class DeviceBuffer {
 /// Bump allocator that hands out [BufferView] slices from a chain of
 /// [DeviceBuffer] blocks. Re-cycles blocks every [frameCount] frames when
 /// [reset] is called.
+///
+/// A faithful port of flutter_gpu's HostBuffer (block bump allocation,
+/// [frameCount]-frame rotation, per-emplacement uniform alignment) so the
+/// shim stays a drop-in flutter_gpu replacement. The one deliberate
+/// difference: block rollover accounts for the write's own length, and an
+/// emplacement into a fresh block gets a view of the data's length; the
+/// upstream check hands out views that overrun the block when an aligned
+/// offset fits but the write's end does not (fix submitted upstream).
+///
+/// flutter_scene's renderer does not use HostBuffer (its transients ride
+/// the completion-aware arenas in `render/frame_transients.dart`), so the
+/// buffer-ghosting cost of rewriting live GL buffers only affects direct
+/// shim consumers who emplace against in-flight frames, matching what
+/// flutter_gpu does natively.
 base class HostBuffer {
   static const int kDefaultBlockLengthInBytes = 1024000;
   static const int _kFrameCount = 4;
-
-  /// Pooled emplacement size classes. Each emplacement gets its own small GL
-  /// buffer, written exactly once and then only read until its frame slot
-  /// comes around again. Writing into a buffer that in-flight draws already
-  /// read forces the browser's GL implementation to ghost (copy) the buffer
-  /// per write, which dominated per-draw cost out of all proportion to the
-  /// bytes moved; one-write-per-cycle buffers never ghost.
-  static const List<int> _kPoolClassSizes = [512, 4096];
 
   HostBuffer._initialize(
     this._gpuContext, {
     this.blockLengthInBytes = HostBuffer.kDefaultBlockLengthInBytes,
   }) {
     for (var frame = 0; frame < _kFrameCount; frame++) {
-      _pools.add([for (final _ in _kPoolClassSizes) <DeviceBuffer>[]]);
-      _cursors.add(List<int>.filled(_kPoolClassSizes.length, 0));
+      _buffers.add([_allocateNewBlock(blockLengthInBytes)]);
     }
   }
 
   final GpuContext _gpuContext;
 
-  /// Retained for API compatibility with flutter_gpu's HostBuffer; the web
-  /// backend pools per-emplacement buffers instead of bump-allocating blocks.
+  /// The length of each [DeviceBuffer] block.
   final int blockLengthInBytes;
 
   int get frameCount => _kFrameCount;
 
   int _frameCursor = 0;
+  int _bufferCursor = 0;
+  int _offsetCursor = 0;
 
-  /// Pooled emplacement buffers: [frame][sizeClass] -> buffers, reused in
-  /// order each time their frame slot comes around.
-  final List<List<List<DeviceBuffer>>> _pools = [];
-  final List<List<int>> _cursors = [];
+  /// Per-frame block chains, matching flutter_gpu's layout.
+  final List<List<DeviceBuffer>> _buffers = [];
 
   DeviceBuffer _allocateNewBlock(int length) =>
       _gpuContext.createDeviceBuffer(StorageMode.hostVisible, length);
 
-  /// Append byte data and return a view at the resulting GPU offset.
-  BufferView emplace(ByteData bytes) {
-    final length = bytes.lengthInBytes;
-    for (var sizeClass = 0; sizeClass < _kPoolClassSizes.length; sizeClass++) {
-      if (length > _kPoolClassSizes[sizeClass]) continue;
-      final pool = _pools[_frameCursor][sizeClass];
-      final cursor = _cursors[_frameCursor][sizeClass]++;
-      final DeviceBuffer buffer;
-      if (cursor < pool.length) {
-        buffer = pool[cursor];
-      } else {
-        buffer = _allocateNewBlock(_kPoolClassSizes[sizeClass]);
-        pool.add(buffer);
-      }
-      if (!buffer.overwrite(bytes)) {
-        throw Exception('HostBuffer emplace failed');
-      }
-      return BufferView(buffer, offsetInBytes: 0, lengthInBytes: length);
+  BufferView _allocateEmplacement(ByteData bytes) {
+    if (bytes.lengthInBytes > blockLengthInBytes) {
+      return BufferView(
+        _allocateNewBlock(bytes.lengthInBytes),
+        offsetInBytes: 0,
+        lengthInBytes: bytes.lengthInBytes,
+      );
     }
-    // Oversize emplacement: a dedicated buffer of its own.
-    final buffer = _allocateNewBlock(length);
-    if (!buffer.overwrite(bytes)) {
-      throw Exception('HostBuffer emplace failed');
+
+    var padding =
+        _gpuContext.minimumUniformByteAlignment -
+        (_offsetCursor % _gpuContext.minimumUniformByteAlignment);
+    padding %= _gpuContext.minimumUniformByteAlignment;
+    if (_offsetCursor + padding + bytes.lengthInBytes > blockLengthInBytes) {
+      final buffer = _allocateNewBlock(blockLengthInBytes);
+      _buffers[_frameCursor].add(buffer);
+      _bufferCursor++;
+      _offsetCursor = bytes.lengthInBytes;
+      return BufferView(
+        buffer,
+        offsetInBytes: 0,
+        lengthInBytes: bytes.lengthInBytes,
+      );
     }
-    return BufferView(buffer, offsetInBytes: 0, lengthInBytes: length);
+
+    _offsetCursor += padding;
+    final view = BufferView(
+      _buffers[_frameCursor][_bufferCursor],
+      offsetInBytes: _offsetCursor,
+      lengthInBytes: bytes.lengthInBytes,
+    );
+    _offsetCursor += bytes.lengthInBytes;
+    return view;
   }
 
-  /// Advance the frame cursor; subsequent [emplace] calls reuse the next
-  /// frame's buffers.
+  /// Append byte data and return a view at the resulting GPU offset.
+  BufferView emplace(ByteData bytes) {
+    final view = _allocateEmplacement(bytes);
+    if (!view.buffer.overwrite(
+      bytes,
+      destinationOffsetInBytes: view.offsetInBytes,
+    )) {
+      throw Exception(
+        'Failed to write range (offset=${view.offsetInBytes}, '
+        'length=${view.lengthInBytes}) to HostBuffer-managed DeviceBuffer '
+        '(frame=$_frameCursor, buffer=$_bufferCursor, '
+        'offset=$_offsetCursor).',
+      );
+    }
+    return view;
+  }
+
+  /// Resets the bump allocator to the beginning of the next frame's first
+  /// [DeviceBuffer] block.
   void reset() {
     _frameCursor = (_frameCursor + 1) % frameCount;
-    final cursors = _cursors[_frameCursor];
-    for (var i = 0; i < cursors.length; i++) {
-      cursors[i] = 0;
-    }
+    _bufferCursor = 0;
+    _offsetCursor = 0;
   }
 }

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// Packs the engine lighting half of the shared `FragInfo` uniform block and
 /// binds the image-based-lighting and shadow samplers.
@@ -139,7 +140,7 @@ class EngineLightingUniforms {
   static void bindFog(
     gpu.RenderPass pass,
     gpu.Shader shader,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     final fog = lighting.fog;

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -11,6 +11,7 @@ import 'package:flutter_scene/src/material/unlit_material.dart';
 import 'package:flutter_scene/src/render_texture.dart';
 import 'package:flutter_scene/src/shaders.dart';
 import 'package:flutter_scene/src/texture/texture2d.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// Resolves a texture-slot value to the texture to sample this frame.
 ///
@@ -240,7 +241,7 @@ abstract class Material {
   void bindVertexStage(
     gpu.RenderPass pass,
     gpu.Shader vertexShader,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
   ) {}
 
   /// Binds this material's render-pass state, uniforms, and textures.
@@ -253,7 +254,7 @@ abstract class Material {
   /// shadow resources that materials shade against.
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     pass.setCullMode(renderCullMode);

--- a/packages/flutter_scene/lib/src/material/material_parameters.dart
+++ b/packages/flutter_scene/lib/src/material/material_parameters.dart
@@ -8,6 +8,7 @@ import 'package:vector_math/vector_math.dart';
 import 'package:flutter_scene/src/fmat/fmat_ast.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 class _ParamSlot {
   _ParamSlot(this.type, this.offsetBytes, {this.sourceColor = false});
@@ -406,7 +407,7 @@ class MaterialParameters {
   void bindUniformBlock(
     gpu.RenderPass pass,
     gpu.Shader shader,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
   ) {
     if (_block.lengthInBytes > 0) {
       pass.bindUniform(
@@ -420,7 +421,7 @@ class MaterialParameters {
   void bind(
     gpu.RenderPass pass,
     gpu.Shader shader,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
   ) {
     bindUniformBlock(pass, shader, transientsBuffer);
     for (final entry in _samplers.entries) {

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/texture/texture2d.dart';
 
 import 'package:vector_math/vector_math.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// How a [PhysicallyBasedMaterial]'s alpha channel is interpreted,
 /// matching glTF's `alphaMode`.
@@ -167,7 +168,7 @@ class PhysicallyBasedMaterial extends Material {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     super.bind(pass, transientsBuffer, lighting);

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/material/material_parameters.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// A material driven by a `.fmat` custom-material shader and its sidecar
 /// metadata (produced at build time by `buildMaterials`).
@@ -61,7 +62,7 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
   void bindVertexStage(
     gpu.RenderPass pass,
     gpu.Shader vertexShader,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
   ) {
     // The generated vertex variant declares the same MaterialParams block as
     // the fragment shader, so a parameter reads the same value in both stages.
@@ -110,7 +111,7 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     pass.setCullMode(renderCullMode);

--- a/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
@@ -3,6 +3,7 @@ import 'package:flutter_scene/src/hot_reload/hot_reloadable_fmat.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material_parameters.dart';
 import 'package:flutter_scene/src/skybox.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// A sky driven by a `.fmat` sky shader (`sky { vec3 Sky(vec3 direction) }`)
 /// and its sidecar metadata (produced at build time by `buildMaterials`).
@@ -49,7 +50,7 @@ class PreprocessedSky extends ShaderSkySource implements HotReloadableFmat {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     EnvironmentMap environment,
   ) {
     // Parameters (the MaterialParams block plus any declared samplers) carry

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -6,6 +6,7 @@ import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/texture/texture2d.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// A [Material] backed by a caller-supplied fragment shader.
 ///
@@ -191,7 +192,7 @@ class ShaderMaterial extends Material {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     pass.setCullMode(cullingMode);

--- a/packages/flutter_scene/lib/src/material/sprite_material.dart
+++ b/packages/flutter_scene/lib/src/material/sprite_material.dart
@@ -8,6 +8,7 @@ import 'package:flutter_scene/src/shaders.dart';
 import 'package:flutter_scene/src/texture/texture2d.dart';
 
 import 'package:vector_math/vector_math.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// Selects how a sprite's color is blended into the scene.
 /// {@category Materials}
@@ -71,7 +72,7 @@ class SpriteMaterial extends Material {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     super.bind(pass, transientsBuffer, lighting);

--- a/packages/flutter_scene/lib/src/material/unlit_material.dart
+++ b/packages/flutter_scene/lib/src/material/unlit_material.dart
@@ -8,6 +8,7 @@ import 'package:flutter_scene/src/material/physically_based_material.dart'
     show AlphaMode;
 
 import 'package:vector_math/vector_math.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// A material that draws geometry with a flat color or texture, ignoring
 /// scene lighting.
@@ -62,7 +63,7 @@ class UnlitMaterial extends Material {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     super.bind(pass, transientsBuffer, lighting);

--- a/packages/flutter_scene/lib/src/post_process/post_effect.dart
+++ b/packages/flutter_scene/lib/src/post_process/post_effect.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/shader_uniform_bindings.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// Where in the post-processing chain a [PostEffect] runs.
 /// {@category Rendering}
@@ -118,6 +119,6 @@ class PostEffect {
   Iterable<String> get textureNames => _bindings.textureNames;
 
   /// Binds this effect's own uniform blocks and textures. Engine-internal.
-  void bindUniforms(gpu.RenderPass pass, gpu.HostBuffer transientsBuffer) =>
+  void bindUniforms(gpu.RenderPass pass, TransientWriter transientsBuffer) =>
       _bindings.bind(pass, fragmentShader, transientsBuffer);
 }

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -184,7 +184,7 @@ class _DepthPrepassEncoder {
   }
 
   final gpu.RenderPass _renderPass;
-  final gpu.HostBuffer _transientsBuffer;
+  final TransientWriter _transientsBuffer;
   final Matrix4 _cameraTransform;
   final Vector3 _cameraPosition;
   final int _layerMask;

--- a/packages/flutter_scene/lib/src/render/env_prefilter.dart
+++ b/packages/flutter_scene/lib/src/render/env_prefilter.dart
@@ -221,7 +221,7 @@ void prefilterEquirectRadianceCubeFace(
     ..[16] = (sourceEquirect.mipLevelCount - 1).toDouble();
   renderPass.bindUniform(
     fragmentShader.getUniformSlot('PrefilterCubeInfo'),
-    gpu.gpuContext.createHostBuffer().emplace(ByteData.sublistView(info)),
+    uniformTransients.emplace(ByteData.sublistView(info)),
   );
   drawCompat(renderPass, 6);
   rendererSubmissions.submit(commandBuffer);
@@ -332,7 +332,7 @@ void _prefilterPass(
     ..[2] = mipLayout ? 1.0 : 0.0;
   renderPass.bindUniform(
     fragmentShader.getUniformSlot('PrefilterInfo'),
-    gpu.gpuContext.createHostBuffer().emplace(ByteData.sublistView(info)),
+    uniformTransients.emplace(ByteData.sublistView(info)),
   );
   drawCompat(renderPass, 6);
   rendererSubmissions.submit(commandBuffer);

--- a/packages/flutter_scene/lib/src/render/frame_transients.dart
+++ b/packages/flutter_scene/lib/src/render/frame_transients.dart
@@ -13,6 +13,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 class GpuSubmissionTracker {
   int _lastId = 0;
   final SplayTreeSet<int> _pending = SplayTreeSet<int>();
+  final List<void Function(int id)> _beforeSubmit = [];
 
   /// The id of the most recent submission.
   int get latestSubmission => _lastId;
@@ -20,6 +21,13 @@ class GpuSubmissionTracker {
   /// The highest id such that all submissions up to and including it have
   /// completed.
   int get completedThrough => _pending.isEmpty ? _lastId : _pending.first - 1;
+
+  /// Registers [listener] to run just before every submission, with the id
+  /// the submission will get. Transient arenas use this to upload and seal
+  /// their staged blocks so the submitted work reads complete data.
+  void addBeforeSubmitListener(void Function(int id) listener) {
+    _beforeSubmit.add(listener);
+  }
 
   /// Submits [commandBuffer] and records it for completion tracking.
   void submit(gpu.CommandBuffer commandBuffer) {
@@ -30,7 +38,11 @@ class GpuSubmissionTracker {
   /// Records a submission without a command buffer. Prefer [submit].
   @visibleForTesting
   int record() {
-    final int id = ++_lastId;
+    final int id = _lastId + 1;
+    for (final listener in _beforeSubmit) {
+      listener(id);
+    }
+    _lastId = id;
     _pending.add(id);
     return id;
   }
@@ -45,72 +57,266 @@ class GpuSubmissionTracker {
 /// The tracker for every command buffer the renderer submits.
 final GpuSubmissionTracker rendererSubmissions = GpuSubmissionTracker();
 
-/// Rotates per-frame transient [gpu.HostBuffer]s so that one is never reset
-/// while the GPU may still read data written into it.
+/// Destination for per-frame transient GPU data (uniform blocks, instance
+/// vertex data). Emplaced data is valid for the current frame only.
 ///
-/// [gpu.HostBuffer] recycles its internal storage a fixed number of resets
-/// after data is written, which corrupts rendering when frames are deep in
-/// flight on the GPU. The pool sidesteps that by handing out a buffer whose
-/// previously submitted work has completed, or a fresh buffer when none has.
-/// Buffer memory therefore grows with actual GPU queue depth and shrinks
-/// back when the queue drains.
-class TransientsPool {
-  TransientsPool(this._tracker);
+/// {@category Rendering}
+abstract interface class TransientWriter {
+  /// Appends [bytes] and returns a view referencing them, aligned per the
+  /// writer's purpose. The view must only be used by work submitted this
+  /// frame.
+  gpu.BufferView emplace(ByteData bytes);
+}
+
+/// A completion-aware bump allocator for per-frame transient GPU data.
+///
+/// Emplacements are staged CPU-side into fixed-size blocks and returned as
+/// views of the block's device buffer. Just before each command buffer
+/// submission (via [GpuSubmissionTracker.addBeforeSubmitListener]), every
+/// open block uploads its used range in a single write and is sealed; the
+/// next emplacement opens a fresh block. A sealed block's device buffer is
+/// never written again until the GPU work referencing it completes and the
+/// block is recycled, so in-flight frames can never observe a partial or
+/// overwritten buffer, no backend ever needs to ghost (copy) a buffer on
+/// write, and per-emplacement device writes collapse into one write per
+/// block per submitting pass.
+///
+/// Blocks are pooled: reuse is gated on the tracker's completion watermark,
+/// the pool grows with actual GPU queue depth, and idle blocks beyond the
+/// previous frame's usage (plus a spare) are dropped so memory shrinks back
+/// after load spikes. Requests larger than [blockLengthInBytes] get a
+/// dedicated buffer that is pooled the same way.
+class TransientArena implements TransientWriter {
+  TransientArena(
+    this._tracker, {
+    int? alignment,
+    this.blockLengthInBytes = kDefaultBlockLengthInBytes,
+  }) : _alignmentOverride = alignment {
+    _tracker.addBeforeSubmitListener(_onBeforeSubmit);
+  }
+
+  /// The default block size. Small enough that sealing a barely-used block
+  /// per pass is cheap, large enough that heavy frames don't roll over
+  /// constantly.
+  static const int kDefaultBlockLengthInBytes = 256 * 1024;
 
   final GpuSubmissionTracker _tracker;
-  final List<_PoolEntry> _entries = [];
-  _PoolEntry? _current;
+  final int blockLengthInBytes;
 
-  /// The number of pooled buffers. Used for tests.
+  /// Emplacement alignment. When null, the GPU context's minimum uniform
+  /// alignment is used (resolved lazily; the context itself initializes on
+  /// the raster thread after startup on some backends).
+  final int? _alignmentOverride;
+  int? _resolvedAlignment;
+  int get _alignment =>
+      _resolvedAlignment ??
+      (_resolvedAlignment =
+          _alignmentOverride ?? gpu.gpuContext.minimumUniformByteAlignment);
+
+  /// Blocks open for writing this frame, in fill order; the last one is the
+  /// bump target. All of them seal on the next submission.
+  final List<_TransientBlock> _open = [];
+
+  /// Sealed blocks whose GPU work has not necessarily completed. Reused once
+  /// the tracker's watermark passes their stamp.
+  final List<_TransientBlock> _sealed = [];
+
+  /// Standard-size blocks acquired by the previous/current frame, for the
+  /// shrink policy.
+  int _lastFrameBlockCount = 0;
+  int _thisFrameBlockCount = 0;
+
+  /// Total pooled blocks (open + sealed). For tests.
   @visibleForTesting
-  int get length => _entries.length;
+  int get blockCount => _open.length + _sealed.length;
 
-  /// Returns a reset [gpu.HostBuffer] that is safe to write this frame.
-  ///
-  /// Call exactly once per frame before any emplacement.
-  gpu.HostBuffer beginFrame() {
-    // Everything submitted so far may reference the previous frame's buffer.
-    _current?.stamp = _tracker.latestSubmission;
-
-    final int completed = _tracker.completedThrough;
-    _PoolEntry? chosen;
-    for (final _PoolEntry entry in _entries) {
-      if (!identical(entry, _current) && entry.stamp <= completed) {
-        chosen = entry;
-        break;
-      }
+  /// Begins a new frame: applies the shrink policy and resets frame stats.
+  /// Open blocks from the previous frame (possible when a frame emplaced
+  /// data but submitted nothing) seal with the latest submission stamp, so
+  /// they stay safe against any in-flight work.
+  void beginFrame() {
+    for (final block in _open) {
+      _seal(block, _tracker.latestSubmission);
     }
-    if (chosen == null) {
-      chosen = _PoolEntry(gpu.gpuContext.createHostBuffer());
-      _entries.add(chosen);
-    }
+    _open.clear();
 
-    // Drop surplus idle buffers so the pool shrinks after load spikes. One
-    // idle spare is kept to avoid churn at steady state.
-    int idleKept = 0;
-    _entries.removeWhere((_PoolEntry entry) {
-      final bool idle =
-          !identical(entry, _current) &&
-          !identical(entry, chosen) &&
-          entry.stamp <= completed;
-      if (!idle) {
-        return false;
-      }
-      idleKept++;
-      return idleKept > 1;
+    // Shrink: drop completed standard blocks beyond last frame's usage plus
+    // one spare. Oversize blocks are dropped as soon as they complete (they
+    // are rare and their sizes rarely repeat).
+    final completed = _tracker.completedThrough;
+    final keepStandard = _lastFrameBlockCount + 1;
+    var idleStandard = 0;
+    _sealed.removeWhere((block) {
+      if (block.stamp > completed) return false; // still in flight
+      if (block.oversize) return true;
+      idleStandard++;
+      return idleStandard > keepStandard;
     });
 
-    chosen.buffer.reset();
-    _current = chosen;
-    return chosen.buffer;
+    _lastFrameBlockCount = _thisFrameBlockCount;
+    _thisFrameBlockCount = 0;
+  }
+
+  /// Decides where an emplacement of [length] lands: at the aligned offset
+  /// within the current block, or at 0 in a fresh block when the write's END
+  /// would cross the block's capacity. The full write length participates in
+  /// the bounds check; checking only the aligned start (the flutter_gpu
+  /// HostBuffer bug) hands out views that overrun the buffer.
+  @visibleForTesting
+  static ({bool rollOver, int offset}) planEmplacement({
+    required int cursor,
+    required int alignment,
+    required int length,
+    required int blockLength,
+  }) {
+    final misalignment = cursor % alignment;
+    final aligned = misalignment == 0
+        ? cursor
+        : cursor + alignment - misalignment;
+    if (aligned + length > blockLength) {
+      return (rollOver: true, offset: 0);
+    }
+    return (rollOver: false, offset: aligned);
+  }
+
+  @override
+  gpu.BufferView emplace(ByteData bytes) {
+    final length = bytes.lengthInBytes;
+    if (length > blockLengthInBytes) {
+      return _emplaceOversize(bytes);
+    }
+
+    var block = _open.isEmpty ? null : _open.last;
+    var offset = 0;
+    if (block != null) {
+      final plan = planEmplacement(
+        cursor: block.cursor,
+        alignment: _alignment,
+        length: length,
+        blockLength: block.length,
+      );
+      offset = plan.offset;
+      if (plan.rollOver) block = null;
+    }
+    if (block == null) {
+      block = _acquireBlock(blockLengthInBytes);
+      _open.add(block);
+      _thisFrameBlockCount++;
+      offset = 0;
+    }
+
+    block.staging.buffer
+        .asUint8List(block.staging.offsetInBytes)
+        .setRange(
+          offset,
+          offset + length,
+          bytes.buffer.asUint8List(bytes.offsetInBytes, length),
+        );
+    block.cursor = offset + length;
+    return gpu.BufferView(
+      block.device,
+      offsetInBytes: offset,
+      lengthInBytes: length,
+    );
+  }
+
+  gpu.BufferView _emplaceOversize(ByteData bytes) {
+    final block = _acquireBlock(bytes.lengthInBytes, oversize: true);
+    _open.add(block);
+    block.staging.buffer
+        .asUint8List(block.staging.offsetInBytes)
+        .setRange(
+          0,
+          bytes.lengthInBytes,
+          bytes.buffer.asUint8List(bytes.offsetInBytes, bytes.lengthInBytes),
+        );
+    block.cursor = bytes.lengthInBytes;
+    return gpu.BufferView(
+      block.device,
+      offsetInBytes: 0,
+      lengthInBytes: bytes.lengthInBytes,
+    );
+  }
+
+  /// Reuses a completed pooled block or creates a new one. For oversize
+  /// requests, a pooled oversize block is reused when it fits without more
+  /// than doubling the waste.
+  _TransientBlock _acquireBlock(int length, {bool oversize = false}) {
+    final completed = _tracker.completedThrough;
+    for (var i = 0; i < _sealed.length; i++) {
+      final block = _sealed[i];
+      if (block.stamp > completed) continue;
+      if (block.oversize != oversize) continue;
+      if (oversize && (block.length < length || block.length > 2 * length)) {
+        continue;
+      }
+      _sealed.removeAt(i);
+      block.cursor = 0;
+      return block;
+    }
+    final device = gpu.gpuContext.createDeviceBuffer(
+      gpu.StorageMode.hostVisible,
+      oversize ? length : blockLengthInBytes,
+    );
+    final capacity = oversize ? length : blockLengthInBytes;
+    return _TransientBlock(device, ByteData(capacity), capacity, oversize);
+  }
+
+  /// Uploads and seals every open block. Runs just before each submission,
+  /// so the submitted work reads fully-written buffers; [id] is the
+  /// submission being recorded, which is the last one that may reference
+  /// these blocks.
+  void _onBeforeSubmit(int id) {
+    for (final block in _open) {
+      _seal(block, id);
+    }
+    _open.clear();
+  }
+
+  void _seal(_TransientBlock block, int stamp) {
+    if (block.cursor > 0) {
+      final ok = block.device.overwrite(
+        ByteData.sublistView(block.staging, 0, block.cursor),
+      );
+      if (!ok) {
+        // A failed upload must not throw mid-encode (an aborted frame is
+        // strictly worse than one pass reading zeroes); it also cannot
+        // happen by construction (the staged range always fits the buffer).
+        debugPrint(
+          'TransientArena: failed to upload ${block.cursor} bytes to a '
+          '${block.length}-byte transient block.',
+        );
+      }
+      block.device.flush(offsetInBytes: 0, lengthInBytes: block.cursor);
+    }
+    block.stamp = stamp;
+    block.cursor = 0;
+    _sealed.add(block);
   }
 }
 
-class _PoolEntry {
-  _PoolEntry(this.buffer);
+class _TransientBlock {
+  _TransientBlock(this.device, this.staging, this.length, this.oversize);
 
-  final gpu.HostBuffer buffer;
+  final gpu.DeviceBuffer device;
+  final ByteData staging;
+  final int length;
+  final bool oversize;
 
-  /// The last submission id that may reference this buffer's contents.
+  /// Bytes staged so far while open; reset when sealed.
+  int cursor = 0;
+
+  /// The last submission id that may reference this block's device buffer.
   int stamp = 0;
 }
+
+/// The renderer's per-frame uniform transients (alignment resolved from the
+/// GPU context's minimum uniform alignment).
+final TransientArena uniformTransients = TransientArena(rendererSubmissions);
+
+/// The renderer's per-frame instance-rate vertex transients. Vertex fetch
+/// needs only element alignment; 16 bytes covers a vec4 column.
+final TransientArena instanceTransients = TransientArena(
+  rendererSubmissions,
+  alignment: 16,
+);

--- a/packages/flutter_scene/lib/src/render/frame_transients.dart
+++ b/packages/flutter_scene/lib/src/render/frame_transients.dart
@@ -2,6 +2,10 @@ import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+// Whether GPU commands execute while passes are encoded (the WebGL2 backend)
+// rather than after submission. Decides the default transients strategy.
+import 'package:flutter_scene/src/render/transients_execution_native.dart'
+    if (dart.library.js_interop) 'package:flutter_scene/src/render/transients_execution_web.dart';
 
 /// Tracks GPU completion of command buffers submitted by the renderer.
 ///
@@ -68,6 +72,142 @@ abstract interface class TransientWriter {
   gpu.BufferView emplace(ByteData bytes);
 }
 
+/// A [TransientWriter] with the renderer's per-frame lifecycle. Implemented
+/// by [TransientArena] (deferred-execution backends) and
+/// [ImmediatePoolTransients] (the immediate-execution WebGL2 backend); the
+/// engine's shared instances pick per platform via [createFrameTransients].
+abstract interface class FrameTransients implements TransientWriter {
+  /// Recycles completed buffers and resets frame stats. Called once per
+  /// frame from the render setup.
+  void beginFrame();
+}
+
+/// Per-emplacement pooled transients for the immediate-execution WebGL2
+/// backend.
+///
+/// GL commands run while passes are encoded, so emplaced bytes must be
+/// device-resident before the caller binds the returned view, and a buffer
+/// written while earlier draws reference it forces the browser to ghost
+/// (copy) it, which dominated per-draw cost before per-emplacement buffers
+/// were introduced. Every emplacement therefore gets its own small device
+/// buffer (sized to the next power-of-two class), written exactly once via
+/// `overwrite` before the view is returned and never touched again while in
+/// flight. Buffers recycle through a completion-gated pool per size class
+/// and idle buffers beyond the previous frame's usage (plus a spare per
+/// class) are dropped, the same policies as [TransientArena].
+class ImmediatePoolTransients implements FrameTransients {
+  ImmediatePoolTransients(this._tracker) {
+    _tracker.addBeforeSubmitListener(_onBeforeSubmit);
+  }
+
+  /// The smallest pooled buffer size; tiny uniform blocks share this class.
+  static const int kMinBufferLengthInBytes = 512;
+
+  final GpuSubmissionTracker _tracker;
+
+  /// Buffers handed out since the last submission; stamped by it.
+  final List<_TransientBlock> _used = [];
+
+  /// Stamped buffers, reusable once the watermark passes their stamp.
+  final List<_TransientBlock> _pooled = [];
+
+  /// Per-size-class usage counts for the shrink policy.
+  final Map<int, int> _lastFrameUse = {};
+  final Map<int, int> _thisFrameUse = {};
+
+  /// Total live buffers. For tests.
+  @visibleForTesting
+  int get bufferCount => _used.length + _pooled.length;
+
+  static int _sizeClassFor(int length) {
+    var size = kMinBufferLengthInBytes;
+    while (size < length) {
+      size <<= 1;
+    }
+    return size;
+  }
+
+  @override
+  gpu.BufferView emplace(ByteData bytes) {
+    final length = bytes.lengthInBytes;
+    final sizeClass = _sizeClassFor(length);
+    final completed = _tracker.completedThrough;
+
+    _TransientBlock? block;
+    for (var i = 0; i < _pooled.length; i++) {
+      final candidate = _pooled[i];
+      if (candidate.length == sizeClass && candidate.stamp <= completed) {
+        block = candidate;
+        _pooled.removeAt(i);
+        break;
+      }
+    }
+    block ??= _TransientBlock(
+      gpu.gpuContext.createDeviceBuffer(gpu.StorageMode.hostVisible, sizeClass),
+      ByteData(0), // No CPU staging: writes go straight to the device.
+      sizeClass,
+      false,
+    );
+    _used.add(block);
+    _thisFrameUse[sizeClass] = (_thisFrameUse[sizeClass] ?? 0) + 1;
+
+    // Device-resident before the view is returned: the immediate backend
+    // consumes it as soon as the caller binds and draws.
+    if (!block.device.overwrite(bytes)) {
+      debugPrint(
+        'ImmediatePoolTransients: failed to upload $length bytes to a '
+        '$sizeClass-byte transient buffer.',
+      );
+    }
+    return gpu.BufferView(
+      block.device,
+      offsetInBytes: 0,
+      lengthInBytes: length,
+    );
+  }
+
+  void _onBeforeSubmit(int id) {
+    for (final block in _used) {
+      block.stamp = id;
+      _pooled.add(block);
+    }
+    _used.clear();
+  }
+
+  @override
+  void beginFrame() {
+    _onBeforeSubmit(_tracker.latestSubmission);
+
+    // Shrink: per size class, keep completed buffers up to last frame's
+    // usage plus one spare; drop the rest.
+    final completed = _tracker.completedThrough;
+    final kept = <int, int>{};
+    _pooled.removeWhere((block) {
+      if (block.stamp > completed) return false; // still in flight
+      final keep = (_lastFrameUse[block.length] ?? 0) + 1;
+      final count = (kept[block.length] ?? 0) + 1;
+      kept[block.length] = count;
+      return count > keep;
+    });
+
+    _lastFrameUse
+      ..clear()
+      ..addAll(_thisFrameUse);
+    _thisFrameUse.clear();
+  }
+}
+
+/// Creates the platform-default [FrameTransients]: a staged, block-based
+/// [TransientArena] where GPU work executes after submission, and a
+/// per-emplacement [ImmediatePoolTransients] where GL commands execute at
+/// encode time and a bound buffer can never be written again.
+FrameTransients createFrameTransients(
+  GpuSubmissionTracker tracker, {
+  int? alignment,
+}) => kImmediateGpuExecution
+    ? ImmediatePoolTransients(tracker)
+    : TransientArena(tracker, alignment: alignment);
+
 /// A completion-aware bump allocator for per-frame transient GPU data.
 ///
 /// Emplacements are staged CPU-side into fixed-size blocks and returned as
@@ -86,7 +226,7 @@ abstract interface class TransientWriter {
 /// previous frame's usage (plus a spare) are dropped so memory shrinks back
 /// after load spikes. Requests larger than [blockLengthInBytes] get a
 /// dedicated buffer that is pooled the same way.
-class TransientArena implements TransientWriter {
+class TransientArena implements FrameTransients {
   TransientArena(
     this._tracker, {
     int? alignment,
@@ -134,6 +274,7 @@ class TransientArena implements TransientWriter {
   /// Open blocks from the previous frame (possible when a frame emplaced
   /// data but submitted nothing) seal with the latest submission stamp, so
   /// they stay safe against any in-flight work.
+  @override
   void beginFrame() {
     for (final block in _open) {
       _seal(block, _tracker.latestSubmission);
@@ -312,11 +453,13 @@ class _TransientBlock {
 
 /// The renderer's per-frame uniform transients (alignment resolved from the
 /// GPU context's minimum uniform alignment).
-final TransientArena uniformTransients = TransientArena(rendererSubmissions);
+final FrameTransients uniformTransients = createFrameTransients(
+  rendererSubmissions,
+);
 
 /// The renderer's per-frame instance-rate vertex transients. Vertex fetch
 /// needs only element alignment; 16 bytes covers a vec4 column.
-final TransientArena instanceTransients = TransientArena(
+final FrameTransients instanceTransients = createFrameTransients(
   rendererSubmissions,
   alignment: 16,
 );

--- a/packages/flutter_scene/lib/src/render/instance_packing.dart
+++ b/packages/flutter_scene/lib/src/render/instance_packing.dart
@@ -79,53 +79,20 @@ void bindSingleInstanceTransform(
 
 /// Uploads [packed] transforms and binds them to the instance-rate slot.
 ///
-/// The transforms are emplaced into [instanceTransformBuffers], a `HostBuffer`
-/// dedicated to instance vertex data, separate from the per-frame transient
-/// uniform `HostBuffer`. The split dates from debugging stale instance
-/// transforms on the GLES backend, which turned out to be an engine bug
-/// (flutter/flutter#187931, buffer writes racing the GL upload) that a
-/// dedicated buffer does not actually avoid. Kept for now since it is
-/// harmless and the engine fix has not shipped in the SDK yet.
+/// The transforms are emplaced into [instanceTransients], the arena
+/// dedicated to instance-rate vertex data. It stays separate from the
+/// uniform arena because the two need different alignments (vertex fetch
+/// needs element alignment; uniforms need the context's minimum uniform
+/// alignment), and separate blocks keep either stream from padding the
+/// other.
 void bindInstanceTransforms(
   gpu.RenderPass pass,
   Float32List packed, {
   int slot = 1,
 }) {
-  // TODO(gles-dirty-range): fold instance transforms back into the shared
-  // transients HostBuffer once flutter/flutter#187931 is fixed in the SDK.
   if (packed.isEmpty) return;
   pass.bindVertexBuffer(
-    instanceTransformBuffers.emplace(ByteData.sublistView(packed)),
+    instanceTransients.emplace(ByteData.sublistView(packed)),
     slot: slot,
   );
 }
-
-/// A `HostBuffer` dedicated to instance-rate transform vertex data, kept
-/// apart from the uniform transients buffer (see [bindInstanceTransforms]
-/// for why). [beginFrame] cycles it to the next frame's backing storage
-/// and is driven once per frame from the render setup.
-class InstanceTransformBuffers {
-  // Pooled so a buffer is never reset while in-flight frames still read it.
-  // Buffers are created lazily inside [beginFrame]: the GPU context
-  // initializes on the raster thread after the first frame on some
-  // backends, so it isn't available at startup.
-  final TransientsPool _pool = TransientsPool(rendererSubmissions);
-  gpu.HostBuffer? _host;
-
-  /// Acquires this frame's backing storage. Call once per frame before any
-  /// [emplace].
-  void beginFrame() => _host = _pool.beginFrame();
-
-  /// Emplaces [data] and returns a view to bind as the instance-rate
-  /// vertex buffer.
-  gpu.BufferView emplace(ByteData data) => _host!.emplace(data);
-}
-
-/// The process-wide instance-transform vertex buffer. One GPU context per
-/// process, so a single buffer serves every scene; [beginFrame] is driven
-/// from the per-frame render setup.
-// TODO(instance-buffer-ownership): a single process-wide buffer means two
-// Scenes rendering in the same frame both reset it; make it per-Surface if
-// multi-scene-per-frame becomes common.
-final InstanceTransformBuffers instanceTransformBuffers =
-    InstanceTransformBuffers();

--- a/packages/flutter_scene/lib/src/render/object_filter.dart
+++ b/packages/flutter_scene/lib/src/render/object_filter.dart
@@ -65,7 +65,7 @@ void renderObjectMask({
   required Matrix4 cameraTransform,
   required Vector3 cameraPosition,
   required RenderScene renderScene,
-  required gpu.HostBuffer transientsBuffer,
+  required TransientWriter transientsBuffer,
   required int layerMask,
   required NodeFilter filter,
   required Vector4 Function(RenderItem item) colorOf,
@@ -114,7 +114,7 @@ class _ObjectMaskEncoder {
   }
 
   final gpu.RenderPass _renderPass;
-  final gpu.HostBuffer _transientsBuffer;
+  final TransientWriter _transientsBuffer;
   final Matrix4 _cameraTransform;
   final Vector3 _cameraPosition;
   final int _layerMask;

--- a/packages/flutter_scene/lib/src/render/render_graph.dart
+++ b/packages/flutter_scene/lib/src/render/render_graph.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// A typed scratch store passed between [RenderPass]es within a single
 /// frame.
@@ -188,7 +189,7 @@ class RenderGraphContext {
     required this.blackboard,
   });
 
-  final gpu.HostBuffer transientsBuffer;
+  final TransientWriter transientsBuffer;
   final TransientTexturePool texturePool;
   final Blackboard blackboard;
 }
@@ -233,7 +234,7 @@ class RenderGraph {
   /// creates and submits its own command buffer. Clears the blackboard
   /// first so state never leaks between frames.
   void execute({
-    required gpu.HostBuffer transientsBuffer,
+    required TransientWriter transientsBuffer,
     required TransientTexturePool texturePool,
   }) {
     _blackboard._clear();

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -8,6 +8,7 @@ import 'package:vector_math/vector_math.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/scene_encoder.dart' show resolvePipeline;
 import 'package:flutter_scene/src/shaders.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// Records each opaque shadow caster's depth into a shadow-map render
 /// pass, from a directional light's point of view.
@@ -42,7 +43,7 @@ class ShadowEncoder {
   }
 
   final gpu.RenderPass _renderPass;
-  final gpu.HostBuffer _transientsBuffer;
+  final TransientWriter _transientsBuffer;
   final Matrix4 _lightSpaceMatrix;
 
   // The scene camera position, bound as FrameInfo.camera_position so a

--- a/packages/flutter_scene/lib/src/render/sky_bake.dart
+++ b/packages/flutter_scene/lib/src/render/sky_bake.dart
@@ -132,7 +132,9 @@ void _renderFace(
       gpu.ColorAttachment(texture: face, clearValue: Vector4.zero()),
     ),
   );
-  final transients = gpu.gpuContext.createHostBuffer();
+  // One-shot bake uniforms ride the shared uniform arena; the bake's own
+  // submission (via rendererSubmissions) seals the blocks it wrote.
+  final transients = uniformTransients;
   final vertexShader = baseShaderLibrary['SkyboxVertex']!;
   pass.bindPipeline(resolvePipeline(vertexShader, source.fragmentShader));
   pass.setColorBlendEnable(false);
@@ -187,7 +189,7 @@ void _assembleEquirect(
   final faceInfo = Float32List(4)..[0] = _faceOverscan(faceResolution);
   pass.bindUniform(
     fragmentShader.getUniformSlot('CubeFaceInfo'),
-    gpu.gpuContext.createHostBuffer().emplace(ByteData.sublistView(faceInfo)),
+    uniformTransients.emplace(ByteData.sublistView(faceInfo)),
   );
   drawCompat(pass, 6);
   rendererSubmissions.submit(commandBuffer);

--- a/packages/flutter_scene/lib/src/render/skybox_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/skybox_encoder.dart
@@ -11,6 +11,7 @@ import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/scene_encoder.dart' show resolvePipeline;
 import 'package:flutter_scene/src/shaders.dart';
 import 'package:flutter_scene/src/skybox.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 // Two triangles of NDC positions covering the whole render target (6 vec2s).
 final gpu.DeviceBuffer _fullscreenQuad = gpu.gpuContext
@@ -41,7 +42,7 @@ final gpu.BufferView _fullscreenQuadView = gpu.BufferView(
 /// re-asserts the opaque-phase state when it is constructed afterward.
 void encodeSkybox(
   gpu.RenderPass renderPass,
-  gpu.HostBuffer transientsBuffer,
+  TransientWriter transientsBuffer,
   Skybox skybox,
   EnvironmentMap environment,
   double environmentIntensity,
@@ -114,7 +115,7 @@ void encodeSkybox(
 // mat4, camera position) on the sky vertex shader.
 void _bindFrameInfo(
   gpu.RenderPass renderPass,
-  gpu.HostBuffer transientsBuffer,
+  TransientWriter transientsBuffer,
   gpu.Shader vertexShader,
   Matrix3? environmentTransform,
   Camera camera,
@@ -137,7 +138,7 @@ void _bindFrameInfo(
 /// draw (via the camera) and the offscreen bake (one call per cube face).
 void bindSkyboxFrameInfo(
   gpu.RenderPass renderPass,
-  gpu.HostBuffer transientsBuffer,
+  TransientWriter transientsBuffer,
   gpu.Shader vertexShader,
   Matrix4 inverseViewProjection,
   Vector3 cameraPosition,
@@ -168,7 +169,7 @@ void bindSkyboxFrameInfo(
 // atlases (primary plus the secondary cross-fade pair).
 void _bindEnvironmentSource(
   gpu.RenderPass renderPass,
-  gpu.HostBuffer transientsBuffer,
+  TransientWriter transientsBuffer,
   gpu.Shader fragmentShader,
   EnvironmentSkySource source,
   EnvironmentMap environment,

--- a/packages/flutter_scene/lib/src/render/transients_execution_native.dart
+++ b/packages/flutter_scene/lib/src/render/transients_execution_native.dart
@@ -1,0 +1,4 @@
+/// Native Flutter GPU backends (Metal, Vulkan, GLES via Impeller) execute
+/// GPU work after command buffer submission, so transient uploads can be
+/// batched per block and flushed just before each submit.
+const bool kImmediateGpuExecution = false;

--- a/packages/flutter_scene/lib/src/render/transients_execution_web.dart
+++ b/packages/flutter_scene/lib/src/render/transients_execution_web.dart
@@ -1,0 +1,6 @@
+/// The WebGL2 backend executes GL commands while passes are encoded
+/// (`CommandBuffer.submit` is bookkeeping), so a draw consumes its buffers
+/// immediately: transient bytes must be device-resident when the view is
+/// bound, and a buffer must never be rewritten after a draw referenced it
+/// (the browser ghosts, copies, any buffer written while in use).
+const bool kImmediateGpuExecution = true;

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -32,7 +32,6 @@ import 'render/render_graph.dart';
 import 'render/render_scene.dart';
 import 'render/punctual_lights.dart';
 import 'render/spot_shadow.dart';
-import 'render/instance_packing.dart';
 import 'render/scene_pass.dart';
 import 'render/ssr_pass.dart';
 import 'screen_space_reflections.dart';
@@ -382,12 +381,6 @@ base class Scene implements SceneGraph {
   final Surface surface = Surface();
 
   /// Transient-uniform allocator, created once and reused every frame.
-  ///
-  /// Pools the per-frame uniform host buffers, handing out one whose prior
-  /// GPU work has completed so a buffer is never reset while frames that
-  /// read it are still in flight.
-  final TransientsPool _transientsPool = TransientsPool(rendererSubmissions);
-
   /// The image-based-lighting environment, or null to use the engine's
   /// default (the built-in procedural [EnvironmentMap.studio], built
   /// lazily on first render).
@@ -883,13 +876,12 @@ base class Scene implements SceneGraph {
     // thread only after the first frame.
     final environmentMap = environment ?? Material.getDefaultEnvironmentMap();
 
-    // Acquire this frame's uniform host buffer. Shared by every view this
-    // frame.
-    final transientsBuffer = _transientsPool.beginFrame();
-    // Advance the instance-transform buffer pool to this frame's set (it
-    // backs the instance-rate vertex buffer, separate from the uniform
-    // host buffer above; see instance_packing.dart).
-    instanceTransformBuffers.beginFrame();
+    // Advance the per-frame transient arenas (uniform blocks and
+    // instance-rate vertex data): recycle blocks whose GPU work completed
+    // and reset the frame stats. Shared by every view this frame.
+    uniformTransients.beginFrame();
+    instanceTransients.beginFrame();
+    final TransientWriter transientsBuffer = uniformTransients;
 
     // Advance the scene once per frame (not once per view): tick components
     // and animations and refresh the flat render list before the passes
@@ -1021,7 +1013,7 @@ base class Scene implements SceneGraph {
     required double dpr,
     required int viewIndex,
     required EnvironmentMap environmentMap,
-    required gpu.HostBuffer transientsBuffer,
+    required TransientWriter transientsBuffer,
     required DirectionalLightComponent? lightComponent,
     required PunctualLighting punctualLighting,
     required SpotShadowFrame? spotShadowFrame,
@@ -1075,7 +1067,7 @@ base class Scene implements SceneGraph {
     required ui.Size pixelSize,
     required TransientTexturePool pool,
     required EnvironmentMap environmentMap,
-    required gpu.HostBuffer transientsBuffer,
+    required TransientWriter transientsBuffer,
     required DirectionalLightComponent? lightComponent,
     required PunctualLighting punctualLighting,
     required SpotShadowFrame? spotShadowFrame,

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -11,6 +11,7 @@ import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/render/instance_packing.dart';
 import 'package:flutter_scene/src/render/lod.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// A deferred opaque draw. Holds the [RenderItem] (instanced or not), its
 /// resolved pipeline, a per-pipeline grouping key, and the camera
@@ -131,7 +132,7 @@ void evictPipelinesForShaders(Set<gpu.Shader> shaders) {
 /// Applications typically do not construct `SceneEncoder` directly;
 /// custom [Geometry] or [Material] subclasses interact with it through
 /// their `bind` callbacks, which receive the `gpu.RenderPass` and
-/// `gpu.HostBuffer` directly.
+/// `TransientWriter` directly.
 base class SceneEncoder {
   /// Creates an encoder that records into [renderPass], allocating
   /// transient uniforms from [transientsBuffer].
@@ -142,7 +143,7 @@ base class SceneEncoder {
   /// configured for the opaque phase (depth writes on, blending off).
   SceneEncoder(
     gpu.RenderPass renderPass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     this._camera,
     ui.Size dimensions,
     this._lighting,
@@ -166,7 +167,7 @@ base class SceneEncoder {
   final Lighting _lighting;
   final int _layerMask;
   final gpu.RenderPass _renderPass;
-  final gpu.HostBuffer _transientsBuffer;
+  final TransientWriter _transientsBuffer;
   late final Matrix4 _cameraTransform;
   // The camera's vertical field of view in radians, or null for a
   // non-perspective camera (which disables screen-size LOD).

--- a/packages/flutter_scene/lib/src/shader_uniform_bindings.dart
+++ b/packages/flutter_scene/lib/src/shader_uniform_bindings.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// Stores caller-supplied uniform blocks and textures keyed by name and
 /// binds them to a render pass against a shader's reflection.
@@ -49,7 +50,7 @@ class ShaderUniformBindings {
   void bind(
     gpu.RenderPass pass,
     gpu.Shader shader,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
   ) {
     for (final entry in _uniformBlocks.entries) {
       pass.bindUniform(

--- a/packages/flutter_scene/lib/src/sky_sources.dart
+++ b/packages/flutter_scene/lib/src/sky_sources.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/skybox.dart';
 import 'package:vector_math/vector_math.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// A stylized gradient sky: zenith, horizon, and ground colors with an HDR
 /// sun disk.
@@ -71,7 +72,7 @@ class GradientSkySource extends ShaderSkySource implements SunSky {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     EnvironmentMap environment,
   ) {
     setUniformBlockFromFloats('GradientSkyInfo', <double>[
@@ -169,7 +170,7 @@ class PhysicalSkySource extends ShaderSkySource implements SunSky {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     EnvironmentMap environment,
   ) {
     setUniformBlockFromFloats('PhysicalSkyInfo', <double>[

--- a/packages/flutter_scene/lib/src/skybox.dart
+++ b/packages/flutter_scene/lib/src/skybox.dart
@@ -11,6 +11,7 @@ import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/shaders.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// A sky that exposes a directional sun, so the engine can drive a matching
 /// shadow-casting directional light from it.
@@ -155,7 +156,7 @@ class ShaderSkySource extends SkySource {
   /// during the background draw; not part of the app-facing API.
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     EnvironmentMap environment,
   ) {
     for (final entry in _uniformBlocks.entries) {

--- a/packages/flutter_scene/test/bounds_test.dart
+++ b/packages/flutter_scene/test/bounds_test.dart
@@ -26,7 +26,7 @@ class _StubGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {
@@ -41,7 +41,7 @@ class _StubMaterial extends Material {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     throw UnsupportedError('Stub material is not renderable');

--- a/packages/flutter_scene/test/bvh_test.dart
+++ b/packages/flutter_scene/test/bvh_test.dart
@@ -12,7 +12,7 @@ class _StubGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {
@@ -26,7 +26,7 @@ class _StubMaterial extends Material {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     throw UnsupportedError('Stub material is not renderable');

--- a/packages/flutter_scene/test/cull_test.dart
+++ b/packages/flutter_scene/test/cull_test.dart
@@ -24,7 +24,7 @@ class _StubGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {
@@ -38,7 +38,7 @@ class _StubGeometryNoBounds extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {
@@ -52,7 +52,7 @@ class _StubMaterial extends Material {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     throw UnsupportedError('Stub material is not renderable');

--- a/packages/flutter_scene/test/geometry_test.dart
+++ b/packages/flutter_scene/test/geometry_test.dart
@@ -13,7 +13,7 @@ class _StubGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {

--- a/packages/flutter_scene/test/instanced_mesh_test.dart
+++ b/packages/flutter_scene/test/instanced_mesh_test.dart
@@ -24,7 +24,7 @@ class _StubGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {
@@ -38,7 +38,7 @@ class _StubMaterial extends Material {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
     throw UnsupportedError('Stub material is not renderable');

--- a/packages/flutter_scene/test/light_culling_test.dart
+++ b/packages/flutter_scene/test/light_culling_test.dart
@@ -15,7 +15,7 @@ class _StubGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {
@@ -25,8 +25,11 @@ class _StubGeometry extends Geometry {
 
 class _StubMaterial extends Material {
   @override
-  void bind(gpu.RenderPass pass, gpu.HostBuffer transientsBuffer, Lighting l) =>
-      throw UnsupportedError('stub');
+  void bind(
+    gpu.RenderPass pass,
+    TransientWriter transientsBuffer,
+    Lighting l,
+  ) => throw UnsupportedError('stub');
 }
 
 RenderItem _itemAt(double x) =>

--- a/packages/flutter_scene/test/mesh_removal_test.dart
+++ b/packages/flutter_scene/test/mesh_removal_test.dart
@@ -23,7 +23,7 @@ class _StubGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {
@@ -35,7 +35,7 @@ class _StubMaterial extends Material {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) => throw UnsupportedError('Stub material is not renderable');
 }

--- a/packages/flutter_scene/test/node_clone_material_test.dart
+++ b/packages/flutter_scene/test/node_clone_material_test.dart
@@ -21,7 +21,7 @@ class _StubGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {
@@ -33,7 +33,7 @@ class _StubMaterial extends Material {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Lighting lighting,
   ) => throw UnsupportedError('Stub material is not renderable');
 }

--- a/packages/flutter_scene/test/raycast_test.dart
+++ b/packages/flutter_scene/test/raycast_test.dart
@@ -17,7 +17,7 @@ import 'package:flutter_scene/src/raycast.dart'
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart'
     as gpu
-    show IndexType, RenderPass, HostBuffer, Shader;
+    show IndexType, RenderPass, Shader;
 import 'package:vector_math/vector_math.dart';
 
 /// A bare [Geometry] whose only purpose is to exercise the CPU-side raycast
@@ -26,7 +26,7 @@ class _RaycastDataGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {

--- a/packages/flutter_scene/test/render/frame_transients_test.dart
+++ b/packages/flutter_scene/test/render/frame_transients_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene/src/render/frame_transients.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,6 +11,14 @@ bool _gpuAvailable() {
   } catch (_) {
     return false;
   }
+}
+
+ByteData _bytes(int length, [int fill = 0xAB]) {
+  final data = ByteData(length);
+  for (var i = 0; i < length; i++) {
+    data.setUint8(i, fill);
+  }
+  return data;
 }
 
 void main() {
@@ -31,68 +41,195 @@ void main() {
       tracker.complete(c);
       expect(tracker.completedThrough, c);
     });
+
+    test('before-submit listeners run with the id being recorded', () {
+      final tracker = GpuSubmissionTracker();
+      final seen = <int>[];
+      tracker.addBeforeSubmitListener(seen.add);
+      final a = tracker.record();
+      final b = tracker.record();
+      expect(seen, [a, b]);
+    });
+  });
+
+  group('TransientArena.planEmplacement', () {
+    test('aligns within the block', () {
+      final plan = TransientArena.planEmplacement(
+        cursor: 100,
+        alignment: 256,
+        length: 100,
+        blockLength: 1024,
+      );
+      expect(plan.rollOver, isFalse);
+      expect(plan.offset, 256);
+    });
+
+    test('rolls over when the write end crosses the block', () {
+      // The exact numbers from the flutter_gpu HostBuffer bug observed in
+      // the wild: aligned offset 1023744 fits, 1023744 + 656 does not.
+      final plan = TransientArena.planEmplacement(
+        cursor: 1023744,
+        alignment: 256,
+        length: 656,
+        blockLength: 1024000,
+      );
+      expect(plan.rollOver, isTrue);
+      expect(plan.offset, 0);
+    });
+
+    test('a write ending exactly at the block boundary fits', () {
+      final plan = TransientArena.planEmplacement(
+        cursor: 512,
+        alignment: 256,
+        length: 512,
+        blockLength: 1024,
+      );
+      expect(plan.rollOver, isFalse);
+      expect(plan.offset, 512);
+    });
   });
 
   if (!_gpuAvailable()) {
     test(
-      'transients pool suite (skipped: no GPU device)',
+      'transient arena suite (skipped: no GPU device)',
       () {},
       skip: 'Requires a GPU device.',
     );
     return;
   }
 
-  group('TransientsPool', () {
-    test('reuses a buffer once its submissions complete', () {
+  group('TransientArena', () {
+    test('emplacements are aligned and stay inside the block', () {
       final tracker = GpuSubmissionTracker();
-      final pool = TransientsPool(tracker);
+      final arena = TransientArena(tracker, alignment: 256);
 
-      final first = pool.beginFrame();
-      final id = tracker.record();
-      tracker.complete(id);
-
-      // The prior frame's work completed, so the same buffer is reused.
-      final second = pool.beginFrame();
-      expect(identical(second, first), isTrue);
-      expect(pool.length, 1);
+      final first = arena.emplace(_bytes(100));
+      final second = arena.emplace(_bytes(100));
+      expect(first.offsetInBytes, 0);
+      expect(first.lengthInBytes, 100);
+      expect(second.offsetInBytes, 256);
+      expect(second.lengthInBytes, 100);
+      expect(identical(first.buffer, second.buffer), isTrue);
     });
 
-    test('grows while submissions are pending and shrinks after', () {
+    test('rolls to a new block when the write itself would not fit', () {
+      // Regression for the flutter_gpu HostBuffer boundary bug: an aligned
+      // offset that fits while the write's end does not (observed in the
+      // wild as offset 1023744 + length 656 against a 1024000-byte block).
       final tracker = GpuSubmissionTracker();
-      final pool = TransientsPool(tracker);
+      final arena = TransientArena(
+        tracker,
+        alignment: 256,
+        blockLengthInBytes: 1024000,
+      );
 
-      // Three frames whose GPU work never completes: every frame needs a
-      // distinct buffer.
-      final buffers = <Object>{};
-      final pendingIds = <int>[];
-      for (var i = 0; i < 3; i++) {
-        buffers.add(pool.beginFrame());
-        pendingIds.add(tracker.record());
+      final first = arena.emplace(_bytes(1023744));
+      expect(first.offsetInBytes, 0);
+      final second = arena.emplace(_bytes(656));
+      expect(second.offsetInBytes, 0); // new block
+      expect(second.lengthInBytes, 656);
+      expect(identical(first.buffer, second.buffer), isFalse);
+    });
+
+    test('oversize requests get a dedicated block', () {
+      final tracker = GpuSubmissionTracker();
+      final arena = TransientArena(
+        tracker,
+        alignment: 256,
+        blockLengthInBytes: 1024,
+      );
+
+      final big = arena.emplace(_bytes(4096));
+      expect(big.offsetInBytes, 0);
+      expect(big.lengthInBytes, 4096);
+
+      // The oversize block does not become the bump target.
+      final small = arena.emplace(_bytes(64));
+      expect(identical(small.buffer, big.buffer), isFalse);
+    });
+
+    test('reuses blocks only after their submissions complete', () {
+      final tracker = GpuSubmissionTracker();
+      final arena = TransientArena(
+        tracker,
+        alignment: 256,
+        blockLengthInBytes: 1024,
+      );
+
+      final first = arena.emplace(_bytes(100));
+      tracker.record(); // seals + stamps the block
+      arena.beginFrame();
+
+      // Still in flight: the next frame must use a different device buffer.
+      final second = arena.emplace(_bytes(100));
+      expect(identical(second.buffer, first.buffer), isFalse);
+      tracker.record();
+      arena.beginFrame();
+
+      // Everything completed: the first block is reusable now.
+      tracker.complete(1);
+      tracker.complete(2);
+      final third = arena.emplace(_bytes(100));
+      expect(identical(third.buffer, first.buffer), isTrue);
+    });
+
+    test('a submission seals the open block mid-frame', () {
+      final tracker = GpuSubmissionTracker();
+      final arena = TransientArena(
+        tracker,
+        alignment: 256,
+        blockLengthInBytes: 1024,
+      );
+
+      final before = arena.emplace(_bytes(100));
+      tracker.record(); // a pass submits; open blocks seal
+      final after = arena.emplace(_bytes(100));
+      // Sealed blocks are never written again, so the post-submit
+      // emplacement lands in a fresh block.
+      expect(identical(after.buffer, before.buffer), isFalse);
+    });
+
+    test('grows under pending load and shrinks back after completion', () {
+      final tracker = GpuSubmissionTracker();
+      final arena = TransientArena(
+        tracker,
+        alignment: 256,
+        blockLengthInBytes: 1024,
+      );
+
+      final ids = <int>[];
+      for (var frame = 0; frame < 4; frame++) {
+        arena.emplace(_bytes(512));
+        ids.add(tracker.record());
+        arena.beginFrame();
       }
-      expect(buffers.length, 3);
-      expect(pool.length, 3);
+      expect(arena.blockCount, 4);
 
-      // Once everything completes, the pool reuses buffers and trims down
-      // to the active buffer plus one idle spare.
-      for (final id in pendingIds) {
+      for (final id in ids) {
         tracker.complete(id);
       }
-      pool.beginFrame();
-      pool.beginFrame();
-      expect(pool.length, lessThanOrEqualTo(2));
+      // Two idle frames: the pool trims to last frame's usage plus a spare.
+      arena.beginFrame();
+      arena.beginFrame();
+      expect(arena.blockCount, lessThanOrEqualTo(2));
     });
 
-    test('never hands out the buffer stamped by pending work', () {
+    test('single flush per block: staged bytes upload on seal', () {
       final tracker = GpuSubmissionTracker();
-      final pool = TransientsPool(tracker);
+      final arena = TransientArena(
+        tracker,
+        alignment: 256,
+        blockLengthInBytes: 1024,
+      );
 
-      final first = pool.beginFrame();
+      // Interleave two emplacements, then seal via a recorded submission.
+      // The device buffer contents cannot be read back here (no readback in
+      // the shim-agnostic API), so this exercises the code path for
+      // crashes/asserts and leaves visual verification to the smoke scenes.
+      arena.emplace(_bytes(100, 0x11));
+      arena.emplace(_bytes(100, 0x22));
       tracker.record();
-
-      // The pending submission may still read `first`, so the next frame
-      // must get a different buffer.
-      final second = pool.beginFrame();
-      expect(identical(second, first), isFalse);
+      arena.beginFrame();
     });
   });
 }

--- a/packages/flutter_scene/test/render/frame_transients_test.dart
+++ b/packages/flutter_scene/test/render/frame_transients_test.dart
@@ -214,6 +214,65 @@ void main() {
       expect(arena.blockCount, lessThanOrEqualTo(2));
     });
 
+    test(
+      'immediate pool: every emplacement gets its own zero-offset buffer',
+      () {
+        final tracker = GpuSubmissionTracker();
+        final pool = ImmediatePoolTransients(tracker);
+
+        final a = pool.emplace(_bytes(100));
+        final b = pool.emplace(_bytes(100));
+        expect(a.offsetInBytes, 0);
+        expect(b.offsetInBytes, 0);
+        expect(identical(a.buffer, b.buffer), isFalse);
+        expect(pool.bufferCount, 2);
+      },
+    );
+
+    test('immediate pool: recycles same-class buffers after completion', () {
+      final tracker = GpuSubmissionTracker();
+      final pool = ImmediatePoolTransients(tracker);
+
+      final first = pool.emplace(_bytes(100)); // 512 class
+      final id = tracker.record();
+      pool.beginFrame();
+
+      // Pending: a new buffer is required.
+      final second = pool.emplace(_bytes(80));
+      expect(identical(second.buffer, first.buffer), isFalse);
+      final id2 = tracker.record();
+      pool.beginFrame();
+
+      tracker.complete(id);
+      tracker.complete(id2);
+      final third = pool.emplace(_bytes(64)); // same 512 class
+      expect(
+        identical(third.buffer, first.buffer) ||
+            identical(third.buffer, second.buffer),
+        isTrue,
+      );
+    });
+
+    test('immediate pool: shrinks idle size classes', () {
+      final tracker = GpuSubmissionTracker();
+      final pool = ImmediatePoolTransients(tracker);
+
+      final ids = <int>[];
+      for (var frame = 0; frame < 4; frame++) {
+        pool.emplace(_bytes(100));
+        pool.emplace(_bytes(100));
+        ids.add(tracker.record());
+        pool.beginFrame();
+      }
+      for (final id in ids) {
+        tracker.complete(id);
+      }
+      pool.beginFrame();
+      pool.beginFrame();
+      // Last frame used none, so at most one spare per class survives.
+      expect(pool.bufferCount, lessThanOrEqualTo(1));
+    });
+
     test('single flush per block: staged bytes upload on seal', () {
       final tracker = GpuSubmissionTracker();
       final arena = TransientArena(

--- a/packages/flutter_scene_editor/analysis_options.yaml
+++ b/packages/flutter_scene_editor/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/packages/flutter_scene_editor_core/analysis_options.yaml
+++ b/packages/flutter_scene_editor_core/analysis_options.yaml
@@ -1,6 +1,14 @@
 include: package:lints/recommended.yaml
 
 analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   language:
     strict-casts: true
     strict-raw-types: true

--- a/packages/flutter_scene_mcp/analysis_options.yaml
+++ b/packages/flutter_scene_mcp/analysis_options.yaml
@@ -1,6 +1,14 @@
 include: package:lints/recommended.yaml
 
 analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   language:
     strict-casts: true
     strict-raw-types: true


### PR DESCRIPTION
Per-frame transient GPU data (uniform blocks and instance-rate transforms) now allocates from engine-owned completion-aware arenas instead of `package:flutter_gpu`'s `HostBuffer`.

Emplacements stage CPU-side into pooled fixed-size blocks and return device buffer views immediately. Just before each command buffer submission, every open block uploads its used range in a single write and is sealed; the next emplacement opens a fresh block. Reuse is gated on the submission tracker's completion watermark, so a block's device buffer is written exactly once per pooled lifetime and never touched while in-flight frames may read it. Pooled memory grows with actual GPU queue depth and shrinks back after load spikes.

This fixes whole-frame aborts on heavy frames. `HostBuffer`'s block rollover check ignores the write's own length, so once a frame emplaces past a block boundary (roughly 1MB of transients, easily reached by a few thousand draws), `emplace` throws mid-encode and the scene contributes nothing that frame, which presents as the app's background color strobing through. The arena's rollover accounts for the write length, with the observed failure numbers as a regression test. It also retires `HostBuffer`'s internal 4-frame block ring (redundant under completion gating), collapses thousands of per-draw device writes into a handful of block uploads per frame, and never rewrites a live GL buffer, so the web backend's buffer-ghosting mitigation is now structural rather than special-cased.

BREAKING: the material/geometry/custom-pass `bind` surfaces and `RenderPassContext.transientsBuffer` take the new exported `TransientWriter` interface where they previously took a `gpu.HostBuffer`. Call sites that only called `emplace` need no change beyond the parameter type.

The web shim's `HostBuffer` returns to a faithful port of flutter_gpu's block bump allocator (with the corrected length-aware rollover) so the shim stays a drop-in flutter_gpu replacement for direct consumers; the engine itself no longer uses `HostBuffer` on any backend. The upstream rollover fix is being submitted to flutter_gpu separately.

Verified on Metal with a voxel scene at ~2200 chunks (the workload that previously threw hundreds of boundary exceptions per session), plus unit coverage for alignment, rollover, completion-gated reuse, mid-frame sealing, oversize requests, and pool shrink.
