### PR TITLE
Add scene-graph conveniences for framing a loaded model

### DIFF
--- a/examples/flutter_app/lib/example_materialize.dart
+++ b/examples/flutter_app/lib/example_materialize.dart
@@ -85,8 +85,7 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
   final vm.Vector3 _center = vm.Vector3.zero();
   double get _range => math.max(_maxH - _minH, 1e-3);
 
-  vm.Vector3 _cameraPosition = vm.Vector3(0, 0, -3);
-  vm.Vector3 _cameraTarget = vm.Vector3.zero();
+  PerspectiveCamera _camera = PerspectiveCamera(position: vm.Vector3(0, 0, -3));
 
   // Timeline. _t runs past [0, 1] a little so the effect holds briefly when
   // fully materialized and fully hidden.
@@ -112,44 +111,21 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
       final helmet = await Node.fromGlbBytes(bytes);
       if (!mounted) return;
 
-      final meshNodes = <Node>[];
-      _collectMeshNodes(helmet, meshNodes);
+      final meshNodes = helmet.meshNodes.toList();
       if (meshNodes.isEmpty) {
         throw StateError('No mesh found in the downloaded model.');
       }
 
-      // World-space AABB across every node and primitive, for the sweep
-      // extent and the camera framing.
-      var minX = double.infinity, minY = double.infinity;
-      var minZ = double.infinity;
-      var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
-      var maxZ = double.negativeInfinity;
       var primitiveCount = 0;
       var triangleCount = 0;
-      final scratch = vm.Vector3.zero();
 
       for (final meshNode in meshNodes) {
-        final world = meshNode.globalTransform;
         final parts = <MeshData>[];
         for (final primitive in meshNode.mesh!.primitives) {
           final source = primitive.geometry.extractMeshData();
           parts.add(source);
           primitiveCount++;
           triangleCount += source.triangleCount;
-          for (var v = 0; v < source.positions.length; v += 3) {
-            scratch.setValues(
-              source.positions[v],
-              source.positions[v + 1],
-              source.positions[v + 2],
-            );
-            world.transform3(scratch);
-            if (scratch.x < minX) minX = scratch.x;
-            if (scratch.y < minY) minY = scratch.y;
-            if (scratch.z < minZ) minZ = scratch.z;
-            if (scratch.x > maxX) maxX = scratch.x;
-            if (scratch.y > maxY) maxY = scratch.y;
-            if (scratch.z > maxZ) maxZ = scratch.z;
-          }
 
           // Stage 3: this primitive keeps its geometry but shades through the
           // reveal material, mirroring its own imported textures/factors.
@@ -197,28 +173,24 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
         '$primitiveCount primitive(s), $triangleCount triangles',
       );
 
-      _minH = minY;
-      _maxH = maxY;
-      _center.setValues(
-        (minX + maxX) / 2,
-        (minY + maxY) / 2,
-        (minZ + maxZ) / 2,
-      );
-      final radius = math.max(
-        vm.Vector3(maxX - minX, maxY - minY, maxZ - minZ).length * 0.5,
-        0.1,
-      );
+      // The model's world-space bounds drive both the bottom-to-top sweep
+      // extent and the camera framing. Taken before adding the helmet under
+      // the spin node, so the sweep is measured with the spin at identity.
+      final bounds =
+          helmet.combinedWorldBounds ??
+          (throw StateError('Model has no computable bounds.'));
+      _minH = bounds.min.y;
+      _maxH = bounds.max.y;
+      _center.setFrom(bounds.center);
 
       _spin.add(helmet);
       scene.add(_spin);
 
-      // Frame the camera. After the importer's scene-root Z flip glTF
-      // models face -Z, so the camera sits on the -Z side.
-      _cameraTarget = vm.Vector3.copy(_center);
-      _cameraPosition = vm.Vector3(
-        _center.x + radius * 0.4,
-        _center.y + radius * 0.5,
-        _center.z - radius * 2.6,
+      // Frame the model on the -Z side (after the importer's scene-root Z flip
+      // glTF models face -Z), angled slightly up and to the side.
+      _camera = PerspectiveCamera.framing(
+        bounds,
+        direction: vm.Vector3(0.4, 0.5, -2.6),
       );
 
       _applySettings();
@@ -227,16 +199,6 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _error = e);
-    }
-  }
-
-  void _collectMeshNodes(Node node, List<Node> out) {
-    final mesh = node.mesh;
-    if (mesh != null && mesh.primitives.isNotEmpty) {
-      out.add(node);
-    }
-    for (final child in node.children) {
-      _collectMeshNodes(child, out);
     }
   }
 
