### PR TITLE
Expose scene content to assistive technology

### DIFF
--- a/examples/flutter_app/lib/example_accessibility.dart
+++ b/examples/flutter_app/lib/example_accessibility.dart
@@ -313,7 +313,12 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
         Positioned.fill(
           child: _showSemantics ? SemanticsDebugger(child: scene3d) : scene3d,
         ),
-        const Positioned(left: 16, top: 16, child: _Instructions()),
+        const Positioned(
+          top: 16,
+          left: 0,
+          right: 0,
+          child: Align(alignment: Alignment.topCenter, child: _Instructions()),
+        ),
         Positioned(
           right: 16,
           top: 16,

--- a/examples/flutter_app/lib/example_accessibility.dart
+++ b/examples/flutter_app/lib/example_accessibility.dart
@@ -1,23 +1,30 @@
 import 'dart:math';
 
-import 'package:flutter/gestures.dart' show PointerHoverEvent;
+import 'package:flutter/gestures.dart'
+    show PointerDownEvent, PointerHoverEvent, PointerUpEvent;
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart' hide Material;
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_settings.dart';
 
-/// An accessible 3D scene: the car's doors, hood, and trunk are each a
-/// pickable, labeled part. Hover (or accessibility-focus) draws a
-/// see-through outline on the part through the built-in highlight system;
-/// clicking (or activating its semantics) toggles it open or closed with an
-/// animation. Every part is also a [SemanticsComponent], so a screen reader
-/// navigates the same parts and performs the same toggles.
+/// An accessible 3D scene. The car's doors, hood, and trunk are each a
+/// pickable, labeled part: hovering (or landing accessibility focus on)
+/// one draws a see-through outline through the built-in highlight system,
+/// and clicking (or activating its semantics) toggles it open or closed
+/// with an animation.
 ///
-/// Toggle "Show semantics" to overlay Flutter's [SemanticsDebugger], which
-/// draws every semantics rectangle and lets you tap one to fire its action,
-/// a way to verify the accessibility tree without turning a screen reader
-/// on.
+/// A control panel floats beside the car as a widget surface (a live
+/// Flutter subtree rendered to a texture). Its two sliders drive the wheel
+/// speed and steering, and their real semantics project onto the 3D panel,
+/// so a screen reader navigates and drags them like ordinary widgets. The
+/// panel sits to one side, so it is visible from that side and occluded by
+/// the car body from the other; while occluded, its semantics leave the
+/// tree (`WidgetComponent.occlusionHiding`).
+///
+/// "Show semantics" overlays Flutter's [SemanticsDebugger], which draws
+/// every semantics rectangle and lets you tap one to fire its action, a
+/// way to verify the accessibility tree without a screen reader.
 class ExampleAccessibility extends StatefulWidget {
   const ExampleAccessibility({super.key});
 
@@ -103,11 +110,26 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
 
   final Map<Node, _Part> _partByNode = {};
 
+  // Wheel nodes and their rest poses, spun and steered by the panel.
+  final Map<String, Node> _wheels = {};
+  final Map<String, vm.Matrix4> _wheelRest = {};
+  double _speed = 0;
+  double _steer = 0;
+  double _wheelRotation = 0;
+
+  // The control panel node, so pointer picks over it defer to the scene's
+  // widget-input forwarding instead of toggling a car part.
+  Node? _panelNode;
+
   _Part? _hoveredPart;
   _Part? _focusedPart;
 
-  // Camera orbit, paused while the pointer is over the scene so parts are
-  // stationary (and easy to click) under the cursor.
+  // Car-part press tracking (a tap toggles; a drag does not).
+  _Part? _pressedPart;
+  Offset? _pressPosition;
+
+  // Camera orbit, paused while the pointer is over the scene so parts hold
+  // still under the cursor (and the panel stays put to drag its sliders).
   double _orbitPhase = 0;
   bool _pointerInside = false;
   Camera? _lastCamera;
@@ -149,6 +171,39 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
       _partByNode[node] = part;
     }
 
+    for (final name in const [
+      'WheelFront.L',
+      'WheelFront.R',
+      'WheelBack.L',
+      'WheelBack.R',
+    ]) {
+      final node = car.getChildByNamePath([name])!;
+      _wheels[name] = node;
+      _wheelRest[name] = node.localTransform.clone();
+    }
+
+    // A widget surface beside the car (+X side): visible from that side,
+    // occluded by the body from the other. The quad faces +Z locally, so a
+    // quarter turn about Y points it outward along +X.
+    final panel = Node(
+      name: 'ControlPanel',
+      localTransform: vm.Matrix4.translation(vm.Vector3(2.6, 1.1, 0))
+        ..rotate(vm.Vector3(0, 1, 0), pi / 2),
+    );
+    panel.addComponent(
+      WidgetComponent(
+        size: const Size(320, 200),
+        worldHeight: 1.25,
+        occlusionHiding: true,
+        child: _ControlPanel(
+          onSpeed: (v) => _speed = v,
+          onSteer: (v) => _steer = v,
+        ),
+      ),
+    );
+    scene.add(panel);
+    _panelNode = panel;
+
     scene.environment = environment;
     scene.exposure = 2.5;
     scene.skybox = Skybox(_skySource);
@@ -170,6 +225,15 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
       if (part != null) return part;
     }
     return null;
+  }
+
+  bool _isInPanel(Node node) {
+    final panel = _panelNode;
+    if (panel == null) return false;
+    for (Node? current = node; current != null; current = current.parent) {
+      if (identical(current, panel)) return true;
+    }
+    return false;
   }
 
   void _togglePart(_Part part) {
@@ -229,7 +293,12 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
     if (!_pointerInside) {
       _orbitPhase += deltaSeconds * 0.2;
     }
-    // Animate each part toward its open/closed target.
+    _animateParts(deltaSeconds);
+    _updateWheels(deltaSeconds);
+    exampleSettings.applyTo(scene);
+  }
+
+  void _animateParts(double deltaSeconds) {
     const speed = 3.0; // reaches the target in ~1/3 second
     for (final part in _parts) {
       if (part.amount == part.target) continue;
@@ -242,10 +311,64 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
       part.node.localTransform = part.startTransform.clone()
         ..rotate(part.axis, part.amount * pi / 2);
     }
-    exampleSettings.applyTo(scene);
   }
 
-  void _onEnter() => _pointerInside = true;
+  void _updateWheels(double deltaSeconds) {
+    _wheelRotation += _speed * deltaSeconds * 6;
+    for (final name in const ['WheelBack.L', 'WheelBack.R']) {
+      _wheels[name]?.localTransform = _wheelRest[name]!.clone()
+        ..rotate(vm.Vector3(0, 0, -1), _wheelRotation);
+    }
+    for (final name in const ['WheelFront.L', 'WheelFront.R']) {
+      _wheels[name]?.localTransform =
+          _wheelRest[name]!.clone() *
+          vm.Matrix4.rotationY(-_steer / 2) *
+          vm.Matrix4.rotationZ(-_wheelRotation);
+    }
+  }
+
+  SceneRaycastHit? _rawPick(Offset localPosition) {
+    final camera = _lastCamera;
+    if (camera == null || _viewSize.isEmpty) return null;
+    return scene.raycast(camera.screenPointToRay(localPosition, _viewSize));
+  }
+
+  void _onHover(PointerHoverEvent event) {
+    final hit = _rawPick(event.localPosition);
+    final part = hit == null ? null : _partForNode(hit.node);
+    if (part == _hoveredPart) return;
+    setState(() {
+      _hoveredPart = part;
+      _refreshHighlights();
+    });
+  }
+
+  void _onPointerDown(PointerDownEvent event) {
+    final hit = _rawPick(event.localPosition);
+    // A press on the panel drives its sliders through the scene's widget
+    // input forwarding; do not also arm a car-part toggle.
+    if (hit == null || _isInPanel(hit.node)) {
+      _pressedPart = null;
+      return;
+    }
+    _pressedPart = _partForNode(hit.node);
+    _pressPosition = event.localPosition;
+  }
+
+  void _onPointerUp(PointerUpEvent event) {
+    final part = _pressedPart;
+    _pressedPart = null;
+    if (part == null) return;
+    // A drag is not a tap.
+    if (_pressPosition != null &&
+        (event.localPosition - _pressPosition!).distance > 8) {
+      return;
+    }
+    final hit = _rawPick(event.localPosition);
+    if (hit != null && _partForNode(hit.node) == part) {
+      _togglePart(part);
+    }
+  }
 
   void _onExit() {
     _pointerInside = false;
@@ -255,29 +378,6 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
         _refreshHighlights();
       });
     }
-  }
-
-  _Part? _pick(Offset localPosition) {
-    final camera = _lastCamera;
-    if (camera == null || _viewSize.isEmpty) return null;
-    final hit = scene.raycast(
-      camera.screenPointToRay(localPosition, _viewSize),
-    );
-    return hit == null ? null : _partForNode(hit.node);
-  }
-
-  void _onHover(PointerHoverEvent event) {
-    final part = _pick(event.localPosition);
-    if (part == _hoveredPart) return;
-    setState(() {
-      _hoveredPart = part;
-      _refreshHighlights();
-    });
-  }
-
-  void _onTapUp(TapUpDetails details) {
-    final part = _pick(details.localPosition);
-    if (part != null) _togglePart(part);
   }
 
   @override
