### PR TITLE
fix(flutter_app): support splat asset fetch

### DIFF
--- a/examples/flutter_app/tool/fetch_splat_asset.sh
+++ b/examples/flutter_app/tool/fetch_splat_asset.sh
@@ -40,6 +40,8 @@ for value in meta.values():
         files.update(value['files'])
 print('\n'.join(sorted(files)))
 EOF
+    # Windows Python writes CRLF; read removes only the trailing LF.
+    f=${f%$'\r'}
     curl -fsS -o "$out_dir/$f" "$url_dir/$f"
   done
 }
@@ -63,7 +65,8 @@ fetch_asset() {
     metas+=("$TMP/$name$sub/meta.json")
   done
   npx -y @playcanvas/splat-transform "${metas[@]}" "$TMP/$name.ply"
-  dart run tool/ply_to_splat.dart "$TMP/$name.ply" "$out"
+  # Avoid running unrelated native build hooks while retaining package imports.
+  dart --packages=../../.dart_tool/package_config.json tool/ply_to_splat.dart "$TMP/$name.ply" "$out"
   echo "Wrote $out"
 }
 

--- a/examples/flutter_app/tool/ply_to_splat.dart
+++ b/examples/flutter_app/tool/ply_to_splat.dart
@@ -4,7 +4,8 @@
 // carry. Used by fetch_splat_asset.sh to keep the example's captured asset
 // small enough to bundle.
 //
-// Run with `dart run tool/ply_to_splat.dart <in.ply> <out.splat>`.
+// Run with `dart --packages=../../.dart_tool/package_config.json
+// tool/ply_to_splat.dart <in.ply> <out.splat>` from examples/flutter_app.
 
 // The splat codec is engine-internal, but this dev tool may import it.
 // ignore_for_file: implementation_imports
@@ -17,7 +18,8 @@ import 'package:flutter_scene/src/splats/splat_codec.dart';
 void main(List<String> args) {
   if (args.length != 2) {
     stderr.writeln(
-      'Usage: dart run tool/ply_to_splat.dart <in.ply> <out.splat>',
+      'Usage: dart --packages=../../.dart_tool/package_config.json '
+      'tool/ply_to_splat.dart <in.ply> <out.splat>',
     );
     exit(64);
   }


### PR DESCRIPTION
## Summary

- normalize CRLF file names before using them as SOG download paths
- run the PLY converter with the workspace package configuration to avoid unrelated native build hooks

## Validation

- ran the fetch script on Windows Git Bash
- generated `strawberry.splat` and `classroom.splat`