@@ -408,10 +370,7 @@ class _ExampleMaterializeState extends State<ExampleMaterialize> {
         Positioned.fill(
           child: SceneView(
             scene,
-            camera: PerspectiveCamera(
-              position: _cameraPosition,
-              target: _cameraTarget,
-            ),
+            camera: _camera,
             onTick: (elapsed, deltaSeconds) {
               final seconds = elapsed.inMicroseconds / 1e6;
               if (_playing) {

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 0.19.0
 
+* Scene-graph conveniences for working with a loaded model. `Node.meshNodes`
+  iterates the drawable nodes in a subtree, `Node.combinedWorldBounds` gives
+  the subtree's world-space AABB (the bound the renderer culls against), and
+  `PerspectiveCamera.framing(bounds)` places a camera to fit that AABB in the
+  view. Together they turn "load a model, find its meshes, frame the camera on
+  it" into a few lines instead of a hand-rolled vertex loop.
+
 * Per-frame transient GPU data (uniform blocks, instance transforms) now
   rides an engine-owned, completion-aware arena allocator instead of
   `package:flutter_gpu`'s `HostBuffer`. Emplacements stage CPU-side and

--- a/packages/flutter_scene/lib/src/camera.dart
+++ b/packages/flutter_scene/lib/src/camera.dart
@@ -194,6 +194,38 @@ class PerspectiveCamera extends Camera {
        target = target ?? Vector3(0, 0, 0),
        up = up ?? Vector3(0, 1, 0);
 
+  /// Places a camera to frame [bounds] (a model's world-space AABB, from
+  /// [Node.combinedWorldBounds]) so it fills the view.
+  ///
+  /// The camera looks at the bounds' center from [direction] (the offset from
+  /// the center toward the eye; defaults to `(0, 0, -1)`, matching the default
+  /// placement and the direction glTF models face after import). The distance
+  /// fits the bounds' bounding sphere within the vertical field of view, so it
+  /// frames cleanly on a landscape view; [margin] above `1` pulls the camera
+  /// back for padding (a portrait view, whose horizontal field of view is
+  /// narrower, may want some). The near and far planes are set around the
+  /// model so a tiny or a huge one both stay in range.
+  factory PerspectiveCamera.framing(
+    Aabb3 bounds, {
+    Vector3? direction,
+    double fovRadiansY = 45 * degrees2Radians,
+    Vector3? up,
+    double margin = 1.1,
+  }) {
+    final center = bounds.center;
+    final radius = max((bounds.max - bounds.min).length * 0.5, 1e-4);
+    final distance = radius / sin(fovRadiansY / 2) * margin;
+    final dir = (direction ?? Vector3(0, 0, -1)).normalized();
+    return PerspectiveCamera(
+      fovRadiansY: fovRadiansY,
+      position: center + dir * distance,
+      target: center,
+      up: up,
+      fovNear: max(distance - radius, distance * 1e-3),
+      fovFar: distance + radius * 2,
+    );
+  }
+
   /// Vertical field of view, in radians.
   ///
   /// The horizontal field of view is computed at render time from this

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -353,6 +353,35 @@ base class Node implements SceneGraph {
     _combinedBoundsCached = true;
   }
 
+  /// The subtree's axis-aligned bounds in world space, or `null` when the
+  /// subtree is unbounded ([combinedLocalBounds] is `null`, e.g. skinned
+  /// content or caller-managed geometry).
+  ///
+  /// This is [combinedLocalBounds] placed into world space with this node's
+  /// [globalTransform], the same bound the renderer frustum-culls against.
+  /// Handy for framing a camera on a loaded model (see
+  /// [PerspectiveCamera.framing]) or sizing an effect to a model's extent,
+  /// without walking vertices by hand.
+  vm.Aabb3? get combinedWorldBounds {
+    final bounds = combinedLocalBounds;
+    if (bounds == null) return null;
+    return vm.Aabb3.copy(bounds)..transform(globalTransform);
+  }
+
+  /// The nodes in this subtree (this node and its descendants, depth-first)
+  /// that carry a mesh with at least one primitive.
+  ///
+  /// The usual entry point after loading a model, when you need the drawable
+  /// nodes to read geometry back, swap materials, or attach effects. Includes
+  /// this node when it has a mesh.
+  Iterable<Node> get meshNodes sync* {
+    final m = mesh;
+    if (m != null && m.primitives.isNotEmpty) yield this;
+    for (final child in children) {
+      yield* child.meshNodes;
+    }
+  }
+
   /// Whether this node's subtree would survive frustum culling against
   /// [camera] for a render target of the given [dimensions].
   ///

--- a/packages/flutter_scene/test/bounds_test.dart
+++ b/packages/flutter_scene/test/bounds_test.dart
@@ -332,4 +332,73 @@ void main() {
       expect(node.combinedLocalBounds!.max, Vector3(2, 2, 2));
     });
   });
+
+  group('Node.combinedWorldBounds', () {
+    test('places the local bounds into world space via globalTransform', () {
+      final node = Node(
+        localTransform: Matrix4.translation(Vector3(10, 0, 0)),
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+          ],
+        ),
+      );
+      final world = node.combinedWorldBounds!;
+      expect(world.min, Vector3(9, -1, -1));
+      expect(world.max, Vector3(11, 1, 1));
+    });
+
+    test('composes ancestor transforms', () {
+      final parent = Node(localTransform: Matrix4.diagonal3(Vector3(2, 2, 2)));
+      final child = Node(
+        localTransform: Matrix4.translation(Vector3(1, 0, 0)),
+        mesh: Mesh.primitives(
+          primitives: [
+            _primWithBounds(_aabb(Vector3(-1, -1, -1), Vector3(1, 1, 1))),
+          ],
+        ),
+      );
+      parent.add(child);
+      // Child bounds [-1,1] translated by (1,0,0) then scaled by 2 -> [0,4].
+      final world = child.combinedWorldBounds!;
+      expect(world.min.x, closeTo(0, 1e-9));
+      expect(world.max.x, closeTo(4, 1e-9));
+    });
+
+    test('null when the subtree is unbounded', () {
+      final node = Node(
+        mesh: Mesh.primitives(primitives: [_primWithBounds(null)]),
+      );
+      expect(node.combinedWorldBounds, isNull);
+    });
+  });
+
+  group('Node.meshNodes', () {
+    test('yields self and descendants that carry a drawable mesh', () {
+      final root = Node(name: 'root');
+      final meshChild = Node(
+        name: 'meshChild',
+        mesh: Mesh.primitives(primitives: [_primWithBounds(null)]),
+      );
+      final emptyChild = Node(name: 'emptyChild');
+      final grandchild = Node(
+        name: 'grandchild',
+        mesh: Mesh.primitives(primitives: [_primWithBounds(null)]),
+      );
+      emptyChild.add(grandchild);
+      root
+        ..add(meshChild)
+        ..add(emptyChild);
+
+      expect(root.meshNodes.map((n) => n.name), ['meshChild', 'grandchild']);
+    });
+
+    test('includes the receiver when it has a mesh', () {
+      final node = Node(
+        name: 'self',
+        mesh: Mesh.primitives(primitives: [_primWithBounds(null)]),
+      );
+      expect(node.meshNodes.map((n) => n.name), ['self']);
+    });
+  });
 }

