### PR TITLE
Add Gaussian splatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ pubspec.lock
 build/
 **/ephemeral/
 pubspec_overrides.yaml
+
+# Fetched splat capture for the Gaussian Splats example (see
+# examples/flutter_app/tool/fetch_splat_asset.sh).
+examples/assets_src/*.splat

--- a/examples/flutter_app/lib/example_splats.dart
+++ b/examples/flutter_app/lib/example_splats.dart
@@ -9,13 +9,13 @@ import 'package:vector_math/vector_math.dart' as vm;
 import 'example_settings.dart';
 import 'quake_camera.dart';
 
-/// Gaussian splat rendering with real captures: an isolated-object macro
-/// capture (Strawberry by danylyon, CC BY 4.0) and a room-scale capture
-/// (a Chinese classroom by hite404, CC BY 4.0), both fetched by
+/// Gaussian splat rendering with two real captures, an isolated-object macro
+/// capture (Strawberry by danylyon, CC BY 4.0) and a room-scale one (a
+/// Chinese classroom by hite404, CC BY 4.0), both fetched by
 /// `tool/fetch_splat_asset.sh`. A PBR sphere sits inside each scene proving
 /// splats and forward-rendered geometry occlude each other, an animated
 /// crop box demonstrates GPU-side cropping, and a Quake-style free camera
-/// (bottom right) explores the room capture from inside.
+/// (bottom right) explores the room from inside.
 class ExampleSplats extends StatefulWidget {
   const ExampleSplats({super.key});
 
@@ -23,7 +23,7 @@ class ExampleSplats extends StatefulWidget {
   ExampleSplatsState createState() => ExampleSplatsState();
 }
 
-/// One selectable capture: where to load it from and how to frame it.
+/// One selectable capture, where to load it from and how to frame it.
 class _SourceConfig {
   const _SourceConfig({
     required this.label,
@@ -152,7 +152,7 @@ class ExampleSplatsState extends State<ExampleSplats> {
       scene.add(entry.value);
     }
 
-    // A shiny sphere inside each capture: splats in front of it must cover
+    // A shiny sphere inside each capture. Splats in front of it must cover
     // it, and it must occlude the splats behind it.
     scene.add(
       Node(
@@ -169,9 +169,8 @@ class ExampleSplatsState extends State<ExampleSplats> {
     if (mounted) setState(() => _ready = true);
   }
 
-  /// Places a capture: recentered on its bounds, flipped upright (training
-  /// captures are y-down), scaled, and lifted so it sits in front of the
-  /// camera.
+  /// Places a capture, recentered on its bounds, flipped upright (training
+  /// captures are y-down), scaled, and lifted in front of the camera.
   static Node _placeCapture(SplatComponent component, _SourceConfig config) {
     final bounds = component.splats.bounds;
     final center = bounds == null
@@ -214,10 +213,10 @@ class ExampleSplatsState extends State<ExampleSplats> {
     if (splats == null || active == null) return;
     final extent = _cropExtents[active]!;
     final t = elapsed.inMicroseconds / 1e6;
-    // A wipe: a big exclude box slides through the set, eating and then
-    // restoring it. Evaluated per splat on the GPU, so this is free to
-    // animate. The box lives in the capture's local (pre-flip) space, so
-    // the sweep axis is x either way.
+    // A wipe. A big exclude box slides through the set, eating and then
+    // restoring it, evaluated per splat on the GPU so it is free to animate.
+    // The box lives in the capture's local (pre-flip) space, so the sweep
+    // axis is x either way.
     final sweep = math.sin(t * 0.5) * extent / active.scale;
     final half = extent / active.scale;
     splats.setCropBox(

--- a/examples/flutter_app/lib/example_splats.dart
+++ b/examples/flutter_app/lib/example_splats.dart
@@ -9,18 +9,18 @@ import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene/src/components/splat_component.dart';
 import 'package:flutter_scene/src/geometry/splat_geometry.dart';
 import 'package:flutter_scene/src/splats/gaussian_splats.dart';
-import 'package:flutter_scene/src/splats/splat_data.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_settings.dart';
 import 'quake_camera.dart';
 
-/// Gaussian splat rendering: a procedural nebula (60k anisotropic splats)
-/// and, when `assets_src/strawberry.splat` is present (fetched by
-/// `tool/fetch_splat_asset.sh`, a CC BY capture by danylyon), a real 1.5M
-/// splat macro capture. A PBR sphere sits inside each scene proving splats
-/// and forward-rendered geometry occlude each other, and an animated crop
-/// box demonstrates GPU-side cropping.
+/// Gaussian splat rendering with real captures: an isolated-object macro
+/// capture (Strawberry by danylyon, CC BY 4.0) and a room-scale capture
+/// (a Chinese classroom by hite404, CC BY 4.0), both fetched by
+/// `tool/fetch_splat_asset.sh`. A PBR sphere sits inside each scene proving
+/// splats and forward-rendered geometry occlude each other, an animated
+/// crop box demonstrates GPU-side cropping, and a Quake-style free camera
+/// (bottom right) explores the room capture from inside.
 class ExampleSplats extends StatefulWidget {
   const ExampleSplats({super.key});
 
@@ -28,21 +28,62 @@ class ExampleSplats extends StatefulWidget {
   ExampleSplatsState createState() => ExampleSplatsState();
 }
 
-enum _SplatSource { nebula, capture }
+/// One selectable capture: where to load it from and how to frame it.
+class _SourceConfig {
+  const _SourceConfig({
+    required this.label,
+    required this.asset,
+    required this.scale,
+    required this.lift,
+    required this.orbitRadius,
+    required this.orbitHeight,
+    required this.targetHeight,
+  });
+
+  final String label;
+  final String asset;
+
+  /// Uniform scale applied to the capture (captures come at their trained
+  /// size; the strawberry is a few centimeters across).
+  final double scale;
+
+  /// World-space height the capture's center is lifted to.
+  final double lift;
+
+  final double orbitRadius;
+  final double orbitHeight;
+  final double targetHeight;
+}
+
+const List<_SourceConfig> _sourceConfigs = [
+  _SourceConfig(
+    label: 'Strawberry',
+    asset: 'assets_src/strawberry.splat',
+    scale: 4.0,
+    lift: 1.0,
+    orbitRadius: 14.0,
+    orbitHeight: 4.0,
+    targetHeight: 0.5,
+  ),
+  _SourceConfig(
+    label: 'Classroom',
+    asset: 'assets_src/classroom.splat',
+    scale: 1.0,
+    lift: 1.4,
+    orbitRadius: 4.5,
+    orbitHeight: 1.9,
+    targetHeight: 1.2,
+  ),
+];
 
 class ExampleSplatsState extends State<ExampleSplats> {
   Scene scene = Scene();
   bool _ready = false;
 
-  final Map<_SplatSource, Node> _sourceNodes = {};
-  final Map<_SplatSource, SplatComponent> _sources = {};
-  _SplatSource _active = _SplatSource.nebula;
-
-  // Local-space X extent of each set, used to scale the crop sweep.
-  static const Map<_SplatSource, double> _cropExtent = {
-    _SplatSource.nebula: 10.0,
-    _SplatSource.capture: 1.2,
-  };
+  final Map<_SourceConfig, Node> _sourceNodes = {};
+  final Map<_SourceConfig, SplatComponent> _sources = {};
+  final Map<_SourceConfig, double> _cropExtents = {};
+  _SourceConfig? _active;
 
   double _opacity = 1.0;
   double _splatScale = 1.0;
@@ -54,7 +95,7 @@ class ExampleSplatsState extends State<ExampleSplats> {
   // orbit camera so toggling it on does not jump the view.
   bool _freeCamera = false;
   final QuakeCamera _freeCam = QuakeCamera(position: vm.Vector3(0, 4, 14))
-    ..speed = 6.0
+    ..speed = 4.0
     ..enabled = false;
   double _elapsedSeconds = 0;
 
@@ -91,58 +132,72 @@ class ExampleSplatsState extends State<ExampleSplats> {
       ),
     );
 
-    final nebula = SplatComponent(GaussianSplats.fromData(_nebula(seed: 7)));
-    _sources[_SplatSource.nebula] = nebula;
-    _sourceNodes[_SplatSource.nebula] = Node()..addComponent(nebula);
-
-    // The captured asset is optional (fetched by tool/fetch_splat_asset.sh).
-    try {
-      final capture = SplatComponent(
-        await GaussianSplats.fromAsset('assets_src/strawberry.splat'),
-      );
-      _sources[_SplatSource.capture] = capture;
-      // Training captures are y-down; flip upright and scale up to scene
-      // size.
-      _sourceNodes[_SplatSource.capture] = Node(
-        localTransform: vm.Matrix4.compose(
-          vm.Vector3(0, 1.0, 0),
-          vm.Quaternion.axisAngle(vm.Vector3(1, 0, 0), math.pi),
-          vm.Vector3.all(4.0),
-        ),
-      )..addComponent(capture);
-    } catch (_) {
-      // Asset absent; the nebula still demonstrates everything.
+    for (final config in _sourceConfigs) {
+      try {
+        final component = SplatComponent(
+          await GaussianSplats.fromAsset(config.asset),
+        );
+        _sources[config] = component;
+        _sourceNodes[config] = _placeCapture(component, config);
+        final bounds = component.splats.bounds;
+        _cropExtents[config] = bounds == null
+            ? 5.0
+            : ((bounds.max.x - bounds.min.x) * 0.5 * config.scale).clamp(
+                3.0,
+                12.0,
+              );
+      } catch (_) {
+        // Asset absent (tool/fetch_splat_asset.sh not run); hide the source.
+      }
     }
+    _active = _sources.keys.isEmpty ? null : _sources.keys.first;
 
     for (final entry in _sourceNodes.entries) {
       entry.value.visible = entry.key == _active;
       scene.add(entry.value);
     }
 
-    // A shiny sphere inside the cloud: splats in front of it must cover it,
-    // and it must occlude the splats behind it.
+    // A shiny sphere inside each capture: splats in front of it must cover
+    // it, and it must occlude the splats behind it.
     scene.add(
       Node(
         mesh: Mesh(
-          SphereGeometry(radius: 1.2),
+          SphereGeometry(radius: 0.8),
           PhysicallyBasedMaterial()
             ..baseColorFactor = vm.Vector4(0.9, 0.85, 0.8, 1.0)
             ..metallicFactor = 1.0
             ..roughnessFactor = 0.15,
         ),
-      )..localTransform = vm.Matrix4.translation(vm.Vector3(2.5, 0.4, 0)),
+      )..localTransform = vm.Matrix4.translation(vm.Vector3(2.2, 1.0, 0)),
     );
 
     if (mounted) setState(() => _ready = true);
   }
 
-  SplatComponent get _activeSplats => _sources[_active]!;
+  /// Places a capture: recentered on its bounds, flipped upright (training
+  /// captures are y-down), scaled, and lifted so it sits in front of the
+  /// camera.
+  static Node _placeCapture(SplatComponent component, _SourceConfig config) {
+    final bounds = component.splats.bounds;
+    final center = bounds == null
+        ? vm.Vector3.zero()
+        : (bounds.min + bounds.max) * 0.5;
+    final transform = vm.Matrix4.compose(
+      vm.Vector3(0, config.lift, 0),
+      vm.Quaternion.axisAngle(vm.Vector3(1, 0, 0), math.pi),
+      vm.Vector3.all(config.scale),
+    )..multiply(vm.Matrix4.translation(-center));
+    return Node(localTransform: transform)..addComponent(component);
+  }
 
-  void _setActive(_SplatSource source) {
+  SplatComponent? get _activeSplats =>
+      _active == null ? null : _sources[_active];
+
+  void _setActive(_SourceConfig config) {
     setState(() {
-      _active = source;
+      _active = config;
       for (final entry in _sourceNodes.entries) {
-        entry.value.visible = entry.key == source;
+        entry.value.visible = entry.key == config;
       }
       _applyKnobs();
     });
@@ -150,6 +205,7 @@ class ExampleSplatsState extends State<ExampleSplats> {
 
   void _applyKnobs() {
     final splats = _activeSplats;
+    if (splats == null) return;
     splats.opacity = _opacity;
     splats.splatScale = _splatScale;
     splats.antialiased = _antialiased;
@@ -159,115 +215,44 @@ class ExampleSplatsState extends State<ExampleSplats> {
   void _tickCrop(Duration elapsed) {
     if (!_cropSweep) return;
     final splats = _activeSplats;
-    final extent = _cropExtent[_active]!;
+    final active = _active;
+    if (splats == null || active == null) return;
+    final extent = _cropExtents[active]!;
     final t = elapsed.inMicroseconds / 1e6;
     // A wipe: a big exclude box slides through the set, eating and then
     // restoring it. Evaluated per splat on the GPU, so this is free to
-    // animate.
-    final sweep = math.sin(t * 0.5) * extent;
+    // animate. The box lives in the capture's local (pre-flip) space, so
+    // the sweep axis is x either way.
+    final sweep = math.sin(t * 0.5) * extent / active.scale;
+    final half = extent / active.scale;
     splats.setCropBox(
       vm.Matrix4.compose(
-        vm.Vector3(sweep - extent, 0, 0),
+        vm.Vector3(sweep - half, 0, 0),
         vm.Quaternion.identity(),
-        vm.Vector3(extent, extent * 2, extent * 2),
+        vm.Vector3(half, half * 3, half * 3),
       ),
       mode: SplatCropMode.exclude,
     );
   }
 
-  /// Builds a three-armed spiral nebula with a bright core. Anisotropic
-  /// splats stretch along their arm's tangent, showing off oriented
-  /// covariances; colors are authored in linear space.
-  static SplatData _nebula({required int seed}) {
-    const arms = 3;
-    const perArm = 17000;
-    const core = 9000;
-    const count = arms * perArm + core;
-    final rng = math.Random(seed);
-    final data = SplatData.zeroed(count);
+  void _toggleFreeCamera() {
+    setState(() {
+      _freeCamera = !_freeCamera;
+      _freeCam
+        ..enabled = _freeCamera
+        ..releaseKeys()
+        ..move(_elapsedSeconds); // Reset the frame clock without moving.
+    });
+  }
 
-    double gauss() {
-      // Box-Muller.
-      final u = math.max(rng.nextDouble(), 1e-9);
-      return math.sqrt(-2 * math.log(u)) *
-          math.cos(2 * math.pi * rng.nextDouble());
+  void _tickFps(double deltaSeconds) {
+    _fpsAccum += deltaSeconds;
+    _fpsFrames++;
+    if (_fpsAccum >= 0.25) {
+      _fps.value = _fpsFrames / _fpsAccum;
+      _fpsAccum = 0;
+      _fpsFrames = 0;
     }
-
-    void writeSplat(
-      int i, {
-      required vm.Vector3 position,
-      required vm.Vector3 scale,
-      required double yaw,
-      required vm.Vector3 color,
-      required double opacity,
-    }) {
-      final p = i * 3, q = i * 4;
-      data.positions[p] = position.x;
-      data.positions[p + 1] = position.y;
-      data.positions[p + 2] = position.z;
-      data.scales[p] = scale.x;
-      data.scales[p + 1] = scale.y;
-      data.scales[p + 2] = scale.z;
-      // Rotation about +Y by yaw: aligns local x with the arm tangent.
-      data.rotations[q + 1] = math.sin(yaw / 2);
-      data.rotations[q + 3] = math.cos(yaw / 2);
-      data.colors[p] = color.x;
-      data.colors[p + 1] = color.y;
-      data.colors[p + 2] = color.z;
-      data.opacities[i] = opacity;
-    }
-
-    final armColors = [
-      vm.Vector3(0.25, 0.45, 1.0), // blue
-      vm.Vector3(0.65, 0.3, 1.0), // violet
-      vm.Vector3(0.2, 0.9, 0.85), // teal
-    ];
-
-    var i = 0;
-    for (var arm = 0; arm < arms; arm++) {
-      final armBase = arm * 2 * math.pi / arms;
-      for (var n = 0; n < perArm; n++, i++) {
-        final r = 1.2 + 7.5 * math.sqrt(rng.nextDouble());
-        final theta = armBase + r * 0.55 + gauss() * (0.35 / math.sqrt(r));
-        final spread = 0.25 + r * 0.06;
-        final position = vm.Vector3(
-          r * math.cos(theta) + gauss() * spread,
-          gauss() * spread * 0.35,
-          r * math.sin(theta) + gauss() * spread,
-        );
-        // The arm tangent direction (derivative of the spiral) is close to
-        // the angular direction; stretch splats along it.
-        final tangentYaw = -(theta + math.pi / 2);
-        final len = 0.06 + rng.nextDouble() * 0.12;
-        final scale = vm.Vector3(len * 2.2, len * 0.7, len);
-        final t = ((r - 1.2) / 7.5).clamp(0.0, 1.0);
-        final color =
-            armColors[arm] * (0.35 + 0.5 * t) +
-            vm.Vector3(1.0, 0.85, 0.6) * (1.0 - t) * 0.5;
-        writeSplat(
-          i,
-          position: position,
-          scale: scale,
-          yaw: tangentYaw,
-          color: color * (2.2 - 1.4 * t),
-          opacity: 0.25 + rng.nextDouble() * 0.5,
-        );
-      }
-    }
-    for (var n = 0; n < core; n++, i++) {
-      final position = vm.Vector3(gauss() * 0.9, gauss() * 0.45, gauss() * 0.9);
-      final len = 0.04 + rng.nextDouble() * 0.1;
-      final heat = math.max(0.0, 1.0 - position.length / 2.2);
-      writeSplat(
-        i,
-        position: position,
-        scale: vm.Vector3(len, len, len),
-        yaw: rng.nextDouble() * math.pi,
-        color: vm.Vector3(1.0, 0.9, 0.7) * (1.5 + 6.0 * heat * heat),
-        opacity: 0.35 + rng.nextDouble() * 0.55,
-      );
-    }
-    return data;
   }
 
   vm.Vector3 _cameraPosition = vm.Vector3(0, 4, 14);
@@ -278,6 +263,20 @@ class ExampleSplatsState extends State<ExampleSplats> {
       return const ColoredBox(
         color: Color(0xFF040408),
         child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (_active == null) {
+      return const ColoredBox(
+        color: Color(0xFF040408),
+        child: Center(
+          child: Text(
+            'No splat captures found.\n'
+            'Run examples/flutter_app/tool/fetch_splat_asset.sh, then '
+            'restart this example.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Colors.white70),
+          ),
+        ),
       );
     }
     return Focus(
@@ -298,17 +297,19 @@ class ExampleSplatsState extends State<ExampleSplats> {
                     _freeCam.move(_elapsedSeconds);
                     return _freeCam.camera;
                   }
+                  final config = _active!;
                   if (_orbit) {
                     final t = _elapsedSeconds;
                     _cameraPosition = vm.Vector3(
-                      math.sin(t * 0.12) * 14,
-                      4.0 + math.sin(t * 0.05) * 2.0,
-                      math.cos(t * 0.12) * 14,
+                      math.sin(t * 0.12) * config.orbitRadius,
+                      config.orbitHeight +
+                          math.sin(t * 0.05) * config.orbitHeight * 0.4,
+                      math.cos(t * 0.12) * config.orbitRadius,
                     );
                   }
                   final camera = PerspectiveCamera(
                     position: _cameraPosition,
-                    target: vm.Vector3(0, 0.5, 0),
+                    target: vm.Vector3(0, config.targetHeight, 0),
                   );
                   // Keep the free camera parked on the live view so
                   // enabling it starts from what is on screen.
@@ -345,29 +346,9 @@ class ExampleSplatsState extends State<ExampleSplats> {
     );
   }
 
-  void _toggleFreeCamera() {
-    setState(() {
-      _freeCamera = !_freeCamera;
-      _freeCam
-        ..enabled = _freeCamera
-        ..releaseKeys()
-        ..move(_elapsedSeconds); // Reset the frame clock without moving.
-    });
-  }
-
-  void _tickFps(double deltaSeconds) {
-    _fpsAccum += deltaSeconds;
-    _fpsFrames++;
-    if (_fpsAccum >= 0.25) {
-      _fps.value = _fpsFrames / _fpsAccum;
-      _fpsAccum = 0;
-      _fpsFrames = 0;
-    }
-  }
-
   Widget _panel() {
     final splats = _activeSplats;
-    final hasCapture = _sources.containsKey(_SplatSource.capture);
+    if (splats == null) return const SizedBox.shrink();
     return Card(
       color: Colors.black.withValues(alpha: 0.55),
       child: Padding(
@@ -376,25 +357,14 @@ class ExampleSplatsState extends State<ExampleSplats> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (hasCapture)
-              SegmentedButton<_SplatSource>(
-                segments: const [
-                  ButtonSegment(
-                    value: _SplatSource.nebula,
-                    label: Text('Nebula'),
-                  ),
-                  ButtonSegment(
-                    value: _SplatSource.capture,
-                    label: Text('Strawberry'),
-                  ),
+            if (_sources.length > 1)
+              SegmentedButton<_SourceConfig>(
+                segments: [
+                  for (final config in _sources.keys)
+                    ButtonSegment(value: config, label: Text(config.label)),
                 ],
-                selected: {_active},
+                selected: {_active!},
                 onSelectionChanged: (s) => _setActive(s.first),
-              )
-            else
-              const Text(
-                'Run tool/fetch_splat_asset.sh for the captured scene',
-                style: TextStyle(color: Colors.white38, fontSize: 11),
               ),
             const SizedBox(height: 4),
             ValueListenableBuilder<double>(

--- a/examples/flutter_app/lib/example_splats.dart
+++ b/examples/flutter_app/lib/example_splats.dart
@@ -7,19 +7,19 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene/src/components/splat_component.dart';
+import 'package:flutter_scene/src/geometry/splat_geometry.dart';
 import 'package:flutter_scene/src/splats/gaussian_splats.dart';
 import 'package:flutter_scene/src/splats/splat_data.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_settings.dart';
 
-/// A procedural Gaussian splat nebula (60k anisotropic splats) with a PBR
-/// sphere parked inside it, proving splats and forward-rendered geometry
-/// occlude each other correctly in one scene. The camera orbits slowly; the
-/// panel exposes the splat knobs.
-///
-/// TODO(splats): also load a captured `.ply`/`.splat` asset (downloaded by
-/// the asset hook) once the example asset pipeline grows a splat step.
+/// Gaussian splat rendering: a procedural nebula (60k anisotropic splats)
+/// and, when `assets_src/strawberry.splat` is present (fetched by
+/// `tool/fetch_splat_asset.sh`, a CC BY capture by danylyon), a real 1.5M
+/// splat macro capture. A PBR sphere sits inside each scene proving splats
+/// and forward-rendered geometry occlude each other, and an animated crop
+/// box demonstrates GPU-side cropping.
 class ExampleSplats extends StatefulWidget {
   const ExampleSplats({super.key});
 
@@ -27,16 +27,27 @@ class ExampleSplats extends StatefulWidget {
   ExampleSplatsState createState() => ExampleSplatsState();
 }
 
+enum _SplatSource { nebula, capture }
+
 class ExampleSplatsState extends State<ExampleSplats> {
   Scene scene = Scene();
-  SplatComponent? _splats;
   bool _ready = false;
+
+  final Map<_SplatSource, Node> _sourceNodes = {};
+  final Map<_SplatSource, SplatComponent> _sources = {};
+  _SplatSource _active = _SplatSource.nebula;
+
+  // Local-space X extent of each set, used to scale the crop sweep.
+  static const Map<_SplatSource, double> _cropExtent = {
+    _SplatSource.nebula: 10.0,
+    _SplatSource.capture: 1.2,
+  };
 
   double _opacity = 1.0;
   double _splatScale = 1.0;
   bool _antialiased = true;
+  bool _cropSweep = false;
   bool _orbit = true;
-  vm.Vector3 _cameraPosition = vm.Vector3(0, 4, 14);
 
   @override
   void initState() {
@@ -54,25 +65,88 @@ class ExampleSplatsState extends State<ExampleSplats> {
       ),
     );
 
-    final splats = GaussianSplats.fromData(_nebula(seed: 7));
-    final component = SplatComponent(splats);
-    _splats = component;
-    scene.add(Node()..addComponent(component));
+    final nebula = SplatComponent(GaussianSplats.fromData(_nebula(seed: 7)));
+    _sources[_SplatSource.nebula] = nebula;
+    _sourceNodes[_SplatSource.nebula] = Node()..addComponent(nebula);
+
+    // The captured asset is optional (fetched by tool/fetch_splat_asset.sh).
+    try {
+      final capture = SplatComponent(
+        await GaussianSplats.fromAsset('assets_src/strawberry.splat'),
+      );
+      _sources[_SplatSource.capture] = capture;
+      // Training captures are y-down; flip upright and scale up to scene
+      // size.
+      _sourceNodes[_SplatSource.capture] = Node(
+        localTransform: vm.Matrix4.compose(
+          vm.Vector3(0, 1.0, 0),
+          vm.Quaternion.axisAngle(vm.Vector3(1, 0, 0), math.pi),
+          vm.Vector3.all(4.0),
+        ),
+      )..addComponent(capture);
+    } catch (_) {
+      // Asset absent; the nebula still demonstrates everything.
+    }
+
+    for (final entry in _sourceNodes.entries) {
+      entry.value.visible = entry.key == _active;
+      scene.add(entry.value);
+    }
 
     // A shiny sphere inside the cloud: splats in front of it must cover it,
     // and it must occlude the splats behind it.
-    final sphere = Node(
-      mesh: Mesh(
-        SphereGeometry(radius: 1.2),
-        PhysicallyBasedMaterial()
-          ..baseColorFactor = vm.Vector4(0.9, 0.85, 0.8, 1.0)
-          ..metallicFactor = 1.0
-          ..roughnessFactor = 0.15,
-      ),
-    )..localTransform = vm.Matrix4.translation(vm.Vector3(2.5, 0.4, 0));
-    scene.add(sphere);
+    scene.add(
+      Node(
+        mesh: Mesh(
+          SphereGeometry(radius: 1.2),
+          PhysicallyBasedMaterial()
+            ..baseColorFactor = vm.Vector4(0.9, 0.85, 0.8, 1.0)
+            ..metallicFactor = 1.0
+            ..roughnessFactor = 0.15,
+        ),
+      )..localTransform = vm.Matrix4.translation(vm.Vector3(2.5, 0.4, 0)),
+    );
 
     if (mounted) setState(() => _ready = true);
+  }
+
+  SplatComponent get _activeSplats => _sources[_active]!;
+
+  void _setActive(_SplatSource source) {
+    setState(() {
+      _active = source;
+      for (final entry in _sourceNodes.entries) {
+        entry.value.visible = entry.key == source;
+      }
+      _applyKnobs();
+    });
+  }
+
+  void _applyKnobs() {
+    final splats = _activeSplats;
+    splats.opacity = _opacity;
+    splats.splatScale = _splatScale;
+    splats.antialiased = _antialiased;
+    if (!_cropSweep) splats.setCropBox(null);
+  }
+
+  void _tickCrop(Duration elapsed) {
+    if (!_cropSweep) return;
+    final splats = _activeSplats;
+    final extent = _cropExtent[_active]!;
+    final t = elapsed.inMicroseconds / 1e6;
+    // A wipe: a big exclude box slides through the set, eating and then
+    // restoring it. Evaluated per splat on the GPU, so this is free to
+    // animate.
+    final sweep = math.sin(t * 0.5) * extent;
+    splats.setCropBox(
+      vm.Matrix4.compose(
+        vm.Vector3(sweep - extent, 0, 0),
+        vm.Quaternion.identity(),
+        vm.Vector3(extent, extent * 2, extent * 2),
+      ),
+      mode: SplatCropMode.exclude,
+    );
   }
 
   /// Builds a three-armed spiral nebula with a bright core. Anisotropic
@@ -138,8 +212,8 @@ class ExampleSplatsState extends State<ExampleSplats> {
         // The arm tangent direction (derivative of the spiral) is close to
         // the angular direction; stretch splats along it.
         final tangentYaw = -(theta + math.pi / 2);
-        final len = 0.10 + rng.nextDouble() * 0.22;
-        final scale = vm.Vector3(len * 3.0, len * 0.8, len);
+        final len = 0.06 + rng.nextDouble() * 0.12;
+        final scale = vm.Vector3(len * 2.2, len * 0.7, len);
         final t = ((r - 1.2) / 7.5).clamp(0.0, 1.0);
         final color =
             armColors[arm] * (0.35 + 0.5 * t) +
@@ -156,7 +230,7 @@ class ExampleSplatsState extends State<ExampleSplats> {
     }
     for (var n = 0; n < core; n++, i++) {
       final position = vm.Vector3(gauss() * 0.9, gauss() * 0.45, gauss() * 0.9);
-      final len = 0.05 + rng.nextDouble() * 0.2;
+      final len = 0.04 + rng.nextDouble() * 0.1;
       final heat = math.max(0.0, 1.0 - position.length / 2.2);
       writeSplat(
         i,
@@ -169,6 +243,8 @@ class ExampleSplatsState extends State<ExampleSplats> {
     }
     return data;
   }
+
+  vm.Vector3 _cameraPosition = vm.Vector3(0, 4, 14);
 
   @override
   Widget build(BuildContext context) {
@@ -194,10 +270,13 @@ class ExampleSplatsState extends State<ExampleSplats> {
               }
               return PerspectiveCamera(
                 position: _cameraPosition,
-                target: vm.Vector3(0, 0, 0),
+                target: vm.Vector3(0, 0.5, 0),
               );
             },
-            onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+            onTick: (elapsed, deltaSeconds) {
+              _tickCrop(elapsed);
+              exampleSettings.applyTo(scene);
+            },
           ),
         ),
         Positioned(left: 12, bottom: 12, child: _panel()),
@@ -206,8 +285,8 @@ class ExampleSplatsState extends State<ExampleSplats> {
   }
 
   Widget _panel() {
-    final splats = _splats;
-    if (splats == null) return const SizedBox.shrink();
+    final splats = _activeSplats;
+    final hasCapture = _sources.containsKey(_SplatSource.capture);
     return Card(
       color: Colors.black.withValues(alpha: 0.55),
       child: Padding(
@@ -216,6 +295,27 @@ class ExampleSplatsState extends State<ExampleSplats> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            if (hasCapture)
+              SegmentedButton<_SplatSource>(
+                segments: const [
+                  ButtonSegment(
+                    value: _SplatSource.nebula,
+                    label: Text('Nebula'),
+                  ),
+                  ButtonSegment(
+                    value: _SplatSource.capture,
+                    label: Text('Strawberry'),
+                  ),
+                ],
+                selected: {_active},
+                onSelectionChanged: (s) => _setActive(s.first),
+              )
+            else
+              const Text(
+                'Run tool/fetch_splat_asset.sh for the captured scene',
+                style: TextStyle(color: Colors.white38, fontSize: 11),
+              ),
+            const SizedBox(height: 4),
             Text(
               '${splats.splats.count} splats',
               style: const TextStyle(color: Colors.white70, fontSize: 12),
@@ -227,7 +327,7 @@ class ExampleSplatsState extends State<ExampleSplats> {
               1.0,
               (v) => setState(() {
                 _opacity = v;
-                splats.opacity = v;
+                _applyKnobs();
               }),
             ),
             _slider(
@@ -237,7 +337,7 @@ class ExampleSplatsState extends State<ExampleSplats> {
               2.5,
               (v) => setState(() {
                 _splatScale = v;
-                splats.splatScale = v;
+                _applyKnobs();
               }),
             ),
             Row(
@@ -247,7 +347,16 @@ class ExampleSplatsState extends State<ExampleSplats> {
                   _antialiased,
                   (v) => setState(() {
                     _antialiased = v;
-                    splats.antialiased = v;
+                    _applyKnobs();
+                  }),
+                ),
+                const SizedBox(width: 12),
+                _toggle(
+                  'Crop sweep',
+                  _cropSweep,
+                  (v) => setState(() {
+                    _cropSweep = v;
+                    _applyKnobs();
                   }),
                 ),
                 const SizedBox(width: 12),

--- a/examples/flutter_app/lib/example_splats.dart
+++ b/examples/flutter_app/lib/example_splats.dart
@@ -1,14 +1,9 @@
-// Gaussian splat rendering demo. The splat types live under lib/src (not yet
-// part of the public barrel); a dev app may import them directly.
-// ignore_for_file: implementation_imports
+// Gaussian splat rendering demo.
 
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart';
-import 'package:flutter_scene/src/components/splat_component.dart';
-import 'package:flutter_scene/src/geometry/splat_geometry.dart';
-import 'package:flutter_scene/src/splats/gaussian_splats.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_settings.dart';

--- a/examples/flutter_app/lib/example_splats.dart
+++ b/examples/flutter_app/lib/example_splats.dart
@@ -13,6 +13,7 @@ import 'package:flutter_scene/src/splats/splat_data.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_settings.dart';
+import 'quake_camera.dart';
 
 /// Gaussian splat rendering: a procedural nebula (60k anisotropic splats)
 /// and, when `assets_src/strawberry.splat` is present (fetched by
@@ -49,10 +50,35 @@ class ExampleSplatsState extends State<ExampleSplats> {
   bool _cropSweep = false;
   bool _orbit = true;
 
+  // The free "inspection" camera. While inactive it is kept synced to the
+  // orbit camera so toggling it on does not jump the view.
+  bool _freeCamera = false;
+  final QuakeCamera _freeCam = QuakeCamera(position: vm.Vector3(0, 4, 14))
+    ..speed = 6.0
+    ..enabled = false;
+  double _elapsedSeconds = 0;
+
+  // Smoothed frames-per-second readout, updated a few times a second so
+  // the panel text does not rebuild every frame.
+  final ValueNotifier<double> _fps = ValueNotifier<double>(0);
+  double _fpsAccum = 0;
+  int _fpsFrames = 0;
+
   @override
   void initState() {
     super.initState();
+    // Splat footprints are soft, so MSAA buys nothing here while
+    // multiplying blend cost across millions of tiny triangles; prefer the
+    // post-process path for this example (still adjustable in the shared
+    // settings sidebar).
+    exampleSettings.antiAliasingMode = AntiAliasingMode.fxaa;
     _load();
+  }
+
+  @override
+  void dispose() {
+    _fps.dispose();
+    super.dispose();
   }
 
   Future<void> _load() async {
@@ -254,34 +280,89 @@ class ExampleSplatsState extends State<ExampleSplats> {
         child: Center(child: CircularProgressIndicator()),
       );
     }
-    return Stack(
-      children: [
-        Positioned.fill(
-          child: SceneView(
-            scene,
-            cameraBuilder: (elapsed) {
-              if (_orbit) {
-                final t = elapsed.inMicroseconds / 1e6;
-                _cameraPosition = vm.Vector3(
-                  math.sin(t * 0.12) * 14,
-                  4.0 + math.sin(t * 0.05) * 2.0,
-                  math.cos(t * 0.12) * 14,
-                );
-              }
-              return PerspectiveCamera(
-                position: _cameraPosition,
-                target: vm.Vector3(0, 0.5, 0),
-              );
-            },
-            onTick: (elapsed, deltaSeconds) {
-              _tickCrop(elapsed);
-              exampleSettings.applyTo(scene);
-            },
+    return Focus(
+      autofocus: true,
+      onKeyEvent: _freeCam.onKeyEvent,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: GestureDetector(
+              onPanUpdate: _freeCamera
+                  ? (details) => setState(() => _freeCam.look(details.delta))
+                  : null,
+              child: SceneView(
+                scene,
+                cameraBuilder: (elapsed) {
+                  _elapsedSeconds = elapsed.inMicroseconds / 1e6;
+                  if (_freeCamera) {
+                    _freeCam.move(_elapsedSeconds);
+                    return _freeCam.camera;
+                  }
+                  if (_orbit) {
+                    final t = _elapsedSeconds;
+                    _cameraPosition = vm.Vector3(
+                      math.sin(t * 0.12) * 14,
+                      4.0 + math.sin(t * 0.05) * 2.0,
+                      math.cos(t * 0.12) * 14,
+                    );
+                  }
+                  final camera = PerspectiveCamera(
+                    position: _cameraPosition,
+                    target: vm.Vector3(0, 0.5, 0),
+                  );
+                  // Keep the free camera parked on the live view so
+                  // enabling it starts from what is on screen.
+                  _freeCam.syncTo(camera);
+                  return camera;
+                },
+                onTick: (elapsed, deltaSeconds) {
+                  _tickCrop(elapsed);
+                  _tickFps(deltaSeconds);
+                  exampleSettings.applyTo(scene);
+                },
+              ),
+            ),
           ),
-        ),
-        Positioned(left: 12, bottom: 12, child: _panel()),
-      ],
+          Positioned(left: 12, bottom: 12, child: _panel()),
+          Positioned(
+            right: 12,
+            bottom: 12,
+            child: Tooltip(
+              message: _freeCamera
+                  ? 'Back to the orbit camera'
+                  : 'Free camera (WASD + drag)',
+              child: FilledButton.tonalIcon(
+                onPressed: _toggleFreeCamera,
+                icon: Icon(
+                  _freeCamera ? Icons.threesixty : Icons.videogame_asset,
+                ),
+                label: Text(_freeCamera ? 'Orbit cam' : 'Free cam'),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
+  }
+
+  void _toggleFreeCamera() {
+    setState(() {
+      _freeCamera = !_freeCamera;
+      _freeCam
+        ..enabled = _freeCamera
+        ..releaseKeys()
+        ..move(_elapsedSeconds); // Reset the frame clock without moving.
+    });
+  }
+
+  void _tickFps(double deltaSeconds) {
+    _fpsAccum += deltaSeconds;
+    _fpsFrames++;
+    if (_fpsAccum >= 0.25) {
+      _fps.value = _fpsFrames / _fpsAccum;
+      _fpsAccum = 0;
+      _fpsFrames = 0;
+    }
   }
 
   Widget _panel() {
@@ -316,9 +397,12 @@ class ExampleSplatsState extends State<ExampleSplats> {
                 style: TextStyle(color: Colors.white38, fontSize: 11),
               ),
             const SizedBox(height: 4),
-            Text(
-              '${splats.splats.count} splats',
-              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ValueListenableBuilder<double>(
+              valueListenable: _fps,
+              builder: (context, fps, _) => Text(
+                '${splats.splats.count} splats · ${fps.toStringAsFixed(0)} fps',
+                style: const TextStyle(color: Colors.white70, fontSize: 12),
+              ),
             ),
             _slider(
               'Opacity',

--- a/examples/flutter_app/lib/example_splats.dart
+++ b/examples/flutter_app/lib/example_splats.dart
@@ -1,0 +1,307 @@
+// Gaussian splat rendering demo. The splat types live under lib/src (not yet
+// part of the public barrel); a dev app may import them directly.
+// ignore_for_file: implementation_imports
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/components/splat_component.dart';
+import 'package:flutter_scene/src/splats/gaussian_splats.dart';
+import 'package:flutter_scene/src/splats/splat_data.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+
+/// A procedural Gaussian splat nebula (60k anisotropic splats) with a PBR
+/// sphere parked inside it, proving splats and forward-rendered geometry
+/// occlude each other correctly in one scene. The camera orbits slowly; the
+/// panel exposes the splat knobs.
+///
+/// TODO(splats): also load a captured `.ply`/`.splat` asset (downloaded by
+/// the asset hook) once the example asset pipeline grows a splat step.
+class ExampleSplats extends StatefulWidget {
+  const ExampleSplats({super.key});
+
+  @override
+  ExampleSplatsState createState() => ExampleSplatsState();
+}
+
+class ExampleSplatsState extends State<ExampleSplats> {
+  Scene scene = Scene();
+  SplatComponent? _splats;
+  bool _ready = false;
+
+  double _opacity = 1.0;
+  double _splatScale = 1.0;
+  bool _antialiased = true;
+  bool _orbit = true;
+  vm.Vector3 _cameraPosition = vm.Vector3(0, 4, 14);
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    scene.skybox = Skybox(
+      GradientSkySource(
+        zenithColor: vm.Vector3(0.008, 0.008, 0.02),
+        horizonColor: vm.Vector3(0.02, 0.015, 0.045),
+        groundColor: vm.Vector3(0.005, 0.005, 0.012),
+        sunColor: vm.Vector3(0.06, 0.06, 0.09),
+      ),
+    );
+
+    final splats = GaussianSplats.fromData(_nebula(seed: 7));
+    final component = SplatComponent(splats);
+    _splats = component;
+    scene.add(Node()..addComponent(component));
+
+    // A shiny sphere inside the cloud: splats in front of it must cover it,
+    // and it must occlude the splats behind it.
+    final sphere = Node(
+      mesh: Mesh(
+        SphereGeometry(radius: 1.2),
+        PhysicallyBasedMaterial()
+          ..baseColorFactor = vm.Vector4(0.9, 0.85, 0.8, 1.0)
+          ..metallicFactor = 1.0
+          ..roughnessFactor = 0.15,
+      ),
+    )..localTransform = vm.Matrix4.translation(vm.Vector3(2.5, 0.4, 0));
+    scene.add(sphere);
+
+    if (mounted) setState(() => _ready = true);
+  }
+
+  /// Builds a three-armed spiral nebula with a bright core. Anisotropic
+  /// splats stretch along their arm's tangent, showing off oriented
+  /// covariances; colors are authored in linear space.
+  static SplatData _nebula({required int seed}) {
+    const arms = 3;
+    const perArm = 17000;
+    const core = 9000;
+    const count = arms * perArm + core;
+    final rng = math.Random(seed);
+    final data = SplatData.zeroed(count);
+
+    double gauss() {
+      // Box-Muller.
+      final u = math.max(rng.nextDouble(), 1e-9);
+      return math.sqrt(-2 * math.log(u)) *
+          math.cos(2 * math.pi * rng.nextDouble());
+    }
+
+    void writeSplat(
+      int i, {
+      required vm.Vector3 position,
+      required vm.Vector3 scale,
+      required double yaw,
+      required vm.Vector3 color,
+      required double opacity,
+    }) {
+      final p = i * 3, q = i * 4;
+      data.positions[p] = position.x;
+      data.positions[p + 1] = position.y;
+      data.positions[p + 2] = position.z;
+      data.scales[p] = scale.x;
+      data.scales[p + 1] = scale.y;
+      data.scales[p + 2] = scale.z;
+      // Rotation about +Y by yaw: aligns local x with the arm tangent.
+      data.rotations[q + 1] = math.sin(yaw / 2);
+      data.rotations[q + 3] = math.cos(yaw / 2);
+      data.colors[p] = color.x;
+      data.colors[p + 1] = color.y;
+      data.colors[p + 2] = color.z;
+      data.opacities[i] = opacity;
+    }
+
+    final armColors = [
+      vm.Vector3(0.25, 0.45, 1.0), // blue
+      vm.Vector3(0.65, 0.3, 1.0), // violet
+      vm.Vector3(0.2, 0.9, 0.85), // teal
+    ];
+
+    var i = 0;
+    for (var arm = 0; arm < arms; arm++) {
+      final armBase = arm * 2 * math.pi / arms;
+      for (var n = 0; n < perArm; n++, i++) {
+        final r = 1.2 + 7.5 * math.sqrt(rng.nextDouble());
+        final theta = armBase + r * 0.55 + gauss() * (0.35 / math.sqrt(r));
+        final spread = 0.25 + r * 0.06;
+        final position = vm.Vector3(
+          r * math.cos(theta) + gauss() * spread,
+          gauss() * spread * 0.35,
+          r * math.sin(theta) + gauss() * spread,
+        );
+        // The arm tangent direction (derivative of the spiral) is close to
+        // the angular direction; stretch splats along it.
+        final tangentYaw = -(theta + math.pi / 2);
+        final len = 0.10 + rng.nextDouble() * 0.22;
+        final scale = vm.Vector3(len * 3.0, len * 0.8, len);
+        final t = ((r - 1.2) / 7.5).clamp(0.0, 1.0);
+        final color =
+            armColors[arm] * (0.35 + 0.5 * t) +
+            vm.Vector3(1.0, 0.85, 0.6) * (1.0 - t) * 0.5;
+        writeSplat(
+          i,
+          position: position,
+          scale: scale,
+          yaw: tangentYaw,
+          color: color * (2.2 - 1.4 * t),
+          opacity: 0.25 + rng.nextDouble() * 0.5,
+        );
+      }
+    }
+    for (var n = 0; n < core; n++, i++) {
+      final position = vm.Vector3(gauss() * 0.9, gauss() * 0.45, gauss() * 0.9);
+      final len = 0.05 + rng.nextDouble() * 0.2;
+      final heat = math.max(0.0, 1.0 - position.length / 2.2);
+      writeSplat(
+        i,
+        position: position,
+        scale: vm.Vector3(len, len, len),
+        yaw: rng.nextDouble() * math.pi,
+        color: vm.Vector3(1.0, 0.9, 0.7) * (1.5 + 6.0 * heat * heat),
+        opacity: 0.35 + rng.nextDouble() * 0.55,
+      );
+    }
+    return data;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_ready) {
+      return const ColoredBox(
+        color: Color(0xFF040408),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: SceneView(
+            scene,
+            cameraBuilder: (elapsed) {
+              if (_orbit) {
+                final t = elapsed.inMicroseconds / 1e6;
+                _cameraPosition = vm.Vector3(
+                  math.sin(t * 0.12) * 14,
+                  4.0 + math.sin(t * 0.05) * 2.0,
+                  math.cos(t * 0.12) * 14,
+                );
+              }
+              return PerspectiveCamera(
+                position: _cameraPosition,
+                target: vm.Vector3(0, 0, 0),
+              );
+            },
+            onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+          ),
+        ),
+        Positioned(left: 12, bottom: 12, child: _panel()),
+      ],
+    );
+  }
+
+  Widget _panel() {
+    final splats = _splats;
+    if (splats == null) return const SizedBox.shrink();
+    return Card(
+      color: Colors.black.withValues(alpha: 0.55),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${splats.splats.count} splats',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+            _slider(
+              'Opacity',
+              _opacity,
+              0.0,
+              1.0,
+              (v) => setState(() {
+                _opacity = v;
+                splats.opacity = v;
+              }),
+            ),
+            _slider(
+              'Splat scale',
+              _splatScale,
+              0.2,
+              2.5,
+              (v) => setState(() {
+                _splatScale = v;
+                splats.splatScale = v;
+              }),
+            ),
+            Row(
+              children: [
+                _toggle(
+                  'Antialiased',
+                  _antialiased,
+                  (v) => setState(() {
+                    _antialiased = v;
+                    splats.antialiased = v;
+                  }),
+                ),
+                const SizedBox(width: 12),
+                _toggle('Orbit', _orbit, (v) => setState(() => _orbit = v)),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _slider(
+    String label,
+    double value,
+    double min,
+    double max,
+    ValueChanged<double> onChanged,
+  ) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 78,
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white70, fontSize: 12),
+          ),
+        ),
+        SizedBox(
+          width: 160,
+          child: Slider(value: value, min: min, max: max, onChanged: onChanged),
+        ),
+        SizedBox(
+          width: 34,
+          child: Text(
+            value.toStringAsFixed(2),
+            style: const TextStyle(color: Colors.white70, fontSize: 12),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _toggle(String label, bool value, ValueChanged<bool> onChanged) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(color: Colors.white70, fontSize: 12),
+        ),
+        Switch(value: value, onChanged: onChanged),
+      ],
+    );
+  }
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -28,6 +28,7 @@ import 'example_render_target.dart';
 import 'example_settings.dart';
 import 'example_shapes.dart';
 import 'example_particles.dart';
+import 'example_splats.dart';
 import 'example_skybox.dart';
 import 'example_sprites.dart';
 import 'example_ssr.dart';
@@ -97,6 +98,7 @@ class _MyAppState extends State<MyApp> {
       'Spot Shadow': (context) => const ExampleSpotShadow(),
       'Sprites': (context) => const ExampleSprites(),
       'Particles': (context) => const ExampleParticles(),
+      'Gaussian Splats': (context) => const ExampleSplats(),
       'Instancing': (context) => const ExampleInstancing(),
       'Geometry LOD': (context) => const ExampleLod(),
       'Screen-space Reflections': (context) => const ExampleSsr(),

--- a/examples/flutter_app/tool/fetch_splat_asset.sh
+++ b/examples/flutter_app/tool/fetch_splat_asset.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Fetches the "Strawberry" Gaussian splat capture by danylyon
+# (https://superspl.at/scene/84df8849, CC BY 4.0; the author notes
+# attribution is appreciated but not required) and converts it to
+# assets_src/strawberry.splat for the Gaussian Splats example. The example
+# falls back to a procedural scene when the file is absent, so running this
+# is optional.
+#
+# The hosted format is SOG (webp-image-backed); @playcanvas/splat-transform
+# unpacks it to PLY, and tool/ply_to_splat.dart compacts that to the
+# 32-byte .splat layout (drops rest SH, quantizes color/rotation to 8 bits)
+# so the bundled asset stays ~48MB instead of ~340MB.
+#
+# Requires curl, node (npx), and dart on PATH.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BASE=https://d28zzqy0iyovbz.cloudfront.net/84df8849/v1
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# The file list matches the pinned /v1/ upload of the scene.
+for f in meta.json means_l.webp means_u.webp quats.webp scales.webp \
+         sh0.webp shN_centroids.webp shN_labels.webp; do
+  echo "Fetching $f"
+  curl -fsS -o "$TMP/$f" "$BASE/$f"
+done
+
+npx -y @playcanvas/splat-transform "$TMP/meta.json" "$TMP/strawberry.ply"
+dart run tool/ply_to_splat.dart "$TMP/strawberry.ply" \
+  assets_src/strawberry.splat
+echo "Wrote assets_src/strawberry.splat"

--- a/examples/flutter_app/tool/fetch_splat_asset.sh
+++ b/examples/flutter_app/tool/fetch_splat_asset.sh
@@ -1,33 +1,71 @@
 #!/usr/bin/env bash
 #
-# Fetches the "Strawberry" Gaussian splat capture by danylyon
-# (https://superspl.at/scene/84df8849, CC BY 4.0; the author notes
-# attribution is appreciated but not required) and converts it to
-# assets_src/strawberry.splat for the Gaussian Splats example. The example
-# falls back to a procedural scene when the file is absent, so running this
-# is optional.
+# Fetches the Gaussian splat captures the Gaussian Splats example uses and
+# converts them to bundleable .splat files under assets_src/. The example
+# hides whichever asset is absent, so running this is optional.
+#
+#   strawberry  "Strawberry" by danylyon, https://superspl.at/scene/84df8849
+#               CC BY 4.0 (the author notes attribution is appreciated
+#               rather than required). 1.5M splats.
+#   classroom   "Classroom of Class 6 Grade 9, China" by hite404,
+#               https://superspl.at/scene/712d5b78, CC BY 4.0. 1.2M splats
+#               (the streamed hosting's full-detail level, two chunks).
 #
 # The hosted format is SOG (webp-image-backed); @playcanvas/splat-transform
-# unpacks it to PLY, and tool/ply_to_splat.dart compacts that to the
-# 32-byte .splat layout (drops rest SH, quantizes color/rotation to 8 bits)
-# so the bundled asset stays ~48MB instead of ~340MB.
+# unpacks (and for chunked scenes, merges) it to PLY, and
+# tool/ply_to_splat.dart compacts that to the 32-byte .splat layout (drops
+# rest SH, quantizes color/rotation to 8 bits) so each bundled asset stays
+# under ~50MB instead of several hundred.
 #
-# Requires curl, node (npx), and dart on PATH.
+# Requires curl, python3, node (npx), and dart on PATH.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-BASE=https://d28zzqy0iyovbz.cloudfront.net/84df8849/v1
+CDN=https://d28zzqy0iyovbz.cloudfront.net
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-# The file list matches the pinned /v1/ upload of the scene.
-for f in meta.json means_l.webp means_u.webp quats.webp scales.webp \
-         sh0.webp shN_centroids.webp shN_labels.webp; do
-  echo "Fetching $f"
-  curl -fsS -o "$TMP/$f" "$BASE/$f"
-done
+# Downloads one SOG directory (a meta.json plus the webp payloads it
+# references) into $2.
+fetch_sog() {
+  local url_dir="$1" out_dir="$2"
+  mkdir -p "$out_dir"
+  curl -fsS -o "$out_dir/meta.json" "$url_dir/meta.json"
+  python3 - "$out_dir/meta.json" <<'EOF' | while read -r f; do
+import json, sys
+meta = json.load(open(sys.argv[1]))
+files = set()
+for value in meta.values():
+    if isinstance(value, dict) and 'files' in value:
+        files.update(value['files'])
+print('\n'.join(sorted(files)))
+EOF
+    curl -fsS -o "$out_dir/$f" "$url_dir/$f"
+  done
+}
 
-npx -y @playcanvas/splat-transform "$TMP/meta.json" "$TMP/strawberry.ply"
-dart run tool/ply_to_splat.dart "$TMP/strawberry.ply" \
-  assets_src/strawberry.splat
-echo "Wrote assets_src/strawberry.splat"
+# fetch_asset <name> <scene id> <sog subdirs...>; "." means the scene is a
+# single flat SOG at the scene root.
+fetch_asset() {
+  local name="$1" id="$2"
+  shift 2
+  local out="assets_src/$name.splat"
+  if [ -e "$out" ]; then
+    echo "$out already exists, skipping (delete it to refetch)"
+    return
+  fi
+  local metas=()
+  for dir in "$@"; do
+    local sub=""
+    [ "$dir" != "." ] && sub="/$dir"
+    echo "Fetching $name$sub"
+    fetch_sog "$CDN/$id/v1$sub" "$TMP/$name$sub"
+    metas+=("$TMP/$name$sub/meta.json")
+  done
+  npx -y @playcanvas/splat-transform "${metas[@]}" "$TMP/$name.ply"
+  dart run tool/ply_to_splat.dart "$TMP/$name.ply" "$out"
+  echo "Wrote $out"
+}
+
+fetch_asset strawberry 84df8849 .
+fetch_asset classroom 712d5b78 0_0 0_1

--- a/examples/flutter_app/tool/ply_to_splat.dart
+++ b/examples/flutter_app/tool/ply_to_splat.dart
@@ -1,0 +1,53 @@
+// Converts a Gaussian-splat PLY into the compact 32-byte-per-splat `.splat`
+// layout (float position and scale, 8-bit color/opacity, 8-bit scalar-first
+// quaternion). Rest spherical harmonics are dropped; the format carries
+// none. Used by fetch_splat_asset.sh to keep the example's captured asset
+// small enough to bundle.
+//
+// Usage: dart run tool/ply_to_splat.dart <in.ply> <out.splat>
+
+// The splat codec is engine-internal; this dev tool may import it directly.
+// ignore_for_file: implementation_imports
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/splats/splat_codec.dart';
+
+void main(List<String> args) {
+  if (args.length != 2) {
+    stderr.writeln(
+      'Usage: dart run tool/ply_to_splat.dart <in.ply> <out.splat>',
+    );
+    exit(64);
+  }
+  final bytes = File(args[0]).readAsBytesSync();
+  final data = parseSplatPly(bytes);
+
+  int quantize8(double v, double scale) =>
+      ((v * scale) + 128).round().clamp(0, 255);
+
+  final out = Uint8List(data.count * 32);
+  final view = ByteData.sublistView(out);
+  for (var i = 0; i < data.count; i++) {
+    final base = i * 32;
+    final p = i * 3, q = i * 4;
+    view.setFloat32(base, data.positions[p], Endian.little);
+    view.setFloat32(base + 4, data.positions[p + 1], Endian.little);
+    view.setFloat32(base + 8, data.positions[p + 2], Endian.little);
+    view.setFloat32(base + 12, data.scales[p], Endian.little);
+    view.setFloat32(base + 16, data.scales[p + 1], Endian.little);
+    view.setFloat32(base + 20, data.scales[p + 2], Endian.little);
+    out[base + 24] = (data.colors[p].clamp(0.0, 1.0) * 255).round();
+    out[base + 25] = (data.colors[p + 1].clamp(0.0, 1.0) * 255).round();
+    out[base + 26] = (data.colors[p + 2].clamp(0.0, 1.0) * 255).round();
+    out[base + 27] = (data.opacities[i].clamp(0.0, 1.0) * 255).round();
+    // Scalar first, matching the training PLY's rot_* order.
+    out[base + 28] = quantize8(data.rotations[q + 3], 128);
+    out[base + 29] = quantize8(data.rotations[q], 128);
+    out[base + 30] = quantize8(data.rotations[q + 1], 128);
+    out[base + 31] = quantize8(data.rotations[q + 2], 128);
+  }
+  File(args[1]).writeAsBytesSync(out);
+  stdout.writeln('${data.count} splats -> ${args[1]} (${out.length} bytes)');
+}

--- a/examples/flutter_app/tool/ply_to_splat.dart
+++ b/examples/flutter_app/tool/ply_to_splat.dart
@@ -1,12 +1,12 @@
 // Converts a Gaussian-splat PLY into the compact 32-byte-per-splat `.splat`
 // layout (float position and scale, 8-bit color/opacity, 8-bit scalar-first
-// quaternion). Rest spherical harmonics are dropped; the format carries
-// none. Used by fetch_splat_asset.sh to keep the example's captured asset
+// quaternion), dropping the rest spherical harmonics the format cannot
+// carry. Used by fetch_splat_asset.sh to keep the example's captured asset
 // small enough to bundle.
 //
-// Usage: dart run tool/ply_to_splat.dart <in.ply> <out.splat>
+// Run with `dart run tool/ply_to_splat.dart <in.ply> <out.splat>`.
 
-// The splat codec is engine-internal; this dev tool may import it directly.
+// The splat codec is engine-internal, but this dev tool may import it.
 // ignore_for_file: implementation_imports
 
 import 'dart:io';

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -334,14 +334,13 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
     );
     return (scene: scene, camera: _camera());
   }),
-  // Gaussian splatting: a procedural anisotropic splat cloud (degree-1 SH)
-  // composited around an opaque cuboid, with a crop box carving one side.
-  // One scene covers the splat path across backends: the vertex-stage data
-  // texture fetch, the EWA covariance projection and 2D eigendecomposition,
-  // the background depth sort, premultiplied translucent blending over
-  // opaque geometry, the SH texture fetch and evaluation, and the crop
-  // branch. The splats surround an opaque cuboid so the splat/mesh depth
-  // composite (occlusion both ways) is exercised too.
+  // A procedural anisotropic splat cloud (degree-1 SH) composited around an
+  // opaque cuboid, with a crop box carving one side. One scene covers the
+  // splat path across backends, the vertex-stage data texture fetch, the EWA
+  // covariance projection and 2D eigendecomposition, the background depth
+  // sort, premultiplied translucent blending over opaque geometry, the SH
+  // texture fetch and evaluation, and the crop branch. The surrounding
+  // cuboid exercises the splat/mesh depth composite (occlusion both ways).
   SmokeScene('gaussian_splats', () {
     final scene = Scene();
     scene.add(_cuboid(vm.Vector4(0.85, 0.75, 0.20, 1.0), 0.1, 0.5));

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -49,6 +50,50 @@ Node _cuboid(vm.Vector4 baseColor, double metallic, double roughness) {
     ..vertexColorWeight = 0.0;
   return Node(mesh: Mesh(CuboidGeometry(vm.Vector3(1, 1, 1)), material))
     ..localTransform = vm.Matrix4.rotationY(0.6) * vm.Matrix4.rotationX(0.3);
+}
+
+/// A deterministic anisotropic Gaussian splat cloud (degree-1 SH) for the
+/// splat smoke scene. Built from a fixed seed, so the packed data and the
+/// resulting depth sort are identical across runs and backends. Splats form
+/// a fuzzy spherical shell so the corners stay the magenta clear.
+GaussianSplats _splatCloud() {
+  const count = 2500;
+  final rng = math.Random(20260705);
+  final data = SplatData.zeroed(count, shDegree: 1);
+  for (var i = 0; i < count; i++) {
+    // A point on a fuzzy spherical shell around the origin.
+    final theta = rng.nextDouble() * 2 * math.pi;
+    final phi = math.acos(2 * rng.nextDouble() - 1);
+    final r = 0.45 + rng.nextDouble() * 0.65;
+    final sinPhi = math.sin(phi);
+    final p = i * 3, q = i * 4;
+    data.positions[p] = r * sinPhi * math.cos(theta);
+    data.positions[p + 1] = r * math.cos(phi);
+    data.positions[p + 2] = r * sinPhi * math.sin(theta);
+    // Anisotropic scales plus a yaw, so the covariance projection and the
+    // 2D eigendecomposition see non-circular footprints at varied angles.
+    final len = 0.05 + rng.nextDouble() * 0.055;
+    data.scales[p] = len * 2.4;
+    data.scales[p + 1] = len * 0.8;
+    data.scales[p + 2] = len;
+    final yaw = rng.nextDouble() * math.pi;
+    data.rotations[q + 1] = math.sin(yaw / 2);
+    data.rotations[q + 3] = math.cos(yaw / 2);
+    // Hue rotation by height for many distinct colors (linear space).
+    final h = (data.positions[p + 1] + 1.2) / 2.4;
+    data.colors[p] = 0.5 + 0.5 * math.cos(6.28318 * h);
+    data.colors[p + 1] = 0.5 + 0.5 * math.cos(6.28318 * (h + 0.33));
+    data.colors[p + 2] = 0.5 + 0.5 * math.cos(6.28318 * (h + 0.66));
+    data.opacities[i] = 0.55 + rng.nextDouble() * 0.4;
+    // A gentle view-dependent tint (degree-1 SH), small so the base color
+    // leads. Exercises the SH texture fetch and evaluation branch.
+    for (var c = 0; c < 3; c++) {
+      for (var ch = 0; ch < 3; ch++) {
+        data.sh![(i * 3 + c) * 3 + ch] = (rng.nextDouble() - 0.5) * 0.3;
+      }
+    }
+  }
+  return GaussianSplats.fromData(data);
 }
 
 /// Custom-material assets pre-loaded by [loadSmokeMaterials], so the
@@ -287,6 +332,31 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
             vm.Matrix4.rotationY(0.6) *
             vm.Matrix4.rotationX(0.3),
     );
+    return (scene: scene, camera: _camera());
+  }),
+  // Gaussian splatting: a procedural anisotropic splat cloud (degree-1 SH)
+  // composited around an opaque cuboid, with a crop box carving one side.
+  // One scene covers the splat path across backends: the vertex-stage data
+  // texture fetch, the EWA covariance projection and 2D eigendecomposition,
+  // the background depth sort, premultiplied translucent blending over
+  // opaque geometry, the SH texture fetch and evaluation, and the crop
+  // branch. The splats surround an opaque cuboid so the splat/mesh depth
+  // composite (occlusion both ways) is exercised too.
+  SmokeScene('gaussian_splats', () {
+    final scene = Scene();
+    scene.add(_cuboid(vm.Vector4(0.85, 0.75, 0.20, 1.0), 0.1, 0.5));
+    final splats = SplatComponent(_splatCloud())
+      // Exclude a slab off the -x side, so the crop branch culls real splats
+      // while the central coverage the frame-sanity check samples stays high.
+      ..setCropBox(
+        vm.Matrix4.compose(
+          vm.Vector3(-1.25, 0, 0),
+          vm.Quaternion.identity(),
+          vm.Vector3(0.6, 2.0, 2.0),
+        ),
+        mode: SplatCropMode.exclude,
+      );
+    scene.add(Node()..addComponent(splats));
     return (scene: scene, camera: _camera());
   }),
 ];

--- a/packages/flutter_scene/dartdoc_options.yaml
+++ b/packages/flutter_scene/dartdoc_options.yaml
@@ -9,4 +9,5 @@ dartdoc:
     - "Physics"
     - "Picking and input"
     - "Widgets"
+    - "Gaussian splatting"
     - "Assets and loading"

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -102,9 +102,14 @@ export 'src/components/instanced_mesh_component.dart'
 export 'src/components/lod_component.dart' show LodComponent;
 export 'src/components/mesh_component.dart' show MeshComponent;
 export 'src/components/point_light_component.dart' show PointLightComponent;
+export 'src/components/splat_component.dart' show SplatComponent;
 export 'src/components/spot_light_component.dart' show SpotLightComponent;
 export 'src/render/lod.dart' show LodLevel;
 export 'src/components/widget_component.dart' show WidgetComponent, WidgetInput;
+export 'src/geometry/splat_geometry.dart' show SplatCropMode;
+export 'src/splats/gaussian_splats.dart' show GaussianSplats;
+export 'src/splats/splat_codec.dart' show SplatFormat;
+export 'src/splats/splat_data.dart' show SplatColorSpace, SplatData;
 export 'src/instanced_mesh.dart' show InstancedMesh;
 export 'src/light.dart'
     show

--- a/packages/flutter_scene/lib/src/components/splat_component.dart
+++ b/packages/flutter_scene/lib/src/components/splat_component.dart
@@ -38,6 +38,13 @@ class SplatComponent extends MeshComponent {
 
   final SplatGeometry _geometry;
 
+  @override
+  void onUnmount() {
+    super.onUnmount();
+    // Stop the background sorter; a remount lazily respawns it.
+    _geometry.disposeSorter();
+  }
+
   /// Global opacity multiplier in [0, 1].
   double get opacity => _geometry.opacity;
   set opacity(double value) => _geometry.opacity = value;

--- a/packages/flutter_scene/lib/src/components/splat_component.dart
+++ b/packages/flutter_scene/lib/src/components/splat_component.dart
@@ -59,4 +59,20 @@ class SplatComponent extends MeshComponent {
   /// rasterization) is enabled.
   bool get antialiased => _geometry.antialiased;
   set antialiased(bool value) => _geometry.antialiased = value;
+
+  /// The active crop box (a unit cube placed in the set's local space), or
+  /// null when no crop is set. See [setCropBox].
+  vm.Matrix4? get cropBox => _geometry.cropBox;
+
+  /// How the crop box filters splats.
+  SplatCropMode get cropMode => _geometry.cropMode;
+
+  /// Sets or clears the crop box: [box] places a unit cube (corners at
+  /// +/-1) in the set's local space, and [mode] keeps only the splats
+  /// inside it or drops them. Cropping is evaluated per frame on the GPU,
+  /// so the box can animate freely.
+  void setCropBox(
+    vm.Matrix4? box, {
+    SplatCropMode mode = SplatCropMode.include,
+  }) => _geometry.setCropBox(box, mode: mode);
 }

--- a/packages/flutter_scene/lib/src/components/splat_component.dart
+++ b/packages/flutter_scene/lib/src/components/splat_component.dart
@@ -6,10 +6,6 @@ import 'package:flutter_scene/src/material/splat_material.dart';
 import 'package:flutter_scene/src/mesh.dart';
 import 'package:flutter_scene/src/splats/gaussian_splats.dart';
 
-// TODO(splats): export this (and GaussianSplats/SplatData under
-// lib/src/splats/) from lib/scene.dart with doc categories once the API
-// settles across the later phases (crop volumes, modifier hook, spz).
-
 /// An engine component that draws a [GaussianSplats] set.
 ///
 /// Attach it to a node like any other component; the node's transform
@@ -22,6 +18,7 @@ import 'package:flutter_scene/src/splats/gaussian_splats.dart';
 /// final splats = await GaussianSplats.fromAsset('assets/garden.ply');
 /// scene.add(Node()..addComponent(SplatComponent(splats)));
 /// ```
+/// {@category Gaussian splatting}
 class SplatComponent extends MeshComponent {
   /// Creates a component that draws [splats].
   factory SplatComponent(GaussianSplats splats) {

--- a/packages/flutter_scene/lib/src/components/splat_component.dart
+++ b/packages/flutter_scene/lib/src/components/splat_component.dart
@@ -71,10 +71,10 @@ class SplatComponent extends MeshComponent {
   /// How the crop box filters splats.
   SplatCropMode get cropMode => _geometry.cropMode;
 
-  /// Sets or clears the crop box: [box] places a unit cube (corners at
+  /// Sets or clears the crop box. [box] places a unit cube (corners at
   /// +/-1) in the set's local space, and [mode] keeps only the splats
-  /// inside it or drops them. Cropping is evaluated per frame on the GPU,
-  /// so the box can animate freely.
+  /// inside it or drops them. Cropping runs per frame on the GPU, so the box
+  /// can animate freely.
   void setCropBox(
     vm.Matrix4? box, {
     SplatCropMode mode = SplatCropMode.include,

--- a/packages/flutter_scene/lib/src/components/splat_component.dart
+++ b/packages/flutter_scene/lib/src/components/splat_component.dart
@@ -1,0 +1,62 @@
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'package:flutter_scene/src/components/mesh_component.dart';
+import 'package:flutter_scene/src/geometry/splat_geometry.dart';
+import 'package:flutter_scene/src/material/splat_material.dart';
+import 'package:flutter_scene/src/mesh.dart';
+import 'package:flutter_scene/src/splats/gaussian_splats.dart';
+
+// TODO(splats): export this (and GaussianSplats/SplatData under
+// lib/src/splats/) from lib/scene.dart with doc categories once the API
+// settles across the later phases (crop volumes, modifier hook, spz).
+
+/// An engine component that draws a [GaussianSplats] set.
+///
+/// Attach it to a node like any other component; the node's transform
+/// places and orients the set (uniform scale only, since a non-uniform
+/// scale distorts the splat covariances). The inherited mesh-component
+/// machinery registers, culls, and bounds the draw; the splats render in
+/// the translucent phase, depth-tested against opaque scene geometry.
+///
+/// ```dart
+/// final splats = await GaussianSplats.fromAsset('assets/garden.ply');
+/// scene.add(Node()..addComponent(SplatComponent(splats)));
+/// ```
+class SplatComponent extends MeshComponent {
+  /// Creates a component that draws [splats].
+  factory SplatComponent(GaussianSplats splats) {
+    final geometry = SplatGeometry(splats);
+    final material = SplatMaterial();
+    return SplatComponent._(splats, geometry, material);
+  }
+
+  SplatComponent._(this.splats, this._geometry, SplatMaterial material)
+    : super(Mesh(_geometry, material));
+
+  /// The splat set this component draws.
+  final GaussianSplats splats;
+
+  final SplatGeometry _geometry;
+
+  /// Global opacity multiplier in [0, 1].
+  double get opacity => _geometry.opacity;
+  set opacity(double value) => _geometry.opacity = value;
+
+  /// Multiplier on every splat's footprint; 1 is the captured size.
+  double get splatScale => _geometry.splatScale;
+  set splatScale(double value) => _geometry.splatScale = value;
+
+  /// Linear RGBA tint multiplied into every splat.
+  vm.Vector4 get tint => _geometry.tint;
+  set tint(vm.Vector4 value) => _geometry.tint = value;
+
+  /// The spherical-harmonic degree evaluated per splat, clamped to what the
+  /// set carries.
+  int get shDegree => _geometry.shDegree;
+  set shDegree(int value) => _geometry.shDegree = value;
+
+  /// Whether small-footprint opacity compensation (anti-aliased
+  /// rasterization) is enabled.
+  bool get antialiased => _geometry.antialiased;
+  set antialiased(bool value) => _geometry.antialiased = value;
+}

--- a/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
@@ -14,6 +14,19 @@ import 'package:flutter_scene/src/splats/splat_data.dart';
 import 'package:flutter_scene/src/splats/splat_sorter.dart';
 import 'package:flutter_scene/src/render/frame_transients.dart';
 
+/// How a crop box filters the splats of a [SplatGeometry].
+/// {@category Geometry}
+enum SplatCropMode {
+  /// No crop; every splat draws.
+  none,
+
+  /// Only splats inside the box draw.
+  include,
+
+  /// Splats inside the box are dropped.
+  exclude,
+}
+
 /// Draws a [GaussianSplats] set as one instanced batch of screen-space
 /// Gaussian footprints.
 ///
@@ -57,6 +70,38 @@ class SplatGeometry extends Geometry {
   bool antialiased = true;
 
   int _shDegree = 2;
+
+  vm.Matrix4? _cropInverse;
+  SplatCropMode _cropMode = SplatCropMode.none;
+
+  /// The active crop box's placement in the splat set's local space (the
+  /// box is the unit cube, corners at +/-1), or null when no crop is set.
+  vm.Matrix4? get cropBox => _cropBox;
+  vm.Matrix4? _cropBox;
+
+  /// How the crop box filters splats.
+  SplatCropMode get cropMode => _cropMode;
+
+  /// Sets or clears the crop box.
+  ///
+  /// [box] places a unit cube (corners at +/-1) in the set's local space;
+  /// [mode] keeps only the splats inside it ([SplatCropMode.include]) or
+  /// drops them ([SplatCropMode.exclude]). Pass null (or
+  /// [SplatCropMode.none]) to clear.
+  void setCropBox(
+    vm.Matrix4? box, {
+    SplatCropMode mode = SplatCropMode.include,
+  }) {
+    if (box == null || mode == SplatCropMode.none) {
+      _cropBox = null;
+      _cropInverse = null;
+      _cropMode = SplatCropMode.none;
+      return;
+    }
+    _cropBox = box.clone();
+    _cropInverse = vm.Matrix4.inverted(box);
+    _cropMode = mode;
+  }
 
   /// The spherical-harmonic degree evaluated per splat, clamped to what the
   /// set carries. Lowering it cheapens the vertex stage.
@@ -242,30 +287,39 @@ class SplatGeometry extends Geometry {
     );
 
     final viewport = currentSceneEncoderViewport;
-    final frameInfo = Float32List(56);
+    final frameInfo = Float32List(72);
     frameInfo.setRange(0, 16, mvp.storage);
     frameInfo.setRange(16, 32, modelTransform.storage);
-    frameInfo[32] = cameraPosition.x;
-    frameInfo[33] = cameraPosition.y;
-    frameInfo[34] = cameraPosition.z;
-    frameInfo[35] = splats.colorSpace == SplatColorSpace.linear ? 1.0 : 0.0;
-    frameInfo[36] = splats.paramsWidth.toDouble();
-    frameInfo[37] = splats.paramsHeight.toDouble();
-    // [38], [39] reserved.
-    frameInfo[40] = splats.shWidth.toDouble();
-    frameInfo[41] = splats.shHeight.toDouble();
-    frameInfo[42] = splats.shStride.toDouble();
-    frameInfo[43] = shDegree.toDouble();
-    frameInfo[44] = viewport.width;
-    frameInfo[45] = viewport.height;
-    frameInfo[46] = antialiased ? 1.0 : 0.0;
-    frameInfo[47] = splatScale;
-    frameInfo[48] = opacity;
-    // [49..51] reserved.
-    frameInfo[52] = tint.x;
-    frameInfo[53] = tint.y;
-    frameInfo[54] = tint.z;
-    frameInfo[55] = tint.w;
+    final cropInverse = _cropInverse;
+    if (cropInverse != null) {
+      frameInfo.setRange(32, 48, cropInverse.storage);
+    }
+    frameInfo[48] = cameraPosition.x;
+    frameInfo[49] = cameraPosition.y;
+    frameInfo[50] = cameraPosition.z;
+    frameInfo[51] = splats.colorSpace == SplatColorSpace.linear ? 1.0 : 0.0;
+    frameInfo[52] = splats.paramsWidth.toDouble();
+    frameInfo[53] = splats.paramsHeight.toDouble();
+    // [54], [55] reserved.
+    frameInfo[56] = splats.shWidth.toDouble();
+    frameInfo[57] = splats.shHeight.toDouble();
+    frameInfo[58] = splats.shStride.toDouble();
+    frameInfo[59] = shDegree.toDouble();
+    frameInfo[60] = viewport.width;
+    frameInfo[61] = viewport.height;
+    frameInfo[62] = antialiased ? 1.0 : 0.0;
+    frameInfo[63] = splatScale;
+    frameInfo[64] = opacity;
+    frameInfo[65] = switch (_cropMode) {
+      SplatCropMode.none => 0.0,
+      SplatCropMode.include => 1.0,
+      SplatCropMode.exclude => 2.0,
+    };
+    // [66], [67] reserved.
+    frameInfo[68] = tint.x;
+    frameInfo[69] = tint.y;
+    frameInfo[70] = tint.z;
+    frameInfo[71] = tint.w;
     pass.bindUniform(
       vertexShader.getUniformSlot('FrameInfo'),
       transientsBuffer.emplace(ByteData.sublistView(frameInfo)),

--- a/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
@@ -29,15 +29,13 @@ enum SplatCropMode {
 /// Draws a [GaussianSplats] set as one instanced batch of screen-space
 /// Gaussian footprints.
 ///
-/// Each instance is one splat; the vertex shader fetches the splat's
+/// Each instance is one splat. The vertex shader fetches the splat's
 /// parameters from the set's data textures and expands a quad over its
-/// projected footprint. Instances draw in presorted back-to-front order; the
-/// sort runs on a background isolate and is retriggered when the view
-/// direction (in the set's local space) drifts past a small threshold, so a
-/// fast orbit can lag the true order by a few frames.
+/// projected footprint. Instances draw presorted back to front by a
+/// background sort that reruns when the view direction drifts, so a fast
+/// orbit can lag the true order by a few frames.
 ///
-/// Pair with a `SplatMaterial`; attach to the scene through a
-/// `SplatComponent`.
+/// Pair with a `SplatMaterial` and attach through a `SplatComponent`.
 /// {@category Geometry}
 class SplatGeometry extends Geometry {
   /// Creates geometry for [splats].
@@ -113,9 +111,9 @@ class SplatGeometry extends Geometry {
   // one degree (dot < cos(1.1 degrees)).
   static const double _kResortDotThreshold = 0.99982;
 
-  // The sorted-order instance buffers. A ring so a completing sort never
-  // overwrites the buffer a recent frame's command buffer may still read.
-  // Slots fill lazily; _activeSlot is the one bind() uses this frame.
+  // A ring of sorted-order instance buffers, so a completing sort never
+  // overwrites one a recent frame's command buffer may still read. Slots
+  // fill lazily; _activeSlot is the one bind() uses this frame.
   // TODO(splats): reuse slots with completion tracking (the transient
   // arena's mechanism) instead of relying on sort cadence spacing.
   static const int _kIndexRingSize = 3;
@@ -271,7 +269,7 @@ class SplatGeometry extends Geometry {
       }
     }
 
-    // Slot 0: the quad. Slot 1: the sorted splat indices, instance rate.
+    // Slot 0 is the quad, slot 1 the sorted splat indices (instance rate).
     bindGeometryBuffers(pass);
     final indexBuffer = _indexRing[_activeSlot]!;
     pass.bindVertexBuffer(
@@ -343,9 +341,9 @@ class SplatGeometry extends Geometry {
   }
 }
 
-/// The splat pipeline layout: slot 0 the per-vertex unit quad, slot 1 the
-/// per-instance splat index (a float; the broadest GLES tier has no integer
-/// vertex attributes).
+/// The splat pipeline layout, slot 0 the per-vertex unit quad and slot 1 the
+/// per-instance splat index (a float, since the broadest GLES tier has no
+/// integer vertex attributes).
 final VertexLayoutDescriptor _kSplatLayout = VertexLayoutDescriptor(
   buffers: const [
     VertexBufferDescriptor(

--- a/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
@@ -1,7 +1,6 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:flutter/foundation.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'package:flutter_scene/src/geometry/geometry.dart';
@@ -11,7 +10,7 @@ import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
 import 'package:flutter_scene/src/scene_encoder.dart';
 import 'package:flutter_scene/src/splats/gaussian_splats.dart';
 import 'package:flutter_scene/src/splats/splat_data.dart';
-import 'package:flutter_scene/src/splats/splat_sorter.dart';
+import 'package:flutter_scene/src/splats/splat_sort_service.dart';
 import 'package:flutter_scene/src/render/frame_transients.dart';
 
 /// How a crop box filters the splats of a [SplatGeometry].
@@ -130,6 +129,19 @@ class SplatGeometry extends Geometry {
   vm.Vector3? _lastSortDir;
   vm.Vector3? _pendingSortDir;
 
+  SplatSortService? _sorter;
+
+  /// Shuts down the background sorter (called when the owning component
+  /// unmounts). A later draw lazily respawns it.
+  void disposeSorter() {
+    _sorter?.dispose();
+    _sorter = null;
+    _sortInFlight = false;
+    _pendingSortDir = null;
+    // Force a fresh sort on remount.
+    _lastSortDir = null;
+  }
+
   gpu.BufferView? _quadVertices;
   gpu.BufferView? _quadIndices;
 
@@ -195,7 +207,8 @@ class SplatGeometry extends Geometry {
 
   // Kicks a background sort along [dirLocal] (the local-space direction of
   // increasing view depth), coalescing to the latest request while one is
-  // in flight.
+  // in flight. The sorter worker holds its own copy of the positions, so a
+  // request ships twelve bytes out and the order transfers back.
   void _requestSort(vm.Vector3 dirLocal) {
     if (_sortInFlight) {
       _pendingSortDir = dirLocal;
@@ -204,16 +217,13 @@ class SplatGeometry extends Geometry {
     _sortInFlight = true;
     _lastSortDir = dirLocal;
     final generation = ++_sortGeneration;
-    // TODO(splats): a long-lived sorter isolate would avoid re-sending the
-    // positions array on every sort (compute copies its arguments).
-    compute(sortSplatsForIsolate, (
-      positions: splats.data.positions,
-      count: splats.count,
-      dirX: dirLocal.x,
-      dirY: dirLocal.y,
-      dirZ: dirLocal.z,
-    ), debugLabel: 'sortSplats').then((order) {
+    final sorter = _sorter ??= SplatSortService(
+      splats.data.positions,
+      splats.count,
+    );
+    sorter.sort(dirLocal.x, dirLocal.y, dirLocal.z).then((order) {
       _sortInFlight = false;
+      if (order == null) return; // Disposed mid-sort.
       if (generation != _sortGeneration) return;
       final slot = (_activeSlot + 1) % _kIndexRingSize;
       final bytes = ByteData.sublistView(order);

--- a/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
@@ -13,8 +13,8 @@ import 'package:flutter_scene/src/splats/splat_data.dart';
 import 'package:flutter_scene/src/splats/splat_sort_service.dart';
 import 'package:flutter_scene/src/render/frame_transients.dart';
 
-/// How a crop box filters the splats of a [SplatGeometry].
-/// {@category Geometry}
+/// How a crop box filters the splats of a `SplatComponent`.
+/// {@category Gaussian splatting}
 enum SplatCropMode {
   /// No crop; every splat draws.
   none,

--- a/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
@@ -1,0 +1,307 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'package:flutter_scene/src/geometry/geometry.dart';
+import 'package:flutter_scene/src/geometry/vertex_layout.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
+import 'package:flutter_scene/src/scene_encoder.dart';
+import 'package:flutter_scene/src/splats/gaussian_splats.dart';
+import 'package:flutter_scene/src/splats/splat_data.dart';
+import 'package:flutter_scene/src/splats/splat_sorter.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
+
+/// Draws a [GaussianSplats] set as one instanced batch of screen-space
+/// Gaussian footprints.
+///
+/// Each instance is one splat; the vertex shader fetches the splat's
+/// parameters from the set's data textures and expands a quad over its
+/// projected footprint. Instances draw in presorted back-to-front order; the
+/// sort runs on a background isolate and is retriggered when the view
+/// direction (in the set's local space) drifts past a small threshold, so a
+/// fast orbit can lag the true order by a few frames.
+///
+/// Pair with a `SplatMaterial`; attach to the scene through a
+/// `SplatComponent`.
+/// {@category Geometry}
+class SplatGeometry extends Geometry {
+  /// Creates geometry for [splats].
+  SplatGeometry(this.splats) {
+    setVertexShaderName('SplatsVertex');
+    final bounds = splats.bounds;
+    if (bounds != null) {
+      final center = (bounds.min + bounds.max) * 0.5;
+      final radius = (bounds.max - bounds.min).length * 0.5;
+      setLocalBounds(bounds, vm.Sphere.centerRadius(center, radius));
+    }
+  }
+
+  /// The splat set this geometry draws.
+  final GaussianSplats splats;
+
+  /// Global opacity multiplier in [0, 1].
+  double opacity = 1.0;
+
+  /// Multiplier on every splat's footprint (standard deviation), 1 is the
+  /// captured size.
+  double splatScale = 1.0;
+
+  /// Linear RGBA tint multiplied into every splat.
+  vm.Vector4 tint = vm.Vector4(1.0, 1.0, 1.0, 1.0);
+
+  /// Whether the low-pass kernel compensates opacity so distant splats dim
+  /// instead of shimmering (the anti-aliased rasterization convention).
+  bool antialiased = true;
+
+  int _shDegree = 2;
+
+  /// The spherical-harmonic degree evaluated per splat, clamped to what the
+  /// set carries. Lowering it cheapens the vertex stage.
+  int get shDegree => math.min(_shDegree, splats.data.shDegree);
+  set shDegree(int value) {
+    _shDegree = value.clamp(0, 2);
+  }
+
+  // Re-sort when the local-space view direction rotates by more than about
+  // one degree (dot < cos(1.1 degrees)).
+  static const double _kResortDotThreshold = 0.99982;
+
+  // The sorted-order instance buffers. A ring so a completing sort never
+  // overwrites the buffer a recent frame's command buffer may still read.
+  // Slots fill lazily; _activeSlot is the one bind() uses this frame.
+  // TODO(splats): reuse slots with completion tracking (the transient
+  // arena's mechanism) instead of relying on sort cadence spacing.
+  static const int _kIndexRingSize = 3;
+  final List<gpu.DeviceBuffer?> _indexRing = List<gpu.DeviceBuffer?>.filled(
+    _kIndexRingSize,
+    null,
+  );
+  int _activeSlot = 0;
+  int _sortGeneration = 0;
+  bool _sortInFlight = false;
+  vm.Vector3? _lastSortDir;
+  vm.Vector3? _pendingSortDir;
+
+  gpu.BufferView? _quadVertices;
+  gpu.BufferView? _quadIndices;
+
+  static const int _kQuadIndexCount = 6;
+
+  final gpu.SamplerOptions _dataSampler = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.nearest,
+    magFilter: gpu.MinMagFilter.nearest,
+    mipFilter: gpu.MipFilter.nearest,
+    widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+    heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  );
+
+  @override
+  VertexLayoutDescriptor? get instancedVertexLayout => _kSplatLayout;
+
+  // The splat index arrives through the slot-1 instance buffer; the model
+  // transform rides the FrameInfo uniform.
+  @override
+  bool get bindsModelTransformInstance => false;
+
+  // A screen-space footprint has no meaningful winding.
+  @override
+  bool get isDoubleSided => true;
+
+  void _ensureGpuResources() {
+    if (_quadVertices != null) return;
+
+    // The unit quad, corners in [-1, 1] (two triangles, shared by every
+    // draw of this geometry).
+    final verts = Float32List.fromList(<double>[-1, -1, 1, -1, -1, 1, 1, 1]);
+    final indices = Uint16List.fromList(<int>[0, 1, 2, 2, 1, 3]);
+    final vBuffer = gpu.gpuContext.createDeviceBufferWithCopy(
+      ByteData.sublistView(verts),
+    );
+    final iBuffer = gpu.gpuContext.createDeviceBufferWithCopy(
+      ByteData.sublistView(indices),
+    );
+    _quadVertices = gpu.BufferView(
+      vBuffer,
+      offsetInBytes: 0,
+      lengthInBytes: verts.lengthInBytes,
+    );
+    _quadIndices = gpu.BufferView(
+      iBuffer,
+      offsetInBytes: 0,
+      lengthInBytes: indices.lengthInBytes,
+    );
+    setVertices(_quadVertices!, 4);
+    setIndices(_quadIndices!, gpu.IndexType.int16);
+
+    // Slot 0 starts as identity order so the set renders (approximately)
+    // before the first sort lands.
+    final identity = Float32List(splats.count);
+    for (var i = 0; i < identity.length; i++) {
+      identity[i] = i.toDouble();
+    }
+    _indexRing[0] = gpu.gpuContext.createDeviceBufferWithCopy(
+      ByteData.sublistView(identity),
+    );
+    _activeSlot = 0;
+  }
+
+  // Kicks a background sort along [dirLocal] (the local-space direction of
+  // increasing view depth), coalescing to the latest request while one is
+  // in flight.
+  void _requestSort(vm.Vector3 dirLocal) {
+    if (_sortInFlight) {
+      _pendingSortDir = dirLocal;
+      return;
+    }
+    _sortInFlight = true;
+    _lastSortDir = dirLocal;
+    final generation = ++_sortGeneration;
+    // TODO(splats): a long-lived sorter isolate would avoid re-sending the
+    // positions array on every sort (compute copies its arguments).
+    compute(sortSplatsForIsolate, (
+      positions: splats.data.positions,
+      count: splats.count,
+      dirX: dirLocal.x,
+      dirY: dirLocal.y,
+      dirZ: dirLocal.z,
+    ), debugLabel: 'sortSplats').then((order) {
+      _sortInFlight = false;
+      if (generation != _sortGeneration) return;
+      final slot = (_activeSlot + 1) % _kIndexRingSize;
+      final bytes = ByteData.sublistView(order);
+      final buffer =
+          _indexRing[slot] ??
+          gpu.gpuContext.createDeviceBuffer(
+            gpu.StorageMode.hostVisible,
+            splats.count * 4,
+          );
+      buffer.overwrite(bytes);
+      _indexRing[slot] = buffer;
+      _activeSlot = slot;
+      final pending = _pendingSortDir;
+      _pendingSortDir = null;
+      if (pending != null) _requestSort(pending);
+    });
+  }
+
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    TransientWriter transientsBuffer,
+    vm.Matrix4 modelTransform,
+    vm.Matrix4 cameraTransform,
+    vm.Vector3 cameraPosition, {
+    // Splats use the engine's splat vertex shader; custom material vertex
+    // variants do not apply, so this override is accepted and ignored.
+    gpu.Shader? shaderOverride,
+  }) {
+    if (splats.count == 0) return;
+    _ensureGpuResources();
+
+    final mvp = cameraTransform * modelTransform;
+
+    // The MVP's w row measures view depth per unit of local position, so its
+    // xyz is the local-space sort direction. Ordering along a direction is
+    // unaffected by camera translation, so only rotation triggers a re-sort.
+    final storage = mvp.storage;
+    final sortDir = vm.Vector3(storage[3], storage[7], storage[11]);
+    if (sortDir.length2 > 1e-12) {
+      sortDir.normalize();
+      final last = _lastSortDir;
+      if (last == null || last.dot(sortDir) < _kResortDotThreshold) {
+        _requestSort(sortDir);
+      }
+    }
+
+    // Slot 0: the quad. Slot 1: the sorted splat indices, instance rate.
+    bindGeometryBuffers(pass);
+    final indexBuffer = _indexRing[_activeSlot]!;
+    pass.bindVertexBuffer(
+      gpu.BufferView(
+        indexBuffer,
+        offsetInBytes: 0,
+        lengthInBytes: splats.count * 4,
+      ),
+      slot: 1,
+    );
+
+    pass.bindTexture(
+      vertexShader.getUniformSlot('splat_params_texture'),
+      splats.paramsTexture,
+      sampler: _dataSampler,
+    );
+    // The SH slot must always be bound; a set with no rest coefficients
+    // binds the params texture as a placeholder (degree 0 never samples it).
+    pass.bindTexture(
+      vertexShader.getUniformSlot('splat_sh_texture'),
+      splats.shTexture ?? splats.paramsTexture,
+      sampler: _dataSampler,
+    );
+
+    final viewport = currentSceneEncoderViewport;
+    final frameInfo = Float32List(56);
+    frameInfo.setRange(0, 16, mvp.storage);
+    frameInfo.setRange(16, 32, modelTransform.storage);
+    frameInfo[32] = cameraPosition.x;
+    frameInfo[33] = cameraPosition.y;
+    frameInfo[34] = cameraPosition.z;
+    frameInfo[35] = splats.colorSpace == SplatColorSpace.linear ? 1.0 : 0.0;
+    frameInfo[36] = splats.paramsWidth.toDouble();
+    frameInfo[37] = splats.paramsHeight.toDouble();
+    // [38], [39] reserved.
+    frameInfo[40] = splats.shWidth.toDouble();
+    frameInfo[41] = splats.shHeight.toDouble();
+    frameInfo[42] = splats.shStride.toDouble();
+    frameInfo[43] = shDegree.toDouble();
+    frameInfo[44] = viewport.width;
+    frameInfo[45] = viewport.height;
+    frameInfo[46] = antialiased ? 1.0 : 0.0;
+    frameInfo[47] = splatScale;
+    frameInfo[48] = opacity;
+    // [49..51] reserved.
+    frameInfo[52] = tint.x;
+    frameInfo[53] = tint.y;
+    frameInfo[54] = tint.z;
+    frameInfo[55] = tint.w;
+    pass.bindUniform(
+      vertexShader.getUniformSlot('FrameInfo'),
+      transientsBuffer.emplace(ByteData.sublistView(frameInfo)),
+    );
+  }
+
+  @override
+  void draw(gpu.RenderPass pass, {int instanceCount = 1}) {
+    if (splats.count == 0) return;
+    drawIndexedCompat(pass, _kQuadIndexCount, instanceCount: splats.count);
+  }
+}
+
+/// The splat pipeline layout: slot 0 the per-vertex unit quad, slot 1 the
+/// per-instance splat index (a float; the broadest GLES tier has no integer
+/// vertex attributes).
+final VertexLayoutDescriptor _kSplatLayout = VertexLayoutDescriptor(
+  buffers: const [
+    VertexBufferDescriptor(
+      strideInBytes: 8,
+      attributes: [
+        VertexAttributeDescriptor(
+          name: 'corner',
+          format: gpu.VertexFormat.float32x2,
+        ),
+      ],
+    ),
+    VertexBufferDescriptor(
+      strideInBytes: 4,
+      stepMode: gpu.VertexStepMode.instance,
+      attributes: [
+        VertexAttributeDescriptor(
+          name: 'splat_index',
+          format: gpu.VertexFormat.float32,
+        ),
+      ],
+    ),
+  ],
+);

--- a/packages/flutter_scene/lib/src/material/splat_material.dart
+++ b/packages/flutter_scene/lib/src/material/splat_material.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/shaders.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
+
+/// The material for `SplatGeometry`: evaluates the Gaussian falloff over
+/// each footprint and outputs linear HDR premultiplied alpha.
+///
+/// Splats are always translucent (drawn depth-sorted in the renderer's
+/// translucent phase, skipping the shadow and depth passes) and unlit; the
+/// captured colors already bake in the capture's lighting. All tuning knobs
+/// (opacity, tint, footprint scale, SH degree) live on the geometry, which
+/// owns the per-splat data.
+/// {@category Materials}
+class SplatMaterial extends Material {
+  /// Creates a [SplatMaterial] wrapping the `SplatsFragment` shader from
+  /// [baseShaderLibrary].
+  SplatMaterial() {
+    setFragmentShaderName('SplatsFragment');
+  }
+
+  // Splats always blend and never write depth or cast shadows.
+  @override
+  bool isOpaque() => false;
+
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    TransientWriter transientsBuffer,
+    Lighting lighting,
+  ) {
+    super.bind(pass, transientsBuffer, lighting);
+    // A screen-space footprint has no meaningful winding; cull nothing.
+    pass.setCullMode(gpu.CullMode.none);
+    // The fragment stage reads only varyings; there are no material
+    // uniforms to bind.
+  }
+}

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -65,6 +65,15 @@ base class _TranslucentRecord {
   final int lightListCount;
 }
 
+/// The viewport size of the scene color pass currently being encoded.
+///
+/// Set by [SceneEncoder] at construction and read by geometry whose
+/// projection math needs the pixel scale (splat footprints). Encoding is
+/// single-threaded, so a frame-scoped module value is safe.
+/// TODO(splats): thread the viewport through `Geometry.bind` instead once
+/// another consumer appears.
+ui.Size currentSceneEncoderViewport = ui.Size.zero;
+
 /// Render pipelines keyed by their (vertex shader, fragment shader, vertex
 /// layout) triple.
 ///
@@ -150,6 +159,7 @@ base class SceneEncoder {
     this._layerMask,
   ) : _renderPass = renderPass,
       _transientsBuffer = transientsBuffer {
+    currentSceneEncoderViewport = dimensions;
     _cameraTransform = _camera.getViewTransform(dimensions);
     frustum = Frustum.matrix(_cameraTransform);
     // The screen-size LOD metric is perspective-specific; with any other

--- a/packages/flutter_scene/lib/src/splats/gaussian_splats.dart
+++ b/packages/flutter_scene/lib/src/splats/gaussian_splats.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/splats/splat_codec.dart';
+import 'package:flutter_scene/src/splats/splat_data.dart';
+
+/// A loaded Gaussian splat set: the decoded splat arrays plus the GPU
+/// textures the splat shaders fetch from.
+///
+/// Load one with [fromAsset] or [fromBytes] (file decoding and texel packing
+/// run on a background isolate), or build one procedurally with [fromData].
+/// Attach it to the scene through a `SplatComponent`.
+///
+/// The GPU textures are created lazily on first draw, so a
+/// `GaussianSplats` can be constructed before
+/// `Scene.initializeStaticResources` completes.
+/// {@category Geometry}
+class GaussianSplats {
+  GaussianSplats._(PackedSplats packed, this.colorSpace)
+    : data = packed.data,
+      paramsWidth = packed.paramsWidth,
+      paramsHeight = packed.paramsHeight,
+      shWidth = packed.shWidth,
+      shHeight = packed.shHeight,
+      shStride = packed.shStride,
+      _paramsTexels = packed.paramsTexels,
+      _shTexels = packed.shTexels {
+    bounds = data.computeBounds();
+  }
+
+  /// Wraps an already-decoded-and-packed splat set.
+  factory GaussianSplats.fromPacked(
+    PackedSplats packed, {
+    SplatColorSpace colorSpace = SplatColorSpace.displayReferred,
+  }) => GaussianSplats._(packed, colorSpace);
+
+  /// Packs [data] (procedurally constructed splats) synchronously on the
+  /// calling thread.
+  ///
+  /// Procedural colors are usually already linear, so [colorSpace] defaults
+  /// to [SplatColorSpace.linear]. For large captured sets prefer [fromBytes],
+  /// which decodes and packs off-thread.
+  factory GaussianSplats.fromData(
+    SplatData data, {
+    SplatColorSpace colorSpace = SplatColorSpace.linear,
+  }) => GaussianSplats._(packSplats(data), colorSpace);
+
+  /// Loads and decodes a splat file from the asset bundle.
+  ///
+  /// The format is sniffed from the file magic, falling back to the asset
+  /// extension (`.ply` vs `.splat`); pass [format] to override. Decoding and
+  /// packing run on a background isolate.
+  static Future<GaussianSplats> fromAsset(
+    String assetPath, {
+    SplatFormat? format,
+    double alphaCullThreshold = 1.0 / 255.0,
+    int maxShDegree = 2,
+    SplatColorSpace colorSpace = SplatColorSpace.displayReferred,
+  }) async {
+    final bytes = await rootBundle.load(assetPath);
+    return fromBytes(
+      bytes.buffer.asUint8List(bytes.offsetInBytes, bytes.lengthInBytes),
+      format:
+          format ??
+          (assetPath.toLowerCase().endsWith('.ply')
+              ? SplatFormat.ply
+              : SplatFormat.splat),
+      alphaCullThreshold: alphaCullThreshold,
+      maxShDegree: maxShDegree,
+      colorSpace: colorSpace,
+    );
+  }
+
+  /// Decodes splat file [bytes] on a background isolate.
+  static Future<GaussianSplats> fromBytes(
+    Uint8List bytes, {
+    SplatFormat? format,
+    double alphaCullThreshold = 1.0 / 255.0,
+    int maxShDegree = 2,
+    SplatColorSpace colorSpace = SplatColorSpace.displayReferred,
+  }) async {
+    final sniffed = sniffSplatFormat(bytes, fallback: format);
+    final packed = await compute(decodeSplatsForIsolate, (
+      bytes: bytes,
+      format: sniffed,
+      alphaCullThreshold: alphaCullThreshold,
+      maxShDegree: maxShDegree,
+    ), debugLabel: 'decodeSplats');
+    return GaussianSplats._(packed, colorSpace);
+  }
+
+  /// The decoded splat arrays (positions drive depth sorting; the rest are
+  /// kept for bounds and readback).
+  final SplatData data;
+
+  /// How [data]'s colors map into the linear HDR pipeline.
+  final SplatColorSpace colorSpace;
+
+  /// Local-space bounds of the set (splat centers padded by three standard
+  /// deviations), or null for an empty set.
+  late final vm.Aabb3? bounds;
+
+  /// The number of splats.
+  int get count => data.count;
+
+  /// Parameter texture dimensions in texels.
+  final int paramsWidth;
+  final int paramsHeight;
+
+  /// Rest-SH texture dimensions and per-splat texel stride (zero when the
+  /// set carries no rest coefficients).
+  final int shWidth;
+  final int shHeight;
+  final int shStride;
+
+  // Texel arrays are held only until the first upload, then released.
+  Float32List? _paramsTexels;
+  Float32List? _shTexels;
+
+  gpu.Texture? _paramsTexture;
+  gpu.Texture? _shTexture;
+
+  /// The RGBA32F parameter texture ([kParamsTexelsPerSplat] texels per
+  /// splat). Created on first access; requires the GPU context.
+  gpu.Texture get paramsTexture {
+    var texture = _paramsTexture;
+    if (texture == null) {
+      texture = _upload(_paramsTexels!, paramsWidth, paramsHeight);
+      _paramsTexture = texture;
+      _paramsTexels = null;
+    }
+    return texture;
+  }
+
+  /// The RGBA32F rest-SH texture, or null when [SplatData.shDegree] is 0.
+  gpu.Texture? get shTexture {
+    if (data.shDegree == 0) return null;
+    var texture = _shTexture;
+    if (texture == null) {
+      texture = _upload(_shTexels!, shWidth, shHeight);
+      _shTexture = texture;
+      _shTexels = null;
+    }
+    return texture;
+  }
+
+  static gpu.Texture _upload(Float32List texels, int width, int height) {
+    final texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.hostVisible,
+      width,
+      height,
+      format: gpu.PixelFormat.r32g32b32a32Float,
+    );
+    texture.overwrite(ByteData.sublistView(texels));
+    return texture;
+  }
+}

--- a/packages/flutter_scene/lib/src/splats/gaussian_splats.dart
+++ b/packages/flutter_scene/lib/src/splats/gaussian_splats.dart
@@ -6,16 +6,15 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/splats/splat_codec.dart';
 import 'package:flutter_scene/src/splats/splat_data.dart';
 
-/// A loaded Gaussian splat set: the decoded splat arrays plus the GPU
-/// textures the splat shaders fetch from.
+/// A loaded Gaussian splat set, the decoded arrays plus the GPU textures the
+/// splat shaders fetch from.
 ///
-/// Load one with [fromAsset] or [fromBytes] (file decoding and texel packing
-/// run on a background isolate), or build one procedurally with [fromData].
-/// Attach it to the scene through a `SplatComponent`.
+/// Load one with [fromAsset] or [fromBytes] (decoded and packed on a
+/// background isolate), or build one procedurally with [fromData], then
+/// attach it through a `SplatComponent`.
 ///
-/// The GPU textures are created lazily on first draw, so a
-/// `GaussianSplats` can be constructed before
-/// `Scene.initializeStaticResources` completes.
+/// The GPU textures are created lazily on first draw, so a `GaussianSplats`
+/// can be constructed before `Scene.initializeStaticResources` completes.
 /// {@category Gaussian splatting}
 class GaussianSplats {
   GaussianSplats._(PackedSplats packed, this.colorSpace)

--- a/packages/flutter_scene/lib/src/splats/gaussian_splats.dart
+++ b/packages/flutter_scene/lib/src/splats/gaussian_splats.dart
@@ -16,7 +16,7 @@ import 'package:flutter_scene/src/splats/splat_data.dart';
 /// The GPU textures are created lazily on first draw, so a
 /// `GaussianSplats` can be constructed before
 /// `Scene.initializeStaticResources` completes.
-/// {@category Geometry}
+/// {@category Gaussian splatting}
 class GaussianSplats {
   GaussianSplats._(PackedSplats packed, this.colorSpace)
     : data = packed.data,
@@ -30,7 +30,9 @@ class GaussianSplats {
     bounds = data.computeBounds();
   }
 
-  /// Wraps an already-decoded-and-packed splat set.
+  /// Wraps an already-decoded-and-packed splat set. Takes the internal
+  /// packer output, so it is not application API.
+  @internal
   factory GaussianSplats.fromPacked(
     PackedSplats packed, {
     SplatColorSpace colorSpace = SplatColorSpace.displayReferred,
@@ -105,14 +107,27 @@ class GaussianSplats {
   /// The number of splats.
   int get count => data.count;
 
-  /// Parameter texture dimensions in texels.
+  /// Parameter texture dimensions in texels. Consumed by `SplatGeometry` to
+  /// address the data texture; not application API.
+  @internal
   final int paramsWidth;
+
+  /// See [paramsWidth].
+  @internal
   final int paramsHeight;
 
   /// Rest-SH texture dimensions and per-splat texel stride (zero when the
-  /// set carries no rest coefficients).
+  /// set carries no rest coefficients). Consumed by `SplatGeometry`; not
+  /// application API.
+  @internal
   final int shWidth;
+
+  /// See [shWidth].
+  @internal
   final int shHeight;
+
+  /// See [shWidth].
+  @internal
   final int shStride;
 
   // Texel arrays are held only until the first upload, then released.
@@ -123,7 +138,9 @@ class GaussianSplats {
   gpu.Texture? _shTexture;
 
   /// The RGBA32F parameter texture ([kParamsTexelsPerSplat] texels per
-  /// splat). Created on first access; requires the GPU context.
+  /// splat). Created on first access; requires the GPU context. Consumed by
+  /// `SplatGeometry`; not application API.
+  @internal
   gpu.Texture get paramsTexture {
     var texture = _paramsTexture;
     if (texture == null) {
@@ -135,6 +152,8 @@ class GaussianSplats {
   }
 
   /// The RGBA32F rest-SH texture, or null when [SplatData.shDegree] is 0.
+  /// Consumed by `SplatGeometry`; not application API.
+  @internal
   gpu.Texture? get shTexture {
     if (data.shDegree == 0) return null;
     var texture = _shTexture;

--- a/packages/flutter_scene/lib/src/splats/splat_codec.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_codec.dart
@@ -1,0 +1,545 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/splats/splat_data.dart';
+
+/// The splat file formats the runtime loader understands.
+/// {@category Geometry}
+enum SplatFormat {
+  /// An uncompressed Gaussian-splat PLY (binary little-endian), the training
+  /// interchange layout: `x y z ... f_dc_* f_rest_* opacity scale_* rot_*`.
+  ply,
+
+  /// The compact 32-byte-per-splat `.splat` layout common in web pipelines:
+  /// float position and scale, 8-bit color/opacity, 8-bit quaternion.
+  splat,
+}
+
+/// Options applied while decoding a splat file.
+class SplatDecodeOptions {
+  const SplatDecodeOptions({
+    this.alphaCullThreshold = 1.0 / 255.0,
+    this.maxShDegree = 2,
+  });
+
+  /// Splats whose decoded opacity falls below this are dropped at load.
+  final double alphaCullThreshold;
+
+  /// The highest spherical-harmonic degree to keep (0 to 2). Coefficients
+  /// beyond it are discarded at load, saving GPU memory.
+  final int maxShDegree;
+}
+
+/// A decoded splat set together with its GPU-ready texel arrays.
+///
+/// Produced by [decodeSplats] (usually on a background isolate); consumed by
+/// `GaussianSplats`, which uploads the texel arrays verbatim.
+class PackedSplats {
+  PackedSplats({
+    required this.data,
+    required this.paramsTexels,
+    required this.paramsWidth,
+    required this.paramsHeight,
+    this.shTexels,
+    this.shWidth = 0,
+    this.shHeight = 0,
+    this.shStride = 0,
+  });
+
+  /// The decoded splat arrays (kept for sorting, bounds, and readback).
+  final SplatData data;
+
+  /// RGBA32F texels for the parameter texture, [kParamsTexelsPerSplat]
+  /// consecutive texels per splat:
+  /// `pos.xyz, opacity | cov.xx,xy,xz,yy | cov.yz,zz,0,0 | color.rgb, 0`.
+  final Float32List paramsTexels;
+
+  /// Parameter texture dimensions. The width is a power of two so the
+  /// per-splat texel groups never straddle a row.
+  final int paramsWidth;
+  final int paramsHeight;
+
+  /// RGBA32F texels for the rest-SH texture ([shStride] texels per splat,
+  /// one coefficient's `r, g, b` per texel), or null when the set carries
+  /// no rest coefficients.
+  final Float32List? shTexels;
+  final int shWidth;
+  final int shHeight;
+
+  /// Texels per splat in the SH texture (4 for degree 1, 8 for degree 2;
+  /// a power of two so groups never straddle rows).
+  final int shStride;
+}
+
+/// Texels per splat in the parameter texture.
+const int kParamsTexelsPerSplat = 4;
+
+/// The widest data texture the packer will emit. 4096 is universally
+/// supported by the backends flutter_scene ships on.
+const int kMaxSplatTextureWidth = 4096;
+
+/// The degree-0 spherical-harmonic basis constant.
+const double kShC0 = 0.28209479177387814;
+
+/// Decodes [bytes] as [format] and packs the result into GPU-ready texel
+/// arrays. Pure and allocation-only, so it can run on a background isolate
+/// (`compute`).
+PackedSplats decodeSplats(
+  Uint8List bytes,
+  SplatFormat format, {
+  SplatDecodeOptions options = const SplatDecodeOptions(),
+}) {
+  final data = switch (format) {
+    SplatFormat.ply => parseSplatPly(bytes, options: options),
+    SplatFormat.splat => parseSplatFile(bytes, options: options),
+  };
+  return packSplats(data);
+}
+
+/// The top-level `compute` entry point for [decodeSplats].
+PackedSplats decodeSplatsForIsolate(
+  ({
+    Uint8List bytes,
+    SplatFormat format,
+    double alphaCullThreshold,
+    int maxShDegree,
+  })
+  args,
+) {
+  return decodeSplats(
+    args.bytes,
+    args.format,
+    options: SplatDecodeOptions(
+      alphaCullThreshold: args.alphaCullThreshold,
+      maxShDegree: args.maxShDegree,
+    ),
+  );
+}
+
+/// Parses a binary little-endian Gaussian-splat PLY.
+///
+/// Recognizes the training layout's properties by name (`x`, `f_dc_0`,
+/// `f_rest_*`, `opacity`, `scale_*`, `rot_*`); other float properties are
+/// skipped by stride. Applies the training-space transforms: `exp` on
+/// scales, sigmoid on opacity, `0.5 + C0 * f_dc` on the base color, and
+/// quaternion normalization.
+SplatData parseSplatPly(
+  Uint8List bytes, {
+  SplatDecodeOptions options = const SplatDecodeOptions(),
+}) {
+  final header = _parsePlyHeader(bytes);
+  final props = header.properties;
+
+  int require(String name) {
+    final offset = props[name];
+    if (offset == null) {
+      throw FormatException('Splat PLY is missing property "$name".');
+    }
+    return offset;
+  }
+
+  final xOff = require('x'), yOff = require('y'), zOff = require('z');
+  final dc0 = require('f_dc_0'),
+      dc1 = require('f_dc_1'),
+      dc2 = require('f_dc_2');
+  final opacityOff = require('opacity');
+  final s0 = require('scale_0'),
+      s1 = require('scale_1'),
+      s2 = require('scale_2');
+  final r0 = require('rot_0'),
+      r1 = require('rot_1'),
+      r2 = require('rot_2'),
+      r3 = require('rot_3');
+
+  // The f_rest count determines the file's SH degree. The PLY stores rest
+  // coefficients channel-major (all R coefficients, then G, then B).
+  var fileRest = 0;
+  while (props.containsKey('f_rest_$fileRest')) {
+    fileRest++;
+  }
+  final restPerChannel = fileRest ~/ 3;
+  final fileDegree = switch (restPerChannel) {
+    0 => 0,
+    3 => 1,
+    8 => 2,
+    15 => 3,
+    _ => throw FormatException(
+      'Splat PLY has an unexpected f_rest count ($fileRest).',
+    ),
+  };
+  final degree = math.min(math.min(fileDegree, options.maxShDegree), 2);
+  final keptRest = SplatData.shRestCoeffCount(degree);
+
+  final stride = header.strideInBytes;
+  final view = ByteData.sublistView(bytes, header.dataOffset);
+  final total = header.vertexCount;
+  if (view.lengthInBytes < total * stride) {
+    throw FormatException('Splat PLY is truncated.');
+  }
+
+  // First pass: count survivors of the alpha cull so the arrays allocate
+  // exactly once.
+  var kept = 0;
+  for (var i = 0; i < total; i++) {
+    final op = _sigmoid(
+      view.getFloat32(i * stride + opacityOff, Endian.little),
+    );
+    if (op >= options.alphaCullThreshold) kept++;
+  }
+
+  final out = SplatData.zeroed(kept, shDegree: degree);
+  final sh = out.sh;
+  final restBase = sh != null ? require('f_rest_0') : 0;
+  var w = 0;
+  for (var i = 0; i < total; i++) {
+    final base = i * stride;
+    final opacity = _sigmoid(view.getFloat32(base + opacityOff, Endian.little));
+    if (opacity < options.alphaCullThreshold) continue;
+
+    final p = w * 3;
+    out.positions[p] = view.getFloat32(base + xOff, Endian.little);
+    out.positions[p + 1] = view.getFloat32(base + yOff, Endian.little);
+    out.positions[p + 2] = view.getFloat32(base + zOff, Endian.little);
+
+    out.scales[p] = math.exp(view.getFloat32(base + s0, Endian.little));
+    out.scales[p + 1] = math.exp(view.getFloat32(base + s1, Endian.little));
+    out.scales[p + 2] = math.exp(view.getFloat32(base + s2, Endian.little));
+
+    out.colors[p] = 0.5 + kShC0 * view.getFloat32(base + dc0, Endian.little);
+    out.colors[p + 1] =
+        0.5 + kShC0 * view.getFloat32(base + dc1, Endian.little);
+    out.colors[p + 2] =
+        0.5 + kShC0 * view.getFloat32(base + dc2, Endian.little);
+
+    // rot_0 is the scalar (w) in the training layout; store x, y, z, w.
+    final qw = view.getFloat32(base + r0, Endian.little);
+    final qx = view.getFloat32(base + r1, Endian.little);
+    final qy = view.getFloat32(base + r2, Endian.little);
+    final qz = view.getFloat32(base + r3, Endian.little);
+    final qn = math.sqrt(qw * qw + qx * qx + qy * qy + qz * qz);
+    final inv = qn > 0 ? 1.0 / qn : 0.0;
+    final q = w * 4;
+    out.rotations[q] = qx * inv;
+    out.rotations[q + 1] = qy * inv;
+    out.rotations[q + 2] = qz * inv;
+    out.rotations[q + 3] = qw * inv;
+
+    out.opacities[w] = opacity;
+
+    if (sh != null) {
+      final shOut = w * keptRest * 3;
+      for (var c = 0; c < keptRest; c++) {
+        for (var ch = 0; ch < 3; ch++) {
+          // Channel-major in the file: coefficient c of channel ch is at
+          // rest index ch * restPerChannel + c.
+          sh[shOut + c * 3 + ch] = view.getFloat32(
+            base + restBase + (ch * restPerChannel + c) * 4,
+            Endian.little,
+          );
+        }
+      }
+    }
+    w++;
+  }
+  return out;
+}
+
+/// Parses the 32-byte-per-splat `.splat` layout.
+///
+/// Colors and opacity are 8-bit (color already includes the degree-0 SH
+/// term); the quaternion is 8-bit with the scalar first, matching the
+/// training PLY's `rot_*` order. The format carries no rest SH.
+SplatData parseSplatFile(
+  Uint8List bytes, {
+  SplatDecodeOptions options = const SplatDecodeOptions(),
+}) {
+  const stride = 32;
+  if (bytes.length % stride != 0) {
+    throw FormatException('.splat data length is not a multiple of 32.');
+  }
+  final total = bytes.length ~/ stride;
+  final view = ByteData.sublistView(bytes);
+
+  var kept = 0;
+  for (var i = 0; i < total; i++) {
+    if (bytes[i * stride + 27] / 255.0 >= options.alphaCullThreshold) kept++;
+  }
+
+  final out = SplatData.zeroed(kept);
+  var w = 0;
+  for (var i = 0; i < total; i++) {
+    final base = i * stride;
+    final opacity = bytes[base + 27] / 255.0;
+    if (opacity < options.alphaCullThreshold) continue;
+
+    final p = w * 3;
+    out.positions[p] = view.getFloat32(base, Endian.little);
+    out.positions[p + 1] = view.getFloat32(base + 4, Endian.little);
+    out.positions[p + 2] = view.getFloat32(base + 8, Endian.little);
+    out.scales[p] = view.getFloat32(base + 12, Endian.little);
+    out.scales[p + 1] = view.getFloat32(base + 16, Endian.little);
+    out.scales[p + 2] = view.getFloat32(base + 20, Endian.little);
+    out.colors[p] = bytes[base + 24] / 255.0;
+    out.colors[p + 1] = bytes[base + 25] / 255.0;
+    out.colors[p + 2] = bytes[base + 26] / 255.0;
+    out.opacities[w] = opacity;
+
+    final qw = (bytes[base + 28] - 128) / 128.0;
+    final qx = (bytes[base + 29] - 128) / 128.0;
+    final qy = (bytes[base + 30] - 128) / 128.0;
+    final qz = (bytes[base + 31] - 128) / 128.0;
+    final qn = math.sqrt(qw * qw + qx * qx + qy * qy + qz * qz);
+    final inv = qn > 0 ? 1.0 / qn : 0.0;
+    final q = w * 4;
+    out.rotations[q] = qx * inv;
+    out.rotations[q + 1] = qy * inv;
+    out.rotations[q + 2] = qz * inv;
+    out.rotations[q + 3] = qw * inv;
+    w++;
+  }
+  return out;
+}
+
+/// Packs [data] into the RGBA32F texel arrays the splat shaders fetch.
+///
+/// The 3D covariance is precomputed here (`M = R * S`, `Sigma = M * Mt`) so
+/// the vertex shader fetches six floats instead of rebuilding it from the
+/// quaternion and scales per vertex.
+PackedSplats packSplats(SplatData data) {
+  final count = data.count;
+  final paramsWidth = _textureWidthFor(count * kParamsTexelsPerSplat);
+  final paramsHeight = math.max(
+    1,
+    ((count * kParamsTexelsPerSplat) / paramsWidth).ceil(),
+  );
+  _checkTextureHeight(paramsHeight, 'parameter');
+  final params = Float32List(paramsWidth * paramsHeight * 4);
+
+  for (var i = 0; i < count; i++) {
+    final p = i * 3, q = i * 4;
+    final sx = data.scales[p], sy = data.scales[p + 1], sz = data.scales[p + 2];
+    final x = data.rotations[q],
+        y = data.rotations[q + 1],
+        z = data.rotations[q + 2],
+        w = data.rotations[q + 3];
+
+    // Rotation matrix from the unit quaternion, columns scaled by S.
+    final m00 = (1 - 2 * (y * y + z * z)) * sx;
+    final m01 = (2 * (x * y - w * z)) * sy;
+    final m02 = (2 * (x * z + w * y)) * sz;
+    final m10 = (2 * (x * y + w * z)) * sx;
+    final m11 = (1 - 2 * (x * x + z * z)) * sy;
+    final m12 = (2 * (y * z - w * x)) * sz;
+    final m20 = (2 * (x * z - w * y)) * sx;
+    final m21 = (2 * (y * z + w * x)) * sy;
+    final m22 = (1 - 2 * (x * x + y * y)) * sz;
+
+    final covXX = m00 * m00 + m01 * m01 + m02 * m02;
+    final covXY = m00 * m10 + m01 * m11 + m02 * m12;
+    final covXZ = m00 * m20 + m01 * m21 + m02 * m22;
+    final covYY = m10 * m10 + m11 * m11 + m12 * m12;
+    final covYZ = m10 * m20 + m11 * m21 + m12 * m22;
+    final covZZ = m20 * m20 + m21 * m21 + m22 * m22;
+
+    final o = i * kParamsTexelsPerSplat * 4;
+    params[o] = data.positions[p];
+    params[o + 1] = data.positions[p + 1];
+    params[o + 2] = data.positions[p + 2];
+    params[o + 3] = data.opacities[i];
+    params[o + 4] = covXX;
+    params[o + 5] = covXY;
+    params[o + 6] = covXZ;
+    params[o + 7] = covYY;
+    params[o + 8] = covYZ;
+    params[o + 9] = covZZ;
+    // o+10, o+11 reserved.
+    params[o + 12] = data.colors[p];
+    params[o + 13] = data.colors[p + 1];
+    params[o + 14] = data.colors[p + 2];
+    // o+15 reserved.
+  }
+
+  Float32List? shTexels;
+  var shWidth = 0, shHeight = 0, shStride = 0;
+  final sh = data.sh;
+  if (sh != null && data.shDegree > 0) {
+    final coeffs = SplatData.shRestCoeffCount(data.shDegree);
+    // Pad the per-splat group to a power of two so groups never straddle a
+    // row of the power-of-two-wide texture.
+    shStride = coeffs <= 4 ? 4 : 8;
+    shWidth = _textureWidthFor(count * shStride);
+    shHeight = math.max(1, ((count * shStride) / shWidth).ceil());
+    _checkTextureHeight(shHeight, 'spherical-harmonics');
+    shTexels = Float32List(shWidth * shHeight * 4);
+    for (var i = 0; i < count; i++) {
+      final src = i * coeffs * 3;
+      final dst = i * shStride * 4;
+      for (var c = 0; c < coeffs; c++) {
+        shTexels[dst + c * 4] = sh[src + c * 3];
+        shTexels[dst + c * 4 + 1] = sh[src + c * 3 + 1];
+        shTexels[dst + c * 4 + 2] = sh[src + c * 3 + 2];
+      }
+    }
+  }
+
+  return PackedSplats(
+    data: data,
+    paramsTexels: params,
+    paramsWidth: paramsWidth,
+    paramsHeight: paramsHeight,
+    shTexels: shTexels,
+    shWidth: shWidth,
+    shHeight: shHeight,
+    shStride: shStride,
+  );
+}
+
+/// Sniffs [bytes] for a PLY magic, falling back to [fallback].
+SplatFormat sniffSplatFormat(Uint8List bytes, {SplatFormat? fallback}) {
+  if (bytes.length >= 4 &&
+      bytes[0] == 0x70 && // p
+      bytes[1] == 0x6C && // l
+      bytes[2] == 0x79 && // y
+      (bytes[3] == 0x0A || bytes[3] == 0x0D)) {
+    return SplatFormat.ply;
+  }
+  return fallback ?? SplatFormat.splat;
+}
+
+double _sigmoid(double x) => 1.0 / (1.0 + math.exp(-x));
+
+/// The smallest power-of-two width (at least 4, at most
+/// [kMaxSplatTextureWidth]) that keeps the texture roughly square.
+int _textureWidthFor(int texels) {
+  var width = 4;
+  while (width < kMaxSplatTextureWidth && width * width < texels) {
+    width *= 2;
+  }
+  return width;
+}
+
+void _checkTextureHeight(int height, String label) {
+  if (height > kMaxSplatTextureWidth) {
+    // TODO(splats): split giant sets across multiple textures instead of
+    // rejecting them; 4096x4096 holds ~4.2M splats per texture today.
+    throw ArgumentError(
+      'Splat set is too large for one $label texture '
+      '(height $height exceeds $kMaxSplatTextureWidth rows).',
+    );
+  }
+}
+
+class _PlyHeader {
+  _PlyHeader({
+    required this.vertexCount,
+    required this.strideInBytes,
+    required this.dataOffset,
+    required this.properties,
+  });
+
+  final int vertexCount;
+  final int strideInBytes;
+  final int dataOffset;
+
+  /// Byte offset of each float property within a vertex record.
+  final Map<String, int> properties;
+}
+
+_PlyHeader _parsePlyHeader(Uint8List bytes) {
+  // The header is ASCII, terminated by "end_header\n".
+  final headerEnd = _indexOfSequence(bytes, 'end_header\n'.codeUnits);
+  if (headerEnd < 0) {
+    throw FormatException('PLY header is missing end_header.');
+  }
+  final dataOffset = headerEnd + 'end_header\n'.length;
+  final header = String.fromCharCodes(bytes.sublist(0, headerEnd));
+  final lines = header.split(RegExp(r'\r?\n'));
+
+  if (lines.isEmpty || lines.first.trim() != 'ply') {
+    throw FormatException('Not a PLY file.');
+  }
+
+  var vertexCount = -1;
+  var inVertexElement = false;
+  var stride = 0;
+  final properties = <String, int>{};
+  var sawFormat = false;
+
+  const sizes = {
+    'float': 4,
+    'float32': 4,
+    'double': 8,
+    'float64': 8,
+    'char': 1,
+    'int8': 1,
+    'uchar': 1,
+    'uint8': 1,
+    'short': 2,
+    'int16': 2,
+    'ushort': 2,
+    'uint16': 2,
+    'int': 4,
+    'int32': 4,
+    'uint': 4,
+    'uint32': 4,
+  };
+
+  for (final raw in lines.skip(1)) {
+    final line = raw.trim();
+    if (line.isEmpty || line.startsWith('comment')) continue;
+    final parts = line.split(RegExp(r'\s+'));
+    switch (parts[0]) {
+      case 'format':
+        if (parts.length < 2 || parts[1] != 'binary_little_endian') {
+          throw FormatException(
+            'Only binary little-endian splat PLYs are supported '
+            '(got "${parts.length > 1 ? parts[1] : ''}").',
+          );
+        }
+        sawFormat = true;
+      case 'element':
+        inVertexElement = parts.length >= 3 && parts[1] == 'vertex';
+        if (inVertexElement) {
+          vertexCount = int.parse(parts[2]);
+        } else if (vertexCount >= 0) {
+          // Properties of a later element would corrupt the stride; the
+          // vertex element must come first (it does in training output).
+          break;
+        }
+      case 'property':
+        if (!inVertexElement) continue;
+        if (parts[1] == 'list') {
+          throw FormatException('List properties are not supported.');
+        }
+        final size = sizes[parts[1]];
+        if (size == null) {
+          throw FormatException('Unknown PLY property type "${parts[1]}".');
+        }
+        if (size == 4 && (parts[1] == 'float' || parts[1] == 'float32')) {
+          properties[parts[2]] = stride;
+        }
+        stride += size;
+    }
+  }
+  if (!sawFormat || vertexCount < 0) {
+    throw FormatException('PLY header is missing format or vertex element.');
+  }
+  return _PlyHeader(
+    vertexCount: vertexCount,
+    strideInBytes: stride,
+    dataOffset: dataOffset,
+    properties: properties,
+  );
+}
+
+int _indexOfSequence(Uint8List haystack, List<int> needle) {
+  final limit = math.min(haystack.length - needle.length, 64 * 1024);
+  outer:
+  for (var i = 0; i <= limit; i++) {
+    for (var j = 0; j < needle.length; j++) {
+      if (haystack[i + j] != needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}

--- a/packages/flutter_scene/lib/src/splats/splat_codec.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_codec.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 import 'package:flutter_scene/src/splats/splat_data.dart';
 
 /// The splat file formats the runtime loader understands.
-/// {@category Geometry}
+/// {@category Gaussian splatting}
 enum SplatFormat {
   /// An uncompressed Gaussian-splat PLY (binary little-endian), the training
   /// interchange layout: `x y z ... f_dc_* f_rest_* opacity scale_* rot_*`.

--- a/packages/flutter_scene/lib/src/splats/splat_codec.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_codec.dart
@@ -6,11 +6,11 @@ import 'package:flutter_scene/src/splats/splat_data.dart';
 /// The splat file formats the runtime loader understands.
 /// {@category Gaussian splatting}
 enum SplatFormat {
-  /// An uncompressed Gaussian-splat PLY (binary little-endian), the training
-  /// interchange layout: `x y z ... f_dc_* f_rest_* opacity scale_* rot_*`.
+  /// An uncompressed binary-little-endian PLY in the training interchange
+  /// layout (`x y z ... f_dc_* f_rest_* opacity scale_* rot_*`).
   ply,
 
-  /// The compact 32-byte-per-splat `.splat` layout common in web pipelines:
+  /// The compact 32-byte-per-splat `.splat` layout common in web pipelines,
   /// float position and scale, 8-bit color/opacity, 8-bit quaternion.
   splat,
 }
@@ -32,8 +32,8 @@ class SplatDecodeOptions {
 
 /// A decoded splat set together with its GPU-ready texel arrays.
 ///
-/// Produced by [decodeSplats] (usually on a background isolate); consumed by
-/// `GaussianSplats`, which uploads the texel arrays verbatim.
+/// Produced by [decodeSplats] (usually off-thread) and uploaded verbatim by
+/// `GaussianSplats`.
 class PackedSplats {
   PackedSplats({
     required this.data,
@@ -49,8 +49,7 @@ class PackedSplats {
   /// The decoded splat arrays (kept for sorting, bounds, and readback).
   final SplatData data;
 
-  /// RGBA32F texels for the parameter texture, [kParamsTexelsPerSplat]
-  /// consecutive texels per splat:
+  /// RGBA32F parameter texels, [kParamsTexelsPerSplat] per splat, laid out as
   /// `pos.xyz, opacity | cov.xx,xy,xz,yy | cov.yz,zz,0,0 | color.rgb, 0`.
   final Float32List paramsTexels;
 
@@ -66,8 +65,8 @@ class PackedSplats {
   final int shWidth;
   final int shHeight;
 
-  /// Texels per splat in the SH texture (4 for degree 1, 8 for degree 2;
-  /// a power of two so groups never straddle rows).
+  /// Texels per splat in the SH texture, a power of two so groups never
+  /// straddle rows (4 for degree 1, 8 for degree 2).
   final int shStride;
 }
 
@@ -118,11 +117,10 @@ PackedSplats decodeSplatsForIsolate(
 
 /// Parses a binary little-endian Gaussian-splat PLY.
 ///
-/// Recognizes the training layout's properties by name (`x`, `f_dc_0`,
-/// `f_rest_*`, `opacity`, `scale_*`, `rot_*`); other float properties are
-/// skipped by stride. Applies the training-space transforms: `exp` on
-/// scales, sigmoid on opacity, `0.5 + C0 * f_dc` on the base color, and
-/// quaternion normalization.
+/// Recognizes the training properties by name (`x`, `f_dc_0`, `f_rest_*`,
+/// `opacity`, `scale_*`, `rot_*`) and skips others by stride. Applies the
+/// training-space transforms, `exp` on scales, sigmoid on opacity,
+/// `0.5 + C0 * f_dc` on the base color, and quaternion normalization.
 SplatData parseSplatPly(
   Uint8List bytes, {
   SplatDecodeOptions options = const SplatDecodeOptions(),
@@ -177,8 +175,7 @@ SplatData parseSplatPly(
     throw FormatException('Splat PLY is truncated.');
   }
 
-  // First pass: count survivors of the alpha cull so the arrays allocate
-  // exactly once.
+  // Count survivors of the alpha cull first, so the arrays allocate once.
   var kept = 0;
   for (var i = 0; i < total; i++) {
     final op = _sigmoid(
@@ -230,8 +227,8 @@ SplatData parseSplatPly(
       final shOut = w * keptRest * 3;
       for (var c = 0; c < keptRest; c++) {
         for (var ch = 0; ch < 3; ch++) {
-          // Channel-major in the file: coefficient c of channel ch is at
-          // rest index ch * restPerChannel + c.
+          // Channel-major in the file, so coefficient c of channel ch lands
+          // at rest index ch * restPerChannel + c.
           sh[shOut + c * 3 + ch] = view.getFloat32(
             base + restBase + (ch * restPerChannel + c) * 4,
             Endian.little,

--- a/packages/flutter_scene/lib/src/splats/splat_data.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_data.dart
@@ -19,12 +19,12 @@ enum SplatColorSpace {
   linear,
 }
 
-/// The CPU-side contents of a Gaussian splat set, stored as flat parallel
+/// The CPU-side contents of a Gaussian splat set as flat, index-parallel
 /// arrays (one entry per splat).
 ///
-/// This is the seam between the splat file parsers, procedural construction,
-/// and the renderer: parsers produce a [SplatData], and `GaussianSplats`
-/// packs one into GPU textures. All arrays are index-parallel.
+/// The seam between the file parsers, procedural construction, and the
+/// renderer. Parsers produce a [SplatData], and `GaussianSplats` packs one
+/// into GPU textures.
 /// {@category Gaussian splatting}
 class SplatData {
   /// Wraps existing arrays without copying. Every array's length must match
@@ -82,8 +82,8 @@ class SplatData {
   /// Unit orientation quaternions, `x, y, z, w` per splat.
   final Float32List rotations;
 
-  /// Base RGB color per splat: the evaluated degree-0 spherical-harmonic
-  /// term, in the file's color space (see [SplatColorSpace]).
+  /// Base RGB color per splat, the evaluated degree-0 spherical-harmonic
+  /// term, in the file's [SplatColorSpace].
   final Float32List colors;
 
   /// Opacity in [0, 1] per splat (parsers apply the training sigmoid).
@@ -92,16 +92,15 @@ class SplatData {
   /// Rest (degree >= 1) spherical-harmonic coefficients, or null when
   /// [shDegree] is 0.
   ///
-  /// Layout: per splat, [shRestCoeffCount] coefficients, each `r, g, b`.
-  /// Coefficients are ordered by band then by the standard 3DGS basis order
-  /// within a band.
+  /// Per splat, [shRestCoeffCount] coefficients of `r, g, b`, ordered by band
+  /// then by the standard 3DGS basis order within a band.
   final Float32List? sh;
 
   /// The highest spherical-harmonic degree carried by [sh] (0, 1, or 2).
   final int shDegree;
 
-  /// The number of rest (beyond degree 0) SH coefficients per splat and
-  /// channel for [degree]: 0 for degree 0, 3 for degree 1, 8 for degree 2.
+  /// Rest (beyond degree 0) SH coefficients per splat and channel, 0 at
+  /// [degree] 0, 3 at 1, 8 at 2.
   static int shRestCoeffCount(int degree) => (degree + 1) * (degree + 1) - 1;
 
   /// Computes the axis-aligned bounds of the splat centers, each padded by

--- a/packages/flutter_scene/lib/src/splats/splat_data.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_data.dart
@@ -9,7 +9,7 @@ import 'package:vector_math/vector_math.dart' as vm;
 /// encoded) images, so their colors must be decoded to linear before they
 /// enter the scene's linear HDR pipeline. Procedurally constructed splats
 /// whose colors are already linear skip the decode.
-/// {@category Geometry}
+/// {@category Gaussian splatting}
 enum SplatColorSpace {
   /// Colors are sRGB encoded (the trained-capture convention). The renderer
   /// decodes them to linear after evaluating spherical harmonics.
@@ -25,6 +25,7 @@ enum SplatColorSpace {
 /// This is the seam between the splat file parsers, procedural construction,
 /// and the renderer: parsers produce a [SplatData], and `GaussianSplats`
 /// packs one into GPU textures. All arrays are index-parallel.
+/// {@category Gaussian splatting}
 class SplatData {
   /// Wraps existing arrays without copying. Every array's length must match
   /// [count] times its per-splat stride.

--- a/packages/flutter_scene/lib/src/splats/splat_data.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_data.dart
@@ -1,0 +1,136 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:vector_math/vector_math.dart' as vm;
+
+/// How a splat file's colors relate to the renderer's linear HDR pipeline.
+///
+/// Captured splats are usually trained against display-referred (sRGB
+/// encoded) images, so their colors must be decoded to linear before they
+/// enter the scene's linear HDR pipeline. Procedurally constructed splats
+/// whose colors are already linear skip the decode.
+/// {@category Geometry}
+enum SplatColorSpace {
+  /// Colors are sRGB encoded (the trained-capture convention). The renderer
+  /// decodes them to linear after evaluating spherical harmonics.
+  displayReferred,
+
+  /// Colors are already linear; no decode is applied.
+  linear,
+}
+
+/// The CPU-side contents of a Gaussian splat set, stored as flat parallel
+/// arrays (one entry per splat).
+///
+/// This is the seam between the splat file parsers, procedural construction,
+/// and the renderer: parsers produce a [SplatData], and `GaussianSplats`
+/// packs one into GPU textures. All arrays are index-parallel.
+class SplatData {
+  /// Wraps existing arrays without copying. Every array's length must match
+  /// [count] times its per-splat stride.
+  SplatData({
+    required this.count,
+    required this.positions,
+    required this.scales,
+    required this.rotations,
+    required this.colors,
+    required this.opacities,
+    this.sh,
+    this.shDegree = 0,
+  }) : assert(positions.length == count * 3),
+       assert(scales.length == count * 3),
+       assert(rotations.length == count * 4),
+       assert(colors.length == count * 3),
+       assert(opacities.length == count),
+       assert(shDegree >= 0 && shDegree <= 2),
+       assert(
+         (shDegree == 0) == (sh == null),
+         'sh must be provided exactly when shDegree > 0',
+       ),
+       assert(
+         sh == null || sh.length == count * shRestCoeffCount(shDegree) * 3,
+       );
+
+  /// Allocates a zero-filled splat set for [count] splats, for callers that
+  /// fill the arrays in place (procedural construction).
+  factory SplatData.zeroed(int count, {int shDegree = 0}) {
+    return SplatData(
+      count: count,
+      positions: Float32List(count * 3),
+      scales: Float32List(count * 3),
+      rotations: Float32List(count * 4),
+      colors: Float32List(count * 3),
+      opacities: Float32List(count),
+      sh: shDegree > 0
+          ? Float32List(count * shRestCoeffCount(shDegree) * 3)
+          : null,
+      shDegree: shDegree,
+    );
+  }
+
+  /// The number of splats.
+  final int count;
+
+  /// Splat centers in local space, `x, y, z` per splat.
+  final Float32List positions;
+
+  /// Per-axis Gaussian standard deviations in local units (already linear;
+  /// parsers apply the training log-space `exp`), `x, y, z` per splat.
+  final Float32List scales;
+
+  /// Unit orientation quaternions, `x, y, z, w` per splat.
+  final Float32List rotations;
+
+  /// Base RGB color per splat: the evaluated degree-0 spherical-harmonic
+  /// term, in the file's color space (see [SplatColorSpace]).
+  final Float32List colors;
+
+  /// Opacity in [0, 1] per splat (parsers apply the training sigmoid).
+  final Float32List opacities;
+
+  /// Rest (degree >= 1) spherical-harmonic coefficients, or null when
+  /// [shDegree] is 0.
+  ///
+  /// Layout: per splat, [shRestCoeffCount] coefficients, each `r, g, b`.
+  /// Coefficients are ordered by band then by the standard 3DGS basis order
+  /// within a band.
+  final Float32List? sh;
+
+  /// The highest spherical-harmonic degree carried by [sh] (0, 1, or 2).
+  final int shDegree;
+
+  /// The number of rest (beyond degree 0) SH coefficients per splat and
+  /// channel for [degree]: 0 for degree 0, 3 for degree 1, 8 for degree 2.
+  static int shRestCoeffCount(int degree) => (degree + 1) * (degree + 1) - 1;
+
+  /// Computes the axis-aligned bounds of the splat centers, each padded by
+  /// [sigmaPadding] times the splat's largest axis scale so the visible
+  /// footprint stays inside the box.
+  vm.Aabb3? computeBounds({double sigmaPadding = 3.0}) {
+    if (count == 0) return null;
+    var minX = double.infinity, minY = double.infinity, minZ = double.infinity;
+    var maxX = double.negativeInfinity,
+        maxY = double.negativeInfinity,
+        maxZ = double.negativeInfinity;
+    for (var i = 0; i < count; i++) {
+      final o = i * 3;
+      final r =
+          sigmaPadding *
+          math.max(
+            scales[o].abs(),
+            math.max(scales[o + 1].abs(), scales[o + 2].abs()),
+          );
+      final x = positions[o], y = positions[o + 1], z = positions[o + 2];
+      if (x - r < minX) minX = x - r;
+      if (y - r < minY) minY = y - r;
+      if (z - r < minZ) minZ = z - r;
+      if (x + r > maxX) maxX = x + r;
+      if (y + r > maxY) maxY = y + r;
+      if (z + r > maxZ) maxZ = z + r;
+    }
+    return vm.Aabb3.minMax(
+      vm.Vector3(minX, minY, minZ),
+      vm.Vector3(maxX, maxY, maxZ),
+    );
+  }
+}

--- a/packages/flutter_scene/lib/src/splats/splat_sort_service.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_sort_service.dart
@@ -6,14 +6,13 @@ import 'package:flutter_scene/src/splats/splat_sort_service_native.dart'
 
 /// A long-lived background sorter for one splat set.
 ///
-/// The positions array is copied to the worker once at construction, so a
-/// re-sort only ships the tiny direction request and the sorted order back
-/// (transferred, not copied). The per-sort `compute` alternative re-copies
-/// the whole positions array on the UI thread every time, which shows as a
-/// rhythmic stutter while the camera orbits a large set.
+/// The positions are copied to the worker once at construction, so a re-sort
+/// only ships the direction out and transfers the order back. A per-sort
+/// `compute` would re-copy the whole positions array on the UI thread every
+/// time, a rhythmic stutter while orbiting a large set.
 ///
-/// On the web there are no isolates; the fallback sorts synchronously on
-/// the main thread. TODO(splats): move the web path into a web worker.
+/// The web has no isolates, so its fallback sorts synchronously on the main
+/// thread. TODO(splats): move the web path into a web worker.
 abstract interface class SplatSortService {
   /// Creates the platform sorter over [positions] (`x, y, z` per splat).
   factory SplatSortService(Float32List positions, int count) =>

--- a/packages/flutter_scene/lib/src/splats/splat_sort_service.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_sort_service.dart
@@ -1,0 +1,31 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/splats/splat_sort_service_native.dart'
+    if (dart.library.js_interop) 'package:flutter_scene/src/splats/splat_sort_service_web.dart'
+    as impl;
+
+/// A long-lived background sorter for one splat set.
+///
+/// The positions array is copied to the worker once at construction, so a
+/// re-sort only ships the tiny direction request and the sorted order back
+/// (transferred, not copied). The per-sort `compute` alternative re-copies
+/// the whole positions array on the UI thread every time, which shows as a
+/// rhythmic stutter while the camera orbits a large set.
+///
+/// On the web there are no isolates; the fallback sorts synchronously on
+/// the main thread. TODO(splats): move the web path into a web worker.
+abstract interface class SplatSortService {
+  /// Creates the platform sorter over [positions] (`x, y, z` per splat).
+  factory SplatSortService(Float32List positions, int count) =>
+      impl.createSplatSortService(positions, count);
+
+  /// Resolves with the splat indices in back-to-front order along the given
+  /// local-space view-depth direction (ready to upload as the instance
+  /// stream), or null if the service was disposed first.
+  ///
+  /// Callers must not issue a new sort until the previous one resolves.
+  Future<Float32List?> sort(double dirX, double dirY, double dirZ);
+
+  /// Shuts down the worker. In-flight sorts resolve null.
+  void dispose();
+}

--- a/packages/flutter_scene/lib/src/splats/splat_sort_service_native.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_sort_service_native.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/splats/splat_sort_service.dart';
+import 'package:flutter_scene/src/splats/splat_sorter.dart';
+
+/// Creates the isolate-backed sorter.
+SplatSortService createSplatSortService(Float32List positions, int count) =>
+    _IsolateSplatSortService(positions, count);
+
+class _IsolateSplatSortService implements SplatSortService {
+  _IsolateSplatSortService(this._positions, this._count);
+
+  final Float32List _positions;
+  final int _count;
+
+  bool _disposed = false;
+  Future<SendPort>? _requests;
+  ReceivePort? _fromWorker;
+  Completer<Float32List?>? _pending;
+
+  // Spawns the worker on first use, copying the positions once; the copy
+  // transfers into the isolate rather than being re-serialized.
+  Future<SendPort> _ensureWorker() {
+    return _requests ??= () async {
+      final fromWorker = ReceivePort();
+      _fromWorker = fromWorker;
+      final ready = Completer<SendPort>();
+      fromWorker.listen((message) {
+        if (!ready.isCompleted) {
+          ready.complete(message as SendPort);
+          return;
+        }
+        final pending = _pending;
+        _pending = null;
+        pending?.complete(
+          (message as TransferableTypedData).materialize().asFloat32List(),
+        );
+      });
+      await Isolate.spawn(splatSorterIsolateMain, <Object>[
+        fromWorker.sendPort,
+        TransferableTypedData.fromList([_positions]),
+        _count,
+      ], debugName: 'flutter_scene splat sorter');
+      return ready.future;
+    }();
+  }
+
+  @override
+  Future<Float32List?> sort(double dirX, double dirY, double dirZ) async {
+    if (_disposed) return null;
+    assert(_pending == null, 'A sort is already in flight.');
+    final worker = await _ensureWorker();
+    if (_disposed) return null;
+    final pending = Completer<Float32List?>();
+    _pending = pending;
+    worker.send(<double>[dirX, dirY, dirZ]);
+    return pending.future;
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _pending?.complete(null);
+    _pending = null;
+    // Ask the worker to exit once it is up (it may still be spawning).
+    _requests?.then((worker) {
+      worker.send(null);
+      _fromWorker?.close();
+    });
+  }
+}
+
+/// The sorter isolate: receives the positions once at spawn, then serves
+/// direction requests until a null message asks it to exit.
+void splatSorterIsolateMain(List<Object> init) {
+  final replyTo = init[0] as SendPort;
+  final positions = (init[1] as TransferableTypedData)
+      .materialize()
+      .asFloat32List();
+  final count = init[2] as int;
+
+  final requests = ReceivePort();
+  replyTo.send(requests.sendPort);
+  requests.listen((message) {
+    if (message == null) {
+      requests.close();
+      return;
+    }
+    final dir = message as List<double>;
+    final order = sortSplatsBackToFront(
+      positions,
+      count,
+      dir[0],
+      dir[1],
+      dir[2],
+    );
+    replyTo.send(TransferableTypedData.fromList([order]));
+  });
+}

--- a/packages/flutter_scene/lib/src/splats/splat_sort_service_native.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_sort_service_native.dart
@@ -20,8 +20,8 @@ class _IsolateSplatSortService implements SplatSortService {
   ReceivePort? _fromWorker;
   Completer<Float32List?>? _pending;
 
-  // Spawns the worker on first use, copying the positions once; the copy
-  // transfers into the isolate rather than being re-serialized.
+  // Spawns the worker on first use, transferring the positions in once
+  // rather than re-serializing them per sort.
   Future<SendPort> _ensureWorker() {
     return _requests ??= () async {
       final fromWorker = ReceivePort();
@@ -73,7 +73,7 @@ class _IsolateSplatSortService implements SplatSortService {
   }
 }
 
-/// The sorter isolate: receives the positions once at spawn, then serves
+/// The sorter isolate. Receives the positions once at spawn, then serves
 /// direction requests until a null message asks it to exit.
 void splatSorterIsolateMain(List<Object> init) {
   final replyTo = init[0] as SendPort;

--- a/packages/flutter_scene/lib/src/splats/splat_sort_service_web.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_sort_service_web.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/splats/splat_sort_service.dart';
+import 'package:flutter_scene/src/splats/splat_sorter.dart';
+
+/// Creates the web sorter, which runs synchronously on the main thread
+/// (the web platform has no shared-memory isolates).
+/// TODO(splats): move this into a web worker for large sets.
+SplatSortService createSplatSortService(Float32List positions, int count) =>
+    _SynchronousSplatSortService(positions, count);
+
+class _SynchronousSplatSortService implements SplatSortService {
+  _SynchronousSplatSortService(this._positions, this._count);
+
+  final Float32List _positions;
+  final int _count;
+  bool _disposed = false;
+
+  @override
+  Future<Float32List?> sort(double dirX, double dirY, double dirZ) =>
+      Future(() {
+        if (_disposed) return null;
+        return sortSplatsBackToFront(_positions, _count, dirX, dirY, dirZ);
+      });
+
+  @override
+  void dispose() {
+    _disposed = true;
+  }
+}

--- a/packages/flutter_scene/lib/src/splats/splat_sorter.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_sorter.dart
@@ -1,0 +1,85 @@
+import 'dart:typed_data';
+
+/// Sorts splats back to front along a view direction.
+///
+/// Returns the splat indices as a [Float32List] (largest view depth first),
+/// ready to upload verbatim as the instance-rate index attribute (the
+/// attribute is a float because the broadest GLES tier has no integer vertex
+/// attributes; float indices are exact up to 2^24 splats).
+///
+/// [viewRow] is the direction the depth key is measured along, in the same
+/// (local) space as [positions]. The caller derives it from the
+/// view-projection w row transformed into local space, so the key is exact
+/// view-space depth. Ordering along a fixed direction is unaffected by
+/// camera translation, so a re-sort is only needed when the direction
+/// changes.
+///
+/// A 16-bit counting sort over the normalized depth range: two O(n) passes
+/// and a 65536-bucket histogram, no comparison sort.
+Float32List sortSplatsBackToFront(
+  Float32List positions,
+  int count,
+  double dirX,
+  double dirY,
+  double dirZ,
+) {
+  final keys = Float32List(count);
+  var minKey = double.infinity;
+  var maxKey = double.negativeInfinity;
+  for (var i = 0; i < count; i++) {
+    final o = i * 3;
+    final k =
+        positions[o] * dirX + positions[o + 1] * dirY + positions[o + 2] * dirZ;
+    keys[i] = k;
+    if (k < minKey) minKey = k;
+    if (k > maxKey) maxKey = k;
+  }
+
+  final out = Float32List(count);
+  final range = maxKey - minKey;
+  if (count == 0) return out;
+  if (range <= 0 || !range.isFinite) {
+    for (var i = 0; i < count; i++) {
+      out[i] = i.toDouble();
+    }
+    return out;
+  }
+
+  const buckets = 1 << 16;
+  final scale = (buckets - 1) / range;
+  final histogram = Uint32List(buckets);
+  final quantized = Uint16List(count);
+  for (var i = 0; i < count; i++) {
+    final q = ((keys[i] - minKey) * scale).toInt();
+    quantized[i] = q;
+    histogram[q]++;
+  }
+
+  // Back to front: the largest depth bucket writes first. Convert the
+  // histogram into each bucket's starting output offset, walking buckets
+  // from far to near.
+  var offset = 0;
+  for (var b = buckets - 1; b >= 0; b--) {
+    final n = histogram[b];
+    histogram[b] = offset;
+    offset += n;
+  }
+  for (var i = 0; i < count; i++) {
+    out[histogram[quantized[i]]++] = i.toDouble();
+  }
+  return out;
+}
+
+/// The top-level `compute` entry point for [sortSplatsBackToFront].
+Float32List sortSplatsForIsolate(
+  ({Float32List positions, int count, double dirX, double dirY, double dirZ})
+  args,
+) {
+  return sortSplatsBackToFront(
+    args.positions,
+    args.count,
+    args.dirX,
+    args.dirY,
+    args.dirZ,
+  );
+}

--- a/packages/flutter_scene/lib/src/splats/splat_sorter.dart
+++ b/packages/flutter_scene/lib/src/splats/splat_sorter.dart
@@ -2,20 +2,18 @@ import 'dart:typed_data';
 
 /// Sorts splats back to front along a view direction.
 ///
-/// Returns the splat indices as a [Float32List] (largest view depth first),
-/// ready to upload verbatim as the instance-rate index attribute (the
-/// attribute is a float because the broadest GLES tier has no integer vertex
-/// attributes; float indices are exact up to 2^24 splats).
+/// Returns the splat indices largest-view-depth-first, ready to upload as the
+/// instance-rate index attribute. The attribute is a float (the broadest GLES
+/// tier has no integer vertex attributes), exact up to 2^24 splats.
 ///
-/// [viewRow] is the direction the depth key is measured along, in the same
-/// (local) space as [positions]. The caller derives it from the
-/// view-projection w row transformed into local space, so the key is exact
-/// view-space depth. Ordering along a fixed direction is unaffected by
-/// camera translation, so a re-sort is only needed when the direction
-/// changes.
+/// `dir*` is the direction the depth key is measured along, in the same local
+/// space as [positions]. The caller derives it from the view-projection w row
+/// in local space, so the key is exact view-space depth. Ordering along a
+/// fixed direction is unaffected by camera translation, so a re-sort is only
+/// needed when the direction changes.
 ///
-/// A 16-bit counting sort over the normalized depth range: two O(n) passes
-/// and a 65536-bucket histogram, no comparison sort.
+/// Uses a 16-bit counting sort, two O(n) passes over a 65536-bucket histogram
+/// rather than a comparison sort.
 Float32List sortSplatsBackToFront(
   Float32List positions,
   int count,
@@ -55,9 +53,8 @@ Float32List sortSplatsBackToFront(
     histogram[q]++;
   }
 
-  // Back to front: the largest depth bucket writes first. Convert the
-  // histogram into each bucket's starting output offset, walking buckets
-  // from far to near.
+  // Turn the histogram into each bucket's starting output offset, walking
+  // far to near so the largest depth bucket writes first (back to front).
   var offset = 0;
   for (var b = buckets - 1; b >= 0; b--) {
     final n = histogram[b];

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -130,5 +130,13 @@
   "SkyPhysicalFragment": {
     "type": "fragment",
     "file": "shaders/flutter_scene_sky_physical.frag"
+  },
+  "SplatsVertex": {
+    "type": "vertex",
+    "file": "shaders/flutter_scene_splats.vert"
+  },
+  "SplatsFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_splats.frag"
   }
 }

--- a/packages/flutter_scene/shaders/flutter_scene_splats.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_splats.frag
@@ -10,10 +10,9 @@ out vec4 frag_color;
 void main() {
   float r2 = dot(v_quad, v_quad);
   float alpha = v_color.a * exp(-0.5 * r2);
-  // Below 8-bit blending precision; discarding also keeps the quad corners
-  // from writing outside the elliptical footprint.
-  if (alpha < 1.0 / 255.0) {
-    discard;
-  }
+  // No discard: under premultiplied source-over a zero-alpha output leaves
+  // the destination untouched, and avoiding discard keeps tile-based GPUs
+  // on their fast fragment path (discard disables early elimination for
+  // the whole draw on some hardware).
   frag_color = vec4(v_color.rgb * alpha, alpha);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_splats.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_splats.frag
@@ -1,0 +1,19 @@
+// Gaussian splat fragment stage: evaluates the Gaussian falloff across the
+// footprint quad and outputs linear HDR premultiplied alpha (the translucent
+// pass blends with premultiplied source-over).
+
+in vec2 v_quad;  // position in the footprint, standard-deviation units
+in vec4 v_color; // linear RGB and final opacity
+
+out vec4 frag_color;
+
+void main() {
+  float r2 = dot(v_quad, v_quad);
+  float alpha = v_color.a * exp(-0.5 * r2);
+  // Below 8-bit blending precision; discarding also keeps the quad corners
+  // from writing outside the elliptical footprint.
+  if (alpha < 1.0 / 255.0) {
+    discard;
+  }
+  frag_color = vec4(v_color.rgb * alpha, alpha);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_splats.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_splats.frag
@@ -1,4 +1,4 @@
-// Gaussian splat fragment stage: evaluates the Gaussian falloff across the
+// Gaussian splat fragment stage. Evaluates the Gaussian falloff across the
 // footprint quad and outputs linear HDR premultiplied alpha (the translucent
 // pass blends with premultiplied source-over).
 
@@ -10,9 +10,9 @@ out vec4 frag_color;
 void main() {
   float r2 = dot(v_quad, v_quad);
   float alpha = v_color.a * exp(-0.5 * r2);
-  // No discard: under premultiplied source-over a zero-alpha output leaves
+  // No discard. Under premultiplied source-over a zero-alpha output leaves
   // the destination untouched, and avoiding discard keeps tile-based GPUs
-  // on their fast fragment path (discard disables early elimination for
-  // the whole draw on some hardware).
+  // on their fast fragment path (discard disables early elimination for the
+  // whole draw on some hardware).
   frag_color = vec4(v_color.rgb * alpha, alpha);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_splats.vert
+++ b/packages/flutter_scene/shaders/flutter_scene_splats.vert
@@ -11,11 +11,12 @@
 uniform FrameInfo {
   mat4 mvp_transform;   // camera view-projection * node world transform
   mat4 model_transform; // node world transform (for SH view direction)
+  mat4 crop_transform;  // splat-local -> crop-box space (unit cube, +/-1)
   vec4 camera_position; // xyz: world camera; w: color mode (0 sRGB-encoded, 1 linear)
   vec4 params_texture;  // x: width, y: height (texels)
   vec4 sh_texture;      // x: width, y: height, z: texels per splat, w: SH degree
   vec4 viewport;        // xy: size in pixels; z: kernel mode (0 classic, 1 antialiased); w: splat scale
-  vec4 params;          // x: opacity scale; yzw: reserved
+  vec4 params;          // x: opacity scale; y: crop mode (0 off, 1 include, 2 exclude); zw: reserved
   vec4 tint;            // linear RGBA multiplier
 }
 frame_info;
@@ -33,8 +34,11 @@ in float splat_index;
 out vec2 v_quad;
 out vec4 v_color;
 
-// The footprint half-extent in standard deviations. exp(-0.5 * 3.33^2) is
-// just under 1/255, so the cut is invisible at 8-bit blending precision.
+// The largest footprint half-extent in standard deviations.
+// exp(-0.5 * 3.33^2) is just under 1/255, so the cut is invisible at 8-bit
+// blending precision. Dimmer splats use a tighter cut (their falloff drops
+// below 1/255 sooner), which sharply reduces blended fill area in
+// low-opacity clouds.
 const float kSigmaCut = 3.33;
 
 // Low-pass dilation applied to the projected covariance (in pixel^2),
@@ -52,6 +56,12 @@ vec4 fetchTexel(sampler2D tex, float index, vec2 dims) {
   return texture(tex, vec2((x + 0.5) / dims.x, (y + 0.5) / dims.y));
 }
 
+void cull() {
+  gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
+  v_quad = vec2(0.0);
+  v_color = vec4(0.0);
+}
+
 void main() {
   float base = splat_index * 4.0;
   vec2 dims = frame_info.params_texture.xy;
@@ -60,14 +70,24 @@ void main() {
   vec4 t2 = fetchTexel(splat_params_texture, base + 2.0, dims);
   vec4 t3 = fetchTexel(splat_params_texture, base + 3.0, dims);
 
+  // Crop volume: drop splats outside an include box or inside an exclude
+  // box (the box is the unit cube in crop space).
+  float crop_mode = frame_info.params.y;
+  if (crop_mode > 0.5) {
+    vec3 crop_pos = (frame_info.crop_transform * vec4(t0.xyz, 1.0)).xyz;
+    bool inside = all(lessThanEqual(abs(crop_pos), vec3(1.0)));
+    if (crop_mode < 1.5 ? !inside : inside) {
+      cull();
+      return;
+    }
+  }
+
   vec4 clip = frame_info.mvp_transform * vec4(t0.xyz, 1.0);
   vec3 ndc = clip.xyz / clip.w;
   // Cull splats behind the camera or far outside the frustum (the margin
   // leaves room for large footprints straddling the edge).
   if (clip.w <= 0.0 || abs(ndc.x) > 1.3 || abs(ndc.y) > 1.3 || ndc.z > 1.0) {
-    gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
-    v_quad = vec2(0.0);
-    v_color = vec4(0.0);
+    cull();
     return;
   }
 
@@ -107,6 +127,16 @@ void main() {
     opacity *= sqrt(max(det_raw / det, 0.0));
   }
 
+  // The final blended alpha bounds the useful footprint: past the radius
+  // where the falloff drops under 1/255, fragments only discard. Tighten
+  // the cut per splat so dim splats rasterize far fewer pixels.
+  float alpha = clamp(opacity, 0.0, 1.0) * frame_info.tint.a;
+  if (alpha < 1.0 / 255.0) {
+    cull();
+    return;
+  }
+  float sigma_cut = min(kSigmaCut, sqrt(2.0 * log(alpha * 255.0)));
+
   // Eigen-decomposition of the symmetric 2x2 covariance.
   float mid = 0.5 * (cov_a + cov_d);
   float delta = sqrt(max(mid * mid - det, 0.0));
@@ -116,13 +146,16 @@ void main() {
       ? normalize(vec2(cov_b, lambda1 - cov_a))
       : (cov_a >= cov_d ? vec2(1.0, 0.0) : vec2(0.0, 1.0));
   vec2 axis2 = vec2(-axis1.y, axis1.x);
-  float radius1 = kSigmaCut * sqrt(lambda1);
-  float radius2 = kSigmaCut * sqrt(lambda2);
+  // Clamp against a pathological footprint (the camera sitting inside a
+  // giant Gaussian) so one splat cannot rasterize far past the screen.
+  float max_radius = frame_info.viewport.x + frame_info.viewport.y;
+  float radius1 = min(sigma_cut * sqrt(lambda1), max_radius);
+  float radius2 = min(sigma_cut * sqrt(lambda2), max_radius);
 
   vec2 offset_px = corner.x * radius1 * axis1 + corner.y * radius2 * axis2;
   gl_Position =
       vec4(ndc.xy * clip.w + offset_px / half_viewport * clip.w, clip.zw);
-  v_quad = corner * kSigmaCut;
+  v_quad = corner * sigma_cut;
 
   // Color: the base (degree 0) term plus the view-dependent rest bands.
   vec3 color = t3.rgb;
@@ -158,8 +191,5 @@ void main() {
   if (frame_info.camera_position.w < 0.5) {
     color = pow(color, vec3(2.2));
   }
-  v_color = vec4(
-    color * frame_info.tint.rgb,
-    clamp(opacity, 0.0, 1.0) * frame_info.tint.a
-  );
+  v_color = vec4(color * frame_info.tint.rgb, alpha);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_splats.vert
+++ b/packages/flutter_scene/shaders/flutter_scene_splats.vert
@@ -1,22 +1,22 @@
 // Gaussian splat vertex stage.
 //
-// Each instance is one splat; the per-instance attribute is the splat's
-// index into the parameter texture (a float, since the broadest GLES tier
-// has no integer attributes). The unit quad is expanded to cover the
-// splat's projected footprint: the local 3D covariance (prefetched from the
+// Each instance is one splat, its per-instance attribute the splat's index
+// into the parameter texture (a float, since the broadest GLES tier has no
+// integer attributes). The unit quad is expanded to cover the splat's
+// projected footprint. The local 3D covariance (prefetched from the
 // parameter texture) is pushed through the Jacobian of the full
 // local-to-pixel mapping, and the resulting 2D covariance's eigenvectors
 // give the quad axes. Instances arrive presorted back to front.
 
 uniform FrameInfo {
   mat4 mvp_transform;   // camera view-projection * node world transform
-  mat4 model_transform; // node world transform (for SH view direction)
-  mat4 crop_transform;  // splat-local -> crop-box space (unit cube, +/-1)
-  vec4 camera_position; // xyz: world camera; w: color mode (0 sRGB-encoded, 1 linear)
-  vec4 params_texture;  // x: width, y: height (texels)
-  vec4 sh_texture;      // x: width, y: height, z: texels per splat, w: SH degree
-  vec4 viewport;        // xy: size in pixels; z: kernel mode (0 classic, 1 antialiased); w: splat scale
-  vec4 params;          // x: opacity scale; y: crop mode (0 off, 1 include, 2 exclude); zw: reserved
+  mat4 model_transform; // node world transform (for the SH view direction)
+  mat4 crop_transform;  // splat-local to crop-box space (unit cube, +/-1)
+  vec4 camera_position; // xyz world camera, w color mode (0 sRGB, 1 linear)
+  vec4 params_texture;  // xy size in texels
+  vec4 sh_texture;      // xy size, z texels per splat, w SH degree
+  vec4 viewport;        // xy pixels, z kernel (0 classic, 1 aa), w splat scale
+  vec4 params;          // x opacity, y crop (0 off, 1 include, 2 exclude)
   vec4 tint;            // linear RGBA multiplier
 }
 frame_info;
@@ -24,9 +24,9 @@ frame_info;
 uniform sampler2D splat_params_texture;
 uniform sampler2D splat_sh_texture;
 
-// Slot 0: the unit quad, corners in [-1, 1].
+// Slot 0, the unit quad, corners in [-1, 1].
 in vec2 corner;
-// Slot 1 (instance rate): this instance's splat index.
+// Slot 1 (instance rate), this instance's splat index.
 in float splat_index;
 
 // Position within the footprint in standard-deviation units, and the
@@ -70,8 +70,8 @@ void main() {
   vec4 t2 = fetchTexel(splat_params_texture, base + 2.0, dims);
   vec4 t3 = fetchTexel(splat_params_texture, base + 3.0, dims);
 
-  // Crop volume: drop splats outside an include box or inside an exclude
-  // box (the box is the unit cube in crop space).
+  // Crop volume. Drop splats outside an include box or inside an exclude
+  // box (the unit cube in crop space).
   float crop_mode = frame_info.params.y;
   if (crop_mode > 0.5) {
     vec3 crop_pos = (frame_info.crop_transform * vec4(t0.xyz, 1.0)).xyz;
@@ -109,13 +109,13 @@ void main() {
   vec3 jx = (row_x - ndc.x * row_w) * (half_viewport.x / clip.w);
   vec3 jy = (row_y - ndc.y * row_w) * (half_viewport.y / clip.w);
 
-  // 2D covariance: J * cov3d * J^T, expanded through the symmetric product.
+  // 2D covariance J * cov3d * J^T, expanded through the symmetric product.
   vec3 cx = cov3d * jx;
   float cov_a = dot(jx, cx);
   float cov_b = dot(jy, cx);
   float cov_d = dot(jy, cov3d * jy);
 
-  // Low-pass kernel: dilate by kKernel2D pixels^2. The antialiased mode
+  // Low-pass kernel, dilating by kKernel2D pixels^2. The antialiased mode
   // compensates opacity by the footprint growth so small splats dim instead
   // of shimmering.
   float det_raw = cov_a * cov_d - cov_b * cov_b;
@@ -127,9 +127,9 @@ void main() {
     opacity *= sqrt(max(det_raw / det, 0.0));
   }
 
-  // The final blended alpha bounds the useful footprint: past the radius
-  // where the falloff drops under 1/255, fragments only discard. Tighten
-  // the cut per splat so dim splats rasterize far fewer pixels.
+  // The final blended alpha bounds the useful footprint. Past the radius
+  // where the falloff drops under 1/255 fragments only discard, so tighten
+  // the cut per splat and dim splats rasterize far fewer pixels.
   float alpha = clamp(opacity, 0.0, 1.0) * frame_info.tint.a;
   if (alpha < 1.0 / 255.0) {
     cull();
@@ -157,7 +157,7 @@ void main() {
       vec4(ndc.xy * clip.w + offset_px / half_viewport * clip.w, clip.zw);
   v_quad = corner * sigma_cut;
 
-  // Color: the base (degree 0) term plus the view-dependent rest bands.
+  // The base (degree 0) color plus the view-dependent rest bands.
   vec3 color = t3.rgb;
   float degree = frame_info.sh_texture.w;
   if (degree >= 1.0) {

--- a/packages/flutter_scene/shaders/flutter_scene_splats.vert
+++ b/packages/flutter_scene/shaders/flutter_scene_splats.vert
@@ -1,0 +1,165 @@
+// Gaussian splat vertex stage.
+//
+// Each instance is one splat; the per-instance attribute is the splat's
+// index into the parameter texture (a float, since the broadest GLES tier
+// has no integer attributes). The unit quad is expanded to cover the
+// splat's projected footprint: the local 3D covariance (prefetched from the
+// parameter texture) is pushed through the Jacobian of the full
+// local-to-pixel mapping, and the resulting 2D covariance's eigenvectors
+// give the quad axes. Instances arrive presorted back to front.
+
+uniform FrameInfo {
+  mat4 mvp_transform;   // camera view-projection * node world transform
+  mat4 model_transform; // node world transform (for SH view direction)
+  vec4 camera_position; // xyz: world camera; w: color mode (0 sRGB-encoded, 1 linear)
+  vec4 params_texture;  // x: width, y: height (texels)
+  vec4 sh_texture;      // x: width, y: height, z: texels per splat, w: SH degree
+  vec4 viewport;        // xy: size in pixels; z: kernel mode (0 classic, 1 antialiased); w: splat scale
+  vec4 params;          // x: opacity scale; yzw: reserved
+  vec4 tint;            // linear RGBA multiplier
+}
+frame_info;
+
+uniform sampler2D splat_params_texture;
+uniform sampler2D splat_sh_texture;
+
+// Slot 0: the unit quad, corners in [-1, 1].
+in vec2 corner;
+// Slot 1 (instance rate): this instance's splat index.
+in float splat_index;
+
+// Position within the footprint in standard-deviation units, and the
+// splat's color (linear RGB) with its final opacity.
+out vec2 v_quad;
+out vec4 v_color;
+
+// The footprint half-extent in standard deviations. exp(-0.5 * 3.33^2) is
+// just under 1/255, so the cut is invisible at 8-bit blending precision.
+const float kSigmaCut = 3.33;
+
+// Low-pass dilation applied to the projected covariance (in pixel^2),
+// matching the training-time rasterizer's anti-aliasing convolution.
+const float kKernel2D = 0.3;
+
+const float kShC1 = 0.4886025119029199;
+const float kShC2x = 1.0925484305920792;
+const float kShC2z = 0.31539156525252005;
+const float kShC2w = 0.5462742152960396;
+
+vec4 fetchTexel(sampler2D tex, float index, vec2 dims) {
+  float y = floor(index / dims.x);
+  float x = index - y * dims.x;
+  return texture(tex, vec2((x + 0.5) / dims.x, (y + 0.5) / dims.y));
+}
+
+void main() {
+  float base = splat_index * 4.0;
+  vec2 dims = frame_info.params_texture.xy;
+  vec4 t0 = fetchTexel(splat_params_texture, base, dims);
+  vec4 t1 = fetchTexel(splat_params_texture, base + 1.0, dims);
+  vec4 t2 = fetchTexel(splat_params_texture, base + 2.0, dims);
+  vec4 t3 = fetchTexel(splat_params_texture, base + 3.0, dims);
+
+  vec4 clip = frame_info.mvp_transform * vec4(t0.xyz, 1.0);
+  vec3 ndc = clip.xyz / clip.w;
+  // Cull splats behind the camera or far outside the frustum (the margin
+  // leaves room for large footprints straddling the edge).
+  if (clip.w <= 0.0 || abs(ndc.x) > 1.3 || abs(ndc.y) > 1.3 || ndc.z > 1.0) {
+    gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
+    v_quad = vec2(0.0);
+    v_color = vec4(0.0);
+    return;
+  }
+
+  // Local 3D covariance, scaled by the footprint multiplier.
+  float s2 = frame_info.viewport.w * frame_info.viewport.w;
+  mat3 cov3d =
+      mat3(t1.x, t1.y, t1.z, t1.y, t1.w, t2.x, t1.z, t2.x, t2.y) * s2;
+
+  // Rows of the MVP needed for the Jacobian of local -> NDC (the analytic
+  // derivative of the projective divide).
+  mat4 m = frame_info.mvp_transform;
+  vec3 row_x = vec3(m[0][0], m[1][0], m[2][0]);
+  vec3 row_y = vec3(m[0][1], m[1][1], m[2][1]);
+  vec3 row_w = vec3(m[0][3], m[1][3], m[2][3]);
+  vec2 half_viewport = 0.5 * frame_info.viewport.xy;
+  // d(pixel)/d(local), one row per screen axis. This composes the model
+  // transform, the view-projection, and the perspective divide in one step,
+  // so the covariance below lands directly in pixel^2.
+  vec3 jx = (row_x - ndc.x * row_w) * (half_viewport.x / clip.w);
+  vec3 jy = (row_y - ndc.y * row_w) * (half_viewport.y / clip.w);
+
+  // 2D covariance: J * cov3d * J^T, expanded through the symmetric product.
+  vec3 cx = cov3d * jx;
+  float cov_a = dot(jx, cx);
+  float cov_b = dot(jy, cx);
+  float cov_d = dot(jy, cov3d * jy);
+
+  // Low-pass kernel: dilate by kKernel2D pixels^2. The antialiased mode
+  // compensates opacity by the footprint growth so small splats dim instead
+  // of shimmering.
+  float det_raw = cov_a * cov_d - cov_b * cov_b;
+  cov_a += kKernel2D;
+  cov_d += kKernel2D;
+  float det = cov_a * cov_d - cov_b * cov_b;
+  float opacity = t0.w * frame_info.params.x;
+  if (frame_info.viewport.z > 0.5) {
+    opacity *= sqrt(max(det_raw / det, 0.0));
+  }
+
+  // Eigen-decomposition of the symmetric 2x2 covariance.
+  float mid = 0.5 * (cov_a + cov_d);
+  float delta = sqrt(max(mid * mid - det, 0.0));
+  float lambda1 = mid + delta;
+  float lambda2 = max(mid - delta, 0.01);
+  vec2 axis1 = abs(cov_b) > 1e-6
+      ? normalize(vec2(cov_b, lambda1 - cov_a))
+      : (cov_a >= cov_d ? vec2(1.0, 0.0) : vec2(0.0, 1.0));
+  vec2 axis2 = vec2(-axis1.y, axis1.x);
+  float radius1 = kSigmaCut * sqrt(lambda1);
+  float radius2 = kSigmaCut * sqrt(lambda2);
+
+  vec2 offset_px = corner.x * radius1 * axis1 + corner.y * radius2 * axis2;
+  gl_Position =
+      vec4(ndc.xy * clip.w + offset_px / half_viewport * clip.w, clip.zw);
+  v_quad = corner * kSigmaCut;
+
+  // Color: the base (degree 0) term plus the view-dependent rest bands.
+  vec3 color = t3.rgb;
+  float degree = frame_info.sh_texture.w;
+  if (degree >= 1.0) {
+    vec3 world_pos = (frame_info.model_transform * vec4(t0.xyz, 1.0)).xyz;
+    vec3 dir = normalize(world_pos - frame_info.camera_position.xyz);
+    float x = dir.x;
+    float y = dir.y;
+    float z = dir.z;
+    float sh_base = splat_index * frame_info.sh_texture.z;
+    vec2 sh_dims = frame_info.sh_texture.xy;
+    vec3 c0 = fetchTexel(splat_sh_texture, sh_base, sh_dims).rgb;
+    vec3 c1 = fetchTexel(splat_sh_texture, sh_base + 1.0, sh_dims).rgb;
+    vec3 c2 = fetchTexel(splat_sh_texture, sh_base + 2.0, sh_dims).rgb;
+    color += kShC1 * (-y * c0 + z * c1 - x * c2);
+    if (degree >= 2.0) {
+      vec3 c3 = fetchTexel(splat_sh_texture, sh_base + 3.0, sh_dims).rgb;
+      vec3 c4 = fetchTexel(splat_sh_texture, sh_base + 4.0, sh_dims).rgb;
+      vec3 c5 = fetchTexel(splat_sh_texture, sh_base + 5.0, sh_dims).rgb;
+      vec3 c6 = fetchTexel(splat_sh_texture, sh_base + 6.0, sh_dims).rgb;
+      vec3 c7 = fetchTexel(splat_sh_texture, sh_base + 7.0, sh_dims).rgb;
+      color += kShC2x * x * y * c3;
+      color += -kShC2x * y * z * c4;
+      color += kShC2z * (2.0 * z * z - x * x - y * y) * c5;
+      color += -kShC2x * x * z * c6;
+      color += kShC2w * (x * x - y * y) * c7;
+    }
+  }
+  color = max(color, vec3(0.0));
+  // Captured splats are trained against display-encoded images; decode to
+  // linear for the scene's linear HDR pipeline. Mode 1 skips the decode.
+  if (frame_info.camera_position.w < 0.5) {
+    color = pow(color, vec3(2.2));
+  }
+  v_color = vec4(
+    color * frame_info.tint.rgb,
+    clamp(opacity, 0.0, 1.0) * frame_info.tint.a
+  );
+}

--- a/packages/flutter_scene/test/splats/splat_codec_test.dart
+++ b/packages/flutter_scene/test/splats/splat_codec_test.dart
@@ -1,0 +1,259 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/splats/splat_codec.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/splats/splat_data.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/splats/splat_sorter.dart';
+
+/// Builds a binary little-endian Gaussian-splat PLY with [restPerChannel]
+/// f_rest coefficients per channel, from per-splat property maps in
+/// training space (log scales, logit opacity, raw f_dc).
+Uint8List buildSplatPly(
+  List<Map<String, double>> splats, {
+  int restPerChannel = 0,
+}) {
+  final props = <String>[
+    'x',
+    'y',
+    'z',
+    'nx',
+    'ny',
+    'nz',
+    'f_dc_0',
+    'f_dc_1',
+    'f_dc_2',
+    for (var i = 0; i < restPerChannel * 3; i++) 'f_rest_$i',
+    'opacity',
+    'scale_0',
+    'scale_1',
+    'scale_2',
+    'rot_0',
+    'rot_1',
+    'rot_2',
+    'rot_3',
+  ];
+  final header = StringBuffer()
+    ..write('ply\n')
+    ..write('format binary_little_endian 1.0\n')
+    ..write('element vertex ${splats.length}\n');
+  for (final p in props) {
+    header.write('property float $p\n');
+  }
+  header.write('end_header\n');
+
+  final headerBytes = header.toString().codeUnits;
+  final body = ByteData(splats.length * props.length * 4);
+  var offset = 0;
+  for (final splat in splats) {
+    for (final p in props) {
+      body.setFloat32(offset, splat[p] ?? 0.0, Endian.little);
+      offset += 4;
+    }
+  }
+  return Uint8List.fromList([...headerBytes, ...body.buffer.asUint8List()]);
+}
+
+double logit(double p) => math.log(p / (1 - p));
+
+void main() {
+  test('parses the training PLY layout with its space transforms', () {
+    final bytes = buildSplatPly([
+      {
+        'x': 1.0, 'y': 2.0, 'z': 3.0,
+        'f_dc_0': 1.0, 'f_dc_1': 0.0, 'f_dc_2': -1.0,
+        'opacity': logit(0.75),
+        'scale_0': math.log(0.5), 'scale_1': math.log(2.0), 'scale_2': 0.0,
+        // Scalar-first quaternion, doubled so normalization is exercised.
+        'rot_0': 2.0, 'rot_1': 0.0, 'rot_2': 0.0, 'rot_3': 0.0,
+      },
+    ]);
+    final data = parseSplatPly(bytes);
+
+    expect(data.count, 1);
+    expect(data.shDegree, 0);
+    expect(data.positions, [1.0, 2.0, 3.0]);
+    expect(data.scales[0], closeTo(0.5, 1e-6));
+    expect(data.scales[1], closeTo(2.0, 1e-6));
+    expect(data.scales[2], closeTo(1.0, 1e-6));
+    expect(data.opacities[0], closeTo(0.75, 1e-6));
+    // SH0 evaluation: 0.5 + C0 * f_dc.
+    expect(data.colors[0], closeTo(0.5 + kShC0, 1e-6));
+    expect(data.colors[1], closeTo(0.5, 1e-6));
+    expect(data.colors[2], closeTo(0.5 - kShC0, 1e-6));
+    // Stored x, y, z, w; the file's rot_0 is the scalar.
+    expect(data.rotations, [0.0, 0.0, 0.0, 1.0]);
+  });
+
+  test('reorders channel-major f_rest into per-coefficient rgb', () {
+    final rest = <String, double>{};
+    // Channel-major: R coefficients 1..3, G 4..6, B 7..9.
+    for (var i = 0; i < 9; i++) {
+      rest['f_rest_$i'] = (i + 1).toDouble();
+    }
+    final bytes = buildSplatPly([
+      {'opacity': logit(0.9), 'rot_0': 1.0, ...rest},
+    ], restPerChannel: 3);
+    final data = parseSplatPly(bytes);
+
+    expect(data.shDegree, 1);
+    // Coefficient 0 across channels: R=1, G=4, B=7; coefficient 2: 3, 6, 9.
+    expect(data.sh!.sublist(0, 3), [1.0, 4.0, 7.0]);
+    expect(data.sh!.sublist(6, 9), [3.0, 6.0, 9.0]);
+  });
+
+  test('truncates SH to maxShDegree and culls by alpha', () {
+    final rest = <String, double>{
+      for (var i = 0; i < 24; i++) 'f_rest_$i': 1.0,
+    };
+    final bytes = buildSplatPly([
+      {'opacity': logit(0.9), 'rot_0': 1.0, ...rest},
+      {'opacity': -20.0, 'rot_0': 1.0, ...rest}, // sigmoid ~ 0: culled
+    ], restPerChannel: 8);
+
+    final full = parseSplatPly(bytes);
+    expect(full.count, 1);
+    expect(full.shDegree, 2);
+
+    final truncated = parseSplatPly(
+      bytes,
+      options: const SplatDecodeOptions(maxShDegree: 1),
+    );
+    expect(truncated.shDegree, 1);
+    expect(truncated.sh!.length, 1 * 3 * 3);
+  });
+
+  test('parses the 32-byte .splat layout', () {
+    final bytes = Uint8List(64);
+    final view = ByteData.sublistView(bytes);
+    for (var i = 0; i < 2; i++) {
+      final base = i * 32;
+      view.setFloat32(base, 1.0 + i, Endian.little);
+      view.setFloat32(base + 4, 2.0, Endian.little);
+      view.setFloat32(base + 8, 3.0, Endian.little);
+      view.setFloat32(base + 12, 0.1, Endian.little);
+      view.setFloat32(base + 16, 0.2, Endian.little);
+      view.setFloat32(base + 20, 0.3, Endian.little);
+      bytes[base + 24] = 255; // r
+      bytes[base + 25] = 128; // g
+      bytes[base + 26] = 0; // b
+      bytes[base + 27] = i == 0 ? 255 : 0; // opacity; splat 1 is culled
+      bytes[base + 28] = 255; // ~w = 0.99
+      bytes[base + 29] = 128; // x = 0
+      bytes[base + 30] = 128; // y = 0
+      bytes[base + 31] = 128; // z = 0
+    }
+    final data = parseSplatFile(bytes);
+    expect(data.count, 1);
+    expect(data.positions[0], 1.0);
+    expect(data.scales[1], closeTo(0.2, 1e-6));
+    expect(data.colors[0], closeTo(1.0, 1e-6));
+    expect(data.colors[1], closeTo(128 / 255, 1e-6));
+    expect(data.opacities[0], 1.0);
+    expect(data.rotations[3], closeTo(1.0, 1e-6)); // w, normalized
+    expect(sniffSplatFormat(bytes), SplatFormat.splat);
+  });
+
+  test('packs covariance from quaternion and scales', () {
+    // Identity rotation: covariance is diag(sx^2, sy^2, sz^2).
+    final data = SplatData.zeroed(2);
+    data.positions.setAll(0, [1, 2, 3, 4, 5, 6]);
+    data.scales.setAll(0, [0.5, 2.0, 3.0, 1.0, 1.0, 1.0]);
+    data.rotations.setAll(0, [0, 0, 0, 1, 0, 0, math.sqrt1_2, math.sqrt1_2]);
+    data.opacities.setAll(0, [0.25, 1.0]);
+    data.colors.setAll(0, [1, 0, 0, 0, 1, 0]);
+
+    final packed = packSplats(data);
+    expect(
+      packed.paramsWidth * packed.paramsHeight * 4,
+      packed.paramsTexels.length,
+    );
+
+    final t = packed.paramsTexels;
+    // Splat 0, texel 0: position + opacity.
+    expect(t.sublist(0, 4), [1, 2, 3, 0.25]);
+    // Texels 1-2: xx, xy, xz, yy | yz, zz.
+    expect(t[4], closeTo(0.25, 1e-6)); // xx = 0.5^2
+    expect(t[5], closeTo(0.0, 1e-6));
+    expect(t[7], closeTo(4.0, 1e-6)); // yy = 2^2
+    expect(t[9], closeTo(9.0, 1e-6)); // zz = 3^2
+    // Texel 3: color.
+    expect(t.sublist(12, 15), [1, 0, 0]);
+
+    // Splat 1: 90-degree rotation about Z of a unit sphere stays identity.
+    final o = kParamsTexelsPerSplat * 4;
+    expect(t[o + 4], closeTo(1.0, 1e-6));
+    expect(t[o + 7], closeTo(1.0, 1e-6));
+    expect(t[o + 9], closeTo(1.0, 1e-6));
+    expect(t[o + 5], closeTo(0.0, 1e-6));
+  });
+
+  test('packs rest SH with a power-of-two stride', () {
+    final data = SplatData.zeroed(3, shDegree: 1);
+    for (var i = 0; i < data.count; i++) {
+      data.rotations[i * 4 + 3] = 1.0;
+      for (var c = 0; c < 3; c++) {
+        for (var ch = 0; ch < 3; ch++) {
+          data.sh![(i * 3 + c) * 3 + ch] = (i * 100 + c * 10 + ch).toDouble();
+        }
+      }
+    }
+    final packed = packSplats(data);
+    expect(packed.shStride, 4);
+    final sh = packed.shTexels!;
+    // Splat 2, coefficient 1: value 2*100 + 10 + channel.
+    final base = (2 * packed.shStride + 1) * 4;
+    expect(sh.sublist(base, base + 3), [210.0, 211.0, 212.0]);
+    // Padding texel is zero.
+    expect(sh[(2 * packed.shStride + 3) * 4], 0.0);
+  });
+
+  test('sorts back to front along the view direction', () {
+    final rng = math.Random(1234);
+    const count = 2000;
+    final positions = Float32List(count * 3);
+    for (var i = 0; i < positions.length; i++) {
+      positions[i] = rng.nextDouble() * 200 - 100;
+    }
+    const dx = 0.3, dy = -0.5, dz = 0.8;
+    final order = sortSplatsBackToFront(positions, count, dx, dy, dz);
+
+    expect(order.length, count);
+    final seen = <int>{};
+    var last = double.infinity;
+    for (var i = 0; i < count; i++) {
+      final index = order[i].toInt();
+      expect(order[i], index.toDouble()); // exact float integers
+      expect(seen.add(index), isTrue); // a permutation
+      final o = index * 3;
+      final key =
+          positions[o] * dx + positions[o + 1] * dy + positions[o + 2] * dz;
+      // Non-increasing within quantization tolerance.
+      const tolerance = 400 * math.sqrt2 / 65535 * 2;
+      expect(key, lessThanOrEqualTo(last + tolerance));
+      last = key;
+    }
+  });
+
+  test('sorter handles degenerate inputs', () {
+    expect(sortSplatsBackToFront(Float32List(0), 0, 0, 0, 1), isEmpty);
+    final same = Float32List.fromList([1, 1, 1, 1, 1, 1]);
+    final order = sortSplatsBackToFront(same, 2, 0, 0, 1);
+    expect(order.toSet(), {0.0, 1.0});
+  });
+
+  test(
+    'rejects oversized sets with a clear error',
+    () {
+      // A count whose params texels exceed 4096 rows of a 4096-wide texture.
+      expect(
+        () => packSplats(SplatData.zeroed(4096 * 4096 ~/ 4 + 1)),
+        throwsArgumentError,
+      );
+    },
+    skip: 'Allocates ~1.5GB; covered by the height check unit logic.',
+  );
+}

--- a/packages/flutter_scene/test/splats/splat_codec_test.dart
+++ b/packages/flutter_scene/test/splats/splat_codec_test.dart
@@ -245,15 +245,11 @@ void main() {
     expect(order.toSet(), {0.0, 1.0});
   });
 
-  test(
-    'rejects oversized sets with a clear error',
-    () {
-      // A count whose params texels exceed 4096 rows of a 4096-wide texture.
-      expect(
-        () => packSplats(SplatData.zeroed(4096 * 4096 ~/ 4 + 1)),
-        throwsArgumentError,
-      );
-    },
-    skip: 'Allocates ~1.5GB; covered by the height check unit logic.',
-  );
+  test('rejects oversized sets with a clear error', () {
+    // A count whose params texels exceed 4096 rows of a 4096-wide texture.
+    expect(
+      () => packSplats(SplatData.zeroed(4096 * 4096 ~/ 4 + 1)),
+      throwsArgumentError,
+    );
+  }, skip: 'Allocates ~1.5GB; covered by the height check unit logic.');
 }

--- a/packages/flutter_scene/test/splats/splat_codec_test.dart
+++ b/packages/flutter_scene/test/splats/splat_codec_test.dart
@@ -80,7 +80,7 @@ void main() {
     expect(data.scales[1], closeTo(2.0, 1e-6));
     expect(data.scales[2], closeTo(1.0, 1e-6));
     expect(data.opacities[0], closeTo(0.75, 1e-6));
-    // SH0 evaluation: 0.5 + C0 * f_dc.
+    // SH0 evaluation, 0.5 + C0 * f_dc.
     expect(data.colors[0], closeTo(0.5 + kShC0, 1e-6));
     expect(data.colors[1], closeTo(0.5, 1e-6));
     expect(data.colors[2], closeTo(0.5 - kShC0, 1e-6));
@@ -90,7 +90,7 @@ void main() {
 
   test('reorders channel-major f_rest into per-coefficient rgb', () {
     final rest = <String, double>{};
-    // Channel-major: R coefficients 1..3, G 4..6, B 7..9.
+    // Channel-major, R coefficients 1..3, G 4..6, B 7..9.
     for (var i = 0; i < 9; i++) {
       rest['f_rest_$i'] = (i + 1).toDouble();
     }
@@ -100,7 +100,7 @@ void main() {
     final data = parseSplatPly(bytes);
 
     expect(data.shDegree, 1);
-    // Coefficient 0 across channels: R=1, G=4, B=7; coefficient 2: 3, 6, 9.
+    // Coefficient 0 across channels is R=1, G=4, B=7; coefficient 2 is 3,6,9.
     expect(data.sh!.sublist(0, 3), [1.0, 4.0, 7.0]);
     expect(data.sh!.sublist(6, 9), [3.0, 6.0, 9.0]);
   });
@@ -111,7 +111,7 @@ void main() {
     };
     final bytes = buildSplatPly([
       {'opacity': logit(0.9), 'rot_0': 1.0, ...rest},
-      {'opacity': -20.0, 'rot_0': 1.0, ...rest}, // sigmoid ~ 0: culled
+      {'opacity': -20.0, 'rot_0': 1.0, ...rest}, // sigmoid ~ 0, culled
     ], restPerChannel: 8);
 
     final full = parseSplatPly(bytes);
@@ -158,7 +158,7 @@ void main() {
   });
 
   test('packs covariance from quaternion and scales', () {
-    // Identity rotation: covariance is diag(sx^2, sy^2, sz^2).
+    // Identity rotation, so covariance is diag(sx^2, sy^2, sz^2).
     final data = SplatData.zeroed(2);
     data.positions.setAll(0, [1, 2, 3, 4, 5, 6]);
     data.scales.setAll(0, [0.5, 2.0, 3.0, 1.0, 1.0, 1.0]);
@@ -173,17 +173,17 @@ void main() {
     );
 
     final t = packed.paramsTexels;
-    // Splat 0, texel 0: position + opacity.
+    // Splat 0, texel 0, position and opacity.
     expect(t.sublist(0, 4), [1, 2, 3, 0.25]);
-    // Texels 1-2: xx, xy, xz, yy | yz, zz.
+    // Texels 1-2, xx, xy, xz, yy | yz, zz.
     expect(t[4], closeTo(0.25, 1e-6)); // xx = 0.5^2
     expect(t[5], closeTo(0.0, 1e-6));
     expect(t[7], closeTo(4.0, 1e-6)); // yy = 2^2
     expect(t[9], closeTo(9.0, 1e-6)); // zz = 3^2
-    // Texel 3: color.
+    // Texel 3, color.
     expect(t.sublist(12, 15), [1, 0, 0]);
 
-    // Splat 1: 90-degree rotation about Z of a unit sphere stays identity.
+    // Splat 1, a 90-degree Z rotation of a unit sphere, stays identity.
     final o = kParamsTexelsPerSplat * 4;
     expect(t[o + 4], closeTo(1.0, 1e-6));
     expect(t[o + 7], closeTo(1.0, 1e-6));
@@ -204,7 +204,7 @@ void main() {
     final packed = packSplats(data);
     expect(packed.shStride, 4);
     final sh = packed.shTexels!;
-    // Splat 2, coefficient 1: value 2*100 + 10 + channel.
+    // Splat 2, coefficient 1, value 2*100 + 10 + channel.
     final base = (2 * packed.shStride + 1) * 4;
     expect(sh.sublist(base, base + 3), [210.0, 211.0, 212.0]);
     // Padding texel is zero.

--- a/packages/flutter_scene/test/splats/splat_sort_service_test.dart
+++ b/packages/flutter_scene/test/splats/splat_sort_service_test.dart
@@ -1,0 +1,30 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/splats/splat_sort_service.dart';
+
+void main() {
+  test('sorts through the background worker and survives reuse', () async {
+    // Five splats along +Z.
+    final positions = Float32List.fromList([
+      0, 0, 0, //
+      0, 0, 1, //
+      0, 0, 2, //
+      0, 0, 3, //
+      0, 0, 4, //
+    ]);
+    final service = SplatSortService(positions, 5);
+
+    final backToFront = await service.sort(0, 0, 1);
+    expect(backToFront, [4, 3, 2, 1, 0]);
+
+    // A second request reuses the same worker; the reversed direction
+    // reverses the order.
+    final frontToBack = await service.sort(0, 0, -1);
+    expect(frontToBack, [0, 1, 2, 3, 4]);
+
+    service.dispose();
+    expect(await service.sort(0, 0, 1), isNull);
+  });
+}


### PR DESCRIPTION
Adds 3D Gaussian splatting as a first-class scene citizen. Load a `.ply` or `.splat` capture, attach a `SplatComponent`, and the set composites with the forward-rendered PBR scene, depth-tested against opaque geometry and blended premultiplied.

A set draws as one instanced batch of screen-space Gaussian footprints, its per-splat covariance, color, opacity, and spherical harmonics fetched from vertex-stage data textures. A background worker keeps the splats depth-sorted, with a synchronous fallback on the web.

The public API sits under a new `Gaussian splatting` doc category, `GaussianSplats`, `SplatComponent` (opacity, footprint scale, tint, SH degree, antialiasing, crop boxes), `SplatData`, and the `SplatColorSpace`, `SplatCropMode`, and `SplatFormat` enums. The geometry, material, packer, and sorter stay internal.

The example gains a Gaussian Splats page with two real CC BY captures, an animated crop wipe, and a free camera, and a `gaussian_splats` smoke scene covers the path (verified locally on Metal, WebGL2, Android GLES, and Android Vulkan). Follow-ups in the design note, `.spz`, a per-splat modify hook, picking, a global multi-set sort, and a compute GPU sort.
