### PR TITLE
Add a skinned-animation smoke scene

### DIFF
--- a/examples/smoke_render/assets_src
+++ b/examples/smoke_render/assets_src
@@ -1,0 +1,1 @@
+../assets_src

--- a/examples/smoke_render/integration_test/smoke_test.dart
+++ b/examples/smoke_render/integration_test/smoke_test.dart
@@ -54,6 +54,7 @@ void main() {
       // which must be loaded before SmokeSceneView constructs them.
       await Scene.initializeStaticResources();
       await loadSmokeMaterials();
+      await loadSmokeModels();
 
       await tester.pumpWidget(
         MaterialApp(

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -133,6 +133,16 @@ PreprocessedMaterial _fmatMaterial(String name) {
   );
 }
 
+/// The skinned animated model preloaded by [loadSmokeModels], so the
+/// synchronous [SmokeScene] setup closures can pose and add it.
+Node? _skinnedModel;
+
+/// Loads the skinned test model once. Call before pumping the
+/// skinned_animation scene.
+Future<void> loadSmokeModels() async {
+  _skinnedModel ??= await Node.fromGlbAsset('assets_src/two_triangles.glb');
+}
+
 /// A flat NxN grid in the XZ plane carrying a per-vertex `phase` custom
 /// attribute, for the custom-material scene.
 MeshGeometry _phaseGrid() {
@@ -357,6 +367,29 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
       );
     scene.add(Node()..addComponent(splats));
     return (scene: scene, camera: _camera());
+  }),
+  // A skinned mesh (two bone-driven triangles) posed by seeking a paused
+  // animation clip to a fixed mid-swing time, so the deformation is
+  // deterministic. The only scene that draws through the skinned vertex
+  // shader, whose joints texture rides in the vertex stage on top of the lit
+  // fragment shader's full sampler set. On GLES that combination overflows
+  // the per-stage texture-unit validation on drivers reporting the minimum
+  // 16 fragment units (the skinned-draw crash on Windows ANGLE), so this
+  // scene reproduces that crash on CI's GLES backends.
+  SmokeScene('skinned_animation', () {
+    final scene = Scene();
+    final model = _skinnedModel!;
+    scene.add(model);
+    model
+        .createAnimationClip(model.findAnimationByName('Metronome')!)
+        .seek(0.4);
+    return (
+      scene: scene,
+      camera: PerspectiveCamera(
+        position: vm.Vector3(0.8, 2.0, -6.5),
+        target: vm.Vector3(0, 1.5, 0),
+      ),
+    );
   }),
 ];
 

--- a/examples/smoke_render/pubspec.yaml
+++ b/examples/smoke_render/pubspec.yaml
@@ -31,3 +31,6 @@ flutter:
     # hook/build.dart.
     - build/shaderbundles/materials.shaderbundle
     - build/shaderbundles/materials.fmat.json
+    # Skinned animated test model (assets_src is a symlink into
+    # examples/assets_src), for the skinned_animation scene.
+    - assets_src/two_triangles.glb

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 0.19.0
 