--- a/packages/flutter_scene/test/camera_framing_test.dart
+++ b/packages/flutter_scene/test/camera_framing_test.dart
@@ -1,0 +1,74 @@
+// Tests for PerspectiveCamera.framing, which places a camera to fit a
+// bounding box in the view.
+
+import 'dart:math';
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  group('PerspectiveCamera.framing', () {
+    test('looks at the bounds center from the given direction', () {
+      final bounds = Aabb3.minMax(Vector3(2, 2, 2), Vector3(6, 6, 6));
+      final camera = PerspectiveCamera.framing(
+        bounds,
+        direction: Vector3(0, 0, -1),
+      );
+      expect(camera.target, Vector3(4, 4, 4));
+      // Eye sits on the -Z side of the center.
+      expect(camera.position.x, closeTo(4, 1e-9));
+      expect(camera.position.y, closeTo(4, 1e-9));
+      expect(camera.position.z, lessThan(4));
+    });
+
+    test('the bounding sphere subtends the vertical field of view', () {
+      final bounds = Aabb3.minMax(Vector3(-1, -1, -1), Vector3(1, 1, 1));
+      const fov = 45 * degrees2Radians;
+      final camera = PerspectiveCamera.framing(
+        bounds,
+        fovRadiansY: fov,
+        margin: 1.0,
+      );
+      final radius = (bounds.max - bounds.min).length * 0.5;
+      final distance = (camera.position - camera.target).length;
+      // distance = radius / sin(fov/2) frames the sphere exactly.
+      expect(camera.fovRadiansY, fov);
+      expect(distance, closeTo(radius / sin(fov / 2), 1e-4));
+    });
+
+    test('margin pushes the camera farther back', () {
+      final bounds = Aabb3.minMax(Vector3(-1, -1, -1), Vector3(1, 1, 1));
+      final near = PerspectiveCamera.framing(bounds, margin: 1.0);
+      final far = PerspectiveCamera.framing(bounds, margin: 2.0);
+      final dNear = (near.position - near.target).length;
+      final dFar = (far.position - far.target).length;
+      expect(dFar, closeTo(dNear * 2, 1e-9));
+    });
+
+    test('clip planes bracket the model for any scale', () {
+      for (final extent in [0.01, 1.0, 100.0]) {
+        final bounds = Aabb3.minMax(Vector3.all(-extent), Vector3.all(extent));
+        final camera = PerspectiveCamera.framing(bounds);
+        final distance = (camera.position - camera.target).length;
+        expect(camera.fovNear, greaterThan(0));
+        expect(camera.fovNear, lessThan(distance));
+        expect(camera.fovFar, greaterThan(distance));
+      }
+    });
+
+    test('normalizes a non-unit direction', () {
+      final bounds = Aabb3.minMax(Vector3(-1, -1, -1), Vector3(1, 1, 1));
+      final camera = PerspectiveCamera.framing(
+        bounds,
+        direction: Vector3(0, 0, -5),
+      );
+      final distance = (camera.position - camera.target).length;
+      final radius = (bounds.max - bounds.min).length * 0.5;
+      expect(
+        distance,
+        closeTo(radius / sin((45 * degrees2Radians) / 2) * 1.1, 1e-4),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Adds three small scene-graph conveniences that cover the common "load a model and look at it" path, prompted by the Materialize example hand-rolling all of them.

`Node.meshNodes` iterates the drawable nodes in a subtree (this node and its descendants that carry a mesh with a primitive), the usual entry point after loading a model when you need the meshes to read geometry back, swap materials, or attach effects.

`Node.combinedWorldBounds` returns the subtree's world-space axis-aligned bounds, `combinedLocalBounds` placed into world space by the node's `globalTransform`. It is the same bound the renderer already frustum-culls against (factored out of `isVisibleTo`), so framing a model or sizing an effect to its extent no longer means walking vertices by hand.

`PerspectiveCamera.framing(bounds)` places a camera to fit an AABB in the view. It looks at the bounds' center from a `direction` (defaulting to the -Z side glTF models face after import), sets the distance so the bounds' bounding sphere fits the vertical field of view (a `margin` above 1 pads it, which a portrait view may want), and brackets the near and far planes around the model so a 10 cm prop and a 100 m building both stay in range.

The Materialize example adopts all three: a per-vertex min/max AABB loop, a recursive mesh-node collector, and a manual camera placement collapse into `helmet.meshNodes`, `helmet.combinedWorldBounds`, and `PerspectiveCamera.framing`.

New unit tests cover the world-bounds transform composition, the mesh-node walk, and the framing math (sphere-fits-FOV, margin, clip-plane bracketing across scales). Verified with the full test suite and the example app on Metal.
