### PR TITLE
Add geometry readback, MeshData derivation ops, and thick line segments

### DIFF
--- a/examples/flutter_app/assets/materialize_glass.fmat
+++ b/examples/flutter_app/assets/materialize_glass.fmat
@@ -1,7 +1,7 @@
 // Glass-shard stage of the Materialize example. Rendered over an unwelded
 // triangle soup where every triangle carries flat outward normals plus two
-// custom attributes, its centroid (tri_centroid) and a per-triangle random
-// seed (tri_seed). As the glass front sweeps past a triangle's centroid the
+// custom attributes, its centroid (triangle_centroid) and a per-triangle random
+// seed (triangle_seed). As the glass front sweeps past a triangle's centroid the
 // shard flies in from its scattered pose, fading in at a distance and easing
 // along an s-curve (accelerate, then decelerate into a soft landing), then
 // sits on the surface glowing until the opaque shell phases over it.
@@ -56,8 +56,8 @@ material {
   ],
 
   attributes: [
-    { type: vec3, name: tri_centroid },
-    { type: float, name: tri_seed },
+    { type: vec3, name: triangle_centroid },
+    { type: float, name: triangle_seed },
   ],
 
   varyings: [
@@ -69,7 +69,7 @@ material {
 vertex {
   void Vertex(inout VertexInputs vertex) {
     // World-space height of the shard's centroid drives its timing.
-    float wc = (material_params.model_matrix * vec4(tri_centroid, 1.0)).y;
+    float wc = (material_params.model_matrix * vec4(triangle_centroid, 1.0)).y;
 
     // Raw flight progress: 0 scattered, 1 seated, keeps counting past 1 so
     // the fragment stage knows how long the shard has been down.
@@ -85,16 +85,16 @@ vertex {
     float s = 1.0 - ease;
 
     // Seeded tumble about the centroid, unwinding to zero as it lands.
-    vec3 rel = vertex.position - tri_centroid;
+    vec3 rel = vertex.position - triangle_centroid;
     vec3 n = vertex.normal;
     vec3 axis = normalize(
-        vec3(sin(tri_seed * 19.3), cos(tri_seed * 35.7), sin(tri_seed * 45.9)) +
+        vec3(sin(triangle_seed * 19.3), cos(triangle_seed * 35.7), sin(triangle_seed * 45.9)) +
         vec3(0.0, 0.001, 0.0));
     float wobble =
-        sin(material_params.time * (1.0 + fract(tri_seed) * 1.5) +
-            tri_seed * 40.0) * 0.4;
+        sin(material_params.time * (1.0 + fract(triangle_seed) * 1.5) +
+            triangle_seed * 40.0) * 0.4;
     float angle = s * (material_params.tumble *
-                           (fract(tri_seed * 7.61) - 0.5) * 8.0 +
+                           (fract(triangle_seed * 7.61) - 0.5) * 8.0 +
                        wobble);
     float ca = cos(angle);
     float sa = sin(angle);
@@ -104,7 +104,7 @@ vertex {
         n * ca + cross(axis, n) * sa + axis * dot(axis, n) * (1.0 - ca);
 
     vec3 seated =
-        (material_params.model_matrix * vec4(tri_centroid + rel_rot, 1.0)).xyz;
+        (material_params.model_matrix * vec4(triangle_centroid + rel_rot, 1.0)).xyz;
 
     // Compose the scattered pose (all world space): shared bias direction,
     // radial push from the model center, a push along the shard's own face
@@ -114,12 +114,12 @@ vertex {
     float rlen = length(radial);
     radial = rlen > 1e-5 ? radial / rlen : vec3(0.0, 1.0, 0.0);
     vec3 n_world = normalize(mat3(material_params.model_matrix) * n);
-    vec3 jdir = normalize(vec3(sin(tri_seed * 61.0), sin(tri_seed * 47.0 + 2.0),
-                               cos(tri_seed * 53.0)));
+    vec3 jdir = normalize(vec3(sin(triangle_seed * 61.0), sin(triangle_seed * 47.0 + 2.0),
+                               cos(triangle_seed * 53.0)));
     vec3 offset = fdir * material_params.fly_distance +
         radial * material_params.center_distance +
         n_world * material_params.normal_distance +
-        jdir * (material_params.jitter * (0.5 + fract(tri_seed * 9.19)));
+        jdir * (material_params.jitter * (0.5 + fract(triangle_seed * 9.19)));
 
     vertex.world_position = seated + offset * s;
     vertex.world_normal =

--- a/examples/flutter_app/assets/materialize_wireframe.fmat
+++ b/examples/flutter_app/assets/materialize_wireframe.fmat
@@ -1,12 +1,11 @@
-// Wireframe stage of the Materialize example. Rendered over ribbon geometry,
-// one view-facing quad per unique mesh edge (native line primitives are a
-// fixed one pixel, so thickness is built from triangles). Each vertex carries
-// the opposite edge endpoint and a side sign; the vertex stage expands the
-// quad perpendicular to both the edge and the view direction.
+// Wireframe stage of the Materialize example. Rendered over a
+// LineSegmentsGeometry built from MeshData.extractEdges, which expands each
+// edge into a camera-facing ribbon on the GPU, so this material only shades,
+// no vertex block needed.
 //
-// All gating compares world-space height against fronts driven from Dart
-// (the model only spins about the world up axis, so height is stable), with
-// a shared gradient noise wobbling the boundary so the sweep reads organic.
+// All gating compares world-space height (the model only spins about the
+// world up axis, so height is stable), with a shared gradient noise wobbling
+// the boundary so the sweep reads organic.
 
 material {
   name: "MaterializeWireframe",
@@ -15,58 +14,17 @@ material {
   culling: none,
 
   parameters: [
-    { type: mat4, name: model_matrix },
     // Sweep fronts (world-space heights), driven per tick.
     { type: float, name: wire_front, default: 10.0 },
     { type: float, name: solid_front, default: -10.0 },
     // Height of the fade band around each front.
     { type: float, name: band, default: 0.08 },
-    // World-space ribbon width.
-    { type: float, name: thickness, default: 0.004 },
-    // Push the ribbon off the surface along the vertex normal so it does not
-    // z-fight the shell.
-    { type: float, name: inflate, default: 0.004 },
     { type: vec4, name: wire_color, hint: source_color, default: [0.25, 0.85, 1.0, 0.85] },
     { type: float, name: glow_strength, hint: range(0, 30, 0.1), default: 8.0 },
     // Boundary noise, shared with the glass and shell stages.
     { type: vec3, name: noise_scale, default: [8.0, 8.0, 8.0] },
     { type: float, name: noise_amp, default: 0.0 },
   ],
-
-  attributes: [
-    { type: vec3, name: edge_other },
-    { type: float, name: edge_side },
-  ],
-
-  varyings: [
-    { type: float, name: world_h },
-  ],
-}
-
-vertex {
-  void Vertex(inout VertexInputs vertex) {
-    // Inflate both endpoints along this vertex's normal (the endpoints of an
-    // edge have nearly parallel normals, so sharing one is fine).
-    vec3 p = vertex.position + vertex.normal * material_params.inflate;
-    vec3 o = edge_other + vertex.normal * material_params.inflate;
-
-    vec3 world_p = (material_params.model_matrix * vec4(p, 1.0)).xyz;
-    vec3 world_o = (material_params.model_matrix * vec4(o, 1.0)).xyz;
-    world_h = world_p.y;
-
-    // Expand perpendicular to the edge and the view direction so the ribbon
-    // always faces the camera.
-    vec3 dir = world_o - world_p;
-    vec3 view = vertex.camera_position - world_p;
-    vec3 perp = cross(dir, view);
-    float len = length(perp);
-    perp = len > 1e-6 ? perp / len : vec3(0.0);
-
-    vertex.world_position =
-        world_p + perp * (material_params.thickness * 0.5 * edge_side);
-    vertex.world_normal =
-        normalize(mat3(material_params.model_matrix) * vertex.normal);
-  }
 }
 
 fragment {
@@ -98,23 +56,24 @@ fragment {
   }
 
   void Surface(inout MaterialInputs material) {
+    vec3 world = GetWorldPosition();
     float band = max(material_params.band, 1e-4);
-    float n = SeamNoise(GetWorldPosition() * material_params.noise_scale) *
+    float n = SeamNoise(world * material_params.noise_scale) *
         material_params.noise_amp;
     float wire_front = material_params.wire_front + n;
     float solid_front = material_params.solid_front + n;
 
     // 1 below the wire front, easing to 0 above it.
-    float reveal = 1.0 - smoothstep(wire_front - band, wire_front, world_h);
+    float reveal = 1.0 - smoothstep(wire_front - band, wire_front, world.y);
     // 0 below the solid front (the opaque surface owns that region now).
-    float takeover = smoothstep(solid_front - band, solid_front + band, world_h);
+    float takeover = smoothstep(solid_front - band, solid_front + band, world.y);
     float alpha = reveal * takeover * material_params.wire_color.a;
     if (alpha <= 0.003) {
       discard;
     }
 
     // Hot pulse at the leading edge.
-    float edge = 1.0 - clamp(abs(world_h - wire_front) / (band * 2.0), 0.0, 1.0);
+    float edge = 1.0 - clamp(abs(world.y - wire_front) / (band * 2.0), 0.0, 1.0);
     vec3 color = material_params.wire_color.rgb *
         (1.0 + material_params.glow_strength * edge * edge);
 

--- a/examples/flutter_app/lib/example_materialize.dart
+++ b/examples/flutter_app/lib/example_materialize.dart
@@ -27,18 +27,17 @@
 // playback bar); the panel's print button dumps the current values to the
 // console.
 //
-// The example reads the imported primitives' retained CPU vertex data back
-// through the internal cpuMeshData accessor to derive the wire and soup
-// geometry; in-repo example apps may reach into internals, so the lints are
-// waived for the whole file (same waiver as example_shapes.dart).
-// ignore_for_file: implementation_imports, invalid_use_of_internal_member
+// The wire and shard geometry is derived from the loaded model through the
+// public readback and derivation APIs, Geometry.extractMeshData snapshots
+// each primitive, MeshData.merge/unweld/extractEdges build the shard soup
+// and the edge set (on a background isolate via compute), and
+// LineSegmentsGeometry renders the edges as GPU-expanded thick ribbons.
 
 import 'dart:math' as math;
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show compute;
 import 'package:flutter/material.dart' hide Material;
 import 'package:flutter_scene/scene.dart';
-import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'environment_menu.dart' show EnvironmentSelector, fetchResource;
@@ -74,7 +73,7 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
   // textures), and one wire/glass pass per mesh node (each carries that
   // node's world transform).
   final List<PreprocessedMaterial> _shellMaterials = [];
-  final List<(Node, PreprocessedMaterial)> _wirePasses = [];
+  final List<(PreprocessedMaterial, LineSegmentsGeometry)> _wirePasses = [];
   final List<(Node, PreprocessedMaterial)> _glassPasses = [];
 
   final Node _spin = Node(name: 'materialize_spin');
@@ -131,12 +130,12 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
 
       for (final meshNode in meshNodes) {
         final world = meshNode.globalTransform;
-        final parts = <_TriangleMesh>[];
+        final parts = <MeshData>[];
         for (final primitive in meshNode.mesh!.primitives) {
-          final source = _extractTriangleMesh(primitive.geometry);
+          final source = primitive.geometry.extractMeshData();
           parts.add(source);
           primitiveCount++;
-          triangleCount += source.indices.length ~/ 3;
+          triangleCount += source.triangleCount;
           for (var v = 0; v < source.positions.length; v += 3) {
             scratch.setValues(
               source.positions[v],
@@ -160,24 +159,35 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
           _shellMaterials.add(shell);
         }
 
-        final source = _mergeTriangleMeshes(parts);
+        // Derive the shard soup and the edge set on a background isolate;
+        // both are pure MeshData transforms.
+        final derived = await compute(
+          _deriveMaterializeGeometry,
+          MeshData.merge(parts),
+        );
+        if (!mounted) return;
 
-        // Stage 1: view-facing ribbon quads over this node's unique edges.
+        // Stage 1: the unique edges as GPU-expanded thick ribbons, offset
+        // off the surface so they do not z-fight the shell.
         final wire = await loadFmatMaterial(
           'assets/materialize_wireframe.fmat',
         );
-        final wireNode = Node(
-          name: 'materialize_wire',
-          mesh: Mesh(_buildWireGeometry(source), wire),
+        final wireGeometry = LineSegmentsGeometry(
+          derived.edges,
+          normalOffset: 0.002,
         );
-        meshNode.add(wireNode);
-        _wirePasses.add((wireNode, wire));
+        meshNode.add(
+          Node(name: 'materialize_wire', mesh: Mesh(wireGeometry, wire)),
+        );
+        _wirePasses.add((wire, wireGeometry));
 
-        // Stage 2: this node's unwelded shard soup.
+        // Stage 2: the unwelded shard soup, carrying the canned
+        // triangle_centroid/triangle_seed attributes the glass material's
+        // vertex stage reads.
         final glass = await loadFmatMaterial('assets/materialize_glass.fmat');
         final glassNode = Node(
           name: 'materialize_glass',
-          mesh: Mesh(_buildGlassGeometry(source), glass),
+          mesh: Mesh(MeshGeometry.fromMeshData(derived.shards), glass),
         );
         meshNode.add(glassNode);
         _glassPasses.add((glassNode, glass));
@@ -258,218 +268,6 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
       ..setFloat('occlusion_strength', imported.occlusionStrength);
   }
 
-  /// Reads positions, normals, and triangle indices back from the imported
-  /// geometry's retained CPU copy (interleaved unskinned layout, 12 floats
-  /// per vertex).
-  _TriangleMesh _extractTriangleMesh(Geometry geometry) {
-    final data = geometry.cpuMeshData;
-    final vertices = data.vertices;
-    final indexData = data.indices;
-    if (vertices == null || indexData == null) {
-      throw StateError('Imported geometry retained no CPU vertex data.');
-    }
-    const stride = 12; // floats per unskinned vertex
-    final floats = Float32List.sublistView(vertices);
-    final vertexCount = data.vertexCount;
-    final positions = Float32List(vertexCount * 3);
-    final normals = Float32List(vertexCount * 3);
-    for (var v = 0; v < vertexCount; v++) {
-      final base = v * stride;
-      positions[v * 3] = floats[base];
-      positions[v * 3 + 1] = floats[base + 1];
-      positions[v * 3 + 2] = floats[base + 2];
-      normals[v * 3] = floats[base + 3];
-      normals[v * 3 + 1] = floats[base + 4];
-      normals[v * 3 + 2] = floats[base + 5];
-    }
-    // Note sublistView range args count the SOURCE's elements (bytes for a
-    // ByteData), so no end bound is passed; the buffer holds exactly
-    // indexCount elements.
-    final List<int> indices = data.indexType == gpu.IndexType.int32
-        ? Uint32List.sublistView(indexData)
-        : Uint16List.sublistView(indexData);
-    return _TriangleMesh(positions, normals, indices);
-  }
-
-  /// Concatenates per-primitive triangle meshes (same node space) into one,
-  /// rebasing the indices.
-  _TriangleMesh _mergeTriangleMeshes(List<_TriangleMesh> parts) {
-    if (parts.length == 1) return parts.first;
-    var vertexCount = 0;
-    var indexCount = 0;
-    for (final part in parts) {
-      vertexCount += part.positions.length ~/ 3;
-      indexCount += part.indices.length;
-    }
-    final positions = Float32List(vertexCount * 3);
-    final normals = Float32List(vertexCount * 3);
-    final indices = List<int>.filled(indexCount, 0);
-    var vertexBase = 0;
-    var indexBase = 0;
-    for (final part in parts) {
-      positions.setRange(
-        vertexBase * 3,
-        vertexBase * 3 + part.positions.length,
-        part.positions,
-      );
-      normals.setRange(
-        vertexBase * 3,
-        vertexBase * 3 + part.normals.length,
-        part.normals,
-      );
-      for (var i = 0; i < part.indices.length; i++) {
-        indices[indexBase + i] = part.indices[i] + vertexBase;
-      }
-      vertexBase += part.positions.length ~/ 3;
-      indexBase += part.indices.length;
-    }
-    return _TriangleMesh(positions, normals, indices);
-  }
-
-  /// A view-facing ribbon quad per unique undirected edge. Each vertex
-  /// carries the opposite endpoint and a side sign; the material's vertex
-  /// stage expands the quad perpendicular to the edge and the view.
-  MeshGeometry _buildWireGeometry(_TriangleMesh source) {
-    final seen = <int>{};
-    final edgeA = <int>[];
-    final edgeB = <int>[];
-    void addEdge(int a, int b) {
-      final lo = math.min(a, b);
-      final hi = math.max(a, b);
-      if (seen.add(lo * 0x100000 + hi)) {
-        edgeA.add(lo);
-        edgeB.add(hi);
-      }
-    }
-
-    final srcIndices = source.indices;
-    for (var t = 0; t + 2 < srcIndices.length; t += 3) {
-      addEdge(srcIndices[t], srcIndices[t + 1]);
-      addEdge(srcIndices[t + 1], srcIndices[t + 2]);
-      addEdge(srcIndices[t + 2], srcIndices[t]);
-    }
-
-    final edgeCount = edgeA.length;
-    final positions = Float32List(edgeCount * 12);
-    final normals = Float32List(edgeCount * 12);
-    final others = Float32List(edgeCount * 12);
-    final sides = Float32List(edgeCount * 4);
-    final indices = List<int>.filled(edgeCount * 6, 0);
-    void writeVec3(Float32List dst, int vertex, Float32List src, int index) {
-      dst[vertex * 3] = src[index * 3];
-      dst[vertex * 3 + 1] = src[index * 3 + 1];
-      dst[vertex * 3 + 2] = src[index * 3 + 2];
-    }
-
-    for (var e = 0; e < edgeCount; e++) {
-      final a = edgeA[e], b = edgeB[e];
-      final base = e * 4;
-      for (var corner = 0; corner < 4; corner++) {
-        final v = base + corner;
-        final atA = corner < 2;
-        writeVec3(positions, v, source.positions, atA ? a : b);
-        writeVec3(normals, v, source.normals, atA ? a : b);
-        writeVec3(others, v, source.positions, atA ? b : a);
-        sides[v] = corner.isEven ? 1.0 : -1.0;
-      }
-      final i = e * 6;
-      indices[i] = base;
-      indices[i + 1] = base + 1;
-      indices[i + 2] = base + 2;
-      indices[i + 3] = base;
-      indices[i + 4] = base + 2;
-      indices[i + 5] = base + 3;
-    }
-    return MeshGeometry.fromArrays(
-        positions: positions,
-        normals: normals,
-        indices: indices,
-      )
-      ..setCustomAttribute('edge_other', others, components: 3)
-      ..setCustomAttribute('edge_side', sides, components: 1);
-  }
-
-  /// The shard soup: every triangle unwelded to three unique vertices with a
-  /// flat outward normal, plus the triangle centroid and a random seed as
-  /// custom attributes for the glass material's vertex stage.
-  MeshGeometry _buildGlassGeometry(_TriangleMesh source) {
-    final indices = source.indices;
-    final triangleCount = indices.length ~/ 3;
-    final positions = Float32List(triangleCount * 9);
-    final normals = Float32List(triangleCount * 9);
-    final centroids = Float32List(triangleCount * 9);
-    final seeds = Float32List(triangleCount * 3);
-
-    final p0 = vm.Vector3.zero(),
-        p1 = vm.Vector3.zero(),
-        p2 = vm.Vector3.zero();
-    final smooth = vm.Vector3.zero();
-    var seedState = 0x9e3779b9;
-    for (var t = 0; t < triangleCount; t++) {
-      final i0 = indices[t * 3],
-          i1 = indices[t * 3 + 1],
-          i2 = indices[t * 3 + 2];
-      p0.setValues(
-        source.positions[i0 * 3],
-        source.positions[i0 * 3 + 1],
-        source.positions[i0 * 3 + 2],
-      );
-      p1.setValues(
-        source.positions[i1 * 3],
-        source.positions[i1 * 3 + 1],
-        source.positions[i1 * 3 + 2],
-      );
-      p2.setValues(
-        source.positions[i2 * 3],
-        source.positions[i2 * 3 + 1],
-        source.positions[i2 * 3 + 2],
-      );
-
-      // Flat face normal, sign-checked against the averaged vertex normals
-      // so it always points outward.
-      final flat = (p1 - p0).cross(p2 - p0);
-      if (flat.length2 > 0) flat.normalize();
-      smooth.setValues(
-        source.normals[i0 * 3] +
-            source.normals[i1 * 3] +
-            source.normals[i2 * 3],
-        source.normals[i0 * 3 + 1] +
-            source.normals[i1 * 3 + 1] +
-            source.normals[i2 * 3 + 1],
-        source.normals[i0 * 3 + 2] +
-            source.normals[i1 * 3 + 2] +
-            source.normals[i2 * 3 + 2],
-      );
-      if (flat.dot(smooth) < 0) flat.negate();
-
-      final cx = (p0.x + p1.x + p2.x) / 3;
-      final cy = (p0.y + p1.y + p2.y) / 3;
-      final cz = (p0.z + p1.z + p2.z) / 3;
-
-      // Cheap deterministic per-triangle random in [0, 1).
-      seedState = 0x1fffffff & (seedState * 1103515245 + 12345);
-      final seed = (seedState & 0xffff) / 0x10000;
-
-      for (var v = 0; v < 3; v++) {
-        final src = v == 0 ? p0 : (v == 1 ? p1 : p2);
-        final out = (t * 3 + v) * 3;
-        positions[out] = src.x;
-        positions[out + 1] = src.y;
-        positions[out + 2] = src.z;
-        normals[out] = flat.x;
-        normals[out + 1] = flat.y;
-        normals[out + 2] = flat.z;
-        centroids[out] = cx;
-        centroids[out + 1] = cy;
-        centroids[out + 2] = cz;
-        seeds[t * 3 + v] = seed;
-      }
-    }
-    return MeshGeometry.fromArrays(positions: positions, normals: normals)
-      ..setCustomAttribute('tri_centroid', centroids, components: 3)
-      ..setCustomAttribute('tri_seed', seeds, components: 1);
-  }
-
   /// Writes every look setting into the materials (scaled to the model's
   /// world height where the setting is a fraction).
   void _applySettings() {
@@ -479,11 +277,10 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
     final noiseScale = s.noiseScale / range;
     final noiseAmp = s.noiseAmp * range;
 
-    for (final (_, wire) in _wirePasses) {
+    for (final (wire, wireGeometry) in _wirePasses) {
+      wireGeometry.width = range * s.wireThickness;
       wire.parameters
         ..setFloat('band', range * 0.06)
-        ..setFloat('thickness', range * s.wireThickness)
-        ..setFloat('inflate', range * 0.004)
         ..setVec4(
           'wire_color',
           vm.Vector4(s.wireColor.x, s.wireColor.y, s.wireColor.z, s.wireAlpha),
@@ -550,11 +347,10 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
     final center = vm.Vector3.copy(_center);
     _spin.globalTransform.transform3(center);
 
-    for (final (node, wire) in _wirePasses) {
+    for (final (wire, _) in _wirePasses) {
       wire.parameters
         ..setFloat('wire_front', wireFront)
-        ..setFloat('solid_front', solidFront)
-        ..setMat4('model_matrix', node.globalTransform);
+        ..setFloat('solid_front', solidFront);
     }
     for (final (node, glass) in _glassPasses) {
       glass.parameters
@@ -675,10 +471,15 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
   }
 }
 
-class _TriangleMesh {
-  _TriangleMesh(this.positions, this.normals, this.indices);
-
-  final Float32List positions;
-  final Float32List normals;
-  final List<int> indices;
+/// Derives the Materialize passes' geometry from one node's merged source
+/// mesh. Pure CPU work; runs on a background isolate via `compute`.
+({MeshData shards, LineSegmentData edges}) _deriveMaterializeGeometry(
+  MeshData source,
+) {
+  return (
+    shards: source.unweld(
+      attributes: {UnweldAttribute.centroid, UnweldAttribute.seed},
+    ),
+    edges: source.extractEdges(),
+  );
 }

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -227,9 +227,26 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
     // The custom-material hero: a grid carrying a per-vertex `phase` attribute,
     // rippled by the vertex stage and colored from the attribute. Floats above
     // the ground so its displaced shadow reads clearly.
+    final grid = _phaseGrid();
     scene.add(
-      Node(mesh: Mesh(_phaseGrid(), material))
+      Node(mesh: Mesh(grid, material))
         ..localTransform = vm.Matrix4.translation(vm.Vector3(0, 1.0, 0)),
+    );
+    // A thick-ribbon wireframe derived from the hero grid through the public
+    // readback chain (extractMeshData, extractEdges, LineSegmentsGeometry),
+    // floating above it. Covers the segment-expansion vertex shader and the
+    // derivation pipeline on every backend within this one scene.
+    scene.add(
+      Node(
+        mesh: Mesh(
+          LineSegmentsGeometry(
+            grid.extractMeshData().extractEdges(),
+            width: 0.025,
+            normalOffset: 0.01,
+          ),
+          UnlitMaterial()..baseColorFactor = vm.Vector4(0.2, 0.9, 1.0, 1.0),
+        ),
+      )..localTransform = vm.Matrix4.translation(vm.Vector3(0, 2.1, 0)),
     );
     return (scene: scene, camera: _shadowCamera());
   }),

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -241,12 +241,12 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
         mesh: Mesh(
           LineSegmentsGeometry(
             grid.extractMeshData().extractEdges(),
-            width: 0.025,
+            width: 0.02,
             normalOffset: 0.01,
           ),
           UnlitMaterial()..baseColorFactor = vm.Vector4(0.2, 0.9, 1.0, 1.0),
         ),
-      )..localTransform = vm.Matrix4.translation(vm.Vector3(0, 2.1, 0)),
+      )..localTransform = vm.Matrix4.translation(vm.Vector3(0, 0.5, 0)),
     );
     return (scene: scene, camera: _shadowCamera());
   }),

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -26,7 +26,14 @@ export 'src/geometry/billboard_geometry.dart'
     show BillboardFacing, BillboardGeometry;
 export 'src/geometry/geometry.dart'
     show Geometry, SkinnedGeometry, UnskinnedGeometry;
-export 'src/geometry/mesh_data.dart' show MeshData;
+export 'src/geometry/line_segments_geometry.dart' show LineSegmentsGeometry;
+export 'src/geometry/mesh_data.dart'
+    show
+        LineSegmentData,
+        MeshAttributeData,
+        MeshData,
+        MeshTriangle,
+        UnweldAttribute;
 export 'src/geometry/mesh_geometry.dart'
     show GeometryBuilder, GeometryStorage, MeshGeometry;
 export 'src/geometry/primitives.dart'

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
+import 'package:flutter_scene/src/geometry/mesh_data.dart';
 import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
@@ -46,12 +49,15 @@ abstract class Geometry {
   ByteData? _cpuVertices;
   ByteData? _cpuIndices;
 
-  // Structure-of-arrays CPU copies for raycasting, set by the SoA upload path
-  // instead of the interleaved [_cpuVertices]. Position is required to
-  // raycast; texture coordinates let a hit report a UV. Null for interleaved
-  // geometry (which raycasts off [_cpuVertices]) or non-raycastable geometry.
+  // Structure-of-arrays CPU copies for raycasting and readback, set by the
+  // SoA upload path instead of the interleaved [_cpuVertices]. Position is
+  // required to raycast; texture coordinates let a hit report a UV; normals
+  // and colors exist only for [extractMeshData]. Null for interleaved
+  // geometry (which reads off [_cpuVertices]) or non-readable geometry.
   Float32List? _cpuPositions;
   Float32List? _cpuTexCoords;
+  Float32List? _cpuNormals;
+  Float32List? _cpuColors;
 
   gpu.Shader? _vertexShader;
   String? _vertexShaderName;
@@ -143,8 +149,17 @@ abstract class Geometry {
   // Extra per-vertex attribute streams a material's custom `attributes` read,
   // keyed by the shader `in` name (insertion order is the slot order). Bound
   // after the base vertex streams in the color pass; the depth passes fetch
-  // only position and ignore them. Populated by [setCustomAttribute].
-  final Map<String, ({gpu.VertexFormat format, gpu.BufferView view})>
+  // only position and ignore them. Populated by [setCustomAttribute], which
+  // retains the caller's data for [extractMeshData].
+  final Map<
+    String,
+    ({
+      gpu.VertexFormat format,
+      gpu.BufferView view,
+      Float32List data,
+      int components,
+    })
+  >
   _customAttributes = {};
 
   /// The number of vertex buffer streams this geometry binds: the built-in
@@ -212,6 +227,8 @@ abstract class Geometry {
         offsetInBytes: 0,
         lengthInBytes: bytes.lengthInBytes,
       ),
+      data: data,
+      components: components,
     );
   }
 
@@ -330,9 +347,13 @@ abstract class Geometry {
     required Float32List positions,
     Float32List? texCoords,
     ByteData? indices,
+    Float32List? normals,
+    Float32List? colors,
   }) {
     _cpuPositions = positions;
     _cpuTexCoords = texCoords;
+    _cpuNormals = normals;
+    _cpuColors = colors;
     _cpuIndices = indices;
     _cpuVertices = null;
   }
@@ -360,6 +381,103 @@ abstract class Geometry {
     vertexCount: _vertexCount,
     indexCount: _indexCount,
   );
+
+  /// Whether this geometry retains CPU-side vertex data, making
+  /// [extractMeshData] available.
+  ///
+  /// True for geometry loaded by the importers or built from attribute
+  /// arrays ([MeshGeometry], [GeometryBuilder], the shape geometries).
+  /// False for caller-managed vertex buffers ([setVertices] /
+  /// [setVertexStreams]) and before the first upload.
+  /// {@category Geometry}
+  bool get isReadable => _cpuVertices != null || _cpuPositions != null;
+
+  /// Copies this geometry's retained CPU vertex/index data out as an
+  /// isolate-transferable [MeshData] snapshot.
+  ///
+  /// The snapshot is always a copy (never a view of engine memory) with
+  /// structure-of-arrays attributes regardless of how the data is stored
+  /// internally, so it is safe to send to a background isolate and derive
+  /// new geometry from (see [MeshData.unweld], [MeshData.extractEdges]).
+  /// Attributes the engine did not retain come back null; skinned geometry
+  /// returns bind-pose positions and no joint data.
+  ///
+  /// Throws a [StateError] when [isReadable] is false.
+  /// {@category Geometry}
+  MeshData extractMeshData() {
+    final interleaved = _cpuVertices;
+    final soaPositions = _cpuPositions;
+    if (interleaved == null && soaPositions == null) {
+      throw StateError(
+        'This geometry retains no CPU vertex data to extract '
+        '(isReadable is false). Caller-managed vertex buffers are not '
+        'readable.',
+      );
+    }
+
+    Float32List positions;
+    Float32List? normals;
+    Float32List? texCoords;
+    Float32List? colors;
+    if (interleaved != null) {
+      // Interleaved unskinned (12 floats) or skinned (20 floats, of which
+      // the leading 12 match the unskinned layout) vertices.
+      final stride = this is SkinnedGeometry ? 20 : 12;
+      final floats = Float32List.sublistView(interleaved);
+      positions = Float32List(_vertexCount * 3);
+      normals = Float32List(_vertexCount * 3);
+      texCoords = Float32List(_vertexCount * 2);
+      colors = Float32List(_vertexCount * 4);
+      for (var v = 0; v < _vertexCount; v++) {
+        final base = v * stride;
+        positions[v * 3] = floats[base];
+        positions[v * 3 + 1] = floats[base + 1];
+        positions[v * 3 + 2] = floats[base + 2];
+        normals[v * 3] = floats[base + 3];
+        normals[v * 3 + 1] = floats[base + 4];
+        normals[v * 3 + 2] = floats[base + 5];
+        texCoords[v * 2] = floats[base + 6];
+        texCoords[v * 2 + 1] = floats[base + 7];
+        colors[v * 4] = floats[base + 8];
+        colors[v * 4 + 1] = floats[base + 9];
+        colors[v * 4 + 2] = floats[base + 10];
+        colors[v * 4 + 3] = floats[base + 11];
+      }
+    } else {
+      positions = Float32List.fromList(soaPositions!);
+      final n = _cpuNormals;
+      final t = _cpuTexCoords;
+      final c = _cpuColors;
+      normals = n == null ? null : Float32List.fromList(n);
+      texCoords = t == null ? null : Float32List.fromList(t);
+      colors = c == null ? null : Float32List.fromList(c);
+    }
+
+    List<int>? indices;
+    final indexBytes = _cpuIndices;
+    if (indexBytes != null && _indexCount > 0) {
+      indices = _indexType == gpu.IndexType.int32
+          ? Uint32List.fromList(Uint32List.sublistView(indexBytes))
+          : Uint16List.fromList(Uint16List.sublistView(indexBytes));
+    }
+
+    return MeshData(
+      positions: positions,
+      vertexCount: _vertexCount,
+      normals: normals,
+      texCoords: texCoords,
+      colors: colors,
+      indices: indices,
+      primitiveType: primitiveType,
+      customAttributes: {
+        for (final entry in _customAttributes.entries)
+          entry.key: MeshAttributeData(
+            Float32List.fromList(entry.value.data),
+            components: entry.value.components,
+          ),
+      },
+    );
+  }
 
   /// Internal: populate bounds from a tightly packed position list (three
   /// floats per vertex), used by the structure-of-arrays upload path.
@@ -680,6 +798,8 @@ class UnskinnedGeometry extends Geometry {
     setRaycastAttributes(
       positions: Float32List.sublistView(streams.position),
       texCoords: Float32List.sublistView(streams.texCoord),
+      normals: Float32List.sublistView(streams.normal),
+      colors: Float32List.sublistView(streams.color),
       indices: indices,
     );
     if (localBounds == null && vertexCount > 0) {
@@ -718,6 +838,8 @@ class UnskinnedGeometry extends Geometry {
     setRaycastAttributes(
       positions: Float32List.sublistView(streams.position),
       texCoords: Float32List.sublistView(streams.texCoord),
+      normals: Float32List.sublistView(streams.normal),
+      colors: Float32List.sublistView(streams.color),
       indices: indices,
     );
     if (localBounds == null && vertexCount > 0) {

--- a/packages/flutter_scene/lib/src/geometry/line_segments_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/line_segments_geometry.dart
@@ -1,0 +1,253 @@
+import 'dart:typed_data';
+
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'package:flutter_scene/src/geometry/geometry.dart';
+import 'package:flutter_scene/src/geometry/mesh_data.dart';
+import 'package:flutter_scene/src/geometry/vertex_layout.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
+import 'package:flutter_scene/src/shaders.dart';
+
+/// A batch of thick, disconnected line segments, each expanded into a
+/// camera-facing quad of a fixed world-space width in the vertex shader and
+/// drawn in a single instanced call.
+///
+/// Native line primitives render one pixel wide on every backend;
+/// `LineSegmentsGeometry` is the styled alternative for bulk segment sets, a
+/// model wireframe from [MeshData.extractEdges], debug visualization, or any
+/// large set of independent segments. The expansion runs on the GPU, so the
+/// segments cost no per-frame CPU work (`PolylineGeometry` remains the
+/// choice for connected paths that need joins, caps, and dashes).
+///
+/// Pair it with any material; the expanded ribbon carries the standard
+/// vertex outputs (camera-facing normals, `u` along each segment and `v`
+/// across it, white vertex color). Segment endpoints are in the geometry's
+/// local space and the owning node's transform places the whole batch.
+///
+/// When the source [LineSegmentData] carries normals, [normalOffset] pushes
+/// each endpoint off the surface along them at construction, which keeps a
+/// wireframe overlay from z-fighting the mesh it traces.
+/// {@category Geometry}
+class LineSegmentsGeometry extends Geometry {
+  /// Creates a segment batch from [segments].
+  ///
+  /// [width] is the ribbon's world-space width. [normalOffset] displaces
+  /// endpoints along the source normals (ignored when the segment data
+  /// carries none).
+  LineSegmentsGeometry(
+    LineSegmentData segments, {
+    double width = 0.01,
+    double normalOffset = 0.0,
+  }) : _width = width {
+    setVertexShader(baseShaderLibrary['LineSegmentsVertex']!);
+    final quad = _sharedQuad();
+    setVertices(quad.vertices, _kQuadVertexCount);
+    setIndices(quad.indices, gpu.IndexType.int16);
+
+    final positions = segments.positions;
+    final normals = segments.normals;
+    _segmentCount = segments.segmentCount;
+    final endpoints = Float32List(positions.length);
+    for (var i = 0; i < positions.length; i++) {
+      endpoints[i] = normalOffset != 0.0 && normals != null
+          ? positions[i] + normals[i] * normalOffset
+          : positions[i];
+    }
+    _endpoints = endpoints;
+
+    if (_segmentCount > 0) {
+      final bytes = ByteData.sublistView(endpoints);
+      final buffer = gpu.gpuContext.createDeviceBuffer(
+        gpu.StorageMode.hostVisible,
+        bytes.lengthInBytes,
+      );
+      buffer.overwrite(bytes);
+      _instances = gpu.BufferView(
+        buffer,
+        offsetInBytes: 0,
+        lengthInBytes: bytes.lengthInBytes,
+      );
+    }
+    _recomputeBounds();
+  }
+
+  static const int _kQuadVertexCount = 4;
+  static const int _kQuadIndexCount = 6;
+  static const int _kInstanceStrideBytes = 24; // start (3) + end (3) floats
+
+  late final Float32List _endpoints;
+  int _segmentCount = 0;
+  gpu.BufferView? _instances;
+
+  double _width;
+
+  /// The ribbon's world-space width. Takes effect on the next frame.
+  double get width => _width;
+  set width(double value) {
+    _width = value;
+    _recomputeBounds();
+  }
+
+  /// The number of segments drawn.
+  int get segmentCount => _segmentCount;
+
+  void _recomputeBounds() {
+    if (_segmentCount == 0) {
+      setLocalBounds(null, null);
+      return;
+    }
+    var minX = double.infinity, minY = double.infinity, minZ = double.infinity;
+    var maxX = double.negativeInfinity,
+        maxY = double.negativeInfinity,
+        maxZ = double.negativeInfinity;
+    final e = _endpoints;
+    for (var i = 0; i < e.length; i += 3) {
+      if (e[i] < minX) minX = e[i];
+      if (e[i + 1] < minY) minY = e[i + 1];
+      if (e[i + 2] < minZ) minZ = e[i + 2];
+      if (e[i] > maxX) maxX = e[i];
+      if (e[i + 1] > maxY) maxY = e[i + 1];
+      if (e[i + 2] > maxZ) maxZ = e[i + 2];
+    }
+    // Pad by the half width so an expanded ribbon stays inside the box.
+    final pad = _width * 0.5;
+    final aabb = vm.Aabb3.minMax(
+      vm.Vector3(minX - pad, minY - pad, minZ - pad),
+      vm.Vector3(maxX + pad, maxY + pad, maxZ + pad),
+    );
+    final center = (aabb.min + aabb.max) * 0.5;
+    final radius = (aabb.max - aabb.min).length * 0.5;
+    setLocalBounds(aabb, vm.Sphere.centerRadius(center, radius));
+  }
+
+  @override
+  VertexLayoutDescriptor? get instancedVertexLayout => _kLineSegmentsLayout;
+
+  // The segments supply their own slot-1 instance buffer and read the model
+  // transform from the FrameInfo uniform, so the color encoder must not bind
+  // a model-transform buffer over slot 1.
+  @override
+  bool get bindsModelTransformInstance => false;
+
+  // A camera-facing ribbon's winding flips with the viewing angle, so the
+  // material-less passes (selection mask, depth, shadow) must not cull it.
+  @override
+  bool get isDoubleSided => true;
+
+  // The expansion runs in the engine's own vertex shader; a custom
+  // material's generated vertex variants do not apply to this geometry.
+  @override
+  String get materialVertexVariant => 'line_segments';
+
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    vm.Matrix4 modelTransform,
+    vm.Matrix4 cameraTransform,
+    vm.Vector3 cameraPosition, {
+    // See [materialVertexVariant]; the override is accepted and ignored.
+    gpu.Shader? shaderOverride,
+  }) {
+    // Slot 0: the shared unit quad (and its indices).
+    bindGeometryBuffers(pass);
+
+    // Slot 1: the per-segment endpoints.
+    final instances = _instances;
+    if (instances != null) {
+      pass.bindVertexBuffer(instances, slot: 1);
+    }
+
+    final frameInfo = Float32List(40);
+    frameInfo.setRange(0, 16, cameraTransform.storage);
+    frameInfo.setRange(16, 32, modelTransform.storage);
+    frameInfo[32] = cameraPosition.x;
+    frameInfo[33] = cameraPosition.y;
+    frameInfo[34] = cameraPosition.z;
+    // [35] padding
+    frameInfo[36] = _width * 0.5;
+    // [37..39] unused
+    pass.bindUniform(
+      vertexShader.getUniformSlot('FrameInfo'),
+      transientsBuffer.emplace(ByteData.sublistView(frameInfo)),
+    );
+  }
+
+  @override
+  void draw(gpu.RenderPass pass, {int instanceCount = 1}) {
+    if (_segmentCount == 0) return;
+    drawIndexedCompat(pass, _kQuadIndexCount, instanceCount: _segmentCount);
+  }
+
+  // The static unit quad, shared by every segment batch (one GPU context per
+  // process). Slot 0 layout: corner.x selects the endpoint (0 or 1),
+  // corner.y the ribbon side (-1 or +1).
+  static ({gpu.BufferView vertices, gpu.BufferView indices})? _quad;
+
+  static ({gpu.BufferView vertices, gpu.BufferView indices}) _sharedQuad() {
+    final cached = _quad;
+    if (cached != null) return cached;
+    final verts = Float32List.fromList(<double>[
+      0.0, -1.0, //
+      0.0, 1.0, //
+      1.0, 1.0, //
+      1.0, -1.0,
+    ]);
+    final indices = Uint16List.fromList(<int>[0, 1, 2, 0, 2, 3]);
+    final vertexBytes = ByteData.sublistView(verts);
+    final indexBytes = ByteData.sublistView(indices);
+    final buffer = gpu.gpuContext.createDeviceBuffer(
+      gpu.StorageMode.hostVisible,
+      vertexBytes.lengthInBytes + indexBytes.lengthInBytes,
+    );
+    buffer.overwrite(vertexBytes);
+    buffer.overwrite(
+      indexBytes,
+      destinationOffsetInBytes: vertexBytes.lengthInBytes,
+    );
+    final quad = (
+      vertices: gpu.BufferView(
+        buffer,
+        offsetInBytes: 0,
+        lengthInBytes: vertexBytes.lengthInBytes,
+      ),
+      indices: gpu.BufferView(
+        buffer,
+        offsetInBytes: vertexBytes.lengthInBytes,
+        lengthInBytes: indexBytes.lengthInBytes,
+      ),
+    );
+    _quad = quad;
+    return quad;
+  }
+}
+
+final VertexLayoutDescriptor _kLineSegmentsLayout = VertexLayoutDescriptor(
+  buffers: const [
+    VertexBufferDescriptor(
+      strideInBytes: 8,
+      attributes: [
+        VertexAttributeDescriptor(
+          name: 'corner',
+          format: gpu.VertexFormat.float32x2,
+        ),
+      ],
+    ),
+    VertexBufferDescriptor(
+      strideInBytes: LineSegmentsGeometry._kInstanceStrideBytes,
+      stepMode: gpu.VertexStepMode.instance,
+      attributes: [
+        VertexAttributeDescriptor(
+          name: 'i_start',
+          format: gpu.VertexFormat.float32x3,
+        ),
+        VertexAttributeDescriptor(
+          name: 'i_end',
+          format: gpu.VertexFormat.float32x3,
+          offsetInBytes: 12,
+        ),
+      ],
+    ),
+  ],
+);

--- a/packages/flutter_scene/lib/src/geometry/line_segments_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/line_segments_geometry.dart
@@ -6,6 +6,7 @@ import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/geometry/mesh_data.dart';
 import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/render/frame_transients.dart';
 import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
 import 'package:flutter_scene/src/shaders.dart';
 
@@ -143,7 +144,7 @@ class LineSegmentsGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     vm.Matrix4 modelTransform,
     vm.Matrix4 cameraTransform,
     vm.Vector3 cameraPosition, {

--- a/packages/flutter_scene/lib/src/geometry/mesh_data.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_data.dart
@@ -1,7 +1,101 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
+
+import 'package:vector_math/vector_math.dart' as vm;
 
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+
+/// One named per-vertex attribute stream carried by a [MeshData], matching a
+/// custom material's `attributes` entry (see `Geometry.setCustomAttribute`).
+///
+/// [data] is a tightly packed run of [components]-component float vectors,
+/// one per vertex.
+/// {@category Geometry}
+class MeshAttributeData {
+  MeshAttributeData(this.data, {required this.components}) {
+    if (components < 1 || components > 4) {
+      throw ArgumentError.value(
+        components,
+        'components',
+        'must be between 1 and 4',
+      );
+    }
+  }
+
+  /// The packed attribute values, `components * vertexCount` floats.
+  final Float32List data;
+
+  /// Components per vertex, 1 through 4.
+  final int components;
+}
+
+/// The canned per-triangle attributes [MeshData.unweld] can attach to its
+/// output, under the names custom materials read them by.
+/// {@category Geometry}
+enum UnweldAttribute {
+  /// `triangle_centroid` (vec3), the triangle's centroid position. The
+  /// anchor for per-shard motion (fly-in, tumble about the center).
+  centroid,
+
+  /// `triangle_seed` (float), a deterministic per-triangle random in
+  /// `[0, 1)`. Stable across runs and isolates.
+  seed,
+
+  /// `triangle_index` (float), the source triangle's index.
+  triangleIndex,
+
+  /// `barycentric` (vec3), `(1,0,0)`/`(0,1,0)`/`(0,0,1)` per corner. Enables
+  /// single-pass fragment wireframes and edge-distance effects.
+  barycentric,
+}
+
+/// One triangle of a [MeshData], yielded by [MeshData.triangles].
+/// {@category Geometry}
+class MeshTriangle {
+  MeshTriangle(this.index, this.a, this.b, this.c, this.pa, this.pb, this.pc);
+
+  /// The triangle's index in the mesh.
+  final int index;
+
+  /// The three vertex indices.
+  final int a, b, c;
+
+  /// The three corner positions.
+  final vm.Vector3 pa, pb, pc;
+}
+
+/// Disconnected line segments (point pairs) derived from a mesh, the output
+/// of [MeshData.extractEdges].
+///
+/// Feed [positions] to a line-list mesh for one-pixel debug rendering, or
+/// construct a `LineSegmentsGeometry` for thick, camera-facing segments.
+/// {@category Geometry}
+class LineSegmentData {
+  LineSegmentData({required this.positions, this.normals}) {
+    if (positions.length % 6 != 0) {
+      throw ArgumentError(
+        'positions has ${positions.length} floats; expected six per segment '
+        '(two xyz endpoints)',
+      );
+    }
+    if (normals != null && normals!.length != positions.length) {
+      throw ArgumentError(
+        'normals must match positions in length when supplied',
+      );
+    }
+  }
+
+  /// Endpoint positions, six floats (two xyz points) per segment.
+  final Float32List positions;
+
+  /// Optional per-endpoint surface normals matching [positions], carried
+  /// from the source mesh so callers can offset segments off the surface.
+  final Float32List? normals;
+
+  /// The number of segments.
+  int get segmentCount => positions.length ~/ 6;
+}
 
 /// An isolate-transferable snapshot of a mesh's vertex and index data.
 ///
@@ -11,6 +105,12 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 /// isolate; the result is sent back and turned into a live mesh on the
 /// render isolate. This keeps heavy meshing, such as remeshing a voxel
 /// chunk, off the render isolate.
+///
+/// It is also the interchange type for reading geometry back and deriving
+/// new geometry from it: `Geometry.extractMeshData` produces one from a
+/// loaded mesh, and the pure derivation methods ([unweld], [extractEdges],
+/// [merge]) consume and produce them, so a whole derivation chain can run
+/// off the render isolate.
 ///
 /// Recipe (using `compute` from `package:flutter/foundation.dart`):
 ///
@@ -43,6 +143,7 @@ class MeshData {
     this.colors,
     this.indices,
     this.primitiveType = gpu.PrimitiveType.triangle,
+    this.customAttributes = const {},
   });
 
   /// Builds a snapshot from vertex attribute arrays, generating
@@ -57,6 +158,7 @@ class MeshData {
     Float32List? colors,
     List<int>? indices,
     gpu.PrimitiveType primitiveType = gpu.PrimitiveType.triangle,
+    Map<String, MeshAttributeData> customAttributes = const {},
   }) {
     if (positions.length % 3 != 0) {
       throw ArgumentError(
@@ -82,6 +184,7 @@ class MeshData {
       colors: colors,
       indices: indices,
       primitiveType: primitiveType,
+      customAttributes: customAttributes,
     );
   }
 
@@ -106,4 +209,446 @@ class MeshData {
 
   /// How the vertices assemble into primitives when drawn.
   final gpu.PrimitiveType primitiveType;
+
+  /// Named custom per-vertex attribute streams, forwarded to
+  /// `Geometry.setCustomAttribute` on upload.
+  final Map<String, MeshAttributeData> customAttributes;
+
+  /// The number of triangles (indexed or not). Zero for non-triangle
+  /// primitive types.
+  int get triangleCount => primitiveType == gpu.PrimitiveType.triangle
+      ? (indices?.length ?? vertexCount) ~/ 3
+      : 0;
+
+  /// Iterates the mesh's triangles with their corner indices and positions.
+  ///
+  /// The yielded positions are copies; mutating them does not touch the
+  /// snapshot.
+  Iterable<MeshTriangle> get triangles sync* {
+    _requireTriangles('triangles');
+    final count = triangleCount;
+    for (var t = 0; t < count; t++) {
+      final a = _cornerIndex(t * 3);
+      final b = _cornerIndex(t * 3 + 1);
+      final c = _cornerIndex(t * 3 + 2);
+      yield MeshTriangle(t, a, b, c, _position(a), _position(b), _position(c));
+    }
+  }
+
+  /// A flat-shaded triangle soup derived from this mesh.
+  ///
+  /// Every triangle gets three unique vertices carrying its face normal
+  /// (oriented to agree with the source vertex normals when present), with
+  /// texture coordinates, colors, and custom attributes carried through
+  /// per corner. [attributes] attaches canned per-triangle streams under
+  /// the names in [UnweldAttribute], ready for a custom material's
+  /// `attributes` list.
+  ///
+  /// Triples the vertex data of an indexed mesh; run it on a background
+  /// isolate for large inputs (the whole derivation is pure CPU work).
+  MeshData unweld({Set<UnweldAttribute> attributes = const {}}) {
+    _requireTriangles('unweld');
+    final count = triangleCount;
+    final outCount = count * 3;
+
+    final srcTexCoords = texCoords;
+    final srcColors = colors;
+    final outPositions = Float32List(outCount * 3);
+    final outNormals = Float32List(outCount * 3);
+    final outTexCoords = srcTexCoords == null
+        ? null
+        : Float32List(outCount * 2);
+    final outColors = srcColors == null ? null : Float32List(outCount * 4);
+    final outCustom = <String, MeshAttributeData>{
+      for (final entry in customAttributes.entries)
+        entry.key: MeshAttributeData(
+          Float32List(outCount * entry.value.components),
+          components: entry.value.components,
+        ),
+    };
+
+    final wantCentroid = attributes.contains(UnweldAttribute.centroid);
+    final wantSeed = attributes.contains(UnweldAttribute.seed);
+    final wantIndex = attributes.contains(UnweldAttribute.triangleIndex);
+    final wantBarycentric = attributes.contains(UnweldAttribute.barycentric);
+    final centroids = wantCentroid ? Float32List(outCount * 3) : null;
+    final seeds = wantSeed ? Float32List(outCount) : null;
+    final triIndices = wantIndex ? Float32List(outCount) : null;
+    final barycentrics = wantBarycentric ? Float32List(outCount * 3) : null;
+
+    final srcNormals = normals;
+    var seedState = 0x9e3779b9;
+    for (var t = 0; t < count; t++) {
+      final i0 = _cornerIndex(t * 3);
+      final i1 = _cornerIndex(t * 3 + 1);
+      final i2 = _cornerIndex(t * 3 + 2);
+
+      // Face normal from the winding, sign-checked against the source
+      // vertex normals so mirrored or inconsistently wound data still
+      // points outward.
+      final ax = positions[i0 * 3],
+          ay = positions[i0 * 3 + 1],
+          az = positions[i0 * 3 + 2];
+      final e1x = positions[i1 * 3] - ax,
+          e1y = positions[i1 * 3 + 1] - ay,
+          e1z = positions[i1 * 3 + 2] - az;
+      final e2x = positions[i2 * 3] - ax,
+          e2y = positions[i2 * 3 + 1] - ay,
+          e2z = positions[i2 * 3 + 2] - az;
+      var nx = e1y * e2z - e1z * e2y;
+      var ny = e1z * e2x - e1x * e2z;
+      var nz = e1x * e2y - e1y * e2x;
+      final nLen = math.sqrt(nx * nx + ny * ny + nz * nz);
+      if (nLen > 0) {
+        nx /= nLen;
+        ny /= nLen;
+        nz /= nLen;
+      }
+      if (srcNormals != null) {
+        final sx = srcNormals[i0 * 3] + srcNormals[i1 * 3] + srcNormals[i2 * 3];
+        final sy =
+            srcNormals[i0 * 3 + 1] +
+            srcNormals[i1 * 3 + 1] +
+            srcNormals[i2 * 3 + 1];
+        final sz =
+            srcNormals[i0 * 3 + 2] +
+            srcNormals[i1 * 3 + 2] +
+            srcNormals[i2 * 3 + 2];
+        if (nx * sx + ny * sy + nz * sz < 0) {
+          nx = -nx;
+          ny = -ny;
+          nz = -nz;
+        }
+      }
+
+      final cx =
+          (positions[i0 * 3] + positions[i1 * 3] + positions[i2 * 3]) / 3;
+      final cy =
+          (positions[i0 * 3 + 1] +
+              positions[i1 * 3 + 1] +
+              positions[i2 * 3 + 1]) /
+          3;
+      final cz =
+          (positions[i0 * 3 + 2] +
+              positions[i1 * 3 + 2] +
+              positions[i2 * 3 + 2]) /
+          3;
+
+      // Deterministic per-triangle random in [0, 1).
+      seedState = 0x1fffffff & (seedState * 1103515245 + 12345);
+      final seed = (seedState & 0xffff) / 0x10000;
+
+      for (var corner = 0; corner < 3; corner++) {
+        final src = corner == 0 ? i0 : (corner == 1 ? i1 : i2);
+        final v = t * 3 + corner;
+        outPositions[v * 3] = positions[src * 3];
+        outPositions[v * 3 + 1] = positions[src * 3 + 1];
+        outPositions[v * 3 + 2] = positions[src * 3 + 2];
+        outNormals[v * 3] = nx;
+        outNormals[v * 3 + 1] = ny;
+        outNormals[v * 3 + 2] = nz;
+        if (outTexCoords != null) {
+          outTexCoords[v * 2] = srcTexCoords![src * 2];
+          outTexCoords[v * 2 + 1] = srcTexCoords[src * 2 + 1];
+        }
+        if (outColors != null) {
+          for (var i = 0; i < 4; i++) {
+            outColors[v * 4 + i] = srcColors![src * 4 + i];
+          }
+        }
+        for (final entry in customAttributes.entries) {
+          final components = entry.value.components;
+          final srcData = entry.value.data;
+          final dstData = outCustom[entry.key]!.data;
+          for (var i = 0; i < components; i++) {
+            dstData[v * components + i] = srcData[src * components + i];
+          }
+        }
+        if (centroids != null) {
+          centroids[v * 3] = cx;
+          centroids[v * 3 + 1] = cy;
+          centroids[v * 3 + 2] = cz;
+        }
+        if (seeds != null) seeds[v] = seed;
+        if (triIndices != null) triIndices[v] = t.toDouble();
+        if (barycentrics != null) {
+          barycentrics[v * 3 + corner] = 1.0;
+        }
+      }
+    }
+
+    if (centroids != null) {
+      outCustom['triangle_centroid'] = MeshAttributeData(
+        centroids,
+        components: 3,
+      );
+    }
+    if (seeds != null) {
+      outCustom['triangle_seed'] = MeshAttributeData(seeds, components: 1);
+    }
+    if (triIndices != null) {
+      outCustom['triangle_index'] = MeshAttributeData(
+        triIndices,
+        components: 1,
+      );
+    }
+    if (barycentrics != null) {
+      outCustom['barycentric'] = MeshAttributeData(barycentrics, components: 3);
+    }
+
+    return MeshData(
+      positions: outPositions,
+      vertexCount: outCount,
+      normals: outNormals,
+      texCoords: outTexCoords,
+      colors: outColors,
+      primitiveType: gpu.PrimitiveType.triangle,
+      customAttributes: outCustom,
+    );
+  }
+
+  /// The mesh's unique undirected edges as disconnected line segments.
+  ///
+  /// With a null [creaseAngleDegrees] every edge is kept (a full
+  /// wireframe). With a value, an edge is kept only when its two adjacent
+  /// faces meet at more than that angle (a feature-edge wireframe);
+  /// boundary edges (a single adjacent face) are always kept.
+  ///
+  /// The output carries per-endpoint source normals when this mesh has
+  /// normals, so callers can offset the segments off the surface.
+  LineSegmentData extractEdges({double? creaseAngleDegrees}) {
+    _requireTriangles('extractEdges');
+    final count = triangleCount;
+
+    // Unique undirected edges, keyed lo * vertexCount + hi (safe well past
+    // any practical vertex count). Each edge tracks up to two face normals
+    // for the crease filter.
+    final edgeSlot = <int, int>{};
+    final edgeA = <int>[];
+    final edgeB = <int>[];
+    final faceNx = <double>[];
+    final faceNy = <double>[];
+    final faceNz = <double>[];
+    // Per edge: first face index, second face index (or -1).
+    final firstFace = <int>[];
+    final secondFace = <int>[];
+
+    for (var t = 0; t < count; t++) {
+      final i0 = _cornerIndex(t * 3);
+      final i1 = _cornerIndex(t * 3 + 1);
+      final i2 = _cornerIndex(t * 3 + 2);
+
+      if (creaseAngleDegrees != null) {
+        final ax = positions[i0 * 3],
+            ay = positions[i0 * 3 + 1],
+            az = positions[i0 * 3 + 2];
+        final e1x = positions[i1 * 3] - ax,
+            e1y = positions[i1 * 3 + 1] - ay,
+            e1z = positions[i1 * 3 + 2] - az;
+        final e2x = positions[i2 * 3] - ax,
+            e2y = positions[i2 * 3 + 1] - ay,
+            e2z = positions[i2 * 3 + 2] - az;
+        var nx = e1y * e2z - e1z * e2y;
+        var ny = e1z * e2x - e1x * e2z;
+        var nz = e1x * e2y - e1y * e2x;
+        final len = math.sqrt(nx * nx + ny * ny + nz * nz);
+        if (len > 0) {
+          nx /= len;
+          ny /= len;
+          nz /= len;
+        }
+        faceNx.add(nx);
+        faceNy.add(ny);
+        faceNz.add(nz);
+      }
+
+      void addEdge(int a, int b) {
+        final lo = math.min(a, b);
+        final hi = math.max(a, b);
+        final key = lo * vertexCount + hi;
+        final slot = edgeSlot[key];
+        if (slot == null) {
+          edgeSlot[key] = edgeA.length;
+          edgeA.add(lo);
+          edgeB.add(hi);
+          firstFace.add(t);
+          secondFace.add(-1);
+        } else if (secondFace[slot] == -1) {
+          secondFace[slot] = t;
+        }
+      }
+
+      addEdge(i0, i1);
+      addEdge(i1, i2);
+      addEdge(i2, i0);
+    }
+
+    // cos of the crease angle; adjacent faces whose normals agree more than
+    // this are coplanar enough to drop.
+    final creaseCos = creaseAngleDegrees == null
+        ? null
+        : math.cos(creaseAngleDegrees * math.pi / 180.0);
+
+    final srcNormals = normals;
+    final outPositions = <double>[];
+    final outNormals = srcNormals == null ? null : <double>[];
+    for (var e = 0; e < edgeA.length; e++) {
+      if (creaseCos != null && secondFace[e] != -1) {
+        final f0 = firstFace[e];
+        final f1 = secondFace[e];
+        final dot =
+            faceNx[f0] * faceNx[f1] +
+            faceNy[f0] * faceNy[f1] +
+            faceNz[f0] * faceNz[f1];
+        if (dot > creaseCos) continue;
+      }
+      for (final v in [edgeA[e], edgeB[e]]) {
+        outPositions
+          ..add(positions[v * 3])
+          ..add(positions[v * 3 + 1])
+          ..add(positions[v * 3 + 2]);
+        outNormals
+          ?..add(srcNormals![v * 3])
+          ..add(srcNormals[v * 3 + 1])
+          ..add(srcNormals[v * 3 + 2]);
+      }
+    }
+
+    return LineSegmentData(
+      positions: Float32List.fromList(outPositions),
+      normals: outNormals == null ? null : Float32List.fromList(outNormals),
+    );
+  }
+
+  /// Concatenates [parts] into one snapshot, rebasing indices.
+  ///
+  /// Every part must share the primitive type, the presence of each
+  /// optional attribute, and the same custom attribute names and widths.
+  /// When some parts are indexed and others are not, sequential indices
+  /// are synthesized for the unindexed ones.
+  static MeshData merge(List<MeshData> parts) {
+    if (parts.isEmpty) {
+      throw ArgumentError('merge requires at least one MeshData');
+    }
+    if (parts.length == 1) return parts.first;
+    final first = parts.first;
+    for (final part in parts.skip(1)) {
+      if (part.primitiveType != first.primitiveType ||
+          (part.normals == null) != (first.normals == null) ||
+          (part.texCoords == null) != (first.texCoords == null) ||
+          (part.colors == null) != (first.colors == null)) {
+        throw ArgumentError(
+          'merge requires matching primitive types and attribute sets',
+        );
+      }
+      if (part.customAttributes.length != first.customAttributes.length ||
+          first.customAttributes.entries.any(
+            (e) =>
+                part.customAttributes[e.key]?.components != e.value.components,
+          )) {
+        throw ArgumentError(
+          'merge requires matching custom attribute names and widths',
+        );
+      }
+    }
+
+    final anyIndexed = parts.any((p) => p.indices != null);
+    var vertexCount = 0;
+    var indexCount = 0;
+    for (final part in parts) {
+      vertexCount += part.vertexCount;
+      if (anyIndexed) {
+        indexCount += part.indices?.length ?? part.vertexCount;
+      }
+    }
+
+    final positions = Float32List(vertexCount * 3);
+    final normals = first.normals == null ? null : Float32List(vertexCount * 3);
+    final texCoords = first.texCoords == null
+        ? null
+        : Float32List(vertexCount * 2);
+    final colors = first.colors == null ? null : Float32List(vertexCount * 4);
+    final custom = <String, MeshAttributeData>{
+      for (final entry in first.customAttributes.entries)
+        entry.key: MeshAttributeData(
+          Float32List(vertexCount * entry.value.components),
+          components: entry.value.components,
+        ),
+    };
+    final indices = anyIndexed ? List<int>.filled(indexCount, 0) : null;
+
+    var vertexBase = 0;
+    var indexBase = 0;
+    for (final part in parts) {
+      positions.setRange(
+        vertexBase * 3,
+        vertexBase * 3 + part.positions.length,
+        part.positions,
+      );
+      normals?.setRange(
+        vertexBase * 3,
+        vertexBase * 3 + part.normals!.length,
+        part.normals!,
+      );
+      texCoords?.setRange(
+        vertexBase * 2,
+        vertexBase * 2 + part.texCoords!.length,
+        part.texCoords!,
+      );
+      colors?.setRange(
+        vertexBase * 4,
+        vertexBase * 4 + part.colors!.length,
+        part.colors!,
+      );
+      for (final entry in part.customAttributes.entries) {
+        final components = entry.value.components;
+        custom[entry.key]!.data.setRange(
+          vertexBase * components,
+          vertexBase * components + entry.value.data.length,
+          entry.value.data,
+        );
+      }
+      if (indices != null) {
+        final partIndices = part.indices;
+        final partCount = partIndices?.length ?? part.vertexCount;
+        for (var i = 0; i < partCount; i++) {
+          indices[indexBase + i] = (partIndices?[i] ?? i) + vertexBase;
+        }
+        indexBase += partCount;
+      }
+      vertexBase += part.vertexCount;
+    }
+
+    return MeshData(
+      positions: positions,
+      vertexCount: vertexCount,
+      normals: normals,
+      texCoords: texCoords,
+      colors: colors,
+      indices: indices,
+      primitiveType: first.primitiveType,
+      customAttributes: custom,
+    );
+  }
+
+  int _cornerIndex(int corner) => indices?[corner] ?? corner;
+
+  vm.Vector3 _position(int vertex) => vm.Vector3(
+    positions[vertex * 3],
+    positions[vertex * 3 + 1],
+    positions[vertex * 3 + 2],
+  );
+
+  void _requireTriangles(String operation) {
+    if (primitiveType != gpu.PrimitiveType.triangle) {
+      throw StateError('$operation requires a triangle-list MeshData');
+    }
+    final cornerCount = indices?.length ?? vertexCount;
+    if (cornerCount % 3 != 0) {
+      throw StateError(
+        '$operation requires a whole number of triangles '
+        '($cornerCount corner indices)',
+      );
+    }
+  }
 }

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -148,7 +148,7 @@ class MeshGeometry extends UnskinnedGeometry {
     MeshData data, {
     GeometryStorage storage = GeometryStorage.fixed,
   }) {
-    return MeshGeometry.fromArrays(
+    final geometry = MeshGeometry.fromArrays(
       positions: data.positions,
       normals: data.normals,
       texCoords: data.texCoords,
@@ -157,6 +157,14 @@ class MeshGeometry extends UnskinnedGeometry {
       primitiveType: data.primitiveType,
       storage: storage,
     );
+    for (final entry in data.customAttributes.entries) {
+      geometry.setCustomAttribute(
+        entry.key,
+        entry.value.data,
+        components: entry.value.components,
+      );
+    }
+    return geometry;
   }
 
   /// Replaces this updatable geometry's data from a [MeshData] snapshot.
@@ -172,6 +180,13 @@ class MeshGeometry extends UnskinnedGeometry {
       colors: data.colors,
       indices: data.indices,
     );
+    for (final entry in data.customAttributes.entries) {
+      setCustomAttribute(
+        entry.key,
+        entry.value.data,
+        components: entry.value.components,
+      );
+    }
   }
 
   /// How this geometry's GPU buffers are managed; see [GeometryStorage].
@@ -429,6 +444,8 @@ class MeshGeometry extends UnskinnedGeometry {
     setRaycastAttributes(
       positions: _cpuPositions,
       texCoords: _cpuTexCoords,
+      normals: _cpuNormals,
+      colors: _cpuColors,
       indices: indexBytes,
     );
   }
@@ -493,6 +510,8 @@ class MeshGeometry extends UnskinnedGeometry {
     setRaycastAttributes(
       positions: _cpuPositions,
       texCoords: _cpuTexCoords,
+      normals: _cpuNormals,
+      colors: _cpuColors,
       indices: _packedIndexBytes == null
           ? null
           : ByteData.sublistView(_packedIndexBytes!),

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -1,130 +1,134 @@
 {
-    "UnskinnedVertex": {
-        "type": "vertex",
-        "file": "shaders/flutter_scene_unskinned.vert"
-    },
-    "SkinnedVertex": {
-        "type": "vertex",
-        "file": "shaders/flutter_scene_skinned.vert"
-    },
-    "UnskinnedDepthVertex": {
-        "type": "vertex",
-        "file": "shaders/flutter_scene_unskinned_depth.vert"
-    },
-    "UnlitFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_unlit.frag"
-    },
-    "BillboardVertex": {
-        "type": "vertex",
-        "file": "shaders/flutter_scene_billboard.vert"
-    },
-    "SpriteFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_sprite.frag"
-    },
-    "StandardFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_standard.frag"
-    },
-    "DepthOnlyFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_depth_only.frag"
-    },
-    "LinearDepthFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_linear_depth.frag"
-    },
-    "MaskFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_mask.frag"
-    },
-    "OutlineFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_outline.frag"
-    },
-    "GodRaysFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_god_rays.frag"
-    },
-    "SsaoFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_ssao.frag"
-    },
-    "DepthDownsampleFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_depth_downsample.frag"
-    },
-    "SsaoBlurFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_ssao_blur.frag"
-    },
-    "SsrFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_ssr.frag"
-    },
-    "SsrCompositeFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_ssr_composite.frag"
-    },
-    "LinearDepthNormalFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_linear_depth_normal.frag"
-    },
-    "FullscreenVertex": {
-        "type": "vertex",
-        "file": "shaders/flutter_scene_fullscreen.vert"
-    },
-    "ResolveFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_resolve.frag"
-    },
-    "FxaaFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_fxaa.frag"
-    },
-    "PrefilterEnvFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_prefilter_env.frag"
-    },
-    "PrefilterRadianceCubeFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_prefilter_radiance_cube.frag"
-    },
-    "BloomThresholdFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_bloom_threshold.frag"
-    },
-    "BloomDownsampleFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_bloom_downsample.frag"
-    },
-    "BloomUpsampleFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_bloom_upsample.frag"
-    },
-    "SkyboxVertex": {
-        "type": "vertex",
-        "file": "shaders/flutter_scene_skybox.vert"
-    },
-    "SkyboxEnvironmentFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_skybox_environment.frag"
-    },
-    "CubeToEquirectFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_cube_to_equirect.frag"
-    },
-    "ShProjectFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_sh_project.frag"
-    },
-    "SkyGradientFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_sky_gradient.frag"
-    },
-    "SkyPhysicalFragment": {
-        "type": "fragment",
-        "file": "shaders/flutter_scene_sky_physical.frag"
-    }
+  "UnskinnedVertex": {
+    "type": "vertex",
+    "file": "shaders/flutter_scene_unskinned.vert"
+  },
+  "SkinnedVertex": {
+    "type": "vertex",
+    "file": "shaders/flutter_scene_skinned.vert"
+  },
+  "UnskinnedDepthVertex": {
+    "type": "vertex",
+    "file": "shaders/flutter_scene_unskinned_depth.vert"
+  },
+  "UnlitFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_unlit.frag"
+  },
+  "BillboardVertex": {
+    "type": "vertex",
+    "file": "shaders/flutter_scene_billboard.vert"
+  },
+  "LineSegmentsVertex": {
+    "type": "vertex",
+    "file": "shaders/flutter_scene_line_segments.vert"
+  },
+  "SpriteFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_sprite.frag"
+  },
+  "StandardFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_standard.frag"
+  },
+  "DepthOnlyFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_depth_only.frag"
+  },
+  "LinearDepthFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_linear_depth.frag"
+  },
+  "MaskFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_mask.frag"
+  },
+  "OutlineFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_outline.frag"
+  },
+  "GodRaysFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_god_rays.frag"
+  },
+  "SsaoFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_ssao.frag"
+  },
+  "DepthDownsampleFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_depth_downsample.frag"
+  },
+  "SsaoBlurFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_ssao_blur.frag"
+  },
+  "SsrFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_ssr.frag"
+  },
+  "SsrCompositeFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_ssr_composite.frag"
+  },
+  "LinearDepthNormalFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_linear_depth_normal.frag"
+  },
+  "FullscreenVertex": {
+    "type": "vertex",
+    "file": "shaders/flutter_scene_fullscreen.vert"
+  },
+  "ResolveFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_resolve.frag"
+  },
+  "FxaaFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_fxaa.frag"
+  },
+  "PrefilterEnvFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_prefilter_env.frag"
+  },
+  "PrefilterRadianceCubeFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_prefilter_radiance_cube.frag"
+  },
+  "BloomThresholdFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_bloom_threshold.frag"
+  },
+  "BloomDownsampleFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_bloom_downsample.frag"
+  },
+  "BloomUpsampleFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_bloom_upsample.frag"
+  },
+  "SkyboxVertex": {
+    "type": "vertex",
+    "file": "shaders/flutter_scene_skybox.vert"
+  },
+  "SkyboxEnvironmentFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_skybox_environment.frag"
+  },
+  "CubeToEquirectFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_cube_to_equirect.frag"
+  },
+  "ShProjectFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_sh_project.frag"
+  },
+  "SkyGradientFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_sky_gradient.frag"
+  },
+  "SkyPhysicalFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_sky_physical.frag"
+  }
 }

