### PR TITLE
Fix transparent speckles in BC1-transcoded textures

### DIFF
--- a/packages/flutter_scene/lib/src/texture/block/transcode_bc1.dart
+++ b/packages/flutter_scene/lib/src/texture/block/transcode_bc1.dart
@@ -41,6 +41,22 @@ void transcodeUniversalBlockToBc1(
   // Endpoints, as RGB565.
   var c0 = _pack565(src[si], src[si + 1], src[si + 2]);
   var c1 = _pack565(src[si + 4], src[si + 5], src[si + 6]);
+  // Near-flat blocks can quantize both endpoints to the same 565 value while
+  // the weights stay nonzero. Equal endpoints select the 3-color mode
+  // (color0 <= color1), where index 3 decodes as transparent black, so any
+  // weight in the index-3 band would punch a hole in an opaque texture. The
+  // block is a single color, so emit index 0 everywhere.
+  if (c0 == c1) {
+    out[oi] = c0 & 0xFF;
+    out[oi + 1] = (c0 >> 8) & 0xFF;
+    out[oi + 2] = c1 & 0xFF;
+    out[oi + 3] = (c1 >> 8) & 0xFF;
+    out[oi + 4] = 0;
+    out[oi + 5] = 0;
+    out[oi + 6] = 0;
+    out[oi + 7] = 0;
+    return;
+  }
   // 4-color (opaque) mode requires color0 > color1. If swapped, flip the
   // weight direction below.
   final swapped = c0 < c1;

--- a/packages/flutter_scene/test/texture/transcode_bc1_test.dart
+++ b/packages/flutter_scene/test/texture/transcode_bc1_test.dart
@@ -69,6 +69,50 @@ void main() {
       expect(_psnrRgb(rgba, viaBc1), greaterThan(28));
     });
 
+    test('keeps blocks with 565-equal endpoints opaque', () {
+      // Endpoints that differ in rgba8 but quantize to the same RGB565 value.
+      // Before the equal-endpoint guard, such a block was emitted in BC1's
+      // 3-color mode, where weights in the index-3 band decode as transparent
+      // black (white speckles on opaque textures).
+      final block = Uint8List(kBlockBytes);
+      block.setRange(0, 4, [100, 100, 100, 255]);
+      block.setRange(4, 8, [103, 101, 102, 255]);
+      for (var i = 0; i < 8; i++) {
+        // Weights sweep 0..15, covering every index band.
+        block[8 + i] = (i * 2) | ((i * 2 + 1) << 4);
+      }
+      final bc1 = transcodeUniversalToBc1(block, 1);
+      final decoded = decodeBc1ToRgba8(bc1, 4, 4);
+      for (var i = 0; i < decoded.length; i += 4) {
+        expect(decoded[i + 3], 255);
+        // Every texel is the shared endpoint color, (100,100,100) through
+        // RGB565 quantization and bit-replicated expansion.
+        expect(decoded[i], 99);
+        expect(decoded[i + 1], 101);
+        expect(decoded[i + 2], 99);
+      }
+    });
+
+    test('never produces transparent texels from opaque input', () {
+      const w = 32, h = 32;
+      final rng = math.Random(7);
+      final rgba = Uint8List(w * h * 4);
+      // Near-flat noise, the case that collapses endpoints to equal 565
+      // values while keeping nonzero weights.
+      for (var i = 0; i < rgba.length; i += 4) {
+        rgba[i] = 100 + rng.nextInt(4);
+        rgba[i + 1] = 100 + rng.nextInt(4);
+        rgba[i + 2] = 100 + rng.nextInt(4);
+        rgba[i + 3] = 255;
+      }
+      final blocks = encodeUniversalBlocks(rgba, w, h);
+      final bc1 = transcodeUniversalToBc1(blocks, _blockCount(w, h));
+      final decoded = decodeBc1ToRgba8(bc1, w, h);
+      for (var i = 3; i < decoded.length; i += 4) {
+        expect(decoded[i], 255);
+      }
+    });
+
     test('stays close to the universal-block decode it transcodes from', () {
       const w = 32, h = 32;
       final rng = math.Random(5);


### PR DESCRIPTION
White speckles appeared baked into textured models on devices where BC is the preferred compressed-texture family, most visibly on the web on Windows, where browsers typically expose only s3tc. Devices preferring ASTC or ETC2 never hit the bug, which is why it did not reproduce on macOS.

The BC1 transcoder guarded against `color0 < color1` by swapping endpoints, but not against equality. Near-flat blocks routinely quantize both endpoints to the same RGB565 value while their weights stay nonzero, and equal endpoints select BC1's 3-color mode, where index 3 decodes as transparent black. Any texel whose weight fell in the index-3 band punched a hole in an opaque texture, which premultiplied-alpha rendering shows as a bright speckle.

Equal packed endpoints now emit zero index bits, so every texel decodes to the shared endpoint color, which is exact. BC3 was never affected since its color half always decodes in 4-color mode.

Adds a regression test with a hand-built block whose endpoints differ in rgba8 but collapse to the same 565 value, plus an opacity invariant over near-flat noise through the full encode/transcode/decode path. Both fail against the previous transcoder.