@@ -290,12 +390,12 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
       builder: (context, constraints) {
         _viewSize = constraints.biggest;
         return MouseRegion(
-          onEnter: (_) => _onEnter(),
+          onEnter: (_) => _pointerInside = true,
           onExit: (_) => _onExit(),
           onHover: _onHover,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTapUp: _onTapUp,
+          child: Listener(
+            onPointerDown: _onPointerDown,
+            onPointerUp: _onPointerUp,
             child: SceneView(
               scene,
               cameraBuilder: (elapsed) => _lastCamera = _buildCamera(),
@@ -335,6 +435,71 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
   }
 }
 
+/// The widget surface floating beside the car: two sliders driving the
+/// wheel speed and steering. A live Flutter subtree captured to a texture;
+/// its slider semantics project onto the 3D panel.
+class _ControlPanel extends StatefulWidget {
+  const _ControlPanel({required this.onSpeed, required this.onSteer});
+
+  final ValueChanged<double> onSpeed;
+  final ValueChanged<double> onSteer;
+
+  @override
+  State<_ControlPanel> createState() => _ControlPanelState();
+}
+
+class _ControlPanelState extends State<_ControlPanel> {
+  double _speed = 0;
+  double _steer = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xFF1B2431),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 12, 20, 12),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Car controls',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text('Wheel speed', style: TextStyle(color: Colors.white70)),
+            Slider(
+              value: _speed,
+              label: '${(_speed * 100).round()}%',
+              divisions: 20,
+              onChanged: (v) {
+                setState(() => _speed = v);
+                widget.onSpeed(v);
+              },
+            ),
+            const Text('Steering', style: TextStyle(color: Colors.white70)),
+            Slider(
+              value: _steer,
+              min: -1,
+              max: 1,
+              divisions: 20,
+              label: _steer == 0 ? 'Center' : (_steer < 0 ? 'Left' : 'Right'),
+              onChanged: (v) {
+                setState(() => _steer = v);
+                widget.onSteer(v);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _Instructions extends StatelessWidget {
   const _Instructions();
 
@@ -348,10 +513,13 @@ class _Instructions extends StatelessWidget {
       child: const Padding(
         padding: EdgeInsets.all(12),
         child: Text(
-          'Hover a door, hood, or trunk to outline it.\n'
-          'Click it to open or close it.\n'
-          'Turn on a screen reader, or "Show semantics",\n'
-          'to navigate and toggle the same parts.',
+          'Hover a door, hood, or trunk to outline it; click to open or '
+          'close it.\n'
+          'Drag the panel sliders (visible from one side) to drive the '
+          'wheels.\n'
+          'Turn on a screen reader, or "Show semantics", to navigate and '
+          'operate the same parts and sliders.',
+          textAlign: TextAlign.center,
           style: TextStyle(
             color: Colors.white,
             fontSize: 13,

--- a/examples/flutter_app/lib/example_accessibility.dart
+++ b/examples/flutter_app/lib/example_accessibility.dart
@@ -1,7 +1,12 @@
 import 'dart:math';
 
 import 'package:flutter/gestures.dart'
-    show PointerDownEvent, PointerHoverEvent, PointerUpEvent;
+    show
+        PointerCancelEvent,
+        PointerDownEvent,
+        PointerHoverEvent,
+        PointerMoveEvent,
+        PointerUpEvent;
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart' hide Material;
 import 'package:vector_math/vector_math.dart' as vm;
@@ -128,10 +133,16 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
   _Part? _pressedPart;
   Offset? _pressPosition;
 
-  // Camera orbit, paused while the pointer is over the scene so parts hold
-  // still under the cursor (and the panel stays put to drag its sliders).
-  double _orbitPhase = 0;
+  // Orbit camera (spherical around the car). It auto-orbits while idle, and
+  // a drag on empty space or the car body (not a selectable part or the
+  // panel) turns it by hand. Orbit is paused while the pointer is over the
+  // scene so parts hold still under the cursor.
+  double _azimuth = 0;
+  double _elevation = 0.38;
+  static const double _radius = 11;
   bool _pointerInside = false;
+  bool _draggingCamera = false;
+  Offset _lastDragPosition = Offset.zero;
   Camera? _lastCamera;
   Size _viewSize = Size.zero;
 
@@ -187,7 +198,7 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
     // quarter turn about Y points it outward along +X.
     final panel = Node(
       name: 'ControlPanel',
-      localTransform: vm.Matrix4.translation(vm.Vector3(2.6, 1.1, 0))
+      localTransform: vm.Matrix4.translation(vm.Vector3(4.5, 1.1, 0))
         ..rotate(vm.Vector3(0, 1, 0), pi / 2),
     );
     panel.addComponent(
@@ -278,20 +289,24 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
   }
 
   Camera _buildCamera() {
-    const radius = 10.0;
+    final target = vm.Vector3(0, 0.5, 0);
+    final ce = cos(_elevation);
+    final offset = vm.Vector3(
+      ce * sin(_azimuth),
+      sin(_elevation),
+      ce * cos(_azimuth),
+    );
     return PerspectiveCamera(
-      position: vm.Vector3(
-        sin(_orbitPhase) * radius,
-        4,
-        cos(_orbitPhase) * radius,
-      ),
-      target: vm.Vector3(0, 0.5, 0),
+      position: target + offset * _radius,
+      target: target,
     );
   }
 
   void _onTick(double deltaSeconds) {
-    if (!_pointerInside) {
-      _orbitPhase += deltaSeconds * 0.2;
+    // Auto-orbit only while idle (the pointer is off the scene and not
+    // dragging); a hover or drag holds the view still.
+    if (!_pointerInside && !_draggingCamera) {
+      _azimuth += deltaSeconds * 0.2;
     }
     _animateParts(deltaSeconds);
     _updateWheels(deltaSeconds);
@@ -346,16 +361,44 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
   void _onPointerDown(PointerDownEvent event) {
     final hit = _rawPick(event.localPosition);
     // A press on the panel drives its sliders through the scene's widget
-    // input forwarding; do not also arm a car-part toggle.
-    if (hit == null || _isInPanel(hit.node)) {
+    // input forwarding; leave it alone.
+    if (hit != null && _isInPanel(hit.node)) {
       _pressedPart = null;
       return;
     }
-    _pressedPart = _partForNode(hit.node);
-    _pressPosition = event.localPosition;
+    final part = hit == null ? null : _partForNode(hit.node);
+    if (part != null) {
+      // A press on a selectable part arms a toggle (fired on release).
+      _pressedPart = part;
+      _pressPosition = event.localPosition;
+      return;
+    }
+    // Empty space or the car body: drag to orbit the camera.
+    _pressedPart = null;
+    _draggingCamera = true;
+    _lastDragPosition = event.localPosition;
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    if (!_draggingCamera) return;
+    final delta = event.localPosition - _lastDragPosition;
+    _lastDragPosition = event.localPosition;
+    // Gentle sensitivity; elevation clamped away from the poles. The view
+    // rebuilds from these each frame (no setState needed).
+    _azimuth += delta.dx * 0.005;
+    _elevation = (_elevation + delta.dy * 0.005).clamp(0.05, 1.35);
+  }
+
+  void _onPointerCancel(PointerCancelEvent event) {
+    _draggingCamera = false;
+    _pressedPart = null;
   }
 
   void _onPointerUp(PointerUpEvent event) {
+    if (_draggingCamera) {
+      _draggingCamera = false;
+      return;
+    }
     final part = _pressedPart;
     _pressedPart = null;
     if (part == null) return;
@@ -395,7 +438,9 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
           onHover: _onHover,
           child: Listener(
             onPointerDown: _onPointerDown,
+            onPointerMove: _onPointerMove,
             onPointerUp: _onPointerUp,
+            onPointerCancel: _onPointerCancel,
             child: SceneView(
               scene,
               cameraBuilder: (elapsed) => _lastCamera = _buildCamera(),
@@ -515,8 +560,8 @@ class _Instructions extends StatelessWidget {
         child: Text(
           'Hover a door, hood, or trunk to outline it; click to open or '
           'close it.\n'
-          'Drag the panel sliders (visible from one side) to drive the '
-          'wheels.\n'
+          'Drag empty space to orbit the camera; drag the panel sliders '
+          '(visible from one side) to drive the wheels.\n'
           'Turn on a screen reader, or "Show semantics", to navigate and '
           'operate the same parts and sliders.',
           textAlign: TextAlign.center,

--- a/examples/flutter_app/lib/example_accessibility.dart
+++ b/examples/flutter_app/lib/example_accessibility.dart
@@ -1,16 +1,23 @@
+import 'dart:math';
+
+import 'package:flutter/gestures.dart' show PointerHoverEvent;
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_scene/scene.dart' hide Material;
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_settings.dart';
 
-/// Scene content exposed to assistive technology: labeled 3D objects with
-/// semantics actions (a tappable lamp, an adjustable pedestal), an occluded
-/// gauge that opts into occlusion hiding, and a widget panel whose real
-/// button semantics project onto its 3D surface. Run a screen reader (or
-/// the Flutter semantics debugger) to explore; accessibility focus draws an
-/// in-scene highlight through onDidGainAccessibilityFocus.
+/// An accessible 3D scene: the car's doors, hood, and trunk are each a
+/// pickable, labeled part. Hover (or accessibility-focus) draws a
+/// see-through outline on the part through the built-in highlight system;
+/// clicking (or activating its semantics) toggles it open or closed with an
+/// animation. Every part is also a [SemanticsComponent], so a screen reader
+/// navigates the same parts and performs the same toggles.
+///
+/// Toggle "Show semantics" to overlay Flutter's [SemanticsDebugger], which
+/// draws every semantics rectangle and lets you tap one to fire its action,
+/// a way to verify the accessibility tree without turning a screen reader
+/// on.
 class ExampleAccessibility extends StatefulWidget {
   const ExampleAccessibility({super.key});
 
@@ -18,218 +25,334 @@ class ExampleAccessibility extends StatefulWidget {
   ExampleAccessibilityState createState() => ExampleAccessibilityState();
 }
 
+/// One openable car part: its node, rest pose, hinge axis, animation state,
+/// and the semantics that expose it.
+class _Part {
+  _Part({
+    required this.nodeName,
+    required this.label,
+    required this.axis,
+    required this.sortOrder,
+  });
+
+  final String nodeName;
+  final String label;
+  final vm.Vector3 axis;
+  final double sortOrder;
+
+  late Node node;
+  late vm.Matrix4 startTransform;
+  late SemanticsComponent semantics;
+
+  // Current open fraction (0 closed, 1 open) and the value it animates
+  // toward.
+  double amount = 0;
+  double target = 0;
+  bool get open => target > 0.5;
+}
+
 class ExampleAccessibilityState extends State<ExampleAccessibility> {
   final Scene scene = Scene();
+  bool loaded = false;
 
-  late final Node _lamp;
-  late final Node _pedestal;
-  late final UnlitMaterial _lampMaterial;
-  bool _lampOn = false;
-  double _pedestalScale = 1.0;
-  int _panelPresses = 0;
+  final EnvironmentSkySource _skySource = EnvironmentSkySource();
 
-  static final vm.Vector4 _focusColor = vm.Vector4(1.0, 0.85, 0.2, 1.0);
+  // Hover outline (mouse) and focus outline (assistive technology). Linear
+  // RGBA.
+  static final vm.Vector4 _hoverColor = vm.Vector4(0.2, 0.9, 1.0, 1.0);
+  static final vm.Vector4 _focusColor = vm.Vector4(1.0, 0.75, 0.1, 1.0);
 
-  // The focus highlight rides on Node.highlightColor, set while assistive
-  // technology focuses the object's semantics node.
-  SemanticsProperties _focusable(
-    Node node, {
-    required String label,
-    String? value,
-    String? hint,
-    bool button = false,
-    VoidCallback? onTap,
-    VoidCallback? onIncrease,
-    VoidCallback? onDecrease,
-    String? increasedValue,
-    String? decreasedValue,
-  }) => SemanticsProperties(
-    label: label,
-    value: value,
-    increasedValue: increasedValue,
-    decreasedValue: decreasedValue,
-    hint: hint,
-    button: button ? true : null,
-    textDirection: TextDirection.ltr,
-    onTap: onTap,
-    onIncrease: onIncrease,
-    onDecrease: onDecrease,
-    onDidGainAccessibilityFocus: () =>
-        setState(() => node.highlightColor = _focusColor),
-    onDidLoseAccessibilityFocus: () =>
-        setState(() => node.highlightColor = null),
-  );
+  final List<_Part> _parts = [
+    _Part(
+      nodeName: 'DoorFront.L',
+      label: 'Front left door',
+      axis: vm.Vector3(0, -1, 0),
+      sortOrder: 0,
+    ),
+    _Part(
+      nodeName: 'DoorFront.R',
+      label: 'Front right door',
+      axis: vm.Vector3(0, -1, 0),
+      sortOrder: 1,
+    ),
+    _Part(
+      nodeName: 'DoorBack.L',
+      label: 'Rear left door',
+      axis: vm.Vector3(0, -1, 0),
+      sortOrder: 2,
+    ),
+    _Part(
+      nodeName: 'DoorBack.R',
+      label: 'Rear right door',
+      axis: vm.Vector3(0, -1, 0),
+      sortOrder: 3,
+    ),
+    _Part(
+      nodeName: 'Frunk',
+      label: 'Front trunk',
+      axis: vm.Vector3(0, 0, 1),
+      sortOrder: 4,
+    ),
+    _Part(
+      nodeName: 'Trunk',
+      label: 'Trunk',
+      axis: vm.Vector3(0, 0, -1),
+      sortOrder: 5,
+    ),
+  ];
 
-  void _toggleLamp() {
-    setState(() {
-      _lampOn = !_lampOn;
-      _lampMaterial.baseColorFactor = _lampOn
-          ? vm.Vector4(1.0, 0.9, 0.4, 1.0)
-          : vm.Vector4(0.25, 0.25, 0.3, 1.0);
-      _lampSemantics.value = _lampOn ? 'on' : 'off';
-    });
-  }
+  final Map<Node, _Part> _partByNode = {};
 
-  late final SemanticsComponent _lampSemantics;
+  _Part? _hoveredPart;
+  _Part? _focusedPart;
 
-  void _scalePedestal(double delta) {
-    setState(() {
-      _pedestalScale = (_pedestalScale + delta).clamp(0.5, 2.0);
-      _pedestal.localTransform = vm.Matrix4.translation(vm.Vector3(1.6, 0, 0))
-        ..scaleByVector3(vm.Vector3.all(_pedestalScale));
-      _pedestalSemantics.properties = _pedestalProperties();
-    });
-  }
+  // Camera orbit, paused while the pointer is over the scene so parts are
+  // stationary (and easy to click) under the cursor.
+  double _orbitPhase = 0;
+  bool _pointerInside = false;
+  Camera? _lastCamera;
+  Size _viewSize = Size.zero;
 
-  late final SemanticsComponent _pedestalSemantics;
-
-  SemanticsProperties _pedestalProperties() => _focusable(
-    _pedestal,
-    label: 'Pedestal',
-    value: '${(_pedestalScale * 100).round()} percent',
-    increasedValue:
-        '${((_pedestalScale + 0.25).clamp(0.5, 2.0) * 100).round()} percent',
-    decreasedValue:
-        '${((_pedestalScale - 0.25).clamp(0.5, 2.0) * 100).round()} percent',
-    hint: 'Adjust to change its size',
-    onIncrease: () => _scalePedestal(0.25),
-    onDecrease: () => _scalePedestal(-0.25),
-  );
+  bool _showSemantics = false;
 
   @override
   void initState() {
     super.initState();
+    _load();
+  }
 
-    // A tappable lamp: activating it through the screen reader toggles its
-    // color and reported value.
-    _lampMaterial = UnlitMaterial()
-      ..baseColorFactor = vm.Vector4(0.25, 0.25, 0.3, 1.0);
-    _lamp = Node(
-      name: 'lamp',
-      localTransform: vm.Matrix4.translation(vm.Vector3(-1.6, 0, 0)),
-      mesh: Mesh(SphereGeometry(radius: 0.6), _lampMaterial),
+  Future<void> _load() async {
+    final car = await loadScene('assets_src/fcar.glb');
+    final environment = await EnvironmentMap.fromAssets(
+      radianceImagePath: 'assets/little_paris_eiffel_tower.png',
     );
-    _lampSemantics = SemanticsComponent(
-      properties: _focusable(
-        _lamp,
-        label: 'Lamp',
-        value: 'off',
-        hint: 'Activate to toggle',
+    if (!mounted) return;
+
+    car.name = 'Car';
+    scene.add(car);
+
+    for (final part in _parts) {
+      final node = car.getChildByNamePath([part.nodeName])!;
+      part.node = node;
+      part.startTransform = node.localTransform.clone();
+      part.semantics = SemanticsComponent(
+        label: part.label,
+        value: 'closed',
+        hint: 'Activate to open or close',
         button: true,
-        onTap: _toggleLamp,
-      ),
-    );
-    _lamp.addComponent(_lampSemantics);
-    scene.add(_lamp);
+        sortOrder: part.sortOrder,
+        onTap: () => _togglePart(part),
+        onDidGainAccessibilityFocus: () => _setFocused(part),
+        onDidLoseAccessibilityFocus: () => _clearFocused(part),
+      );
+      node.addComponent(part.semantics);
+      _partByNode[node] = part;
+    }
 
-    // An adjustable pedestal: increase/decrease actions scale it.
-    _pedestal = Node(
-      name: 'pedestal',
-      localTransform: vm.Matrix4.translation(vm.Vector3(1.6, 0, 0)),
-      mesh: Mesh(
-        CuboidGeometry(vm.Vector3(0.9, 0.9, 0.9)),
-        UnlitMaterial()..baseColorFactor = vm.Vector4(0.4, 0.6, 0.9, 1.0),
-      ),
-    );
-    _pedestalSemantics = SemanticsComponent(properties: _pedestalProperties());
-    _pedestal.addComponent(_pedestalSemantics);
-    scene.add(_pedestal);
+    scene.environment = environment;
+    scene.exposure = 2.5;
+    scene.skybox = Skybox(_skySource);
+    scene.highlightStyle.thickness = 4.0;
 
-    // A gauge behind a wall, opted into occlusion hiding: it leaves the
-    // semantics tree while the wall blocks the camera's line of sight.
-    final gauge = Node(
-      name: 'gauge',
-      localTransform: vm.Matrix4.translation(vm.Vector3(0, 0.2, 3)),
-      mesh: Mesh(
-        SphereGeometry(radius: 0.35),
-        UnlitMaterial()..baseColorFactor = vm.Vector4(0.9, 0.3, 0.3, 1.0),
-      ),
-    );
-    gauge.addComponent(
-      SemanticsComponent(
-        label: 'Pressure gauge',
-        value: 'nominal',
-        textDirection: TextDirection.ltr,
-        occlusionHiding: true,
-      ),
-    );
-    scene.add(gauge);
-    final wall = Node(
-      name: 'wall',
-      localTransform: vm.Matrix4.translation(vm.Vector3(0, 0.2, 1.8)),
-      mesh: Mesh(
-        CuboidGeometry(vm.Vector3(1.4, 1.4, 0.1)),
-        UnlitMaterial()..baseColorFactor = vm.Vector4(0.5, 0.5, 0.5, 1.0),
-      ),
-    );
-    scene.add(wall);
+    setState(() => loaded = true);
+  }
 
-    // A widget panel on a quad: the hosted buttons' own semantics project
-    // onto the surface, so a screen reader traverses into them like any
-    // other widgets.
-    final panel = Node(
-      name: 'panel',
-      localTransform: vm.Matrix4.translation(vm.Vector3(0, 1.6, 0)),
+  @override
+  void dispose() {
+    scene.removeAll();
+    super.dispose();
+  }
+
+  // Walks up from a hit node to the openable part it belongs to, or null.
+  _Part? _partForNode(Node node) {
+    for (Node? current = node; current != null; current = current.parent) {
+      final part = _partByNode[current];
+      if (part != null) return part;
+    }
+    return null;
+  }
+
+  void _togglePart(_Part part) {
+    setState(() {
+      part.target = part.open ? 0.0 : 1.0;
+      part.semantics.value = part.open ? 'open' : 'closed';
+    });
+  }
+
+  void _setFocused(_Part part) {
+    setState(() {
+      _focusedPart = part;
+      _refreshHighlights();
+    });
+  }
+
+  void _clearFocused(_Part part) {
+    if (_focusedPart != part) return;
+    setState(() {
+      _focusedPart = null;
+      _refreshHighlights();
+    });
+  }
+
+  // Sets each part's outline color: amber where accessibility focus sits,
+  // cyan where the mouse hovers, none otherwise. highlightColor does not
+  // inherit, so it is set on the part node and all of its descendants.
+  void _refreshHighlights() {
+    for (final part in _parts) {
+      final color = part == _focusedPart
+          ? _focusColor
+          : (part == _hoveredPart ? _hoverColor : null);
+      _applyHighlight(part.node, color);
+    }
+  }
+
+  void _applyHighlight(Node node, vm.Vector4? color) {
+    node.highlightColor = color;
+    for (final child in node.children) {
+      _applyHighlight(child, color);
+    }
+  }
+
+  Camera _buildCamera() {
+    const radius = 10.0;
+    return PerspectiveCamera(
+      position: vm.Vector3(
+        sin(_orbitPhase) * radius,
+        4,
+        cos(_orbitPhase) * radius,
+      ),
+      target: vm.Vector3(0, 0.5, 0),
     );
-    panel.addComponent(
-      WidgetComponent(
-        size: const Size(360, 200),
-        worldHeight: 1.2,
-        child: _PanelContent(
-          onPressed: () => setState(() => _panelPresses++),
-          presses: () => _panelPresses,
+  }
+
+  void _onTick(double deltaSeconds) {
+    if (!_pointerInside) {
+      _orbitPhase += deltaSeconds * 0.2;
+    }
+    // Animate each part toward its open/closed target.
+    const speed = 3.0; // reaches the target in ~1/3 second
+    for (final part in _parts) {
+      if (part.amount == part.target) continue;
+      final step = speed * deltaSeconds;
+      if ((part.target - part.amount).abs() <= step) {
+        part.amount = part.target;
+      } else {
+        part.amount += part.target > part.amount ? step : -step;
+      }
+      part.node.localTransform = part.startTransform.clone()
+        ..rotate(part.axis, part.amount * pi / 2);
+    }
+    exampleSettings.applyTo(scene);
+  }
+
+  void _onEnter() => _pointerInside = true;
+
+  void _onExit() {
+    _pointerInside = false;
+    if (_hoveredPart != null) {
+      setState(() {
+        _hoveredPart = null;
+        _refreshHighlights();
+      });
+    }
+  }
+
+  _Part? _pick(Offset localPosition) {
+    final camera = _lastCamera;
+    if (camera == null || _viewSize.isEmpty) return null;
+    final hit = scene.raycast(
+      camera.screenPointToRay(localPosition, _viewSize),
+    );
+    return hit == null ? null : _partForNode(hit.node);
+  }
+
+  void _onHover(PointerHoverEvent event) {
+    final part = _pick(event.localPosition);
+    if (part == _hoveredPart) return;
+    setState(() {
+      _hoveredPart = part;
+      _refreshHighlights();
+    });
+  }
+
+  void _onTapUp(TapUpDetails details) {
+    final part = _pick(details.localPosition);
+    if (part != null) _togglePart(part);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!loaded) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final scene3d = LayoutBuilder(
+      builder: (context, constraints) {
+        _viewSize = constraints.biggest;
+        return MouseRegion(
+          onEnter: (_) => _onEnter(),
+          onExit: (_) => _onExit(),
+          onHover: _onHover,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTapUp: _onTapUp,
+            child: SceneView(
+              scene,
+              cameraBuilder: (elapsed) => _lastCamera = _buildCamera(),
+              onTick: (elapsed, deltaSeconds) => _onTick(deltaSeconds),
+            ),
+          ),
+        );
+      },
+    );
+
+    // The debugger absorbs pointers to report semantics taps, so the toggle
+    // button rides above it (a later Stack child) to stay interactive.
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: _showSemantics ? SemanticsDebugger(child: scene3d) : scene3d,
         ),
-      ),
-    );
-    scene.add(panel);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return SceneView(
-      scene,
-      camera: PerspectiveCamera(
-        position: vm.Vector3(0, 1.2, -5.5),
-        target: vm.Vector3(0, 0.6, 0),
-      ),
-      onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+        const Positioned(left: 16, top: 16, child: _Instructions()),
+        Positioned(
+          right: 16,
+          top: 16,
+          child: FilledButton.icon(
+            onPressed: () => setState(() => _showSemantics = !_showSemantics),
+            icon: Icon(
+              _showSemantics ? Icons.visibility_off : Icons.accessibility_new,
+            ),
+            label: Text(_showSemantics ? 'Hide semantics' : 'Show semantics'),
+          ),
+        ),
+      ],
     );
   }
 }
 
-class _PanelContent extends StatefulWidget {
-  const _PanelContent({required this.onPressed, required this.presses});
+class _Instructions extends StatelessWidget {
+  const _Instructions();
 
-  final VoidCallback onPressed;
-  final int Function() presses;
-
-  @override
-  State<_PanelContent> createState() => _PanelContentState();
-}
-
-class _PanelContentState extends State<_PanelContent> {
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: const Color(0xFF1F2430),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              'Control panel, pressed ${widget.presses()} times',
-              style: const TextStyle(color: Colors.white, fontSize: 20),
-            ),
-            const SizedBox(height: 16),
-            FilledButton(
-              onPressed: () {
-                widget.onPressed();
-                setState(() {});
-              },
-              child: const Text('Press me'),
-            ),
-          ],
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xAA000000),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: const Padding(
+        padding: EdgeInsets.all(12),
+        child: Text(
+          'Hover a door, hood, or trunk to outline it.\n'
+          'Click it to open or close it.\n'
+          'Turn on a screen reader, or "Show semantics",\n'
+          'to navigate and toggle the same parts.',
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 13,
+            height: 1.4,
+            decoration: TextDecoration.none,
+          ),
         ),
       ),
     );

--- a/examples/flutter_app/lib/example_accessibility.dart
+++ b/examples/flutter_app/lib/example_accessibility.dart
@@ -141,6 +141,10 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
   double _elevation = 0.38;
   static const double _radius = 11;
   bool _pointerInside = false;
+  // Any pointer button held over the scene (a hover leaving on button-press
+  // must not resume the orbit mid-drag, which would move the panel and break
+  // a slider drag's UV tracking).
+  bool _pointerDown = false;
   bool _draggingCamera = false;
   Offset _lastDragPosition = Offset.zero;
   Camera? _lastCamera;
@@ -303,9 +307,10 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
   }
 
   void _onTick(double deltaSeconds) {
-    // Auto-orbit only while idle (the pointer is off the scene and not
-    // dragging); a hover or drag holds the view still.
-    if (!_pointerInside && !_draggingCamera) {
+    // Auto-orbit only while idle: no pointer over the scene and no button
+    // held. Any press (a slider drag, a part tap, a camera drag) holds the
+    // view still, so the camera stays stable while forwarding input.
+    if (!_pointerInside && !_pointerDown) {
       _azimuth += deltaSeconds * 0.2;
     }
     _animateParts(deltaSeconds);
@@ -359,6 +364,7 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
   }
 
   void _onPointerDown(PointerDownEvent event) {
+    _pointerDown = true;
     final hit = _rawPick(event.localPosition);
     // A press on the panel drives its sliders through the scene's widget
     // input forwarding; leave it alone.
@@ -390,11 +396,13 @@ class ExampleAccessibilityState extends State<ExampleAccessibility> {
   }
 
   void _onPointerCancel(PointerCancelEvent event) {
+    _pointerDown = false;
     _draggingCamera = false;
     _pressedPart = null;
   }
 
   void _onPointerUp(PointerUpEvent event) {
+    _pointerDown = false;
     if (_draggingCamera) {
       _draggingCamera = false;
       return;

--- a/examples/flutter_app/lib/example_accessibility.dart
+++ b/examples/flutter_app/lib/example_accessibility.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_scene/scene.dart' hide Material;
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_settings.dart';
+
+/// Scene content exposed to assistive technology: labeled 3D objects with
+/// semantics actions (a tappable lamp, an adjustable pedestal), an occluded
+/// gauge that opts into occlusion hiding, and a widget panel whose real
+/// button semantics project onto its 3D surface. Run a screen reader (or
+/// the Flutter semantics debugger) to explore; accessibility focus draws an
+/// in-scene highlight through onDidGainAccessibilityFocus.
+class ExampleAccessibility extends StatefulWidget {
+  const ExampleAccessibility({super.key});
+
+  @override
+  ExampleAccessibilityState createState() => ExampleAccessibilityState();
+}
+
+class ExampleAccessibilityState extends State<ExampleAccessibility> {
+  final Scene scene = Scene();
+
+  late final Node _lamp;
+  late final Node _pedestal;
+  late final UnlitMaterial _lampMaterial;
+  bool _lampOn = false;
+  double _pedestalScale = 1.0;
+  int _panelPresses = 0;
+
+  static final vm.Vector4 _focusColor = vm.Vector4(1.0, 0.85, 0.2, 1.0);
+
+  // The focus highlight rides on Node.highlightColor, set while assistive
+  // technology focuses the object's semantics node.
+  SemanticsProperties _focusable(
+    Node node, {
+    required String label,
+    String? value,
+    String? hint,
+    bool button = false,
+    VoidCallback? onTap,
+    VoidCallback? onIncrease,
+    VoidCallback? onDecrease,
+    String? increasedValue,
+    String? decreasedValue,
+  }) => SemanticsProperties(
+    label: label,
+    value: value,
+    increasedValue: increasedValue,
+    decreasedValue: decreasedValue,
+    hint: hint,
+    button: button ? true : null,
+    textDirection: TextDirection.ltr,
+    onTap: onTap,
+    onIncrease: onIncrease,
+    onDecrease: onDecrease,
+    onDidGainAccessibilityFocus: () =>
+        setState(() => node.highlightColor = _focusColor),
+    onDidLoseAccessibilityFocus: () =>
+        setState(() => node.highlightColor = null),
+  );
+
+  void _toggleLamp() {
+    setState(() {
+      _lampOn = !_lampOn;
+      _lampMaterial.baseColorFactor = _lampOn
+          ? vm.Vector4(1.0, 0.9, 0.4, 1.0)
+          : vm.Vector4(0.25, 0.25, 0.3, 1.0);
+      _lampSemantics.value = _lampOn ? 'on' : 'off';
+    });
+  }
+
+  late final SemanticsComponent _lampSemantics;
+
+  void _scalePedestal(double delta) {
+    setState(() {
+      _pedestalScale = (_pedestalScale + delta).clamp(0.5, 2.0);
+      _pedestal.localTransform = vm.Matrix4.translation(vm.Vector3(1.6, 0, 0))
+        ..scaleByVector3(vm.Vector3.all(_pedestalScale));
+      _pedestalSemantics.properties = _pedestalProperties();
+    });
+  }
+
+  late final SemanticsComponent _pedestalSemantics;
+
+  SemanticsProperties _pedestalProperties() => _focusable(
+    _pedestal,
+    label: 'Pedestal',
+    value: '${(_pedestalScale * 100).round()} percent',
+    increasedValue:
+        '${((_pedestalScale + 0.25).clamp(0.5, 2.0) * 100).round()} percent',
+    decreasedValue:
+        '${((_pedestalScale - 0.25).clamp(0.5, 2.0) * 100).round()} percent',
+    hint: 'Adjust to change its size',
+    onIncrease: () => _scalePedestal(0.25),
+    onDecrease: () => _scalePedestal(-0.25),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+
+    // A tappable lamp: activating it through the screen reader toggles its
+    // color and reported value.
+    _lampMaterial = UnlitMaterial()
+      ..baseColorFactor = vm.Vector4(0.25, 0.25, 0.3, 1.0);
+    _lamp = Node(
+      name: 'lamp',
+      localTransform: vm.Matrix4.translation(vm.Vector3(-1.6, 0, 0)),
+      mesh: Mesh(SphereGeometry(radius: 0.6), _lampMaterial),
+    );
+    _lampSemantics = SemanticsComponent(
+      properties: _focusable(
+        _lamp,
+        label: 'Lamp',
+        value: 'off',
+        hint: 'Activate to toggle',
+        button: true,
+        onTap: _toggleLamp,
+      ),
+    );
+    _lamp.addComponent(_lampSemantics);
+    scene.add(_lamp);
+
+    // An adjustable pedestal: increase/decrease actions scale it.
+    _pedestal = Node(
+      name: 'pedestal',
+      localTransform: vm.Matrix4.translation(vm.Vector3(1.6, 0, 0)),
+      mesh: Mesh(
+        CuboidGeometry(vm.Vector3(0.9, 0.9, 0.9)),
+        UnlitMaterial()..baseColorFactor = vm.Vector4(0.4, 0.6, 0.9, 1.0),
+      ),
+    );
+    _pedestalSemantics = SemanticsComponent(properties: _pedestalProperties());
+    _pedestal.addComponent(_pedestalSemantics);
+    scene.add(_pedestal);
+
+    // A gauge behind a wall, opted into occlusion hiding: it leaves the
+    // semantics tree while the wall blocks the camera's line of sight.
+    final gauge = Node(
+      name: 'gauge',
+      localTransform: vm.Matrix4.translation(vm.Vector3(0, 0.2, 3)),
+      mesh: Mesh(
+        SphereGeometry(radius: 0.35),
+        UnlitMaterial()..baseColorFactor = vm.Vector4(0.9, 0.3, 0.3, 1.0),
+      ),
+    );
+    gauge.addComponent(
+      SemanticsComponent(
+        label: 'Pressure gauge',
+        value: 'nominal',
+        textDirection: TextDirection.ltr,
+        occlusionHiding: true,
+      ),
+    );
+    scene.add(gauge);
+    final wall = Node(
+      name: 'wall',
+      localTransform: vm.Matrix4.translation(vm.Vector3(0, 0.2, 1.8)),
+      mesh: Mesh(
+        CuboidGeometry(vm.Vector3(1.4, 1.4, 0.1)),
+        UnlitMaterial()..baseColorFactor = vm.Vector4(0.5, 0.5, 0.5, 1.0),
+      ),
+    );
+    scene.add(wall);
+
+    // A widget panel on a quad: the hosted buttons' own semantics project
+    // onto the surface, so a screen reader traverses into them like any
+    // other widgets.
+    final panel = Node(
+      name: 'panel',
+      localTransform: vm.Matrix4.translation(vm.Vector3(0, 1.6, 0)),
+    );
+    panel.addComponent(
+      WidgetComponent(
+        size: const Size(360, 200),
+        worldHeight: 1.2,
+        child: _PanelContent(
+          onPressed: () => setState(() => _panelPresses++),
+          presses: () => _panelPresses,
+        ),
+      ),
+    );
+    scene.add(panel);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SceneView(
+      scene,
+      camera: PerspectiveCamera(
+        position: vm.Vector3(0, 1.2, -5.5),
+        target: vm.Vector3(0, 0.6, 0),
+      ),
+      onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+    );
+  }
+}
+
+class _PanelContent extends StatefulWidget {
+  const _PanelContent({required this.onPressed, required this.presses});
+
+  final VoidCallback onPressed;
+  final int Function() presses;
+
+  @override
+  State<_PanelContent> createState() => _PanelContentState();
+}
+
+class _PanelContentState extends State<_PanelContent> {
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xFF1F2430),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'Control panel, pressed ${widget.presses()} times',
+              style: const TextStyle(color: Colors.white, fontSize: 20),
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: () {
+                widget.onPressed();
+                setState(() {});
+              },
+              child: const Text('Press me'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter_scene_box3d/flutter_scene_box3d.dart'
     show Box3dPhysicsWorld;
 import 'package:example_app/example_animation.dart';
 
+import 'example_accessibility.dart';
 import 'example_cuboid.dart';
 import 'example_dicom.dart';
 import 'example_lights.dart';
@@ -111,6 +112,7 @@ class _MyAppState extends State<MyApp> {
       'DICOM Volume': (context) => const ExampleDicom(),
       'Custom Skybox': (context) => const ExampleSkybox(),
       'Widget Texture': (context) => const ExampleWidgetTexture(),
+      'Accessibility': (context) => const ExampleAccessibility(),
       'Render Targets': (context) => const ExampleRenderTarget(),
       'Physics': (context) => FutureBuilder<void>(
         // The Rapier backend needs its wasm module loaded before a world

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -7,6 +7,28 @@
   view. Together they turn "load a model, find its meshes, frame the camera on
   it" into a few lines instead of a hand-rolled vertex loop.
 
+* Scene content can now be exposed to assistive technology (screen
+  readers, switch access). Attaching the new `SemanticsComponent` to a
+  node publishes it into the enclosing `SceneView`'s semantics tree with a
+  label, value, flags, and actions (tap, increase/decrease, or a full
+  `SemanticsProperties`), with its focus rectangle projected from the
+  node's bounds through the view's camera each frame and traversal order
+  controlled by `sortOrder`. Culled or invisible nodes leave the tree, and
+  an opt-in `occlusionHiding` also removes nodes that scene geometry
+  blocks from the camera. `WidgetComponent` surfaces now expose their
+  hosted subtree's real semantics too, positioned on the projected
+  surface, so screen readers traverse and activate in-scene widget panels
+  like ordinary widgets. All of this is skipped entirely while no
+  assistive technology is active. Multi-view scenes project semantics
+  through the primary view (the first view rendering to the screen).
+
+* Added `Camera.worldToScreen`, the forward counterpart of
+  `Camera.screenPointToRay`.
+
+* A failed static-resource load no longer marks the engine ready to
+  render (which crashed mid-frame); the scene keeps skipping frames and
+  the load is retried on the next `Scene.initializeStaticResources` call.
+
 * Per-frame transient GPU data (uniform blocks, instance transforms) now
   rides an engine-owned, completion-aware arena allocator instead of
   `package:flutter_gpu`'s `HostBuffer`. Emplacements stage CPU-side and

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -22,6 +22,10 @@
   assistive technology is active. Multi-view scenes project semantics
   through the primary view (the first view rendering to the screen).
 
+* `WidgetComponent` gained `occlusionHiding` (opt-in): while scene geometry
+  occludes the surface from the camera, its hosted subtree's semantics leave
+  the tree, matching how its pointer input is already blocked.
+
 * Added `Camera.worldToScreen`, the forward counterpart of
   `Camera.screenPointToRay`.
 

--- a/packages/flutter_scene/dartdoc_options.yaml
+++ b/packages/flutter_scene/dartdoc_options.yaml
@@ -9,6 +9,7 @@ dartdoc:
     - "Physics"
     - "Picking and input"
     - "Widgets"
+    - "Accessibility"
     - "Gaussian splatting"
     - "Assets and loading"
     - "Noise"

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -102,6 +102,7 @@ export 'src/components/instanced_mesh_component.dart'
 export 'src/components/lod_component.dart' show LodComponent;
 export 'src/components/mesh_component.dart' show MeshComponent;
 export 'src/components/point_light_component.dart' show PointLightComponent;
+export 'src/components/semantics_component.dart' show SemanticsComponent;
 export 'src/components/splat_component.dart' show SplatComponent;
 export 'src/components/spot_light_component.dart' show SpotLightComponent;
 export 'src/render/lod.dart' show LodLevel;

--- a/packages/flutter_scene/lib/src/camera.dart
+++ b/packages/flutter_scene/lib/src/camera.dart
@@ -94,6 +94,28 @@ abstract class Camera {
     return Ray.originDirection(near, unproject(1.0) - near);
   }
 
+  /// Maps a world-space point to its position inside a view (logical
+  /// pixels, origin top-left), the forward counterpart of
+  /// [screenPointToRay].
+  ///
+  /// Returns null when [worldPoint] is at or behind the camera plane, where
+  /// it has no on-screen projection. Points outside the view bounds still
+  /// return a position (negative, or beyond [viewSize]); callers decide
+  /// whether to clamp or cull. [viewSize] is the view's logical size (the
+  /// constraints `SceneView` renders into).
+  ui.Offset? worldToScreen(Vector3 worldPoint, ui.Size viewSize) {
+    final clip = getViewTransform(
+      viewSize,
+    ).transform(Vector4(worldPoint.x, worldPoint.y, worldPoint.z, 1));
+    if (clip.w <= 0) {
+      return null;
+    }
+    return ui.Offset(
+      (clip.x / clip.w + 1) / 2 * viewSize.width,
+      (1 - clip.y / clip.w) / 2 * viewSize.height,
+    );
+  }
+
   /// Returns the combined projection-and-view transform for a render target
   /// of the given [dimensions].
   ///

--- a/packages/flutter_scene/lib/src/components/semantics_component.dart
+++ b/packages/flutter_scene/lib/src/components/semantics_component.dart
@@ -1,0 +1,313 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/semantics.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'package:flutter_scene/src/components/component.dart';
+
+/// Exposes the owning `Node` to assistive technology (screen readers,
+/// switch access) as one element of the enclosing `SceneView`'s semantics.
+///
+/// Scene content is opaque to accessibility by default. Attaching a
+/// [SemanticsComponent] to a node publishes it as a semantics element whose
+/// focus rectangle is the node's bounds projected through the view's camera,
+/// recomputed as the camera and the node move. Actions ([onTap],
+/// [onIncrease], [onDecrease], and anything else set through [properties])
+/// are invoked directly by the platform's accessibility system; they do not
+/// pass through scene raycasting.
+///
+/// ```dart
+/// node.addComponent(SemanticsComponent(
+///   label: 'Power switch',
+///   button: true,
+///   onTap: togglePower,
+/// ));
+/// ```
+///
+/// The focus rectangle covers the node's [`combinedLocalBounds`] (the node's
+/// mesh and all descendants). Set [boundsOverride] when that is wrong for
+/// focus, and for subtrees with no computable bounds (skinned content),
+/// which otherwise project as a nominal-size rectangle at the node origin.
+///
+/// Elements read in scene-graph order; set [sortOrder] to control traversal
+/// explicitly. While the node is invisible (or, with [occlusionHiding], is
+/// occluded) it is removed from the semantics tree.
+///
+/// The convenience parameters cover common cases; pass a full
+/// [SemanticsProperties] as [properties] for anything else (sliders, live
+/// regions, custom actions, focus callbacks). The two forms are mutually
+/// exclusive.
+/// {@category Accessibility}
+class SemanticsComponent extends Component {
+  /// Creates semantics for the owning node.
+  ///
+  /// Pass either the convenience parameters or a full [properties] object,
+  /// not both.
+  SemanticsComponent({
+    String? label,
+    String? value,
+    String? hint,
+    bool button = false,
+    VoidCallback? onTap,
+    VoidCallback? onLongPress,
+    VoidCallback? onIncrease,
+    VoidCallback? onDecrease,
+    double? sortOrder,
+    TextDirection? textDirection,
+    bool occlusionHiding = false,
+    vm.Aabb3? boundsOverride,
+    SemanticsProperties? properties,
+  }) : assert(
+         properties == null ||
+             (label == null &&
+                 value == null &&
+                 hint == null &&
+                 !button &&
+                 onTap == null &&
+                 onLongPress == null &&
+                 onIncrease == null &&
+                 onDecrease == null &&
+                 sortOrder == null &&
+                 textDirection == null),
+         'Pass either the convenience parameters or a full properties '
+         'object, not both.',
+       ),
+       _label = label,
+       _value = value,
+       _hint = hint,
+       _button = button,
+       _onTap = onTap,
+       _onLongPress = onLongPress,
+       _onIncrease = onIncrease,
+       _onDecrease = onDecrease,
+       _sortOrder = sortOrder,
+       _textDirection = textDirection,
+       _occlusionHiding = occlusionHiding,
+       _boundsOverride = boundsOverride,
+       _properties = properties;
+
+  String? _label;
+  String? _value;
+  String? _hint;
+  bool _button;
+  VoidCallback? _onTap;
+  VoidCallback? _onLongPress;
+  VoidCallback? _onIncrease;
+  VoidCallback? _onDecrease;
+  double? _sortOrder;
+  TextDirection? _textDirection;
+  bool _occlusionHiding;
+  vm.Aabb3? _boundsOverride;
+  SemanticsProperties? _properties;
+
+  // Bumped by every property setter so the per-frame snapshot can detect
+  // changes without comparing assembled SemanticsProperties objects.
+  int _version = 0;
+
+  void _bump() => _version++;
+
+  // Guards the convenience setters: a component constructed with (or later
+  // given) an explicit [properties] object owns its whole configuration
+  // there.
+  void _assertConvenience() {
+    assert(
+      _properties == null,
+      'This SemanticsComponent uses an explicit SemanticsProperties object; '
+      'set `properties` instead of the convenience fields.',
+    );
+  }
+
+  /// A short description of the node, read by the screen reader.
+  String? get label => _label;
+  set label(String? value) {
+    _assertConvenience();
+    if (value == _label) return;
+    _label = value;
+    _bump();
+  }
+
+  /// The current value the node represents (for example a reading on a
+  /// gauge), read after [label].
+  String? get value => _value;
+  set value(String? newValue) {
+    _assertConvenience();
+    if (newValue == _value) return;
+    _value = newValue;
+    _bump();
+  }
+
+  /// A brief description of what interacting with the node does.
+  String? get hint => _hint;
+  set hint(String? value) {
+    _assertConvenience();
+    if (value == _hint) return;
+    _hint = value;
+    _bump();
+  }
+
+  /// Whether the node behaves like a button.
+  bool get button => _button;
+  set button(bool value) {
+    _assertConvenience();
+    if (value == _button) return;
+    _button = value;
+    _bump();
+  }
+
+  /// Called when assistive technology activates the node (for example a
+  /// VoiceOver double tap).
+  VoidCallback? get onTap => _onTap;
+  set onTap(VoidCallback? value) {
+    _assertConvenience();
+    if (value == _onTap) return;
+    _onTap = value;
+    _bump();
+  }
+
+  /// Called when assistive technology long-presses the node.
+  VoidCallback? get onLongPress => _onLongPress;
+  set onLongPress(VoidCallback? value) {
+    _assertConvenience();
+    if (value == _onLongPress) return;
+    _onLongPress = value;
+    _bump();
+  }
+
+  /// Called when assistive technology increases the node's [value].
+  VoidCallback? get onIncrease => _onIncrease;
+  set onIncrease(VoidCallback? value) {
+    _assertConvenience();
+    if (value == _onIncrease) return;
+    _onIncrease = value;
+    _bump();
+  }
+
+  /// Called when assistive technology decreases the node's [value].
+  VoidCallback? get onDecrease => _onDecrease;
+  set onDecrease(VoidCallback? value) {
+    _assertConvenience();
+    if (value == _onDecrease) return;
+    _onDecrease = value;
+    _bump();
+  }
+
+  /// The node's position in the accessibility traversal order, lower values
+  /// first. Elements without a sort order read in scene-graph order.
+  double? get sortOrder => _sortOrder;
+  set sortOrder(double? value) {
+    _assertConvenience();
+    if (value == _sortOrder) return;
+    _sortOrder = value;
+    _bump();
+  }
+
+  /// The reading direction of [label], [value], and [hint]. When null (the
+  /// default) the enclosing `SceneView`'s ambient [Directionality] is used.
+  TextDirection? get textDirection => _textDirection;
+  set textDirection(TextDirection? value) {
+    _assertConvenience();
+    if (value == _textDirection) return;
+    _textDirection = value;
+    _bump();
+  }
+
+  /// Whether the node leaves the semantics tree while scene geometry
+  /// occludes it from the camera. Defaults to false (an occluded node stays
+  /// focusable), matching how a partially obscured widget behaves.
+  ///
+  /// Checked with a single raycast toward the node's bounds center each
+  /// semantics update, so enable it only where occlusion genuinely changes
+  /// meaning (a gauge behind a hatch).
+  bool get occlusionHiding => _occlusionHiding;
+  set occlusionHiding(bool value) {
+    if (value == _occlusionHiding) return;
+    _occlusionHiding = value;
+    _bump();
+  }
+
+  /// Local-space bounds to project as the focus rectangle, replacing the
+  /// node's own combined bounds.
+  vm.Aabb3? get boundsOverride => _boundsOverride;
+  set boundsOverride(vm.Aabb3? value) {
+    if (value == _boundsOverride) return;
+    _boundsOverride = value;
+    _bump();
+  }
+
+  /// The full semantics configuration, for anything beyond the convenience
+  /// parameters. Mutually exclusive with them.
+  ///
+  /// Used verbatim, so set [SemanticsProperties.textDirection] whenever the
+  /// object carries text (the platform requires a direction on any node
+  /// with a label, value, or hint); the ambient direction only fills in for
+  /// the convenience parameters.
+  SemanticsProperties? get properties => _properties;
+  set properties(SemanticsProperties? value) {
+    assert(
+      value == null ||
+          (_label == null &&
+              _value == null &&
+              _hint == null &&
+              !_button &&
+              _onTap == null &&
+              _onLongPress == null &&
+              _onIncrease == null &&
+              _onDecrease == null &&
+              _sortOrder == null &&
+              _textDirection == null),
+      'Pass either the convenience parameters or a full properties object, '
+      'not both.',
+    );
+    if (identical(value, _properties)) return;
+    _properties = value;
+    _bump();
+  }
+
+  /// Monotonic change counter over every semantics-affecting property, used
+  /// by `SceneView` to detect stale snapshots.
+  @internal
+  int get version => _version;
+
+  SemanticsProperties? _builtProperties;
+  int _builtVersion = -1;
+  TextDirection? _builtAmbient;
+
+  /// The assembled [SemanticsProperties] for the current configuration,
+  /// cached per [version]. [ambientTextDirection] fills in [textDirection]
+  /// when unset (the platform requires a direction on any node with text);
+  /// an explicit [properties] object is returned as-is and owns its own
+  /// direction.
+  @internal
+  SemanticsProperties effectiveProperties(TextDirection? ambientTextDirection) {
+    if (_builtProperties == null ||
+        _builtVersion != _version ||
+        _builtAmbient != ambientTextDirection) {
+      _builtProperties =
+          _properties ??
+          SemanticsProperties(
+            label: _label,
+            value: _value,
+            hint: _hint,
+            button: _button ? true : null,
+            onTap: _onTap,
+            onLongPress: _onLongPress,
+            onIncrease: _onIncrease,
+            onDecrease: _onDecrease,
+            sortKey: _sortOrder == null ? null : OrdinalSortKey(_sortOrder!),
+            textDirection: _textDirection ?? ambientTextDirection,
+          );
+      _builtVersion = _version;
+      _builtAmbient = ambientTextDirection;
+    }
+    return _builtProperties!;
+  }
+
+  @override
+  void onMount() {
+    node.internalRenderScene?.addSemanticsComponent(this);
+  }
+
+  @override
+  void onUnmount() {
+    node.internalRenderScene?.removeSemanticsComponent(this);
+  }
+}

--- a/packages/flutter_scene/lib/src/components/semantics_component.dart
+++ b/packages/flutter_scene/lib/src/components/semantics_component.dart
@@ -299,17 +299,27 @@ class SemanticsComponent extends Component {
   SemanticsProperties? _builtProperties;
   int _builtVersion = -1;
   TextDirection? _builtAmbient;
+  double? _builtFallbackSortOrder;
 
   /// The assembled [SemanticsProperties] for the current configuration,
   /// cached per [version]. [ambientTextDirection] fills in [textDirection]
-  /// when unset (the platform requires a direction on any node with text);
-  /// an explicit [properties] object is returned as-is and owns its own
-  /// direction.
+  /// when unset (the platform requires a direction on any node with text).
+  ///
+  /// [fallbackSortOrder] supplies a traversal ordinal when [sortOrder] is
+  /// unset, so a convenience-configured node always has a stable reading
+  /// order even though `SceneView` emits nodes in depth order (which drives
+  /// hit-test precedence, not reading order). An explicit [properties]
+  /// object is returned as-is and owns its own direction and sort key.
   @internal
-  SemanticsProperties effectiveProperties(TextDirection? ambientTextDirection) {
+  SemanticsProperties effectiveProperties(
+    TextDirection? ambientTextDirection, {
+    double? fallbackSortOrder,
+  }) {
     if (_builtProperties == null ||
         _builtVersion != _version ||
-        _builtAmbient != ambientTextDirection) {
+        _builtAmbient != ambientTextDirection ||
+        _builtFallbackSortOrder != fallbackSortOrder) {
+      final sortOrder = _sortOrder ?? fallbackSortOrder;
       _builtProperties =
           _properties ??
           SemanticsProperties(
@@ -323,11 +333,12 @@ class SemanticsComponent extends Component {
             onDecrease: _onDecrease,
             onDidGainAccessibilityFocus: _onDidGainAccessibilityFocus,
             onDidLoseAccessibilityFocus: _onDidLoseAccessibilityFocus,
-            sortKey: _sortOrder == null ? null : OrdinalSortKey(_sortOrder!),
+            sortKey: sortOrder == null ? null : OrdinalSortKey(sortOrder),
             textDirection: _textDirection ?? ambientTextDirection,
           );
       _builtVersion = _version;
       _builtAmbient = ambientTextDirection;
+      _builtFallbackSortOrder = fallbackSortOrder;
     }
     return _builtProperties!;
   }

--- a/packages/flutter_scene/lib/src/components/semantics_component.dart
+++ b/packages/flutter_scene/lib/src/components/semantics_component.dart
@@ -34,8 +34,7 @@ import 'package:flutter_scene/src/components/component.dart';
 ///
 /// The convenience parameters cover common cases; pass a full
 /// [SemanticsProperties] as [properties] for anything else (sliders, live
-/// regions, custom actions, focus callbacks). The two forms are mutually
-/// exclusive.
+/// regions, custom actions). The two forms are mutually exclusive.
 /// {@category Accessibility}
 class SemanticsComponent extends Component {
   /// Creates semantics for the owning node.
@@ -51,6 +50,8 @@ class SemanticsComponent extends Component {
     VoidCallback? onLongPress,
     VoidCallback? onIncrease,
     VoidCallback? onDecrease,
+    VoidCallback? onDidGainAccessibilityFocus,
+    VoidCallback? onDidLoseAccessibilityFocus,
     double? sortOrder,
     TextDirection? textDirection,
     bool occlusionHiding = false,
@@ -66,6 +67,8 @@ class SemanticsComponent extends Component {
                  onLongPress == null &&
                  onIncrease == null &&
                  onDecrease == null &&
+                 onDidGainAccessibilityFocus == null &&
+                 onDidLoseAccessibilityFocus == null &&
                  sortOrder == null &&
                  textDirection == null),
          'Pass either the convenience parameters or a full properties '
@@ -79,6 +82,8 @@ class SemanticsComponent extends Component {
        _onLongPress = onLongPress,
        _onIncrease = onIncrease,
        _onDecrease = onDecrease,
+       _onDidGainAccessibilityFocus = onDidGainAccessibilityFocus,
+       _onDidLoseAccessibilityFocus = onDidLoseAccessibilityFocus,
        _sortOrder = sortOrder,
        _textDirection = textDirection,
        _occlusionHiding = occlusionHiding,
@@ -93,6 +98,8 @@ class SemanticsComponent extends Component {
   VoidCallback? _onLongPress;
   VoidCallback? _onIncrease;
   VoidCallback? _onDecrease;
+  VoidCallback? _onDidGainAccessibilityFocus;
+  VoidCallback? _onDidLoseAccessibilityFocus;
   double? _sortOrder;
   TextDirection? _textDirection;
   bool _occlusionHiding;
@@ -190,6 +197,26 @@ class SemanticsComponent extends Component {
     _bump();
   }
 
+  /// Called when the node gains accessibility focus (the screen-reader
+  /// cursor lands on it). A natural place to draw an in-scene focus
+  /// indicator (a `Node.highlightColor` outline) or steer the camera.
+  VoidCallback? get onDidGainAccessibilityFocus => _onDidGainAccessibilityFocus;
+  set onDidGainAccessibilityFocus(VoidCallback? value) {
+    _assertConvenience();
+    if (value == _onDidGainAccessibilityFocus) return;
+    _onDidGainAccessibilityFocus = value;
+    _bump();
+  }
+
+  /// Called when the node loses accessibility focus.
+  VoidCallback? get onDidLoseAccessibilityFocus => _onDidLoseAccessibilityFocus;
+  set onDidLoseAccessibilityFocus(VoidCallback? value) {
+    _assertConvenience();
+    if (value == _onDidLoseAccessibilityFocus) return;
+    _onDidLoseAccessibilityFocus = value;
+    _bump();
+  }
+
   /// The node's position in the accessibility traversal order, lower values
   /// first. Elements without a sort order read in scene-graph order.
   double? get sortOrder => _sortOrder;
@@ -252,6 +279,8 @@ class SemanticsComponent extends Component {
               _onLongPress == null &&
               _onIncrease == null &&
               _onDecrease == null &&
+              _onDidGainAccessibilityFocus == null &&
+              _onDidLoseAccessibilityFocus == null &&
               _sortOrder == null &&
               _textDirection == null),
       'Pass either the convenience parameters or a full properties object, '
@@ -292,6 +321,8 @@ class SemanticsComponent extends Component {
             onLongPress: _onLongPress,
             onIncrease: _onIncrease,
             onDecrease: _onDecrease,
+            onDidGainAccessibilityFocus: _onDidGainAccessibilityFocus,
+            onDidLoseAccessibilityFocus: _onDidLoseAccessibilityFocus,
             sortKey: _sortOrder == null ? null : OrdinalSortKey(_sortOrder!),
             textDirection: _textDirection ?? ambientTextDirection,
           );

--- a/packages/flutter_scene/lib/src/components/widget_component.dart
+++ b/packages/flutter_scene/lib/src/components/widget_component.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart' show internal;
 import 'package:flutter/widgets.dart' show Size, Widget;
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/components/mesh_component.dart';
@@ -138,17 +137,6 @@ class WidgetComponent extends Component {
 
   /// The capture policy (see [WidgetUpdatePolicy]).
   WidgetUpdatePolicy get updatePolicy => _update;
-
-  /// Whether this component created its own quad surface (the zero-config
-  /// tier), whose known plane gives the hosted subtree's semantics an exact
-  /// projective screen mapping. Other tiers fall back to fitting the
-  /// projected node bounds.
-  @internal
-  bool get ownsQuadSurface => _createsSurface && _geometry == null;
-
-  /// The world-space height of the owned quad surface.
-  @internal
-  double get worldHeight => _worldHeight;
 
   MeshComponent? _meshComponent;
   UnlitMaterial? _ownedMaterial;

--- a/packages/flutter_scene/lib/src/components/widget_component.dart
+++ b/packages/flutter_scene/lib/src/components/widget_component.dart
@@ -64,6 +64,7 @@ class WidgetComponent extends Component {
     double worldHeight = 1.0,
     WidgetUpdatePolicy update = WidgetUpdatePolicy.everyFrame,
     this.input = WidgetInput.automatic,
+    this.occlusionHiding = false,
     Geometry? geometry,
     Material? material,
     void Function(gpu.Texture texture)? bind,
@@ -87,6 +88,7 @@ class WidgetComponent extends Component {
     double pixelRatio = 1.0,
     WidgetUpdatePolicy update = WidgetUpdatePolicy.everyFrame,
     this.input = WidgetInput.automatic,
+    this.occlusionHiding = false,
   }) : _child = child,
        _size = size,
        _pixelRatio = pixelRatio,
@@ -99,6 +101,17 @@ class WidgetComponent extends Component {
 
   /// How this surface receives pointer input.
   final WidgetInput input;
+
+  /// Whether the surface's hosted subtree leaves the semantics tree while
+  /// scene geometry occludes it from the camera. Defaults to false (an
+  /// occluded surface keeps its semantics, matching a partially obscured
+  /// widget). When true, an occlusion raycast toward the surface center
+  /// each semantics update drops the whole subtree while it is hidden, so
+  /// assistive technology cannot reach controls the viewer cannot see
+  /// (matching how [WidgetInput.automatic] pointer input is already
+  /// blocked by the occluder). Only consulted while assistive technology
+  /// is active.
+  final bool occlusionHiding;
 
   final Widget _child;
   final Size _size;

--- a/packages/flutter_scene/lib/src/components/widget_component.dart
+++ b/packages/flutter_scene/lib/src/components/widget_component.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show internal;
 import 'package:flutter/widgets.dart' show Size, Widget;
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/components/mesh_component.dart';
@@ -124,6 +125,17 @@ class WidgetComponent extends Component {
 
   /// The capture policy (see [WidgetUpdatePolicy]).
   WidgetUpdatePolicy get updatePolicy => _update;
+
+  /// Whether this component created its own quad surface (the zero-config
+  /// tier), whose known plane gives the hosted subtree's semantics an exact
+  /// projective screen mapping. Other tiers fall back to fitting the
+  /// projected node bounds.
+  @internal
+  bool get ownsQuadSurface => _createsSurface && _geometry == null;
+
+  /// The world-space height of the owned quad surface.
+  @internal
+  double get worldHeight => _worldHeight;
 
   MeshComponent? _meshComponent;
   UnlitMaterial? _ownedMaterial;

--- a/packages/flutter_scene/lib/src/render/render_scene.dart
+++ b/packages/flutter_scene/lib/src/render/render_scene.dart
@@ -6,6 +6,7 @@ import 'package:flutter_scene/src/components/camera_component.dart';
 import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/components/environment_volume_component.dart';
 import 'package:flutter_scene/src/components/point_light_component.dart';
+import 'package:flutter_scene/src/components/semantics_component.dart';
 import 'package:flutter_scene/src/components/spot_light_component.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/material/material.dart';
@@ -185,6 +186,27 @@ class RenderScene {
   void removeWidgetComponent(Object component) {
     widgetComponents.remove(component);
     widgetComponentsChanged.value++;
+  }
+
+  /// The mounted [SemanticsComponent]s, in registration order. `SceneView`
+  /// projects each one's node bounds into its semantics tree while
+  /// assistive technology is active.
+  final List<SemanticsComponent> semanticsComponents = [];
+
+  /// Bumped whenever [semanticsComponents] changes.
+  final ValueNotifier<int> semanticsComponentsChanged = ValueNotifier<int>(0);
+
+  /// Registers a mounted semantics component. Called by a
+  /// [SemanticsComponent] when its owning node mounts.
+  void addSemanticsComponent(SemanticsComponent component) {
+    semanticsComponents.add(component);
+    semanticsComponentsChanged.value++;
+  }
+
+  /// Unregisters an unmounted semantics component.
+  void removeSemanticsComponent(SemanticsComponent component) {
+    semanticsComponents.remove(component);
+    semanticsComponentsChanged.value++;
   }
 
   /// Unregisters [light]. Called when its owning node unmounts.

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -331,17 +331,19 @@ base class Scene implements SceneGraph {
               loadBaseShaderLibrary(),
               Material.initializeStaticResources(),
             ])
+            .then((_) {
+              _readyToRender = true;
+            })
             .onError((e, stacktrace) {
+              // Only a successful load marks the scene ready to render;
+              // rendering with these resources missing throws mid-frame.
+              // The memoized future is reset so a later call retries.
               log(
                 'Failed to initialize static Flutter Scene resources',
                 error: e,
                 stackTrace: stacktrace,
               );
               _initializeStaticResources = null;
-              return const <void>[];
-            })
-            .then((_) {
-              _readyToRender = true;
             });
     return _initializeStaticResources!;
   }

--- a/packages/flutter_scene/lib/src/widget_texture.dart
+++ b/packages/flutter_scene/lib/src/widget_texture.dart
@@ -155,11 +155,22 @@ class WidgetTextureController extends ChangeNotifier {
   /// immediate capture (subject to one-in-flight throttling).
   void requestCapture() => _host?._captureNow();
 
+  /// Whether the hosted subtree's semantics are currently hidden. The
+  /// [WidgetTexture] wraps its child in an `ExcludeSemantics` driven by this,
+  /// so an off-screen, culled, or occluded surface (or one with assistive
+  /// technology inactive) contributes no semantics, while the child stays
+  /// structurally present (toggling `ExcludeSemantics` is cheaper and more
+  /// robust than adding and removing the subtree from the semantics walk).
+  @internal
+  final ValueNotifier<bool> semanticsHidden = ValueNotifier<bool>(true);
+
   /// Sets the hosted subtree's semantics placement for this frame: the
   /// transform mapping its logical coordinates onto the enclosing
-  /// `SceneView`'s box, or null to keep the subtree out of the semantics
-  /// tree (surface hidden, culled, or assistive technology inactive).
-  /// `SceneView` pushes this after each rendered frame.
+  /// `SceneView`'s box, or null to hide the subtree's semantics (surface
+  /// off-screen, culled, occluded, or assistive technology inactive).
+  /// `SceneView` pushes this after each rendered frame. The host defers the
+  /// [semanticsHidden] flip to a post-frame callback, since this is called
+  /// during paint (where scheduling a build is not allowed).
   @internal
   void internalUpdateSemantics(Matrix4? transform) =>
       _host?._updateSemantics(transform);
@@ -386,13 +397,18 @@ class _RenderWidgetTexture extends RenderProxyBox {
   // ----- semantics -----
   //
   // The hosted subtree computes real semantics but never paints at its
-  // layout position. While the surface is visible on screen and assistive
+  // layout position. While the surface is on screen and assistive
   // technology is active, `SceneView` pushes the transform mapping the
   // subtree's logical space onto the surface's projected quad; the
   // framework's semantics geometry composes transforms through
   // applyPaintTransform, so overriding it repositions every node in the
-  // subtree at once. Semantics actions dispatch straight to the widgets'
-  // own handlers, independent of the synthetic pointer pipeline above.
+  // subtree at once. The child is always visited for semantics; hiding
+  // (off-screen, culled, occluded) is done by the `ExcludeSemantics` the
+  // host widget wraps the child in, which is robust to toggling in a way
+  // that adding and removing the child from the semantics walk is not (a
+  // rejoining subtree leaves dirty parent data). Semantics actions dispatch
+  // straight to the widgets' own handlers, independent of the synthetic
+  // pointer pipeline above.
 
   Matrix4? _semanticsTransform;
   bool _semanticsUpdateScheduled = false;
@@ -409,10 +425,13 @@ class _RenderWidgetTexture extends RenderProxyBox {
     if (_semanticsUpdateScheduled) return;
     _semanticsUpdateScheduled = true;
     // Deferred to a post-frame callback: the new placement arrives during
-    // the paint flush, where dirtying semantics is not allowed.
+    // the paint flush, where dirtying semantics and scheduling a build
+    // (the ExcludeSemantics toggle) are both disallowed.
     SchedulerBinding.instance.addPostFrameCallback((_) {
       _semanticsUpdateScheduled = false;
-      if (attached) markNeedsSemanticsUpdate();
+      if (!attached) return;
+      _controller.semanticsHidden.value = _semanticsTransform == null;
+      markNeedsSemanticsUpdate();
     }, debugLabel: 'WidgetTexture.semanticsUpdate');
   }
 
@@ -432,13 +451,12 @@ class _RenderWidgetTexture extends RenderProxyBox {
     }
   }
 
-  // The subtree joins the semantics tree only while it has an on-screen
-  // placement; otherwise the child never appears on screen and has no
-  // semantics.
+  // Always visit the child; its semantics are gated by the host widget's
+  // ExcludeSemantics, not by removing it from the walk.
   @override
   void visitChildrenForSemantics(RenderObjectVisitor visitor) {
     final child = this.child;
-    if (child != null && _semanticsTransform != null) {
+    if (child != null) {
       visitor(child);
     }
   }

--- a/packages/flutter_scene/lib/src/widget_texture.dart
+++ b/packages/flutter_scene/lib/src/widget_texture.dart
@@ -154,6 +154,15 @@ class WidgetTextureController extends ChangeNotifier {
   /// [WidgetUpdatePolicy.manual]; under other policies it forces an
   /// immediate capture (subject to one-in-flight throttling).
   void requestCapture() => _host?._captureNow();
+
+  /// Sets the hosted subtree's semantics placement for this frame: the
+  /// transform mapping its logical coordinates onto the enclosing
+  /// `SceneView`'s box, or null to keep the subtree out of the semantics
+  /// tree (surface hidden, culled, or assistive technology inactive).
+  /// `SceneView` pushes this after each rendered frame.
+  @internal
+  void internalUpdateSemantics(Matrix4? transform) =>
+      _host?._updateSemantics(transform);
 }
 
 /// Hosts a live widget subtree and streams its visual output into a
@@ -374,9 +383,65 @@ class _RenderWidgetTexture extends RenderProxyBox {
   @override
   bool hitTest(BoxHitTestResult result, {required Offset position}) => false;
 
-  // The child never appears on screen, so it has no semantics.
+  // ----- semantics -----
+  //
+  // The hosted subtree computes real semantics but never paints at its
+  // layout position. While the surface is visible on screen and assistive
+  // technology is active, `SceneView` pushes the transform mapping the
+  // subtree's logical space onto the surface's projected quad; the
+  // framework's semantics geometry composes transforms through
+  // applyPaintTransform, so overriding it repositions every node in the
+  // subtree at once. Semantics actions dispatch straight to the widgets'
+  // own handlers, independent of the synthetic pointer pipeline above.
+
+  Matrix4? _semanticsTransform;
+  bool _semanticsUpdateScheduled = false;
+
+  void _updateSemantics(Matrix4? transform) {
+    final current = _semanticsTransform;
+    if (transform == null && current == null) return;
+    if (transform != null &&
+        current != null &&
+        _matrixNearEquals(transform, current)) {
+      return;
+    }
+    _semanticsTransform = transform;
+    if (_semanticsUpdateScheduled) return;
+    _semanticsUpdateScheduled = true;
+    // Deferred to a post-frame callback: the new placement arrives during
+    // the paint flush, where dirtying semantics is not allowed.
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _semanticsUpdateScheduled = false;
+      if (attached) markNeedsSemanticsUpdate();
+    }, debugLabel: 'WidgetTexture.semanticsUpdate');
+  }
+
+  static bool _matrixNearEquals(Matrix4 a, Matrix4 b) {
+    for (var i = 0; i < 16; i++) {
+      if ((a.storage[i] - b.storage[i]).abs() > 1e-3) return false;
+    }
+    return true;
+  }
+
   @override
-  void visitChildrenForSemantics(RenderObjectVisitor visitor) {}
+  void applyPaintTransform(RenderObject child, Matrix4 transform) {
+    super.applyPaintTransform(child, transform);
+    final t = _semanticsTransform;
+    if (t != null) {
+      transform.multiply(t);
+    }
+  }
+
+  // The subtree joins the semantics tree only while it has an on-screen
+  // placement; otherwise the child never appears on screen and has no
+  // semantics.
+  @override
+  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
+    final child = this.child;
+    if (child != null && _semanticsTransform != null) {
+      visitor(child);
+    }
+  }
 
   @override
   void paint(PaintingContext context, Offset offset) {

--- a/packages/flutter_scene/lib/src/widgets/scene_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view.dart
@@ -519,7 +519,22 @@ class _SceneViewState extends State<SceneView>
                               height: component.size.height,
                               pixelRatio: component.pixelRatio,
                               update: component.updatePolicy,
-                              child: _WidgetComponentHost(component: component),
+                              // ExcludeSemantics gates the subtree's semantics
+                              // by the coordinator's per-frame decision (see
+                              // WidgetTextureController.semanticsHidden); the
+                              // subtree stays structurally present either way.
+                              child: ValueListenableBuilder<bool>(
+                                valueListenable:
+                                    component.controller.semanticsHidden,
+                                builder: (context, hidden, child) =>
+                                    ExcludeSemantics(
+                                      excluding: hidden,
+                                      child: child,
+                                    ),
+                                child: _WidgetComponentHost(
+                                  component: component,
+                                ),
+                              ),
                             ),
                         ],
                       ),

--- a/packages/flutter_scene/lib/src/widgets/scene_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart'
+    show PipelineOwner, RenderCustomPaint, SemanticsBuilderCallback;
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/semantics.dart' show SemanticsBinding;
 import 'package:flutter/widgets.dart';
 
 import 'package:flutter_scene/src/camera.dart';
@@ -10,6 +13,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter_scene/src/resource_group.dart';
 import 'package:flutter_scene/src/scene.dart';
 import 'package:flutter_scene/src/scene_pointer.dart';
+import 'package:flutter_scene/src/widgets/scene_view_semantics.dart';
 import 'package:flutter_scene/src/widget_texture.dart';
 
 /// Builds a [Camera] for the current frame from the [elapsed] time since the
@@ -231,9 +235,18 @@ class _SceneViewState extends State<SceneView>
   bool get _gated =>
       widget.loading != null || widget.loadingBuilder != null || widget.warmUp;
 
+  // Builds the semantics elements for the scene's SemanticsComponents and
+  // widget surfaces; refreshed by the painter after each rendered frame.
+  late SceneSemanticsCoordinator _sceneSemantics;
+
   @override
   void initState() {
     super.initState();
+    _sceneSemantics = SceneSemanticsCoordinator(widget.scene);
+    SemanticsBinding.instance.addSemanticsEnabledListener(_onSemanticsChanged);
+    widget.scene.renderScene.semanticsComponentsChanged.addListener(
+      _onSemanticsChanged,
+    );
     if (widget.autoTick) {
       _ticker = createTicker(_onTick)..start();
     }
@@ -243,12 +256,26 @@ class _SceneViewState extends State<SceneView>
     }
   }
 
+  // Repaints so the next frame's semantics refresh sees the change (a
+  // screen reader toggling on/off, or semantics components mounting and
+  // unmounting), even when the view is not ticking.
+  void _onSemanticsChanged() => _repaint.notify();
+
   @override
   void didUpdateWidget(SceneView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.autoTick != oldWidget.autoTick) {
       _ticker?.dispose();
       _ticker = widget.autoTick ? (createTicker(_onTick)..start()) : null;
+    }
+    if (!identical(widget.scene, oldWidget.scene)) {
+      oldWidget.scene.renderScene.semanticsComponentsChanged.removeListener(
+        _onSemanticsChanged,
+      );
+      widget.scene.renderScene.semanticsComponentsChanged.addListener(
+        _onSemanticsChanged,
+      );
+      _sceneSemantics = SceneSemanticsCoordinator(widget.scene);
     }
     // A new set of resources to wait for (or newly gated): hold the scene again
     // until they load.
@@ -416,6 +443,12 @@ class _SceneViewState extends State<SceneView>
 
   @override
   void dispose() {
+    SemanticsBinding.instance.removeSemanticsEnabledListener(
+      _onSemanticsChanged,
+    );
+    widget.scene.renderScene.semanticsComponentsChanged.removeListener(
+      _onSemanticsChanged,
+    );
     _ticker?.dispose();
     _repaint.dispose();
     _elapsed.dispose();
@@ -424,6 +457,7 @@ class _SceneViewState extends State<SceneView>
 
   @override
   Widget build(BuildContext context) {
+    _sceneSemantics.ambientTextDirection = Directionality.maybeOf(context);
     return SceneScope(
       scene: widget.scene,
       elapsed: _elapsed,
@@ -447,12 +481,8 @@ class _SceneViewState extends State<SceneView>
             child: Stack(
               fit: StackFit.passthrough,
               children: [
-                CustomPaint(
-                  // Size.infinite fills the largest bounded constraints the view is
-                  // given (both tight constraints and a Stack's loose ones), so the
-                  // scene is never collapsed to zero size. See the class doc: place
-                  // SceneView where it receives bounded constraints.
-                  size: Size.infinite,
+                _SceneCustomPaint(
+                  semantics: _sceneSemantics,
                   painter: _ScenePainter(
                     scene: widget.scene,
                     cameraForFrame: widget.viewsBuilder == null
@@ -462,35 +492,41 @@ class _SceneViewState extends State<SceneView>
                         ? null
                         : _viewsForFrame,
                     pixelRatio: widget.pixelRatio,
+                    semantics: _sceneSemantics,
                     repaint: _repaint,
+                  ),
+                  // Invisible hosts for the scene's WidgetComponents: each hosted
+                  // subtree stays fully live (state, tickers, animations) while
+                  // occupying no layout space and never painting to the screen; its
+                  // visual output streams into the component's texture. The Overlay
+                  // keeps dialogs, dropdowns, and tooltips inside the capture.
+                  // Riding as the paint widget's child puts each subtree's
+                  // semantics under the scene's semantics boundary, beside the
+                  // nodes synthesized for SemanticsComponents.
+                  child: SizedBox.expand(
+                    child: ValueListenableBuilder<int>(
+                      valueListenable:
+                          widget.scene.renderScene.widgetComponentsChanged,
+                      builder: (context, _, _) => Stack(
+                        children: [
+                          for (final component
+                              in widget.scene.renderScene.widgetComponents
+                                  .whereType<WidgetComponent>())
+                            WidgetTexture(
+                              key: ObjectKey(component),
+                              controller: component.controller,
+                              width: component.size.width,
+                              height: component.size.height,
+                              pixelRatio: component.pixelRatio,
+                              update: component.updatePolicy,
+                              child: _WidgetComponentHost(component: component),
+                            ),
+                        ],
+                      ),
+                    ),
                   ),
                 ),
                 if (widget.debugWidgetInput) _buildDebugOverlay(),
-                // Invisible hosts for the scene's WidgetComponents: each hosted
-                // subtree stays fully live (state, tickers, animations) while
-                // occupying no layout space and never painting to the screen; its
-                // visual output streams into the component's texture. The Overlay
-                // keeps dialogs, dropdowns, and tooltips inside the capture.
-                ValueListenableBuilder<int>(
-                  valueListenable:
-                      widget.scene.renderScene.widgetComponentsChanged,
-                  builder: (context, _, _) => Stack(
-                    children: [
-                      for (final component
-                          in widget.scene.renderScene.widgetComponents
-                              .whereType<WidgetComponent>())
-                        WidgetTexture(
-                          key: ObjectKey(component),
-                          controller: component.controller,
-                          width: component.size.width,
-                          height: component.size.height,
-                          pixelRatio: component.pixelRatio,
-                          update: component.updatePolicy,
-                          child: _WidgetComponentHost(component: component),
-                        ),
-                    ],
-                  ),
-                ),
               ],
             ),
           );
@@ -585,6 +621,7 @@ class _ScenePainter extends CustomPainter {
     required this.cameraForFrame,
     required this.viewsForFrame,
     required this.pixelRatio,
+    required this.semantics,
     required Listenable repaint,
   }) : super(repaint: repaint);
 
@@ -592,33 +629,143 @@ class _ScenePainter extends CustomPainter {
   final Camera Function()? cameraForFrame;
   final List<RenderView> Function()? viewsForFrame;
   final double? pixelRatio;
+  final SceneSemanticsCoordinator semantics;
 
   @override
   void paint(Canvas canvas, Size size) {
+    // Semantics refresh in a finally so assistive technology stays current
+    // even on frames the engine skips or fails.
     final views = viewsForFrame;
     if (views != null) {
-      scene.renderViews(
-        views(),
-        canvas,
-        region: Offset.zero & size,
-        pixelRatio: pixelRatio,
-      );
+      final list = views();
+      try {
+        scene.renderViews(
+          list,
+          canvas,
+          region: Offset.zero & size,
+          pixelRatio: pixelRatio,
+        );
+      } finally {
+        // Semantics follow the primary view: the first one rendering to the
+        // screen. Views with an offscreen target contribute nothing.
+        Camera? primary;
+        var area = Offset.zero & size;
+        for (final view in list) {
+          if (view.target == null) {
+            primary = view.camera;
+            area = _viewArea(size, view.viewport);
+            break;
+          }
+        }
+        semantics.refreshAfterRender(primary, area);
+      }
     } else {
-      scene.render(
-        cameraForFrame!(),
-        canvas,
-        viewport: Offset.zero & size,
-        pixelRatio: pixelRatio,
-      );
+      final camera = cameraForFrame!();
+      try {
+        scene.render(
+          camera,
+          canvas,
+          viewport: Offset.zero & size,
+          pixelRatio: pixelRatio,
+        );
+      } finally {
+        semantics.refreshAfterRender(camera, Offset.zero & size);
+      }
     }
   }
+
+  // Maps a view's normalized viewport rectangle (0..1) into the scene box,
+  // matching how Scene.renderViews subdivides its region.
+  static Rect _viewArea(Size size, Rect? viewport) {
+    if (viewport == null) return Offset.zero & size;
+    return Rect.fromLTWH(
+      viewport.left * size.width,
+      viewport.top * size.height,
+      viewport.width * size.width,
+      viewport.height * size.height,
+    );
+  }
+
+  @override
+  SemanticsBuilderCallback? get semanticsBuilder => semantics.buildSemantics;
 
   @override
   bool shouldRepaint(covariant _ScenePainter oldDelegate) =>
       scene != oldDelegate.scene ||
       cameraForFrame != oldDelegate.cameraForFrame ||
       viewsForFrame != oldDelegate.viewsForFrame ||
-      pixelRatio != oldDelegate.pixelRatio;
+      pixelRatio != oldDelegate.pixelRatio ||
+      semantics != oldDelegate.semantics;
+}
+
+/// The scene's [CustomPaint], with a render object the semantics
+/// coordinator can schedule updates on. The widget-surface hosts ride as
+/// its child so their semantics assemble under the same boundary as the
+/// nodes synthesized for the scene's SemanticsComponents.
+class _SceneCustomPaint extends CustomPaint {
+  const _SceneCustomPaint({
+    required this.semantics,
+    required _ScenePainter super.painter,
+    required Widget super.child,
+    // Size.infinite fills the largest bounded constraints the view is given
+    // (both tight constraints and a Stack's loose ones), so the scene is
+    // never collapsed to zero size. See the class doc: place SceneView
+    // where it receives bounded constraints. With a child present the
+    // render object sizes to it, so the child is a SizedBox.expand.
+  }) : super(size: Size.infinite);
+
+  final SceneSemanticsCoordinator semantics;
+
+  @override
+  RenderCustomPaint createRenderObject(BuildContext context) =>
+      _RenderSceneCustomPaint(
+        semantics: semantics,
+        painter: painter,
+        preferredSize: size,
+      );
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    covariant _RenderSceneCustomPaint renderObject,
+  ) {
+    super.updateRenderObject(context, renderObject);
+    renderObject.semantics = semantics;
+  }
+}
+
+class _RenderSceneCustomPaint extends RenderCustomPaint {
+  _RenderSceneCustomPaint({
+    required SceneSemanticsCoordinator semantics,
+    super.painter,
+    required super.preferredSize,
+  }) : _semantics = semantics;
+
+  SceneSemanticsCoordinator _semantics;
+  set semantics(SceneSemanticsCoordinator value) {
+    if (identical(value, _semantics)) return;
+    if (identical(_semantics.renderObject, this)) {
+      _semantics.renderObject = null;
+    }
+    _semantics = value;
+    if (attached) {
+      _semantics.renderObject = this;
+    }
+  }
+
+  @override
+  void attach(PipelineOwner owner) {
+    super.attach(owner);
+    _semantics.renderObject = this;
+  }
+
+  @override
+  void detach() {
+    if (identical(_semantics.renderObject, this)) {
+      _semantics.renderObject = null;
+    }
+    super.detach();
+  }
 }
 
 /// Exposes the active [Scene] (and the per-frame [elapsed] time) to descendants

--- a/packages/flutter_scene/lib/src/widgets/scene_view_semantics.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view_semantics.dart
@@ -1,0 +1,362 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart' show ObjectKey;
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'package:flutter_scene/src/camera.dart';
+import 'package:flutter_scene/src/components/semantics_component.dart';
+import 'package:flutter_scene/src/components/widget_component.dart';
+import 'package:flutter_scene/src/node.dart';
+import 'package:flutter_scene/src/scene.dart';
+
+/// The nominal focus rectangle (logical pixels) for a semantics node whose
+/// subtree has no computable bounds (skinned content without a
+/// `SemanticsComponent.boundsOverride`), matching the platform minimum
+/// touch-target convention.
+const double _kUnboundedFocusExtent = 48.0;
+
+/// One projected semantics element, compared across frames to decide when
+/// the semantics tree needs a rebuild.
+class _SemanticsEntry {
+  _SemanticsEntry(this.component, this.rect, this.version);
+
+  final SemanticsComponent component;
+  final ui.Rect rect;
+  final int version;
+
+  bool matches(_SemanticsEntry other) =>
+      identical(component, other.component) &&
+      version == other.version &&
+      (rect.left - other.rect.left).abs() < 1e-3 &&
+      (rect.top - other.rect.top).abs() < 1e-3 &&
+      (rect.right - other.rect.right).abs() < 1e-3 &&
+      (rect.bottom - other.rect.bottom).abs() < 1e-3;
+}
+
+/// Builds and maintains a `SceneView`'s semantics: one synthesized node per
+/// mounted [SemanticsComponent] (its bounds projected through the primary
+/// view's camera) plus per-frame geometry for each `WidgetComponent`'s
+/// hosted subtree.
+///
+/// The owning view refreshes it from the scene painter after each rendered
+/// frame, where the camera and node transforms are current. Everything is
+/// gated on [SemanticsBinding.semanticsEnabled], so the projection work
+/// costs nothing while no assistive technology runs. Changed snapshots
+/// schedule a semantics update on the scene's render object via a
+/// post-frame callback (marking during the paint flush is not allowed).
+///
+/// Not exported; `SceneView` is the only consumer.
+class SceneSemanticsCoordinator {
+  SceneSemanticsCoordinator(this.scene);
+
+  final Scene scene;
+
+  /// The scene's render object, managed by its attach/detach. Semantics
+  /// updates are dropped while there is none.
+  RenderObject? renderObject;
+
+  /// The view's ambient reading direction, set by `SceneView` from its
+  /// build context. Fills in components that carry text but no explicit
+  /// direction.
+  ui.TextDirection? ambientTextDirection;
+
+  List<_SemanticsEntry> _entries = const [];
+  bool _updateScheduled = false;
+
+  /// Whether the last refresh ran with assistive technology active, so a
+  /// flip to disabled clears the tree exactly once.
+  bool _wasEnabled = false;
+
+  /// The semantics builder handed to the scene painter. Reads the snapshot
+  /// the last refresh produced; the framework calls it whenever the scene's
+  /// semantics node is (re)assembled.
+  List<CustomPainterSemantics> buildSemantics(ui.Size size) => [
+    for (final entry in _entries)
+      CustomPainterSemantics(
+        key: ObjectKey(entry.component),
+        rect: entry.rect,
+        properties: entry.component.effectiveProperties(ambientTextDirection),
+      ),
+  ];
+
+  /// Recomputes the semantics snapshot against the primary view. Called by
+  /// the scene painter after each rendered frame; [camera] is the primary
+  /// view's camera (null when no view renders to the screen) and [viewArea]
+  /// is the sub-rectangle of the scene's box that view draws into.
+  void refreshAfterRender(Camera? camera, ui.Rect viewArea) {
+    final enabled =
+        SemanticsBinding.instance.semanticsEnabled &&
+        camera != null &&
+        !viewArea.isEmpty;
+    if (!enabled) {
+      if (_wasEnabled) {
+        _wasEnabled = false;
+        if (_entries.isNotEmpty) {
+          _entries = const [];
+          _scheduleSemanticsUpdate();
+        }
+        _refreshWidgetSurfaces(null, viewArea);
+      }
+      return;
+    }
+    _wasEnabled = true;
+
+    final entries = <_SemanticsEntry>[];
+    for (final component in scene.renderScene.semanticsComponents) {
+      if (!component.enabled) continue;
+      final node = component.node;
+      if (!_chainVisible(node)) continue;
+      final rect = _projectFocusRect(component, node, camera, viewArea);
+      if (rect == null) continue;
+      if (component.occlusionHiding && _isOccluded(node, component, camera)) {
+        continue;
+      }
+      entries.add(_SemanticsEntry(component, rect, component.version));
+    }
+
+    if (!_entriesMatch(entries)) {
+      _entries = entries;
+      _scheduleSemanticsUpdate();
+    }
+
+    _refreshWidgetSurfaces(camera, viewArea);
+  }
+
+  bool _entriesMatch(List<_SemanticsEntry> entries) {
+    if (entries.length != _entries.length) return false;
+    for (var i = 0; i < entries.length; i++) {
+      if (!entries[i].matches(_entries[i])) return false;
+    }
+    return true;
+  }
+
+  void _scheduleSemanticsUpdate() {
+    if (_updateScheduled) return;
+    _updateScheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _updateScheduled = false;
+      final ro = renderObject;
+      if (ro != null && ro.attached) {
+        ro.markNeedsSemanticsUpdate();
+      }
+    }, debugLabel: 'SceneView.semanticsUpdate');
+  }
+
+  static bool _chainVisible(Node node) {
+    for (Node? current = node; current != null; current = current.parent) {
+      if (!current.visible) return false;
+    }
+    return true;
+  }
+
+  /// Projects the component's focus bounds to a rectangle in the scene
+  /// box's coordinates, or null when the node is entirely behind the
+  /// camera.
+  ui.Rect? _projectFocusRect(
+    SemanticsComponent component,
+    Node node,
+    Camera camera,
+    ui.Rect viewArea,
+  ) {
+    final bounds = component.boundsOverride ?? node.combinedLocalBounds;
+    if (bounds == null) {
+      // No computable bounds (skinned content without an override): a
+      // nominal-size rectangle at the node origin keeps the element
+      // focusable somewhere sensible.
+      final screen = camera.worldToScreen(
+        node.globalTransform.getTranslation(),
+        viewArea.size,
+      );
+      if (screen == null) return null;
+      return ui.Rect.fromCenter(
+        center: screen + viewArea.topLeft,
+        width: _kUnboundedFocusExtent,
+        height: _kUnboundedFocusExtent,
+      );
+    }
+    final world = vm.Aabb3.copy(bounds)..transform(node.globalTransform);
+    return projectAabbToArea(world, camera, viewArea);
+  }
+
+  /// Whether other scene geometry sits between the camera and the node's
+  /// bounds center. A single center-point sample, conservative and cheap;
+  /// the node's own subtree never counts as an occluder.
+  bool _isOccluded(Node node, SemanticsComponent component, Camera camera) {
+    final bounds = component.boundsOverride ?? node.combinedLocalBounds;
+    final vm.Vector3 center;
+    if (bounds == null) {
+      center = node.globalTransform.getTranslation();
+    } else {
+      final world = vm.Aabb3.copy(bounds)..transform(node.globalTransform);
+      center = world.center;
+    }
+    final origin = camera.position;
+    final toCenter = center - origin;
+    final distance = toCenter.length;
+    if (distance <= 1e-6) return false;
+    final hit = scene.raycast(
+      vm.Ray.originDirection(origin, toCenter / distance),
+      maxDistance: distance,
+      where: (candidate) => !_inSubtree(candidate, node),
+    );
+    return hit != null && hit.distance < distance - 1e-4;
+  }
+
+  static bool _inSubtree(Node candidate, Node root) {
+    for (Node? current = candidate; current != null; current = current.parent) {
+      if (identical(current, root)) return true;
+    }
+    return false;
+  }
+
+  /// Pushes each widget surface's semantics geometry (or hides it) into its
+  /// hosting render object. With a null [camera] every surface is hidden
+  /// (assistive technology inactive, or no screen view this frame).
+  void _refreshWidgetSurfaces(Camera? camera, ui.Rect viewArea) {
+    for (final entry in scene.renderScene.widgetComponents) {
+      if (entry is! WidgetComponent) continue;
+      vm.Matrix4? transform;
+      if (camera != null && entry.enabled && _chainVisible(entry.node)) {
+        transform = _widgetSurfaceTransform(entry, camera, viewArea);
+      }
+      // The render layer speaks Flutter's 64-bit matrices; convert at the
+      // boundary (both are column-major).
+      entry.controller.internalUpdateSemantics(
+        transform == null ? null : Matrix4.fromList(transform.storage),
+      );
+    }
+  }
+
+  /// The transform mapping the hosted subtree's logical coordinates onto
+  /// the scene box, or null when the surface has no usable on-screen
+  /// placement this frame.
+  vm.Matrix4? _widgetSurfaceTransform(
+    WidgetComponent component,
+    Camera camera,
+    ui.Rect viewArea,
+  ) {
+    final node = component.node;
+    if (component.ownsQuadSurface) {
+      return _quadSurfaceTransform(component, node, camera, viewArea);
+    }
+    // Custom geometry or bind-only surfaces have no single plane to map
+    // exactly; fit the widget rectangle onto the projected node bounds.
+    // TODO(scene-semantics): exact per-surface mapping for custom widget
+    // geometry (project through the surface's UV parameterization instead
+    // of its AABB).
+    final bounds = node.combinedLocalBounds;
+    if (bounds == null) return null;
+    final world = vm.Aabb3.copy(bounds)..transform(node.globalTransform);
+    final rect = projectAabbToArea(world, camera, viewArea);
+    if (rect == null || rect.isEmpty) return null;
+    final size = component.size;
+    return vm.Matrix4.identity()
+      ..setEntry(0, 0, rect.width / size.width)
+      ..setEntry(1, 1, rect.height / size.height)
+      ..setEntry(0, 3, rect.left)
+      ..setEntry(1, 3, rect.top);
+  }
+
+  /// The exact projective transform for a component-owned quad surface:
+  /// widget logical space onto the quad's local plane, through the node's
+  /// world transform and the camera, into scene-box coordinates.
+  vm.Matrix4? _quadSurfaceTransform(
+    WidgetComponent component,
+    Node node,
+    Camera camera,
+    ui.Rect viewArea,
+  ) {
+    final size = component.size;
+    final quadHeight = component.worldHeight;
+    final quadWidth = quadHeight * (size.width / size.height);
+
+    // Widget space (origin top-left, y down) onto the quad's local plane.
+    // The quad's UVs mirror u across x and run v top-down (see
+    // WidgetComponent's quad geometry), so widget (0, 0) lands on the local
+    // (+halfWidth, +halfHeight) corner.
+    final localFromWidget = vm.Matrix4.identity()
+      ..setEntry(0, 0, -quadWidth / size.width)
+      ..setEntry(0, 3, quadWidth / 2)
+      ..setEntry(1, 1, -quadHeight / size.height)
+      ..setEntry(1, 3, quadHeight / 2);
+
+    final clipFromWidget = camera
+        .getViewTransform(viewArea.size)
+        .multiplied(node.globalTransform)
+        .multiplied(localFromWidget);
+
+    // Reject the mapping when any widget corner reaches the camera plane;
+    // the homography is degenerate there and the surface is unreadable
+    // anyway.
+    for (final corner in [
+      vm.Vector4(0, 0, 0, 1),
+      vm.Vector4(size.width, 0, 0, 1),
+      vm.Vector4(0, size.height, 0, 1),
+      vm.Vector4(size.width, size.height, 0, 1),
+    ]) {
+      final clip = clipFromWidget.transform(corner);
+      if (clip.w <= 0) return null;
+    }
+
+    // Homogeneous clip-to-screen: the perspective divide is deferred to the
+    // consumers of the semantics transform chain, which handle full
+    // projective matrices.
+    final screenFromClip = vm.Matrix4.identity()
+      ..setEntry(0, 0, viewArea.width / 2)
+      ..setEntry(0, 3, viewArea.width / 2 + viewArea.left)
+      ..setEntry(1, 1, -viewArea.height / 2)
+      ..setEntry(1, 3, viewArea.height / 2 + viewArea.top);
+
+    return screenFromClip.multiplied(clipFromWidget);
+  }
+}
+
+/// Projects a world-space AABB through [camera] into [viewArea] (a
+/// sub-rectangle of the scene box, in its coordinates) and returns the
+/// bounding rectangle of the eight projected corners.
+///
+/// Returns null when the box is entirely behind the camera plane. When the
+/// box crosses the camera plane its projection is unbounded, so the whole
+/// [viewArea] is returned as the conservative answer.
+ui.Rect? projectAabbToArea(vm.Aabb3 world, Camera camera, ui.Rect viewArea) {
+  final viewSize = viewArea.size;
+  final viewProjection = camera.getViewTransform(viewSize);
+  final min = world.min;
+  final max = world.max;
+  var anyBehind = false;
+  var anyInFront = false;
+  var left = double.infinity;
+  var top = double.infinity;
+  var right = double.negativeInfinity;
+  var bottom = double.negativeInfinity;
+  for (var i = 0; i < 8; i++) {
+    final corner = vm.Vector4(
+      (i & 1) == 0 ? min.x : max.x,
+      (i & 2) == 0 ? min.y : max.y,
+      (i & 4) == 0 ? min.z : max.z,
+      1,
+    );
+    final clip = viewProjection.transform(corner);
+    if (clip.w <= 0) {
+      anyBehind = true;
+      continue;
+    }
+    anyInFront = true;
+    final x = (clip.x / clip.w + 1) / 2 * viewSize.width;
+    final y = (1 - clip.y / clip.w) / 2 * viewSize.height;
+    if (x < left) left = x;
+    if (y < top) top = y;
+    if (x > right) right = x;
+    if (y > bottom) bottom = y;
+  }
+  if (!anyInFront) return null;
+  if (anyBehind) return viewArea;
+  return ui.Rect.fromLTRB(
+    left + viewArea.left,
+    top + viewArea.top,
+    right + viewArea.left,
+    bottom + viewArea.top,
+  );
+}

--- a/packages/flutter_scene/lib/src/widgets/scene_view_semantics.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view_semantics.dart
@@ -20,11 +20,28 @@ const double _kUnboundedFocusExtent = 48.0;
 /// One projected semantics element, compared across frames to decide when
 /// the semantics tree needs a rebuild.
 class _SemanticsEntry {
-  _SemanticsEntry(this.component, this.rect, this.version);
+  _SemanticsEntry(
+    this.component,
+    this.rect,
+    this.version,
+    this.depth,
+    this.readingOrder,
+  );
 
   final SemanticsComponent component;
   final ui.Rect rect;
   final int version;
+
+  /// Distance from the camera to the node's bounds center. Emitted children
+  /// are ordered farthest-first (nearest last), so when projected rects
+  /// overlap the nearest part wins the reversed hit test that assistive
+  /// technology uses for touch exploration.
+  final double depth;
+
+  /// The component's registration index, used as a stable reading-order
+  /// fallback so traversal order does not follow the depth-driven emission
+  /// order.
+  final double readingOrder;
 
   bool matches(_SemanticsEntry other) =>
       identical(component, other.component) &&
@@ -77,7 +94,10 @@ class SceneSemanticsCoordinator {
       CustomPainterSemantics(
         key: ObjectKey(entry.component),
         rect: entry.rect,
-        properties: entry.component.effectiveProperties(ambientTextDirection),
+        properties: entry.component.effectiveProperties(
+          ambientTextDirection,
+          fallbackSortOrder: entry.readingOrder,
+        ),
       ),
   ];
 
@@ -103,8 +123,10 @@ class SceneSemanticsCoordinator {
     }
     _wasEnabled = true;
 
+    final components = scene.renderScene.semanticsComponents;
     final entries = <_SemanticsEntry>[];
-    for (final component in scene.renderScene.semanticsComponents) {
+    for (var i = 0; i < components.length; i++) {
+      final component = components[i];
       if (!component.enabled) continue;
       final node = component.node;
       if (!_chainVisible(node)) continue;
@@ -113,8 +135,21 @@ class SceneSemanticsCoordinator {
       if (component.occlusionHiding && _isOccluded(node, component, camera)) {
         continue;
       }
-      entries.add(_SemanticsEntry(component, rect, component.version));
+      entries.add(
+        _SemanticsEntry(
+          component,
+          rect,
+          component.version,
+          _cameraDepth(component, node, camera),
+          i.toDouble(),
+        ),
+      );
     }
+
+    // Emit farthest-first so the nearest overlapping part wins the reversed
+    // hit test; reading order stays put via each entry's readingOrder sort
+    // key. A stable sort keeps registration order between equal depths.
+    _mergeSortByDepthDescending(entries);
 
     if (!_entriesMatch(entries)) {
       _entries = entries;
@@ -122,6 +157,54 @@ class SceneSemanticsCoordinator {
     }
 
     _refreshWidgetSurfaces(camera, viewArea);
+  }
+
+  // Distance from the camera to the node's bounds center (or origin when the
+  // subtree is unbounded), the key for depth ordering.
+  double _cameraDepth(SemanticsComponent component, Node node, Camera camera) {
+    final bounds = component.boundsOverride ?? node.combinedLocalBounds;
+    final vm.Vector3 center;
+    if (bounds == null) {
+      center = node.globalTransform.getTranslation();
+    } else {
+      final world = vm.Aabb3.copy(bounds)..transform(node.globalTransform);
+      center = world.center;
+    }
+    return center.distanceTo(camera.position);
+  }
+
+  // A stable descending-by-depth sort. `List.sort` is not guaranteed stable,
+  // and stability matters so equal-depth parts keep registration order (and
+  // the emission order does not jitter frame to frame).
+  static void _mergeSortByDepthDescending(List<_SemanticsEntry> entries) {
+    if (entries.length < 2) return;
+    final sorted = List<_SemanticsEntry>.of(entries);
+    final buffer = List<_SemanticsEntry?>.filled(entries.length, null);
+    for (var width = 1; width < sorted.length; width *= 2) {
+      for (var lo = 0; lo < sorted.length; lo += width * 2) {
+        final mid = (lo + width).clamp(0, sorted.length);
+        final hi = (lo + width * 2).clamp(0, sorted.length);
+        var i = lo, j = mid, k = lo;
+        while (i < mid && j < hi) {
+          // `>=` keeps the left (earlier) entry first on ties: stable.
+          buffer[k++] = sorted[i].depth >= sorted[j].depth
+              ? sorted[i++]
+              : sorted[j++];
+        }
+        while (i < mid) {
+          buffer[k++] = sorted[i++];
+        }
+        while (j < hi) {
+          buffer[k++] = sorted[j++];
+        }
+      }
+      for (var x = 0; x < sorted.length; x++) {
+        sorted[x] = buffer[x]!;
+      }
+    }
+    for (var x = 0; x < entries.length; x++) {
+      entries[x] = sorted[x];
+    }
   }
 
   bool _entriesMatch(List<_SemanticsEntry> entries) {

--- a/packages/flutter_scene/lib/src/widgets/scene_view_semantics.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view_semantics.dart
@@ -132,7 +132,12 @@ class SceneSemanticsCoordinator {
       if (!_chainVisible(node)) continue;
       final rect = _projectFocusRect(component, node, camera, viewArea);
       if (rect == null) continue;
-      if (component.occlusionHiding && _isOccluded(node, component, camera)) {
+      if (component.occlusionHiding &&
+          _isNodeOccluded(
+            node,
+            camera,
+            boundsOverride: component.boundsOverride,
+          )) {
         continue;
       }
       entries.add(
@@ -266,8 +271,8 @@ class SceneSemanticsCoordinator {
   /// Whether other scene geometry sits between the camera and the node's
   /// bounds center. A single center-point sample, conservative and cheap;
   /// the node's own subtree never counts as an occluder.
-  bool _isOccluded(Node node, SemanticsComponent component, Camera camera) {
-    final bounds = component.boundsOverride ?? node.combinedLocalBounds;
+  bool _isNodeOccluded(Node node, Camera camera, {vm.Aabb3? boundsOverride}) {
+    final bounds = boundsOverride ?? node.combinedLocalBounds;
     final vm.Vector3 center;
     if (bounds == null) {
       center = node.globalTransform.getTranslation();
@@ -301,7 +306,10 @@ class SceneSemanticsCoordinator {
     for (final entry in scene.renderScene.widgetComponents) {
       if (entry is! WidgetComponent) continue;
       vm.Matrix4? transform;
-      if (camera != null && entry.enabled && _chainVisible(entry.node)) {
+      if (camera != null &&
+          entry.enabled &&
+          _chainVisible(entry.node) &&
+          !(entry.occlusionHiding && _isNodeOccluded(entry.node, camera))) {
         transform = _widgetSurfaceTransform(entry, camera, viewArea);
       }
       // The render layer speaks Flutter's 64-bit matrices; convert at the

--- a/packages/flutter_scene/lib/src/widgets/scene_view_semantics.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view_semantics.dart
@@ -328,15 +328,17 @@ class SceneSemanticsCoordinator {
     Camera camera,
     ui.Rect viewArea,
   ) {
+    // Fit the widget rectangle onto the surface's projected node bounds with
+    // an affine (translate + scale) transform. A full projective homography
+    // (matching the perspective-warped quad exactly) is not used: platform
+    // semantics geometry mishandles a perspective transform once a subtree
+    // has more than one node (their rects and clips collapse), which drops
+    // the whole surface from the tree. The affine fit is exact for a
+    // head-on surface and a good approximation off-axis.
+    // TODO(scene-semantics): a perspective-correct mapping would need the
+    // framework's semantics geometry to handle projective transforms for
+    // multi-node subtrees, or a custom per-node projection.
     final node = component.node;
-    if (component.ownsQuadSurface) {
-      return _quadSurfaceTransform(component, node, camera, viewArea);
-    }
-    // Custom geometry or bind-only surfaces have no single plane to map
-    // exactly; fit the widget rectangle onto the projected node bounds.
-    // TODO(scene-semantics): exact per-surface mapping for custom widget
-    // geometry (project through the surface's UV parameterization instead
-    // of its AABB).
     final bounds = node.combinedLocalBounds;
     if (bounds == null) return null;
     final world = vm.Aabb3.copy(bounds)..transform(node.globalTransform);
@@ -348,59 +350,6 @@ class SceneSemanticsCoordinator {
       ..setEntry(1, 1, rect.height / size.height)
       ..setEntry(0, 3, rect.left)
       ..setEntry(1, 3, rect.top);
-  }
-
-  /// The exact projective transform for a component-owned quad surface:
-  /// widget logical space onto the quad's local plane, through the node's
-  /// world transform and the camera, into scene-box coordinates.
-  vm.Matrix4? _quadSurfaceTransform(
-    WidgetComponent component,
-    Node node,
-    Camera camera,
-    ui.Rect viewArea,
-  ) {
-    final size = component.size;
-    final quadHeight = component.worldHeight;
-    final quadWidth = quadHeight * (size.width / size.height);
-
-    // Widget space (origin top-left, y down) onto the quad's local plane.
-    // The quad's UVs mirror u across x and run v top-down (see
-    // WidgetComponent's quad geometry), so widget (0, 0) lands on the local
-    // (+halfWidth, +halfHeight) corner.
-    final localFromWidget = vm.Matrix4.identity()
-      ..setEntry(0, 0, -quadWidth / size.width)
-      ..setEntry(0, 3, quadWidth / 2)
-      ..setEntry(1, 1, -quadHeight / size.height)
-      ..setEntry(1, 3, quadHeight / 2);
-
-    final clipFromWidget = camera
-        .getViewTransform(viewArea.size)
-        .multiplied(node.globalTransform)
-        .multiplied(localFromWidget);
-
-    // Reject the mapping when any widget corner reaches the camera plane;
-    // the homography is degenerate there and the surface is unreadable
-    // anyway.
-    for (final corner in [
-      vm.Vector4(0, 0, 0, 1),
-      vm.Vector4(size.width, 0, 0, 1),
-      vm.Vector4(0, size.height, 0, 1),
-      vm.Vector4(size.width, size.height, 0, 1),
-    ]) {
-      final clip = clipFromWidget.transform(corner);
-      if (clip.w <= 0) return null;
-    }
-
-    // Homogeneous clip-to-screen: the perspective divide is deferred to the
-    // consumers of the semantics transform chain, which handle full
-    // projective matrices.
-    final screenFromClip = vm.Matrix4.identity()
-      ..setEntry(0, 0, viewArea.width / 2)
-      ..setEntry(0, 3, viewArea.width / 2 + viewArea.left)
-      ..setEntry(1, 1, -viewArea.height / 2)
-      ..setEntry(1, 3, viewArea.height / 2 + viewArea.top);
-
-    return screenFromClip.multiplied(clipFromWidget);
   }
 }
 

--- a/packages/flutter_scene/test/scene_semantics_test.dart
+++ b/packages/flutter_scene/test/scene_semantics_test.dart
@@ -532,4 +532,48 @@ void main() {
     expect(find.semantics.byLabel('Panel button'), findsNothing);
     handle.dispose();
   });
+
+  testWidgets('occlusionHiding drops an occluded widget surface subtree', (
+    tester,
+  ) async {
+    final scene = await _readyScene(tester);
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    // The default camera sits at z = -5 looking toward the origin. The
+    // panel is at the origin; a wall between them occludes it.
+    final panel = Node(name: 'panel');
+    panel.addComponent(
+      WidgetComponent(
+        size: const Size(100, 100),
+        occlusionHiding: true,
+        child: Center(
+          child: Semantics(
+            label: 'Panel button',
+            button: true,
+            child: const SizedBox(width: 50, height: 50),
+          ),
+        ),
+      ),
+    );
+    scene.add(panel);
+    final wall = _quadNode(
+      name: 'wall',
+      transform: Matrix4.translation(Vector3(0, 0, -2))
+        ..scaleByVector3(Vector3(6, 6, 1)),
+    );
+    scene.add(wall);
+
+    await tester.pumpWidget(_host(scene));
+    await _settleSemantics(tester);
+    expect(find.semantics.byLabel('Panel button'), findsNothing);
+
+    // With the occluder gone the surface's semantics return.
+    wall.visible = false;
+    await _settleSemantics(tester);
+    expect(find.semantics.byLabel('Panel button'), findsOne);
+    handle.dispose();
+  });
 }

--- a/packages/flutter_scene/test/scene_semantics_test.dart
+++ b/packages/flutter_scene/test/scene_semantics_test.dart
@@ -1,0 +1,439 @@
+// Covers scene accessibility: Camera.worldToScreen and the AABB screen
+// projection (pure math, no GPU), and the SceneView semantics tree built
+// from SemanticsComponents and widget surfaces (labels, focus rects,
+// actions, visibility and occlusion filtering, traversal order).
+//
+// Scene construction touches the Flutter GPU context, so the widget-level
+// tests skip cleanly when it is absent (matching the rest of the suite).
+// Scene.render() itself early-returns without static resources; the
+// semantics refresh runs from the scene painter regardless, so these tests
+// exercise the real per-frame path.
+
+import 'dart:typed_data';
+
+import 'package:flutter/rendering.dart' show MatrixUtils;
+import 'package:flutter/semantics.dart'
+    show SemanticsAction, SemanticsNode, SemanticsProperties;
+import 'package:flutter/widgets.dart'
+    show
+        Center,
+        Directionality,
+        Offset,
+        Rect,
+        Semantics,
+        Size,
+        SizedBox,
+        TextDirection,
+        Widget;
+import 'package:flutter_scene/scene.dart';
+// The projection helper is internal SceneView machinery; reach it directly.
+import 'package:flutter_scene/src/widgets/scene_view_semantics.dart'
+    show projectAabbToArea;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+Scene? _tryScene() {
+  try {
+    return Scene();
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Builds a scene, or null without a GPU. The shader-bundle asset is not
+/// loadable under `flutter test`, so pumped frames skip rendering (the
+/// not-ready path); the semantics refresh runs from the scene painter
+/// regardless.
+Future<Scene?> _readyScene(WidgetTester tester) async => _tryScene();
+
+/// A unit quad in the XY plane at z = 0 (two triangles, 0..1 UVs), enough
+/// geometry for bounds and raycasts.
+MeshGeometry _quad() => MeshGeometry.fromArrays(
+  positions: Float32List.fromList([
+    -0.5, -0.5, 0, //
+    0.5, -0.5, 0, //
+    0.5, 0.5, 0, //
+    -0.5, 0.5, 0, //
+  ]),
+  texCoords: Float32List.fromList([0, 1, 1, 1, 1, 0, 0, 0]),
+  indices: [0, 1, 2, 0, 2, 3],
+);
+
+Node _quadNode({String name = 'quad', Matrix4? transform}) => Node(
+  name: name,
+  localTransform: transform,
+  mesh: Mesh(_quad(), UnlitMaterial()),
+);
+
+Aabb3 _unitBounds() =>
+    Aabb3.minMax(Vector3(-0.5, -0.5, -0.5), Vector3(0.5, 0.5, 0.5));
+
+Widget _host(Scene scene, {Camera? camera}) => Directionality(
+  textDirection: TextDirection.ltr,
+  child: Center(
+    child: SizedBox(
+      width: 200,
+      height: 200,
+      child: SceneView(scene, camera: camera ?? PerspectiveCamera()),
+    ),
+  ),
+);
+
+/// The node's rect in global (test surface) coordinates, composed through
+/// its ancestor transforms.
+Rect _globalRect(SemanticsNode node) {
+  var rect = node.rect;
+  for (
+    SemanticsNode? current = node;
+    current != null;
+    current = current.parent
+  ) {
+    final transform = current.transform;
+    if (transform != null) {
+      rect = MatrixUtils.transformRect(transform, rect);
+    }
+  }
+  return rect;
+}
+
+/// Pumps twice: the first frame's paint refreshes the snapshot and its
+/// post-frame callback schedules the semantics update the second frame
+/// flushes.
+Future<void> _settleSemantics(WidgetTester tester) async {
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  group('Camera.worldToScreen', () {
+    test('round-trips screenPointToRay', () {
+      final camera = PerspectiveCamera(
+        position: Vector3(1, 2, -6),
+        target: Vector3(0.5, 0, 1),
+      );
+      const viewSize = Size(320, 240);
+      const screen = Offset(70, 180);
+      final ray = camera.screenPointToRay(screen, viewSize);
+      final world = ray.origin + ray.direction * 0.35;
+      final projected = camera.worldToScreen(world, viewSize);
+      expect(projected, isNotNull);
+      expect(projected!.dx, closeTo(screen.dx, 1e-2));
+      expect(projected.dy, closeTo(screen.dy, 1e-2));
+    });
+
+    test('returns null behind the camera', () {
+      final camera = PerspectiveCamera(
+        position: Vector3(0, 0, -5),
+        target: Vector3.zero(),
+      );
+      expect(
+        camera.worldToScreen(Vector3(0, 0, -10), const Size(100, 100)),
+        isNull,
+      );
+    });
+  });
+
+  group('projectAabbToArea', () {
+    final camera = PerspectiveCamera(
+      position: Vector3(0, 0, -5),
+      target: Vector3.zero(),
+    );
+    const area = Rect.fromLTWH(0, 0, 200, 200);
+
+    test('centers a symmetric box in the view', () {
+      final rect = projectAabbToArea(_unitBounds(), camera, area);
+      expect(rect, isNotNull);
+      expect(rect!.center.dx, closeTo(100, 1e-3));
+      expect(rect.center.dy, closeTo(100, 1e-3));
+      expect(rect.width, greaterThan(0));
+    });
+
+    test('offsets by the view area origin', () {
+      const offsetArea = Rect.fromLTWH(50, 30, 200, 200);
+      final rect = projectAabbToArea(_unitBounds(), camera, offsetArea)!;
+      expect(rect.center.dx, closeTo(150, 1e-3));
+      expect(rect.center.dy, closeTo(130, 1e-3));
+    });
+
+    test('returns null fully behind the camera', () {
+      final rect = projectAabbToArea(
+        Aabb3.minMax(Vector3(-0.5, -0.5, -8), Vector3(0.5, 0.5, -7)),
+        camera,
+        area,
+      );
+      expect(rect, isNull);
+    });
+
+    test('returns the whole area when crossing the camera plane', () {
+      final rect = projectAabbToArea(
+        Aabb3.minMax(Vector3(-0.5, -0.5, -6), Vector3(0.5, 0.5, 0)),
+        camera,
+        area,
+      );
+      expect(rect, area);
+    });
+  });
+
+  testWidgets('SemanticsComponent exposes a projected, actionable node', (
+    tester,
+  ) async {
+    final scene = await _readyScene(tester);
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    var tapped = false;
+    final node = Node(name: 'switch');
+    node.addComponent(
+      SemanticsComponent(
+        label: 'Power switch',
+        button: true,
+        onTap: () => tapped = true,
+        boundsOverride: _unitBounds(),
+      ),
+    );
+    scene.add(node);
+
+    await tester.pumpWidget(_host(scene));
+    await _settleSemantics(tester);
+
+    final finder = find.semantics.byLabel('Power switch');
+    expect(finder, findsOne);
+    expect(
+      finder.found.single,
+      matchesSemantics(
+        label: 'Power switch',
+        isButton: true,
+        hasTapAction: true,
+      ),
+    );
+
+    // The 200x200 view is centered on the default 800x600 test surface, and
+    // a camera-facing symmetric box projects to the view center.
+    final dpr = tester.view.devicePixelRatio;
+    final rect = _globalRect(finder.found.single);
+    expect(rect.center.dx, closeTo(400 * dpr, 1.0));
+    expect(rect.center.dy, closeTo(300 * dpr, 1.0));
+
+    tester.semantics.tap(finder);
+    expect(tapped, isTrue);
+    handle.dispose();
+  });
+
+  testWidgets('invisible and behind-camera nodes drop out of the tree', (
+    tester,
+  ) async {
+    final scene = await _readyScene(tester);
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    final visible = Node(name: 'visible')
+      ..addComponent(
+        SemanticsComponent(label: 'Front', boundsOverride: _unitBounds()),
+      );
+    final behind =
+        Node(
+          name: 'behind',
+          localTransform: Matrix4.translation(Vector3(0, 0, -10)),
+        )..addComponent(
+          SemanticsComponent(label: 'Behind', boundsOverride: _unitBounds()),
+        );
+    scene.add(visible);
+    scene.add(behind);
+
+    await tester.pumpWidget(_host(scene));
+    await _settleSemantics(tester);
+
+    expect(find.semantics.byLabel('Front'), findsOne);
+    expect(find.semantics.byLabel('Behind'), findsNothing);
+
+    visible.visible = false;
+    await _settleSemantics(tester);
+    expect(find.semantics.byLabel('Front'), findsNothing);
+
+    visible.visible = true;
+    await _settleSemantics(tester);
+    expect(find.semantics.byLabel('Front'), findsOne);
+    handle.dispose();
+  });
+
+  testWidgets('sortOrder controls traversal order', (tester) async {
+    final scene = await _readyScene(tester);
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    final bounds = Aabb3.minMax(
+      Vector3(-0.2, -0.2, -0.2),
+      Vector3(0.2, 0.2, 0.2),
+    );
+    // Registered first but sorted last, and vice versa.
+    final first =
+        Node(
+          name: 'first',
+          localTransform: Matrix4.translation(Vector3(-1, 0, 0)),
+        )..addComponent(
+          SemanticsComponent(
+            label: 'Second in order',
+            sortOrder: 2,
+            boundsOverride: bounds,
+          ),
+        );
+    final second =
+        Node(
+          name: 'second',
+          localTransform: Matrix4.translation(Vector3(1, 0, 0)),
+        )..addComponent(
+          SemanticsComponent(
+            label: 'First in order',
+            sortOrder: 1,
+            boundsOverride: bounds,
+          ),
+        );
+    scene.add(first);
+    scene.add(second);
+
+    await tester.pumpWidget(_host(scene));
+    await _settleSemantics(tester);
+
+    final labels = tester.semantics
+        .simulatedAccessibilityTraversal()
+        .map((node) => node.label)
+        .where((label) => label.isNotEmpty)
+        .toList();
+    expect(
+      labels.indexOf('First in order'),
+      lessThan(labels.indexOf('Second in order')),
+    );
+    handle.dispose();
+  });
+
+  testWidgets('occlusionHiding drops a node behind scene geometry', (
+    tester,
+  ) async {
+    final scene = await _readyScene(tester);
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    // Camera on +Z looking at the origin; a wall between them occludes the
+    // gauge at the origin.
+    final camera = PerspectiveCamera(
+      position: Vector3(0, 0, 5),
+      target: Vector3.zero(),
+    );
+    final gauge = _quadNode(name: 'gauge')
+      ..addComponent(SemanticsComponent(label: 'Gauge', occlusionHiding: true));
+    final wall = _quadNode(
+      name: 'wall',
+      transform: Matrix4.translation(Vector3(0, 0, 2))
+        ..scaleByVector3(Vector3(3, 3, 1)),
+    );
+    scene.add(gauge);
+    scene.add(wall);
+
+    await tester.pumpWidget(_host(scene, camera: camera));
+    await _settleSemantics(tester);
+    expect(find.semantics.byLabel('Gauge'), findsNothing);
+
+    wall.visible = false;
+    await _settleSemantics(tester);
+    expect(find.semantics.byLabel('Gauge'), findsOne);
+
+    // Without the opt-in the occluded node stays focusable.
+    wall.visible = true;
+    gauge.getComponents<SemanticsComponent>().first.occlusionHiding = false;
+    await _settleSemantics(tester);
+    expect(find.semantics.byLabel('Gauge'), findsOne);
+    handle.dispose();
+  });
+
+  testWidgets('explicit SemanticsProperties pass through', (tester) async {
+    final scene = await _readyScene(tester);
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    var increased = 0;
+    final node = Node(name: 'slider');
+    node.addComponent(
+      SemanticsComponent(
+        boundsOverride: _unitBounds(),
+        properties: SemanticsProperties(
+          label: 'Volume',
+          value: '40%',
+          increasedValue: '50%',
+          textDirection: TextDirection.ltr,
+          onIncrease: () => increased++,
+        ),
+      ),
+    );
+    scene.add(node);
+
+    await tester.pumpWidget(_host(scene));
+    await _settleSemantics(tester);
+
+    final finder = find.semantics.byLabel('Volume');
+    expect(finder, findsOne);
+    expect(finder.found.single.value, '40%');
+    tester.semantics.performAction(finder, SemanticsAction.increase);
+    expect(increased, 1);
+    handle.dispose();
+  });
+
+  testWidgets('widget surface semantics join the tree and dispatch actions', (
+    tester,
+  ) async {
+    final scene = await _readyScene(tester);
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    var pressed = false;
+    final node = Node(name: 'panel');
+    node.addComponent(
+      WidgetComponent(
+        size: const Size(100, 100),
+        child: Center(
+          child: Semantics(
+            label: 'Panel button',
+            button: true,
+            onTap: () => pressed = true,
+            child: const SizedBox(width: 50, height: 50),
+          ),
+        ),
+      ),
+    );
+    scene.add(node);
+
+    await tester.pumpWidget(_host(scene));
+    await _settleSemantics(tester);
+
+    final finder = find.semantics.byLabel('Panel button');
+    expect(finder, findsOne);
+
+    // The surface faces the default camera head-on and is centered, so the
+    // button's projected rect is centered on the view (and the test
+    // surface).
+    final dpr = tester.view.devicePixelRatio;
+    final rect = _globalRect(finder.found.single);
+    expect(rect.center.dx, closeTo(400 * dpr, 1.0));
+    expect(rect.center.dy, closeTo(300 * dpr, 1.0));
+
+    tester.semantics.tap(finder);
+    expect(pressed, isTrue);
+
+    // Hiding the surface's node removes the subtree from semantics.
+    node.visible = false;
+    await _settleSemantics(tester);
+    expect(find.semantics.byLabel('Panel button'), findsNothing);
+    handle.dispose();
+  });
+}

--- a/packages/flutter_scene/test/scene_semantics_test.dart
+++ b/packages/flutter_scene/test/scene_semantics_test.dart
@@ -312,6 +312,62 @@ void main() {
     handle.dispose();
   });
 
+  testWidgets('the nearer part wins hit precedence when rects overlap', (
+    tester,
+  ) async {
+    final scene = await _readyScene(tester);
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    // The default camera looks down -Z from z = -5, so a box at z = -1 is
+    // nearer than one at z = +1. Both sit on the view axis, so their
+    // projected rects overlap at screen center. The nearer part is
+    // registered first, so only depth ordering (not registration order)
+    // can put it last in the child list, where the reversed hit test
+    // reaches it first.
+    final near =
+        Node(
+          name: 'near',
+          localTransform: Matrix4.translation(Vector3(0, 0, -1)),
+        )..addComponent(
+          SemanticsComponent(label: 'near', boundsOverride: _unitBounds()),
+        );
+    final far =
+        Node(name: 'far', localTransform: Matrix4.translation(Vector3(0, 0, 1)))
+          ..addComponent(
+            SemanticsComponent(label: 'far', boundsOverride: _unitBounds()),
+          );
+    scene.add(near);
+    scene.add(far);
+
+    await tester.pumpWidget(_host(scene));
+    await _settleSemantics(tester);
+
+    // The hit test walks children in reverse, so the nearer part must be
+    // emitted last (after the farther one) in the shared parent's child
+    // order.
+    final nearFinder = find.semantics.byLabel('near');
+    expect(nearFinder, findsOne);
+    final order = <String>[];
+    nearFinder.found.single.parent!.visitChildren((child) {
+      order.add(child.label);
+      return true;
+    });
+    expect(order.indexOf('near'), greaterThan(order.indexOf('far')));
+
+    // Reading order still follows registration order (near before far),
+    // independent of the depth-driven emission order.
+    final reading = tester.semantics
+        .simulatedAccessibilityTraversal()
+        .map((node) => node.label)
+        .where((label) => label == 'near' || label == 'far')
+        .toList();
+    expect(reading.indexOf('near'), lessThan(reading.indexOf('far')));
+    handle.dispose();
+  });
+
   testWidgets('occlusionHiding drops a node behind scene geometry', (
     tester,
   ) async {

--- a/packages/flutter_scene/test/scene_semantics_test.dart
+++ b/packages/flutter_scene/test/scene_semantics_test.dart
@@ -9,23 +9,29 @@
 // semantics refresh runs from the scene painter regardless, so these tests
 // exercise the real per-frame path.
 
+import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:flutter/material.dart'
+    show Material, MaterialApp, Scaffold, Slider;
 import 'package:flutter/rendering.dart' show MatrixUtils;
 import 'package:flutter/semantics.dart'
     show SemanticsAction, SemanticsNode, SemanticsProperties;
 import 'package:flutter/widgets.dart'
     show
         Center,
+        Column,
         Directionality,
+        MainAxisSize,
         Offset,
         Rect,
         Semantics,
         Size,
         SizedBox,
+        Text,
         TextDirection,
         Widget;
-import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/scene.dart' hide Material;
 // The projection helper is internal SceneView machinery; reach it directly.
 import 'package:flutter_scene/src/widgets/scene_view_semantics.dart'
     show projectAabbToArea;
@@ -574,6 +580,118 @@ void main() {
     wall.visible = false;
     await _settleSemantics(tester);
     expect(find.semantics.byLabel('Panel button'), findsOne);
+    handle.dispose();
+  });
+
+  testWidgets('a side-facing rotated widget surface exposes its semantics', (
+    tester,
+  ) async {
+    final scene = await _readyScene(tester);
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    // Mirrors the example's control panel: off to the +X side and turned a
+    // quarter turn about Y so its front faces +X.
+    final panel = Node(
+      name: 'panel',
+      localTransform: Matrix4.translation(Vector3(4.5, 1.1, 0))
+        ..rotate(Vector3(0, 1, 0), math.pi / 2),
+    );
+    panel.addComponent(
+      WidgetComponent(
+        size: const Size(320, 200),
+        worldHeight: 1.25,
+        occlusionHiding: true,
+        child: Center(
+          child: Semantics(
+            label: 'Panel button',
+            button: true,
+            child: const SizedBox(width: 50, height: 50),
+          ),
+        ),
+      ),
+    );
+    scene.add(panel);
+
+    // A camera on the +X side looking back at the origin sees the panel
+    // front-on.
+    await tester.pumpWidget(
+      _host(
+        scene,
+        camera: PerspectiveCamera(
+          position: Vector3(11, 4, 0),
+          target: Vector3(0, 0.5, 0),
+        ),
+      ),
+    );
+    await _settleSemantics(tester);
+    expect(find.semantics.byLabel('Panel button'), findsOne);
+    handle.dispose();
+  });
+
+  testWidgets('a multi-widget surface exposes every child under MaterialApp', (
+    tester,
+  ) async {
+    final scene = _tryScene();
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    // A surface with several sibling controls (like the example's control
+    // panel), hosted under a full MaterialApp. A perspective mapping
+    // collapses multi-node subtree geometry; the affine fit must keep every
+    // child in the tree.
+    final panel = Node(name: 'panel');
+    panel.addComponent(
+      WidgetComponent(
+        size: const Size(320, 200),
+        worldHeight: 1.25,
+        child: Material(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('Wheel speed'),
+              Slider(value: 0.5, onChanged: (_) {}),
+              const Text('Steering'),
+            ],
+          ),
+        ),
+      ),
+    );
+    scene.add(panel);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 200,
+              height: 200,
+              child: SceneView(
+                scene,
+                camera: PerspectiveCamera(
+                  position: Vector3(0, 0, -5),
+                  target: Vector3.zero(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await _settleSemantics(tester);
+
+    expect(find.semantics.byLabel('Wheel speed'), findsOne);
+    expect(find.semantics.byLabel('Steering'), findsOne);
+    expect(
+      find.semantics.byPredicate(
+        (node) => node.getSemanticsData().hasAction(SemanticsAction.increase),
+      ),
+      findsOne,
+    );
     handle.dispose();
   });
 }

--- a/packages/flutter_scene/test/scene_semantics_test.dart
+++ b/packages/flutter_scene/test/scene_semantics_test.dart
@@ -387,6 +387,46 @@ void main() {
     handle.dispose();
   });
 
+  testWidgets('a focus callback coexists with a live, mutable value', (
+    tester,
+  ) async {
+    final scene = await _readyScene(tester);
+    if (scene == null) {
+      markTestSkipped('No Impeller GPU context');
+      return;
+    }
+    final handle = tester.ensureSemantics();
+    var focused = 0;
+    final component = SemanticsComponent(
+      label: 'Lamp',
+      value: 'off',
+      button: true,
+      onDidGainAccessibilityFocus: () => focused++,
+      boundsOverride: _unitBounds(),
+    );
+    scene.add(Node(name: 'lamp')..addComponent(component));
+
+    await tester.pumpWidget(_host(scene));
+    await _settleSemantics(tester);
+
+    expect(find.semantics.byValue('off'), findsOne);
+
+    // The focus callback and the mutable value are both convenience fields,
+    // so updating the value in place is allowed (the escape hatch would
+    // have made this throw).
+    component.value = 'on';
+    await _settleSemantics(tester);
+    expect(find.semantics.byValue('off'), findsNothing);
+    expect(find.semantics.byValue('on'), findsOne);
+
+    tester.semantics.performAction(
+      find.semantics.byLabel('Lamp'),
+      SemanticsAction.didGainAccessibilityFocus,
+    );
+    expect(focused, 1);
+    handle.dispose();
+  });
+
   testWidgets('widget surface semantics join the tree and dispatch actions', (
     tester,
   ) async {


### PR DESCRIPTION
Exposes flutter_scene content to Flutter's semantics tree, so apps and plugins built with the engine can be made accessible to screen readers, switch access, and the accessibility inspectors. Scene content was previously opaque to assistive technology.

Attach a `SemanticsComponent` to a node to publish it as an accessibility element carrying a label, value, hint, flags (button and the rest), and actions (tap, long-press, increase and decrease, accessibility-focus callbacks, or a full `SemanticsProperties`). Its focus rectangle is the node's bounds projected through the view's camera each frame, so it tracks the object as the camera and the object move, and traversal order follows scene-graph order with a `sortOrder` override. Culled and invisible nodes leave the tree, and an opt-in `occlusionHiding` also drops nodes that scene geometry hides from the camera. Overlapping projected rectangles resolve nearest-first, so a part in front wins hit testing and touch exploration over one behind it. Everything is gated on assistive technology being active, so the projection work costs nothing otherwise.

`WidgetComponent` surfaces (live Flutter subtrees rendered into scene textures) now expose their real semantics too, projected onto the on-screen surface, so a screen reader navigates and activates an in-scene widget panel like ordinary widgets. `WidgetComponent.occlusionHiding` drops a surface's semantics while the surface is hidden behind other geometry, matching how its pointer input is already blocked.

New public surface, all under a new Accessibility doc category, is `SemanticsComponent` and `Camera.worldToScreen` (the forward counterpart of `screenPointToRay`); `WidgetComponent` gains `occlusionHiding`.

Also fixes an engine bug where a failed static-resource load still marked the scene ready to render, which crashed mid-frame instead of skipping frames and retrying.

The Accessibility example demonstrates it end to end. The car's doors, hood, and trunk are each a labeled, pickable part (hover or accessibility-focus outlines it through the built-in highlight system, click or activate toggles it open with an animation), and a control panel floats beside the car as a widget surface whose two sliders drive the wheels and expose their slider semantics on the 3D panel. Dragging empty space orbits the camera, and a "Show semantics" toggle overlays `SemanticsDebugger` for checking the tree without a screen reader.

Semantics are verified headlessly with flutter_test's semantics matchers (17 tests), covering projected focus rects, action dispatch, depth-ordered hit precedence, occlusion hiding for both node and widget surfaces, and multi-node widget subtrees under a full MaterialApp. The full CI smoke matrix should exercise the rest.

### Reviewer notes

Semantics follow the primary view (the first view rendering to the screen) in multi-view scenes.

Widget-surface focus rectangles use an affine fit of the widget onto the surface's projected bounds. A perspective-correct mapping collapses multi-node subtree geometry in the platform semantics layer, so the affine fit is exact head-on and a good approximation off-axis.

Widget surfaces are not yet depth-interleaved with 3D-object nodes (they sort after them); occlusion hiding covers the fully-hidden case. Left as a `TODO(scene-semantics)`.

Verified with macOS VoiceOver and the accessibility inspector; not yet checked on a mobile screen reader.