+* The lit shader reads both cross-fade environments' diffuse SH through a
+  single `sh_coefficients` sampler (a 9x2 composite row per environment during
+  a cross-fade), dropping the fragment sampler count from 16 to 15. Skinned
+  draws add a vertex-stage joints texture on top of the fragment samplers, and
+  16 + 1 overflowed the texture-unit validation on GLES drivers reporting the
+  minimum 16 units (ANGLE on D3D11), crashing skinned meshes on Windows. The
+  engine-side validation fix is upstream; this keeps skinned rendering working
+  on stable drivers today and buys back sampler headroom everywhere.
+
 * Scene-graph conveniences for working with a loaded model. `Node.meshNodes`
   iterates the drawable nodes in a subtree, `Node.combinedWorldBounds` gives
   the subtree's world-space AABB (the bound the renderer culls against), and

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -524,6 +524,7 @@ class Lighting {
     this.environmentBlend = 0.0,
     this.environmentIntensity = 1.0,
     Matrix3? environmentTransform,
+    this.diffuseShTexture,
     this.directionalLight,
     this.directionalLightDirection,
     this.punctualParamsTexture,
@@ -566,6 +567,12 @@ class Lighting {
   /// Rotation applied to the image-based-lighting environment (the
   /// scene's `environmentTransform`). Identity leaves it unrotated.
   final Matrix3 environmentTransform;
+
+  /// The diffuse-SH coefficient texture to bind for this draw. During an
+  /// environment cross-fade this is a 9x2 composite (row 0 primary, row 1
+  /// [environmentMapB]); otherwise null, and [environmentMap]'s own 9x1
+  /// texture is bound.
+  final gpu.Texture? diffuseShTexture;
 
   /// The scene's directional light, or null when there isn't one.
   final DirectionalLight? directionalLight;

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -309,17 +309,21 @@ class EngineLightingUniforms {
       // the portable choice.
       sampler: _nearestSampler,
     );
-    // Diffuse irradiance SH: a 9x1 coefficient texture, point-sampled (each
-    // texel is one coefficient). Sampled in EvaluateDiffuseSH.
+    // Diffuse irradiance SH coefficients, point-sampled (each texel is one
+    // coefficient). During a cross-fade [Lighting.diffuseShTexture] carries a
+    // 9x2 composite holding both environments' rows; otherwise the primary's
+    // own 9x1 texture is bound and both shader row coordinates land on its
+    // single row. Sampled in EvaluateDiffuseSH.
     pass.bindTexture(
       shader.getUniformSlot('sh_coefficients'),
-      env.diffuseShTexture,
+      lighting.diffuseShTexture ?? env.diffuseShTexture,
       sampler: _nearestClampSampler,
     );
-    // The secondary cross-fade environment (the *_b samplers). When no
-    // cross-fade is active the primary is bound here too (a valid no-op, since
-    // frag_info.radiance_blend.x is 0 and the shader never reads it).
-    _bindSecondaryRadiance(pass, shader, lighting.environmentMapB ?? env);
+    // The secondary cross-fade environment's radiance (the *_b samplers).
+    // When no cross-fade is active the primary is bound here too (a valid
+    // no-op, since frag_info.radiance_blend.x is 0 and the shader never
+    // reads it).
+    bindSecondaryRadiance(pass, shader, lighting.environmentMapB ?? env);
     // Punctual light parameters (all scene lights) and the per-object light
     // index buffer, both RGBA32F data textures, point-sampled (each texel is
     // packed data). White placeholders are bound when there are no lights or no
@@ -366,27 +370,6 @@ class EngineLightingUniforms {
       shader.getUniformSlot('prefiltered_radiance_cube_b'),
       env.prefilteredRadianceCube,
       sampler: _cubeSampler,
-    );
-  }
-
-  // Binds the secondary environment's prefiltered radiance and diffuse SH to
-  // the `_b` samplers, with the same options as the primary (both share the
-  // bound RadianceLayoutInfo, so the layout flag is not re-bound).
-  static void _bindSecondaryRadiance(
-    gpu.RenderPass pass,
-    gpu.Shader shader,
-    EnvironmentMap env,
-  ) {
-    bindSecondaryRadiance(pass, shader, env);
-    pass.bindTexture(
-      shader.getUniformSlot('sh_coefficients_b'),
-      env.diffuseShTexture,
-      sampler: gpu.SamplerOptions(
-        minFilter: gpu.MinMagFilter.nearest,
-        magFilter: gpu.MinMagFilter.nearest,
-        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
-        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-      ),
     );
   }
 }

--- a/packages/flutter_scene/lib/src/render/scene_pass.dart
+++ b/packages/flutter_scene/lib/src/render/scene_pass.dart
@@ -12,6 +12,7 @@ import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/render/render_layers.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
 import 'package:flutter_scene/src/render/shadow_pass.dart';
+import 'package:flutter_scene/src/render/sh_composite.dart';
 import 'package:flutter_scene/src/render/skybox_encoder.dart';
 import 'package:flutter_scene/src/render/ssao_pass.dart';
 import 'package:flutter_scene/src/scene_encoder.dart';