--- a/packages/flutter_scene/shaders/flutter_scene_line_segments.vert
+++ b/packages/flutter_scene/shaders/flutter_scene_line_segments.vert
@@ -1,0 +1,59 @@
+// Vertex shader for LineSegmentsGeometry: expands each segment instance into
+// a camera-facing quad of a fixed world-space width. Outputs the standard
+// engine varyings so any material fragment (unlit, PBR, a .fmat's Surface())
+// shades the ribbon; the normal faces the camera.
+
+uniform FrameInfo {
+  mat4 camera_transform; // view-projection
+  mat4 model_transform;  // node world transform
+  vec4 camera_position;  // world-space camera position (xyz)
+  // x: half width in world units. yzw: unused.
+  vec4 params;
+}
+frame_info;
+
+// Per-vertex unit quad (slot 0): x selects the endpoint (0 start, 1 end),
+// y is the side of the ribbon (-1 or +1).
+in vec2 corner;
+
+// Per-instance segment endpoints in the geometry's local space (slot 1).
+in vec3 i_start;
+in vec3 i_end;
+
+out vec3 v_position;
+out vec3 v_normal;
+out vec3 v_viewvector;
+out vec2 v_texture_coords;
+out vec4 v_color;
+
+void main() {
+  vec3 world_start = (frame_info.model_transform * vec4(i_start, 1.0)).xyz;
+  vec3 world_end = (frame_info.model_transform * vec4(i_end, 1.0)).xyz;
+  vec3 pos = mix(world_start, world_end, corner.x);
+
+  // Expand perpendicular to the segment and the view direction so the
+  // ribbon always faces the camera. A segment pointing at the eye (or a
+  // degenerate segment) collapses the cross product; it stays a hairline.
+  vec3 dir = world_end - world_start;
+  vec3 view = frame_info.camera_position.xyz - pos;
+  vec3 perp = cross(dir, view);
+  float perp_len = length(perp);
+  perp = perp_len > 1e-12 ? perp / perp_len : vec3(0.0);
+  pos += perp * (frame_info.params.x * corner.y);
+
+  // Camera-facing normal (perpendicular to both the segment and the
+  // expansion direction, flipped toward the eye).
+  float dir_len = length(dir);
+  vec3 n = dir_len > 1e-12 ? cross(perp, dir / dir_len) : vec3(0.0, 0.0, 1.0);
+  if (dot(n, view) < 0.0) {
+    n = -n;
+  }
+
+  v_position = pos;
+  gl_Position = frame_info.camera_transform * vec4(pos, 1.0);
+  v_viewvector = view;
+  v_normal = n;
+  // u runs along the segment, v across the ribbon.
+  v_texture_coords = vec2(corner.x, corner.y * 0.5 + 0.5);
+  v_color = vec4(1.0);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_line_segments.vert
+++ b/packages/flutter_scene/shaders/flutter_scene_line_segments.vert
@@ -39,15 +39,18 @@ void main() {
   vec3 perp = cross(dir, view);
   float perp_len = length(perp);
   perp = perp_len > 1e-12 ? perp / perp_len : vec3(0.0);
+  // Orient the expansion so every quad winds as a front face under the
+  // engine's winding convention (perp flips sign with the segment direction
+  // otherwise, and a back-face culling material would drop the ribbons).
+  if (dot(cross(perp, dir), view) > 0.0) {
+    perp = -perp;
+  }
   pos += perp * (frame_info.params.x * corner.y);
 
-  // Camera-facing normal (perpendicular to both the segment and the
-  // expansion direction, flipped toward the eye).
+  // Camera-facing shading normal, perpendicular to both the segment and
+  // the expansion direction.
   float dir_len = length(dir);
-  vec3 n = dir_len > 1e-12 ? cross(perp, dir / dir_len) : vec3(0.0, 0.0, 1.0);
-  if (dot(n, view) < 0.0) {
-    n = -n;
-  }
+  vec3 n = dir_len > 1e-12 ? cross(dir / dir_len, perp) : vec3(0.0, 0.0, 1.0);
 
   v_position = pos;
   gl_Position = frame_info.camera_transform * vec4(pos, 1.0);

--- a/packages/flutter_scene/test/mesh_data_ops_test.dart
+++ b/packages/flutter_scene/test/mesh_data_ops_test.dart
@@ -18,7 +18,7 @@ class _StubGeometry extends Geometry {
   @override
   void bind(
     gpu.RenderPass pass,
-    gpu.HostBuffer transientsBuffer,
+    TransientWriter transientsBuffer,
     Matrix4 modelTransform,
     Matrix4 cameraTransform,
     Vector3 cameraPosition, {

--- a/packages/flutter_scene/test/mesh_data_ops_test.dart
+++ b/packages/flutter_scene/test/mesh_data_ops_test.dart
@@ -1,0 +1,313 @@
+// Covers the MeshData derivation operations (unweld, extractEdges, merge,
+// triangles) and the readback surface (isReadable, extractMeshData through
+// the structure-of-arrays retention path). The GPU-uploading halves
+// (MeshGeometry.fromMeshData custom-attribute plumbing, the interleaved
+// importer path, LineSegmentsGeometry) draw on a real context and are
+// exercised by the example app.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// Geometry that skips shader-library and GPU access, so the base-class
+/// readback state can be exercised without a Flutter GPU context.
+class _StubGeometry extends Geometry {
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    gpu.HostBuffer transientsBuffer,
+    Matrix4 modelTransform,
+    Matrix4 cameraTransform,
+    Vector3 cameraPosition, {
+    gpu.Shader? shaderOverride,
+  }) {
+    throw UnsupportedError('Stub geometry is not renderable');
+  }
+}
+
+/// A unit quad, two triangles sharing the diagonal 0-2.
+MeshData _quad() {
+  return MeshData.build(
+    positions: Float32List.fromList([
+      0, 0, 0, //
+      1, 0, 0, //
+      1, 1, 0, //
+      0, 1, 0,
+    ]),
+    texCoords: Float32List.fromList([0, 0, 1, 0, 1, 1, 0, 1]),
+    indices: [0, 1, 2, 0, 2, 3],
+  );
+}
+
+/// Two triangles meeting at exactly ninety degrees along the shared edge
+/// 0-1 (face normals (0,-1,0) and (0,0,-1)), for crease-angle filtering.
+MeshData _tent() {
+  return MeshData.build(
+    positions: Float32List.fromList([
+      0, 0, 0, //
+      1, 0, 0, //
+      1, 0, 1, //
+      0, 1, 0,
+    ]),
+    indices: [0, 1, 2, 1, 0, 3],
+  );
+}
+
+void main() {
+  group('triangles', () {
+    test('iterates indexed triangles with corner indices and positions', () {
+      final quad = _quad();
+      final tris = quad.triangles.toList();
+      expect(tris, hasLength(2));
+      expect(quad.triangleCount, 2);
+      expect(tris[0].index, 0);
+      expect([tris[0].a, tris[0].b, tris[0].c], [0, 1, 2]);
+      expect([tris[1].a, tris[1].b, tris[1].c], [0, 2, 3]);
+      expect(tris[1].pa, Vector3(0, 0, 0));
+      expect(tris[1].pc, Vector3(0, 1, 0));
+    });
+
+    test('iterates unindexed soup sequentially', () {
+      final soup = MeshData.build(
+        positions: Float32List.fromList([
+          0, 0, 0, 1, 0, 0, 0, 1, 0, //
+          2, 0, 0, 3, 0, 0, 2, 1, 0,
+        ]),
+      );
+      final tris = soup.triangles.toList();
+      expect(tris, hasLength(2));
+      expect([tris[1].a, tris[1].b, tris[1].c], [3, 4, 5]);
+    });
+
+    test('rejects non-triangle primitive types', () {
+      final lines = MeshData(
+        positions: Float32List(12),
+        vertexCount: 4,
+        primitiveType: gpu.PrimitiveType.line,
+      );
+      expect(() => lines.triangles.toList(), throwsStateError);
+      expect(() => lines.unweld(), throwsStateError);
+      expect(() => lines.extractEdges(), throwsStateError);
+    });
+  });
+
+  group('unweld', () {
+    test('produces an unindexed soup with three vertices per triangle', () {
+      final out = _quad().unweld();
+      expect(out.indices, isNull);
+      expect(out.vertexCount, 6);
+      expect(out.triangleCount, 2);
+      // Corner positions expand through the index buffer.
+      expect(out.positions.sublist(0, 3), [0, 0, 0]);
+      expect(out.positions.sublist(9, 12), [0, 0, 0]); // second tri corner 0
+      // Texture coordinates carry through per corner.
+      expect(out.texCoords!.sublist(0, 2), [0, 0]);
+      expect(out.texCoords!.sublist(10, 12), [0, 1]);
+    });
+
+    test('assigns the face normal to every corner', () {
+      final out = _quad().unweld();
+      for (var v = 0; v < out.vertexCount; v++) {
+        expect(out.normals![v * 3], 0);
+        expect(out.normals![v * 3 + 1], 0);
+        expect(out.normals![v * 3 + 2].abs(), 1);
+      }
+      // Both triangles of the flat quad agree.
+      expect(out.normals![2], out.normals![5 * 3 + 2]);
+    });
+
+    test('face normal sign agrees with authored vertex normals', () {
+      // Author inward (-z) normals on a quad wound for +z; the face normal
+      // must flip to match the authored orientation.
+      final quad = MeshData(
+        positions: _quad().positions,
+        vertexCount: 4,
+        normals: Float32List.fromList([
+          0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, //
+        ]),
+        indices: [0, 1, 2, 0, 2, 3],
+      );
+      final out = quad.unweld();
+      expect(out.normals![2], -1);
+    });
+
+    test('attaches the canned per-triangle attributes', () {
+      final out = _quad().unweld(
+        attributes: {
+          UnweldAttribute.centroid,
+          UnweldAttribute.seed,
+          UnweldAttribute.triangleIndex,
+          UnweldAttribute.barycentric,
+        },
+      );
+      final centroid = out.customAttributes['triangle_centroid']!;
+      expect(centroid.components, 3);
+      // Triangle 0 is (0,0,0)/(1,0,0)/(1,1,0); every corner carries its
+      // centroid.
+      expect(centroid.data[0], closeTo(2 / 3, 1e-6));
+      expect(centroid.data[1], closeTo(1 / 3, 1e-6));
+      expect(centroid.data[2], 0);
+      expect(centroid.data.sublist(6, 9), centroid.data.sublist(0, 3));
+
+      final seed = out.customAttributes['triangle_seed']!;
+      expect(seed.components, 1);
+      expect(seed.data[0], seed.data[1]);
+      expect(seed.data[0], isNot(seed.data[3]));
+      expect(seed.data[0], inInclusiveRange(0, 1));
+      // Deterministic across runs.
+      expect(
+        _quad()
+            .unweld(attributes: {UnweldAttribute.seed})
+            .customAttributes['triangle_seed']!
+            .data[0],
+        seed.data[0],
+      );
+
+      final index = out.customAttributes['triangle_index']!;
+      expect(index.data[0], 0);
+      expect(index.data[3], 1);
+
+      final bary = out.customAttributes['barycentric']!;
+      expect(bary.data.sublist(0, 9), [1, 0, 0, 0, 1, 0, 0, 0, 1]);
+    });
+
+    test('carries existing custom attributes through per corner', () {
+      final quad = _quad();
+      final tagged = MeshData(
+        positions: quad.positions,
+        vertexCount: quad.vertexCount,
+        indices: quad.indices,
+        customAttributes: {
+          'tag': MeshAttributeData(
+            Float32List.fromList([10, 20, 30, 40]),
+            components: 1,
+          ),
+        },
+      );
+      final out = tagged.unweld();
+      expect(out.customAttributes['tag']!.data, [10, 20, 30, 10, 30, 40]);
+    });
+  });
+
+  group('extractEdges', () {
+    test('deduplicates shared edges', () {
+      final edges = _quad().extractEdges();
+      // Four boundary edges plus the shared diagonal.
+      expect(edges.segmentCount, 5);
+      expect(edges.positions.length, 5 * 6);
+      // Normals carry from the source (generated smooth normals here).
+      expect(edges.normals, isNotNull);
+      expect(edges.normals!.length, edges.positions.length);
+    });
+
+    test('crease filter keeps sharp and boundary edges only', () {
+      // The flat quad's diagonal disappears under any crease threshold; the
+      // four boundary edges stay.
+      final flat = _quad().extractEdges(creaseAngleDegrees: 10);
+      expect(flat.segmentCount, 4);
+
+      // The tent's shared edge is a 90-degree crease, kept below the
+      // threshold and dropped above it.
+      expect(_tent().extractEdges(creaseAngleDegrees: 45).segmentCount, 5);
+      expect(_tent().extractEdges(creaseAngleDegrees: 135).segmentCount, 4);
+    });
+  });
+
+  group('merge', () {
+    test('concatenates and rebases indices', () {
+      final merged = MeshData.merge([_quad(), _quad()]);
+      expect(merged.vertexCount, 8);
+      expect(merged.indices, hasLength(12));
+      expect(merged.indices!.sublist(6, 9), [4, 5, 6]);
+      expect(merged.positions.length, 24);
+    });
+
+    test('synthesizes indices for unindexed parts', () {
+      final indexed = MeshData.build(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        indices: [0, 1, 2],
+      );
+      final soup = MeshData.build(
+        positions: Float32List.fromList([2, 0, 0, 3, 0, 0, 2, 1, 0]),
+      );
+      final merged = MeshData.merge([indexed, soup]);
+      expect(merged.vertexCount, 6);
+      expect(merged.indices!.sublist(3), [3, 4, 5]);
+    });
+
+    test('rejects mismatched attribute sets', () {
+      final withUv = _quad();
+      final withoutUv = MeshData.build(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      );
+      expect(() => MeshData.merge([withUv, withoutUv]), throwsArgumentError);
+    });
+
+    test('merges matching custom attributes and rejects mismatches', () {
+      MeshData tagged(double value) => MeshData(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        vertexCount: 3,
+        customAttributes: {
+          'tag': MeshAttributeData(
+            Float32List.fromList([value, value, value]),
+            components: 1,
+          ),
+        },
+      );
+      final merged = MeshData.merge([tagged(1), tagged(2)]);
+      expect(merged.customAttributes['tag']!.data, [1, 1, 1, 2, 2, 2]);
+
+      final untagged = MeshData(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        vertexCount: 3,
+      );
+      expect(() => MeshData.merge([tagged(1), untagged]), throwsArgumentError);
+    });
+  });
+
+  group('readback', () {
+    test('isReadable is false with no retained data, and extract throws', () {
+      final stub = _StubGeometry();
+      expect(stub.isReadable, isFalse);
+      expect(stub.extractMeshData, throwsStateError);
+    });
+
+    test('extractMeshData copies the SoA retention path', () {
+      final stub = _StubGeometry();
+      final positions = Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+      final normals = Float32List.fromList([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+      final indexBytes = Uint16List.fromList([0, 1, 2]);
+      stub.setRaycastAttributes(
+        positions: positions,
+        normals: normals,
+        indices: ByteData.sublistView(indexBytes),
+      );
+      // setRaycastAttributes does not set counts; drive them through the
+      // stream setters the upload paths use.
+      stub.setVertexStreams(const [], 3);
+      expect(stub.isReadable, isTrue);
+
+      final data = stub.extractMeshData();
+      expect(data.vertexCount, 3);
+      expect(data.positions, positions);
+      expect(data.normals, normals);
+      expect(data.texCoords, isNull);
+      // The snapshot is a copy, not a view.
+      data.positions[0] = 99;
+      expect(positions[0], 0);
+    });
+
+    test('extracted custom attributes round-trip through MeshData', () {
+      final stub = _StubGeometry();
+      stub.setRaycastAttributes(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      );
+      stub.setVertexStreams(const [], 3);
+      final extracted = stub.extractMeshData();
+      expect(extracted.customAttributes, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Adds the public geometry readback and derivation surface, so effects and tools can read a loaded model's triangles back and build new geometry from them without touching internals.

`Geometry.isReadable` and `Geometry.extractMeshData()` copy the engine's retained CPU vertex/index data out as an isolate-transferable `MeshData` snapshot, structure-of-arrays regardless of internal storage, always a copy so it is safe to ship to a background isolate. The structure-of-arrays upload paths now retain normals and colors alongside positions, and custom attribute data is retained for extraction; caller-managed buffers report `isReadable` false and extraction fails with a clear error.

`MeshData` becomes the interchange type for the whole chain. It carries name-keyed custom attributes (`MeshAttributeData`, forwarded to `setCustomAttribute` by `fromMeshData`/`applyMeshData`) and grows pure derivation methods that compose on background isolates, `unweld` (flat-shaded triangle soup with optional canned per-triangle attributes, `triangle_centroid`, `triangle_seed`, `triangle_index`, `barycentric`), `extractEdges` (unique undirected edges with an optional crease-angle filter in degrees, boundary edges always kept), `merge`, and a `triangles` iterator.

`LineSegmentsGeometry` renders bulk disconnected segments (a model wireframe from `extractEdges`, debug visualization) as thick camera-facing ribbons, expanded per instance in a new engine vertex shader that emits the standard varyings so any material fragment shades it. Width is world-space, an optional normal offset lifts a wireframe off the surface it traces, and the whole batch is one instanced draw with zero per-frame CPU work. `PolylineGeometry` remains the choice for connected paths with joins, caps, and dashes.

The Materialize example is ported onto the new APIs as the proving consumer. Its hand-rolled internals readback, soup building, and ribbon-quad expansion collapse into `extractMeshData`/`merge`/`unweld`/`extractEdges`/`LineSegmentsGeometry` (about 240 lines removed), the derivation runs off the raster thread via `compute`, the wireframe material loses its vertex block entirely, and the example no longer imports anything from `lib/src`.

Covered by new unit tests for the derivation ops and the readback path, and the custom-material smoke scene now feeds its hero grid through the readback chain into a segment-ribbon wireframe so the new vertex shader renders on every CI backend (the Argos change for that scene is intentional). Verified locally with the full test suite, the example app on Metal, and the macOS smoke matrix.
