### PR TITLE
floor the shadow bias above mobile depth rounding noise

### DIFF
--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -88,7 +88,9 @@ float SampleCascade(int cascade, int count, mat4 cascade_matrix, float box,
   // in light.dart, _casterReachRadii + _forwardMarginRadii, over the half-width
   // that makes box) so a caster crosses the shadow threshold at the same world
   // height in every cascade, with no discontinuity where cascades meet.
-  float receiver_depth = proj.z - frag_info.shadow_bias / (7.0 * box);
+  const float kMinShadowBias = 0.0005;
+  float receiver_depth =
+      proj.z - max(frag_info.shadow_bias / (7.0 * box), kMinShadowBias);
 
   // World-space penumbra -> this cascade's UV space, floored at a texel.
   float radius =


### PR DESCRIPTION
Fixes #234

clamps the converted bias to a floor minShadowBias to stop self shadowing and remove black stripes in distance.

minShadowBias value is based on tuning on my device. stripes are gone at 0.00025 and at 0.0005. so 0.0005 has about 2x headroom over the measured noise. other GPUs may have more noise

tested on Android Pixel 8

before:

<img width="2048" height="921" alt="grafik" src="https://github.com/user-attachments/assets/095b7885-2534-4e2f-b276-95c046880e83" />

after:

<img width="2048" height="863" alt="grafik" src="https://github.com/user-attachments/assets/be0bfbdc-5b61-47e8-9590-417f4aa447c8" />