@@ -143,9 +144,32 @@ class ScenePass extends RenderGraphPass {
     final ssaoMap = context.blackboard.get<gpu.Texture>(
       kSsaoTextureBlackboardKey,
     );
+    // During an environment cross-fade, copy both environments' diffuse-SH
+    // coefficients into one 9x2 composite so the lit shader reads them
+    // through a single sampler. Without a cross-fade the primary's own 9x1
+    // texture is bound directly (both shader row coordinates land on its
+    // single row).
+    final envB = _environmentMapB;
+    gpu.Texture? shComposite;
+    if (envB != null) {
+      shComposite = context.texturePool.acquire(
+        const TransientTextureDescriptor.color(
+          width: 9,
+          height: 2,
+          format: gpu.PixelFormat.r16g16b16a16Float,
+          debugName: 'sh_composite',
+        ),
+      );
+      encodeShComposite(
+        shComposite,
+        _environmentMap.diffuseShTexture,
+        envB.diffuseShTexture,
+      );
+    }
     final lighting = Lighting(
       environmentMap: _environmentMap,
       environmentMapB: _environmentMapB,
+      diffuseShTexture: shComposite,
       environmentBlend: _environmentBlend,
       environmentIntensity: _environmentIntensity,
       environmentTransform: _environmentTransform,

--- a/packages/flutter_scene/lib/src/render/sh_composite.dart
+++ b/packages/flutter_scene/lib/src/render/sh_composite.dart
@@ -1,0 +1,63 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
+import 'package:flutter_scene/src/scene_encoder.dart' show resolvePipeline;
+import 'package:flutter_scene/src/shaders.dart';
+
+// Fullscreen NDC quad (6 vec2s).
+final gpu.DeviceBuffer _quad = gpu.gpuContext.createDeviceBufferWithCopy(
+  ByteData.sublistView(
+    Float32List.fromList(<double>[
+      -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, //
+      -1.0, 1.0, 1.0, -1.0, 1.0, 1.0, //
+    ]),
+  ),
+);
+final gpu.BufferView _quadView = gpu.BufferView(
+  _quad,
+  offsetInBytes: 0,
+  lengthInBytes: 6 * 2 * 4,
+);
+
+final gpu.SamplerOptions _nearestClamp = gpu.SamplerOptions(
+  minFilter: gpu.MinMagFilter.nearest,
+  magFilter: gpu.MinMagFilter.nearest,
+  widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+);
+
+/// Copies the [primary] and [secondary] environments' 9-texel diffuse-SH
+/// coefficient textures into the rows of [target] (9x2, row 0 primary), so
+/// the lit shader reads both cross-fade environments through the single
+/// `sh_coefficients` sampler.
+void encodeShComposite(
+  gpu.Texture target,
+  gpu.Texture primary,
+  gpu.Texture secondary,
+) {
+  final commandBuffer = gpu.gpuContext.createCommandBuffer();
+  final pass = commandBuffer.createRenderPass(
+    gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: target)),
+  );
+  final vertexShader = baseShaderLibrary['FullscreenVertex']!;
+  final fragmentShader = baseShaderLibrary['ShCompositeFragment']!;
+  pass.bindPipeline(resolvePipeline(vertexShader, fragmentShader));
+  pass.setColorBlendEnable(false);
+  pass.setCullMode(gpu.CullMode.none);
+  pass.setPrimitiveType(gpu.PrimitiveType.triangle);
+  bindVertexBufferCompat(pass, _quadView, 6);
+  pass.bindTexture(
+    fragmentShader.getUniformSlot('sh_primary'),
+    primary,
+    sampler: _nearestClamp,
+  );
+  pass.bindTexture(
+    fragmentShader.getUniformSlot('sh_secondary'),
+    secondary,
+    sampler: _nearestClamp,
+  );
+  drawCompat(pass, 6);
+  rendererSubmissions.submit(commandBuffer);
+}

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -123,6 +123,10 @@
     "type": "fragment",
     "file": "shaders/flutter_scene_sh_project.frag"
   },
+  "ShCompositeFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_sh_composite.frag"
+  },
   "SkyGradientFragment": {
     "type": "fragment",
     "file": "shaders/flutter_scene_sky_gradient.frag"

--- a/packages/flutter_scene/shaders/flutter_scene_sh_composite.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_sh_composite.frag
@@ -1,0 +1,16 @@
+// Copies two 9-texel diffuse-SH coefficient textures into the rows of a 9x2
+// composite (row 0 primary, row 1 secondary), so the lit shader reads both
+// cross-fade environments through the single sh_coefficients sampler.
+
+uniform sampler2D sh_primary;
+uniform sampler2D sh_secondary;
+
+in vec2 v_uv;
+
+out vec4 frag_color;
+
+void main() {
+  vec2 uv = vec2(v_uv.x, 0.5);
+  frag_color = v_uv.y < 0.5 ? texture(sh_primary, uv)
+                            : texture(sh_secondary, uv);
+}

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -110,17 +110,19 @@ uniform sampler2D prefiltered_radiance; // PMREM-style roughness-band atlas
 uniform samplerCube prefiltered_radiance_cube;
 uniform sampler2D brdf_lut;
 uniform sampler2D shadow_map;
-// Diffuse irradiance SH coefficients: a 9x1 texture, coefficient i at texel i
-// (RGB). Sampled instead of read from a uniform so a sky's coefficients,
-// computed on the GPU, need no read-back. The diffuse_sh* uniform fields above
-// are unused.
+// Diffuse irradiance SH coefficients, coefficient i at texel i (RGB). Sampled
+// instead of read from a uniform so a sky's coefficients, computed on the GPU,
+// need no read-back (the diffuse_sh* uniform fields above are unused). Rows
+// select the environment: row 0 primary, row 1 the cross-fade secondary. When
+// no cross-fade is active the primary's 9x1 texture is bound directly and both
+// row coordinates land on its single row.
 uniform sampler2D sh_coefficients;
 // The secondary environment cross-faded in by frag_info.radiance_blend.x: its
 // prefiltered radiance (2D atlas and cubemap, the same layout pair as the
-// primary) and diffuse SH. A dummy is bound when no cross-fade is active.
+// primary). Its diffuse SH rides in sh_coefficients row 1. A dummy is bound
+// when no cross-fade is active.
 uniform sampler2D prefiltered_radiance_b;
 uniform samplerCube prefiltered_radiance_cube_b;
-uniform sampler2D sh_coefficients_b;
 // Screen-space ambient occlusion (occlusion factor in .r). A white
 // placeholder is bound when occlusion is disabled, so the sample is a
 // no-op; frag_info.ssao_params.x gates it regardless.

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -17,22 +17,26 @@
 // The coefficients already include the cosine convolution and 1/pi, so
 // the result is E(n)/pi. Must use the same real-SH basis the CPU-side
 // projection in EnvironmentMap.computeDiffuseSphericalHarmonics uses.
-// Fetches SH coefficient i (0..8) from a 9x1 coefficient texture.
-vec3 DiffuseShCoefficient(sampler2D coefficients, float i) {
-  return texture(coefficients, vec2((i + 0.5) / 9.0, 0.5)).xyz;
+// Fetches SH coefficient i (0..8) from the coefficient texture's row `v`.
+vec3 DiffuseShCoefficient(sampler2D coefficients, float i, float v) {
+  return texture(coefficients, vec2((i + 0.5) / 9.0, v)).xyz;
 }
 
-vec3 EvaluateDiffuseSH(sampler2D coefficients, vec3 n) {
-  return DiffuseShCoefficient(coefficients, 0.0) * 0.282095 +
-         DiffuseShCoefficient(coefficients, 1.0) * (0.488603 * n.y) +
-         DiffuseShCoefficient(coefficients, 2.0) * (0.488603 * n.z) +
-         DiffuseShCoefficient(coefficients, 3.0) * (0.488603 * n.x) +
-         DiffuseShCoefficient(coefficients, 4.0) * (1.092548 * n.x * n.y) +
-         DiffuseShCoefficient(coefficients, 5.0) * (1.092548 * n.y * n.z) +
-         DiffuseShCoefficient(coefficients, 6.0) *
+// `row` selects the environment in the composite coefficient texture (0
+// primary, 1 secondary). A 9x1 single-environment texture reads the same
+// row either way.
+vec3 EvaluateDiffuseSH(sampler2D coefficients, vec3 n, float row) {
+  float v = (row + 0.5) / 2.0;
+  return DiffuseShCoefficient(coefficients, 0.0, v) * 0.282095 +
+         DiffuseShCoefficient(coefficients, 1.0, v) * (0.488603 * n.y) +
+         DiffuseShCoefficient(coefficients, 2.0, v) * (0.488603 * n.z) +
+         DiffuseShCoefficient(coefficients, 3.0, v) * (0.488603 * n.x) +
+         DiffuseShCoefficient(coefficients, 4.0, v) * (1.092548 * n.x * n.y) +
+         DiffuseShCoefficient(coefficients, 5.0, v) * (1.092548 * n.y * n.z) +
+         DiffuseShCoefficient(coefficients, 6.0, v) *
              (0.315392 * (3.0 * n.z * n.z - 1.0)) +
-         DiffuseShCoefficient(coefficients, 7.0) * (1.092548 * n.x * n.z) +
-         DiffuseShCoefficient(coefficients, 8.0) *
+         DiffuseShCoefficient(coefficients, 7.0, v) * (1.092548 * n.x * n.z) +
+         DiffuseShCoefficient(coefficients, 8.0, v) *
              (0.546274 * (n.x * n.x - n.y * n.y));
 }
 
@@ -382,7 +386,7 @@ vec4 EvaluateLighting(MaterialInputs material) {
   mat3 environment_transform = mat3(frag_info.environment_transform);
   vec3 env_normal = environment_transform * normal;
   vec3 env_reflection = environment_transform * reflection_normal;
-  vec3 irradiance = max(EvaluateDiffuseSH(sh_coefficients, env_normal),
+  vec3 irradiance = max(EvaluateDiffuseSH(sh_coefficients, env_normal, 0.0),
                         vec3(0.0));
   vec3 prefiltered_color =
       SampleRadianceEnv(prefiltered_radiance, prefiltered_radiance_cube,
@@ -391,7 +395,7 @@ vec4 EvaluateLighting(MaterialInputs material) {
   // share the bound layout, so the same samplers' _b pair is read.
   float env_blend = frag_info.radiance_blend.x;
   if (env_blend > 0.0) {
-    vec3 irradiance_b = max(EvaluateDiffuseSH(sh_coefficients_b, env_normal),
+    vec3 irradiance_b = max(EvaluateDiffuseSH(sh_coefficients, env_normal, 1.0),
                             vec3(0.0));
     vec3 prefiltered_b =
         SampleRadianceEnv(prefiltered_radiance_b, prefiltered_radiance_cube_b,

--- a/packages/flutter_scene/test/sh_composite_test.dart
+++ b/packages/flutter_scene/test/sh_composite_test.dart
@@ -1,0 +1,97 @@
+// Covers the diffuse-SH composite pass: both source textures land in the
+// right rows and column order is preserved, so the lit shader's single
+// sh_coefficients sampler reads the primary in row 0 and the cross-fade
+// secondary in row 1. GPU-gated like the other render suites.
+
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ignore: implementation_imports
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+// ignore: implementation_imports
+import 'package:flutter_scene/src/render/sh_composite.dart';
+
+bool _gpuAvailable() {
+  try {
+    Scene();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+// Minimal float32 to float16 bit conversion for the small positive values
+// used here (no subnormals, infinities, or NaNs).
+int _halfBits(double value) {
+  final bits = Float32List.fromList([value]).buffer.asUint32List()[0];
+  final exponent = ((bits >> 23) & 0xFF) - 127 + 15;
+  final mantissa = (bits >> 13) & 0x3FF;
+  if (value == 0) return 0;
+  return ((exponent & 0x1F) << 10) | mantissa;
+}
+
+// A 9x1 RGBA16F coefficient texture with texel i = (red, i / 16, 0, 1).
+gpu.Texture _shSource(double red) {
+  final texture = gpu.gpuContext.createTexture(
+    gpu.StorageMode.hostVisible,
+    9,
+    1,
+    format: gpu.PixelFormat.r16g16b16a16Float,
+  );
+  final half = Uint16List(9 * 4);
+  for (var i = 0; i < 9; i++) {
+    half[i * 4] = _halfBits(red);
+    half[i * 4 + 1] = _halfBits(i / 16.0);
+    half[i * 4 + 2] = 0;
+    half[i * 4 + 3] = _halfBits(1.0);
+  }
+  texture.overwrite(ByteData.sublistView(half));
+  return texture;
+}
+
+void main() {
+  if (!_gpuAvailable()) {
+    test(
+      'sh composite (skipped: no GPU device)',
+      () {},
+      skip: 'Requires a GPU device.',
+    );
+    return;
+  }
+
+  test('composite places primary in row 0 and secondary in row 1', () async {
+    await Scene.initializeStaticResources();
+
+    final primary = _shSource(0.25);
+    final secondary = _shSource(0.75);
+    // An 8-bit readable target; the copy is value-preserving for values in
+    // [0, 1], and 8-bit quantization is far finer than the 0.5 row contrast.
+    final target = gpu.gpuContext.createTexture(
+      gpu.StorageMode.devicePrivate,
+      9,
+      2,
+      format: gpu.PixelFormat.r8g8b8a8UNormInt,
+      enableRenderTargetUsage: true,
+      enableShaderReadUsage: true,
+    );
+    encodeShComposite(target, primary, secondary);
+
+    final ui.Image image = target.asImage();
+    final bytes = (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!;
+    int red(int x, int y) => bytes.getUint8((y * 9 + x) * 4);
+    int green(int x, int y) => bytes.getUint8((y * 9 + x) * 4 + 1);
+
+    for (var x = 0; x < 9; x++) {
+      expect(red(x, 0), closeTo(64, 3), reason: 'row 0 red at texel $x');
+      expect(red(x, 1), closeTo(191, 3), reason: 'row 1 red at texel $x');
+      // Column order preserved in both rows (green ramps with the texel
+      // index).
+      final ramp = ((x / 16.0) * 255.0).round();
+      expect(green(x, 0), closeTo(ramp, 3), reason: 'row 0 green at $x');
+      expect(green(x, 1), closeTo(ramp, 3), reason: 'row 1 green at $x');
+    }
+  });
+}


### PR DESCRIPTION
The smoke set had no skinned draw, so skinned-only failures slipped through every backend's smoke run. The motivating one is a crash reported on Windows when opening the example app's Animation tab.

```
[ERROR:flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc(507)] Break on 'impeller::ImpellerValidationBreak' to inspect point of failure: Texture units specified exceed the capabilities for this shader stage.
[FATAL:flutter/impeller/renderer/backend/gles/render_pass_gles.cc(844)] Check failed: result. Must be able to encode GL commands without error.
```

The standard lit fragment shader bound exactly 16 samplers, and skinned geometry adds the joints texture in the vertex stage. Impeller's GLES backend assigns fragment texture units starting after the vertex stage's, so a skinned lit draw put the fragment samplers on units 1 through 16, and unit 16 failed the per-stage texture-unit validation on drivers reporting the GLES minimum of 16 fragment units. ANGLE on D3D11 reports that minimum, which is why the crash was Windows-only. Unskinned draws fit exactly on units 0 through 15, which is why only skinned content crashed. The validation itself is overly strict, since GL texture units are a combined resource; that engine-side fix is up as flutter/flutter#189332. The first CI run of this PR (before the second commit) reproduced the crash on the windows smoke job with the exact reported signature.

Two commits:

1. **A `skinned_animation` smoke scene**, the smoke set's first skinned draw. It imports `two_triangles.glb` at runtime and poses it by seeking a paused animation clip to a fixed mid-swing time, so the deformation is deterministic for the visual diff. This is the permanent regression net for sampler-budget overflows on skinned draws.

2. **A sampler merge that fixes the crash on today's drivers.** The lit shader now reads both cross-fade environments' diffuse SH through a single `sh_coefficients` sampler. During an environment cross-fade the scene pass copies both environments' 9-texel coefficient textures into the rows of a pooled 9x2 composite via a tiny new pass; with no cross-fade the primary's own 9x1 texture is bound directly and both row coordinates land on its single row, so no extra pass runs. This drops the lit fragment shader to 15 samplers, so skinned draws fit within 16 units regardless of the engine fix, and buys back a sampler of headroom under Metal's hard 16-per-stage limit. Covered by a GPU-gated composite row-order test.

Verified locally on the full smoke matrix (macOS Metal, Android gles and vulkan emulator flavors, Linux llvmpipe, WebGL2), all green with zero visual diffs expected; the windows job goes green with the second commit in place.
