### PR TITLE
Add an animated Menger sponge sky to the custom skybox example

### DIFF
--- a/examples/flutter_app/assets/menger_sky.fmat
+++ b/examples/flutter_app/assets/menger_sky.fmat
@@ -1,43 +1,51 @@
 // A raymarched Menger sponge interior authored as a `.fmat` sky. The viewer
 // sits inside an infinitely repeating sponge lattice with chrome bracing, lit
-// by a movable point light, distance fog, and an optional neon glow on the
-// bracing. Every parameter feeds the same Sky() function the environment bake
-// samples, so relighting the sky relights the whole scene.
+// by a movable point light, distance fog, an optional neon glow on the
+// bracing, and environment-mapped reflections sampled from the environment
+// the engine binds. Every parameter feeds the same Sky() function the
+// environment bake samples, so relighting the sky relights the whole scene.
 //
 // Adapted from "Menger Sponge Variation" by Shane
 // (https://www.shadertoy.com/view/ldScRt), used and modified under the
 // Shadertoy default license, CC BY-NC-SA 3.0 Unported
 // (https://creativecommons.org/licenses/by-nc-sa/3.0/). Changes include
 // reworking the full-screen camera raymarcher into a directional sky
-// function, replacing the texture lookup with procedural noise, dropping the
-// reflection pass and screen-space post effects, and parameterizing the
-// lighting. This derived shader is likewise CC BY-NC-SA 3.0.
+// function, replacing the texture lookup with procedural noise, replacing
+// the raymarched reflection pass with prefiltered environment sampling,
+// dropping the screen-space post effects, and parameterizing the lighting.
+// This derived shader is likewise CC BY-NC-SA 3.0.
 
 material {
   name: "MengerSky",
+  requires: [environment],
   parameters: [
     // Where along the corridor the viewer sits and how the view is twisted.
-    { type: float, name: travel, hint: range(0, 60, 0.01), default: 1.0 },
-    { type: float, name: spin, hint: range(-3.1416, 3.1416, 0.001), default: 0.5 },
+    // Both are animated from the app; the sponge repeats every 3 units so
+    // travel wraps there.
+    { type: float, name: travel, hint: range(0, 3, 0.001), default: 1.0 },
+    { type: float, name: spin, hint: range(0, 6.2832, 0.001), default: 0.0 },
     // Grows or shrinks the sponge's primary holes.
-    { type: float, name: hole_size, hint: range(-0.02, 0.1, 0.001), default: 0.03 },
+    { type: float, name: hole_size, hint: range(-0.02, 0.1, 0.001), default: -0.01 },
 
     // The point light carried with the viewer.
-    { type: vec3, name: light_color, hint: source_color, default: [1.0, 0.85, 0.6] },
+    { type: vec3, name: light_color, hint: source_color, default: [0.83, 1.0, 0.55] },
     { type: float, name: light_intensity, hint: range(0, 8, 0.01), default: 1.6 },
-    { type: float, name: light_height, hint: range(-1.4, 1.4, 0.01), default: 1.0 },
+    { type: float, name: light_height, hint: range(-1.4, 1.4, 0.01), default: 0.51 },
     { type: float, name: light_forward, hint: range(-3, 3, 0.01), default: 0.0 },
 
     // Emissive tint applied to the chrome bracing.
     { type: vec3, name: glow_color, hint: source_color, default: [0.1, 0.7, 1.0] },
-    { type: float, name: glow_intensity, hint: range(0, 12, 0.01), default: 0.0 },
+    { type: float, name: glow_intensity, hint: range(0, 12, 0.01), default: 8.59 },
 
     // Distance fog, the dominant emitter for most of the sky sphere.
     { type: vec3, name: fog_color, hint: source_color, default: [0.7, 0.8, 1.0] },
-    { type: float, name: fog_brightness, hint: range(0, 8, 0.01), default: 2.5 },
+    { type: float, name: fog_brightness, hint: range(0, 8, 0.01), default: 6.82 },
 
     // Strength of the red-to-blue vertical color grade.
-    { type: float, name: grade, hint: range(0, 1, 0.01), default: 0.5 },
+    { type: float, name: grade, hint: range(0, 1, 0.01), default: 0.48 },
+
+    // Strength of the environment-mapped reflections.
+    { type: float, name: reflection, hint: range(0, 2, 0.01), default: 0.7 },
 
     // Surface tints for the sponge's outer shell and inner core.
     { type: vec3, name: shell_color, default: [1.25, 1.0, 0.75] },
@@ -226,6 +234,14 @@ sky {
       sh = (sh + ao * 0.3) * ao;
 
       col = shade_point(sp, rd, sn, lp, ao, id);
+
+      // Environment-mapped reflection, sharp on the chrome bracing and
+      // glossier, fresnel-weighted on the sponge.
+      float fres = clamp(1.0 + dot(rd, sn), 0.0, 1.0);
+      vec3 env = SampleEnvironment(reflect(rd, sn), id < 0.5 ? 0.1 : 0.5);
+      col += env * material_params.reflection *
+          (id < 0.5 ? 1.0 : fres * fres + 0.1);
+
       col *= 1.0 - edge * 0.9;
       col *= sh;
 

--- a/examples/flutter_app/assets/menger_sky.fmat
+++ b/examples/flutter_app/assets/menger_sky.fmat
@@ -35,7 +35,7 @@ material {
 
     // Emissive tint applied to the chrome bracing.
     { type: vec3, name: glow_color, hint: source_color, default: [0.1, 1.0, 0.32] },
-    { type: float, name: glow_intensity, hint: range(0, 12, 0.01), default: 8.59 },
+    { type: float, name: glow_intensity, hint: range(0, 12, 0.01), default: 1.85 },
 
     // Distance fog, the dominant emitter for most of the sky sphere.
     { type: vec3, name: fog_color, hint: source_color, default: [0.8, 0.7, 1.0] },

--- a/examples/flutter_app/assets/menger_sky.fmat
+++ b/examples/flutter_app/assets/menger_sky.fmat
@@ -1,0 +1,254 @@
+// A raymarched Menger sponge interior authored as a `.fmat` sky. The viewer
+// sits inside an infinitely repeating sponge lattice with chrome bracing, lit
+// by a movable point light, distance fog, and an optional neon glow on the
+// bracing. Every parameter feeds the same Sky() function the environment bake
+// samples, so relighting the sky relights the whole scene.
+//
+// Adapted from "Menger Sponge Variation" by Shane
+// (https://www.shadertoy.com/view/ldScRt), used and modified under the
+// Shadertoy default license, CC BY-NC-SA 3.0 Unported
+// (https://creativecommons.org/licenses/by-nc-sa/3.0/). Changes include
+// reworking the full-screen camera raymarcher into a directional sky
+// function, replacing the texture lookup with procedural noise, dropping the
+// reflection pass and screen-space post effects, and parameterizing the
+// lighting. This derived shader is likewise CC BY-NC-SA 3.0.
+
+material {
+  name: "MengerSky",
+  parameters: [
+    // Where along the corridor the viewer sits and how the view is twisted.
+    { type: float, name: travel, hint: range(0, 60, 0.01), default: 1.0 },
+    { type: float, name: spin, hint: range(-3.1416, 3.1416, 0.001), default: 0.5 },
+    // Grows or shrinks the sponge's primary holes.
+    { type: float, name: hole_size, hint: range(-0.02, 0.1, 0.001), default: 0.03 },
+
+    // The point light carried with the viewer.
+    { type: vec3, name: light_color, hint: source_color, default: [1.0, 0.85, 0.6] },
+    { type: float, name: light_intensity, hint: range(0, 8, 0.01), default: 1.6 },
+    { type: float, name: light_height, hint: range(-1.4, 1.4, 0.01), default: 1.0 },
+    { type: float, name: light_forward, hint: range(-3, 3, 0.01), default: 0.0 },
+
+    // Emissive tint applied to the chrome bracing.
+    { type: vec3, name: glow_color, hint: source_color, default: [0.1, 0.7, 1.0] },
+    { type: float, name: glow_intensity, hint: range(0, 12, 0.01), default: 0.0 },
+
+    // Distance fog, the dominant emitter for most of the sky sphere.
+    { type: vec3, name: fog_color, hint: source_color, default: [0.7, 0.8, 1.0] },
+    { type: float, name: fog_brightness, hint: range(0, 8, 0.01), default: 2.5 },
+
+    // Strength of the red-to-blue vertical color grade.
+    { type: float, name: grade, hint: range(0, 1, 0.01), default: 0.5 },
+
+    // Surface tints for the sponge's outer shell and inner core.
+    { type: vec3, name: shell_color, default: [1.25, 1.0, 0.75] },
+    { type: vec3, name: core_color, default: [1.0, 0.75, 0.5] },
+  ],
+}
+
+sky {
+#include <noise.glsl>
+
+  const float FAR = 50.0;
+  const int MAX_STEPS = 80;
+  const int SHADOW_STEPS = 16;
+
+  // Smooth maximum, from IQ's smooth minimum.
+  float smax(float a, float b, float s) {
+    float h = clamp(0.5 + 0.5 * (a - b) / s, 0.0, 1.0);
+    return mix(b, a, h) + h * (1.0 - h) * s;
+  }
+
+  mat2 rot2(float a) {
+    float c = cos(a), s = sin(a);
+    return mat2(c, s, -s, c);
+  }
+
+  // Distance to the scene in x; y is 1.0 for the sponge, 0.0 for the bracing.
+  // Four Menger layers at different repeat scales, plus a repeated tube
+  // lattice for the bracing.
+  vec2 map2(vec3 q) {
+    // Layer one. hole_size varies the primary hole size.
+    vec3 p = abs(fract(q / 3.0) * 3.0 - 1.5);
+    float d = min(max(p.x, p.y), min(max(p.y, p.z), max(p.x, p.z))) - 1.0 +
+        material_params.hole_size;
+
+    // Bracing. A cross of tubes repeated every cell, notched by a finer
+    // repeat field to read as segmented chrome.
+    float rp = 3.0;
+    p = abs(fract(q / rp + 0.5) * rp - rp * 0.5);
+    float x1 = sqrt(min(dot(p.xy, p.xy), min(dot(p.yz, p.yz), dot(p.xz, p.xz)))) -
+        rp * 0.5 * 0.475;
+    rp = 3.0 / 15.0;
+    p = abs(fract(q / rp) * rp - rp * 0.5);
+    p = abs(p - rp * 0.5);
+    float x2 = min(p.x, min(p.y, p.z)) - 0.0125;
+    float tb = smax(abs(x1), abs(x2), 0.1) - 0.035;
+
+    // Layer two.
+    p = abs(fract(q) - 0.5);
+    d = smax(d,
+        min(max(p.x, p.y), min(max(p.y, p.z), max(p.x, p.z))) - 1.0 / 3.0 + 0.05,
+        0.05);
+
+    // Layer three. Space divided by two instead of three for variance.
+    p = abs(fract(q * 2.0) * 0.5 - 0.25);
+    d = max(d,
+        min(smax(p.x, p.y, 0.125),
+            min(smax(p.y, p.z, 0.125), smax(p.x, p.z, 0.125))) -
+            0.5 / 3.0 - 0.025);
+
+    // Layer four. Little holes for fine detail.
+    p = abs(fract(q * 6.0) / 6.0 - 1.0 / 12.0);
+    d = max(d,
+        min(max(p.x, p.y), min(max(p.y, p.z), max(p.x, p.z))) - 1.0 / 18.0 -
+            0.015);
+
+    return d < tb ? vec2(d, 1.0) : vec2(tb, 0.0);
+  }
+
+  float map(vec3 q) {
+    return map2(q).x;
+  }
+
+  float trace(vec3 ro, vec3 rd) {
+    float t = 0.0;
+    for (int i = 0; i < MAX_STEPS; i++) {
+      float d = map(ro + rd * t);
+      if (abs(d) < 0.001 * (t * 0.125 + 1.0) || t > FAR) break;
+      t += d;
+    }
+    return min(t, FAR);
+  }
+
+  float soft_shadow(vec3 ro, vec3 lp) {
+    vec3 rd = lp - ro;
+    float shade = 1.0;
+    float dist = 0.0025;
+    float end = max(length(rd), 0.0001);
+    rd /= end;
+    for (int i = 0; i < SHADOW_STEPS; i++) {
+      float h = map(ro + rd * dist);
+      shade = min(shade, smoothstep(0.0, 1.0, 16.0 * h / dist));
+      dist += clamp(h, 0.01, 0.2);
+      if (h < 0.0 || dist > end) break;
+    }
+    // Lift the shadow floor a little.
+    return min(max(shade, 0.0) + 0.2, 1.0);
+  }
+
+  float calc_ao(vec3 p, vec3 n) {
+    float sca = 2.0;
+    float occ = 0.0;
+    for (int i = 0; i < 5; i++) {
+      float hr = 0.01 + float(i) * 0.125;
+      occ += (hr - map(n * hr + p)) * sca;
+      sca *= 0.7;
+    }
+    return clamp(1.0 - occ, 0.0, 1.0);
+  }
+
+  vec3 get_normal(vec3 p) {
+    vec2 e = vec2(0.0015, 0.0);
+    return normalize(vec3(
+        map(p + e.xyy) - map(p - e.xyy),
+        map(p + e.yxy) - map(p - e.yxy),
+        map(p + e.yyx) - map(p - e.yyx)));
+  }
+
+  // Edge factor for the dark outline look. Wider sample spread with distance
+  // keeps the outline width roughly stable across depth.
+  float get_edge(vec3 p, float t) {
+    vec2 e = vec2(0.0035 * (1.0 + t * 0.5), 0.0);
+    float d1 = map(p + e.xyy), d2 = map(p - e.xyy);
+    float d3 = map(p + e.yxy), d4 = map(p - e.yxy);
+    float d5 = map(p + e.yyx), d6 = map(p - e.yyx);
+    float d = map(p) * 2.0;
+    float edge = abs(d1 + d2 - d) + abs(d3 + d4 - d) + abs(d5 + d6 - d);
+    return smoothstep(0.0, 1.0, sqrt(edge / e.x * 2.0));
+  }
+
+  // Procedural grain standing in for the original's stone texture, tinted by
+  // shell or core color depending on how deep in the cell the point sits.
+  vec3 object_color(vec3 p, float id) {
+    float g = NoiseSimplex3(p * 2.5, 7) * 0.5 + NoiseSimplex3(p * 7.0, 11) * 0.25;
+    vec3 tx = vec3(clamp(0.55 + 0.35 * g, 0.0, 1.0));
+    tx = smoothstep(0.0, 1.0, tx);
+
+    vec3 q = abs(mod(p, 3.0) - 1.5);
+    if (max(max(q.x, q.y), q.z) > 1.063) {
+      tx *= material_params.shell_color;
+    } else {
+      tx *= material_params.core_color;
+    }
+
+    // Shine up the bracing.
+    if (id < 0.5) tx *= 5.0 / max(material_params.shell_color, vec3(0.05));
+
+    return tx;
+  }
+
+  vec3 shade_point(vec3 sp, vec3 rd, vec3 sn, vec3 lp, float ao, float id) {
+    vec3 ld = lp - sp;
+    float l_dist = max(length(ld), 0.001);
+    ld /= l_dist;
+    float atten = 2.0 / (1.0 + l_dist * 0.125 + l_dist * l_dist * 0.025);
+
+    float diff = max(dot(sn, ld), 0.0);
+    float spec = pow(max(dot(reflect(-ld, sn), -rd), 0.0), 32.0);
+    float fres = clamp(1.0 + dot(rd, sn), 0.0, 1.0);
+
+    vec3 obj = object_color(sp, id);
+    vec3 lcol = material_params.light_color * material_params.light_intensity;
+    // The ambient and fresnel terms take the light tint too, so recoloring
+    // the light regrades the whole interior.
+    vec3 col = obj * (diff + 0.6 * ao + fres * fres) * lcol + lcol.zyx * spec * 2.0;
+    return col * atten;
+  }
+
+  vec3 Sky(vec3 direction) {
+    vec3 rd = direction;
+    rd.xy = rd.xy * rot2(material_params.spin);
+    rd.xz = rd.xz * rot2(material_params.spin);
+
+    vec3 ro = vec3(0.0, 0.0, material_params.travel);
+    vec3 lp = ro +
+        vec3(0.0, material_params.light_height, material_params.light_forward);
+
+    float t = trace(ro, rd);
+    vec3 col = vec3(0.0);
+    if (t < FAR) {
+      vec3 sp = ro + rd * t;
+      float id = map2(sp).y;
+      vec3 sn = get_normal(sp);
+      float edge = get_edge(sp, t);
+      float sh = soft_shadow(sp + sn * 0.002, lp);
+      float ao = calc_ao(sp, sn);
+      sh = (sh + ao * 0.3) * ao;
+
+      col = shade_point(sp, rd, sn, lp, ao, id);
+      col *= 1.0 - edge * 0.9;
+      col *= sh;
+
+      // Neon bracing emission, unaffected by shadowing.
+      if (id < 0.5) {
+        col += material_params.glow_color * material_params.glow_intensity;
+      }
+    }
+
+    // Distance fog, brighter overhead.
+    float fog = smoothstep(0.0, 0.95, t / FAR);
+    vec3 fog_col = material_params.fog_color * (rd.y * 0.5 + 0.5) *
+        material_params.fog_brightness;
+    col = mix(col, fog_col, fog);
+
+    // The original's screen-space red-to-blue grade, keyed on the world-up
+    // component instead so the bake stays view independent. The mix factor
+    // goes negative below the horizon, extrapolating toward red.
+    vec3 graded = pow(min(vec3(1.5, 1.0, 1.0) * col, vec3(1.0)),
+        vec3(1.0, 2.5, 12.0));
+    col = mix(col, graded, direction.y * material_params.grade);
+
+    // Linear HDR radiance; exposure and tone mapping happen engine side.
+    return max(col, 0.0);
+  }
+}

--- a/examples/flutter_app/assets/menger_sky.fmat
+++ b/examples/flutter_app/assets/menger_sky.fmat
@@ -25,27 +25,27 @@ material {
     { type: float, name: travel, hint: range(0, 3, 0.001), default: 1.0 },
     { type: float, name: spin, hint: range(0, 6.2832, 0.001), default: 0.0 },
     // Grows or shrinks the sponge's primary holes.
-    { type: float, name: hole_size, hint: range(-0.02, 0.1, 0.001), default: -0.01 },
+    { type: float, name: hole_size, hint: range(-0.02, 0.1, 0.001), default: -0.02 },
 
     // The point light carried with the viewer.
-    { type: vec3, name: light_color, hint: source_color, default: [0.83, 1.0, 0.55] },
-    { type: float, name: light_intensity, hint: range(0, 8, 0.01), default: 1.6 },
+    { type: vec3, name: light_color, hint: source_color, default: [0.55, 1.0, 0.80] },
+    { type: float, name: light_intensity, hint: range(0, 8, 0.01), default: 0.25 },
     { type: float, name: light_height, hint: range(-1.4, 1.4, 0.01), default: 0.51 },
     { type: float, name: light_forward, hint: range(-3, 3, 0.01), default: 0.0 },
 
     // Emissive tint applied to the chrome bracing.
-    { type: vec3, name: glow_color, hint: source_color, default: [0.1, 0.7, 1.0] },
+    { type: vec3, name: glow_color, hint: source_color, default: [0.1, 1.0, 0.32] },
     { type: float, name: glow_intensity, hint: range(0, 12, 0.01), default: 8.59 },
 
     // Distance fog, the dominant emitter for most of the sky sphere.
-    { type: vec3, name: fog_color, hint: source_color, default: [0.7, 0.8, 1.0] },
-    { type: float, name: fog_brightness, hint: range(0, 8, 0.01), default: 6.82 },
+    { type: vec3, name: fog_color, hint: source_color, default: [0.8, 0.7, 1.0] },
+    { type: float, name: fog_brightness, hint: range(0, 8, 0.01), default: 3.15 },
 
     // Strength of the red-to-blue vertical color grade.
-    { type: float, name: grade, hint: range(0, 1, 0.01), default: 0.48 },
+    { type: float, name: grade, hint: range(0, 1, 0.01), default: 0.59 },
 
     // Strength of the environment-mapped reflections.
-    { type: float, name: reflection, hint: range(0, 2, 0.01), default: 0.7 },
+    { type: float, name: reflection, hint: range(0, 2, 0.01), default: 1.44 },
 
     // Surface tints for the sponge's outer shell and inner core.
     { type: vec3, name: shell_color, default: [1.25, 1.0, 0.75] },

--- a/examples/flutter_app/lib/environment_menu.dart
+++ b/examples/flutter_app/lib/environment_menu.dart
@@ -141,10 +141,16 @@ class EnvironmentSelector extends ChangeNotifier {
   /// Whether a selection is downloading or decoding.
   bool get loading => _loading;
 
-  /// Selects [environment] and applies it to [scene]. Throws when the
+  /// Selects [environment] and applies it to [scene], returning the resolved
+  /// map (null for the renderer's built-in studio default). Throws when the
   /// download or decode fails (the previous environment stays active).
-  Future<void> select(ExampleEnvironment environment, Scene scene) async {
-    if (environment.id == _active.id && !_loading) return;
+  Future<EnvironmentMap?> select(
+    ExampleEnvironment environment,
+    Scene scene,
+  ) async {
+    if (environment.id == _active.id && !_loading) {
+      return _cache[environment.id];
+    }
     final previous = _active;
     _active = environment;
     _loading = true;
@@ -152,6 +158,7 @@ class EnvironmentSelector extends ChangeNotifier {
     try {
       final map = await _resolve(environment);
       scene.environment = map;
+      return map;
     } catch (_) {
       _active = previous;
       rethrow;

--- a/examples/flutter_app/lib/example_skybox.dart
+++ b/examples/flutter_app/lib/example_skybox.dart
@@ -8,6 +8,11 @@
 //      hot-reloadable parameters; assign it to scene.skybox.
 // The engine owns the full-screen draw, depth, and draw order; no geometry is
 // placed for the sky. (For a raw fragment shader instead, see ShaderSkySource.)
+//
+// assets/menger_sky.fmat is a second, much heavier sky (a raymarched Menger
+// sponge interior) driven the same way; its light, glow, and fog parameters
+// change the emitted light dramatically, so re-baking visibly relights the
+// spheres.
 
 import 'dart:math';
 
@@ -27,7 +32,8 @@ class ExampleSkybox extends StatefulWidget {
 enum _SkyType {
   fmatGradient('Gradient (.fmat)'),
   gradient('Gradient (built-in)'),
-  physical('Physical atmosphere');
+  physical('Physical atmosphere'),
+  fmatMenger('Menger sponge (.fmat)');
 
   const _SkyType(this.label);
   final String label;
@@ -38,6 +44,7 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
   bool loaded = false;
 
   PreprocessedSky? _fmatSky;
+  PreprocessedSky? _mengerSky;
   GradientSkySource? _gradientSky;
   PhysicalSkySource? _physicalSky;
   _SkyType _skyType = _SkyType.fmatGradient;
@@ -48,6 +55,20 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
   double _sunAzimuth = 0.6; // radians around +Y
   double _sunSharpness = 400.0; // higher = tighter sun disk
 
+  // Menger sky controls. Hues are in degrees; colors are derived per emitter
+  // with a saturation that suits it.
+  double _mengerTravel = 1.0;
+  double _mengerSpin = 0.5;
+  double _mengerHoleSize = 0.03;
+  double _mengerLightHue = 37.0;
+  double _mengerLightIntensity = 1.6;
+  double _mengerLightHeight = 1.0;
+  double _mengerGlowHue = 200.0;
+  double _mengerGlowIntensity = 2.0;
+  double _mengerFogHue = 220.0;
+  double _mengerFogBrightness = 2.5;
+  double _mengerGrade = 0.5;
+
   @override
   void initState() {
     super.initState();
@@ -56,8 +77,10 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
 
   Future<void> _load() async {
     final sky = await loadFmatSky('assets/gradient_sky.fmat');
+    final menger = await loadFmatSky('assets/menger_sky.fmat');
     if (!mounted) return;
     _fmatSky = sky;
+    _mengerSky = menger;
     _applySkyType(_skyType);
 
     // Left: a smooth metallic sphere mirrors the baked environment (specular).
@@ -101,6 +124,7 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
       _SkyType.fmatGradient => _fmatSky!,
       _SkyType.gradient => _gradientSky ??= GradientSkySource(),
       _SkyType.physical => _physicalSky ??= PhysicalSkySource(),
+      _SkyType.fmatMenger => _mengerSky!,
     };
   }
 
@@ -117,6 +141,17 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
       refresh: _skyEnvironment?.refresh ?? SkyEnvironmentRefresh.manual,
     );
     scene.skyEnvironment = _skyEnvironment;
+  }
+
+  // A slider hue as a light color, with a per-emitter saturation.
+  vm.Vector3 _hueColor(double hueDegrees, double saturation) {
+    final c = HSVColor.fromAHSV(
+      1.0,
+      hueDegrees % 360.0,
+      saturation,
+      1.0,
+    ).toColor();
+    return vm.Vector3(c.r, c.g, c.b);
   }
 
   void _refreshSky() {
@@ -141,7 +176,96 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
         // The physical sun is a disk with a fixed angular size; the sharpness
         // slider does not apply.
         _physicalSky!.sunDirection = dir;
+      case _SkyType.fmatMenger:
+        final sky = _mengerSky;
+        if (sky == null) return;
+        sky.parameters
+          ..setFloat('travel', _mengerTravel)
+          ..setFloat('spin', _mengerSpin)
+          ..setFloat('hole_size', _mengerHoleSize)
+          ..setVec3('light_color', _hueColor(_mengerLightHue, 0.45))
+          ..setFloat('light_intensity', _mengerLightIntensity)
+          ..setFloat('light_height', _mengerLightHeight)
+          ..setVec3('glow_color', _hueColor(_mengerGlowHue, 0.9))
+          ..setFloat('glow_intensity', _mengerGlowIntensity)
+          ..setVec3('fog_color', _hueColor(_mengerFogHue, 0.3))
+          ..setFloat('fog_brightness', _mengerFogBrightness)
+          ..setFloat('grade', _mengerGrade);
     }
+  }
+
+  // One slider per parameter of the active sky. Each one pushes the new
+  // value into the sky source; with the lighting refresh on manual, the
+  // skybox updates immediately while the scene lighting holds until re-bake,
+  // making the environment recompute visible.
+  List<Widget> _parameterRows() {
+    _SliderRow slider(
+      String label,
+      double value,
+      double min,
+      double max,
+      void Function(double) assign,
+    ) {
+      return _SliderRow(
+        label: label,
+        value: value,
+        min: min,
+        max: max,
+        onChanged: (v) => setState(() {
+          assign(v);
+          _refreshSky();
+        }),
+      );
+    }
+
+    if (_skyType != _SkyType.fmatMenger) {
+      return [
+        slider('Sun elevation', _sunElevation, -0.3, 1.4, (v) {
+          _sunElevation = v;
+        }),
+        slider('Sun azimuth', _sunAzimuth, -pi, pi, (v) {
+          _sunAzimuth = v;
+        }),
+        slider('Sun sharpness', _sunSharpness, 16, 2000, (v) {
+          _sunSharpness = v;
+        }),
+      ];
+    }
+    return [
+      slider('Travel', _mengerTravel, 0, 60, (v) {
+        _mengerTravel = v;
+      }),
+      slider('Spin', _mengerSpin, -pi, pi, (v) {
+        _mengerSpin = v;
+      }),
+      slider('Hole size', _mengerHoleSize, -0.02, 0.1, (v) {
+        _mengerHoleSize = v;
+      }),
+      slider('Light hue', _mengerLightHue, 0, 360, (v) {
+        _mengerLightHue = v;
+      }),
+      slider('Light intensity', _mengerLightIntensity, 0, 8, (v) {
+        _mengerLightIntensity = v;
+      }),
+      slider('Light height', _mengerLightHeight, -1.4, 1.4, (v) {
+        _mengerLightHeight = v;
+      }),
+      slider('Glow hue', _mengerGlowHue, 0, 360, (v) {
+        _mengerGlowHue = v;
+      }),
+      slider('Glow intensity', _mengerGlowIntensity, 0, 12, (v) {
+        _mengerGlowIntensity = v;
+      }),
+      slider('Fog hue', _mengerFogHue, 0, 360, (v) {
+        _mengerFogHue = v;
+      }),
+      slider('Fog brightness', _mengerFogBrightness, 0, 8, (v) {
+        _mengerFogBrightness = v;
+      }),
+      slider('Grade', _mengerGrade, 0, 1, (v) {
+        _mengerGrade = v;
+      }),
+    ];
   }
 
   @override
@@ -234,35 +358,11 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
                       ),
                     ],
                   ),
-                  _SliderRow(
-                    label: 'Sun elevation',
-                    value: _sunElevation,
-                    min: -0.3,
-                    max: 1.4,
-                    onChanged: (v) => setState(() {
-                      _sunElevation = v;
-                      _refreshSky();
-                    }),
-                  ),
-                  _SliderRow(
-                    label: 'Sun azimuth',
-                    value: _sunAzimuth,
-                    min: -pi,
-                    max: pi,
-                    onChanged: (v) => setState(() {
-                      _sunAzimuth = v;
-                      _refreshSky();
-                    }),
-                  ),
-                  _SliderRow(
-                    label: 'Sun sharpness',
-                    value: _sunSharpness,
-                    min: 16,
-                    max: 2000,
-                    onChanged: (v) => setState(() {
-                      _sunSharpness = v;
-                      _refreshSky();
-                    }),
+                  Wrap(
+                    children: [
+                      for (final row in _parameterRows())
+                        SizedBox(width: 380, child: row),
+                    ],
                   ),
                 ],
               ),

--- a/examples/flutter_app/lib/example_skybox.dart
+++ b/examples/flutter_app/lib/example_skybox.dart
@@ -12,10 +12,15 @@
 // assets/menger_sky.fmat is a second, much heavier sky (a raymarched Menger
 // sponge interior) driven the same way; its light, glow, and fog parameters
 // change the emitted light dramatically, so re-baking visibly relights the
-// spheres. It also declares `requires: [environment]` and reflects a
-// downloaded environment map (Helipad by default, selectable from the
+// scene. It also declares `requires: [environment]` and reflects a
+// downloaded environment map (Field by default, selectable from the
 // lighting panel) through `sampledEnvironment`, while its own bake keeps
 // driving the scene lighting.
+//
+// The lit content is a 5x5 grid of randomly spinning random shapes, metallic
+// ascending along one axis and roughness along the other, so every
+// combination of the baked environment's specular and diffuse response is
+// visible at once.
 
 import 'dart:math';
 
@@ -26,6 +31,7 @@ import 'package:vector_math/vector_math.dart' as vm;
 import 'environment_menu.dart';
 import 'example_settings.dart';
 import 'lighting_panel.dart';
+import 'quake_camera.dart';
 
 class ExampleSkybox extends StatefulWidget {
   const ExampleSkybox({super.key});
@@ -70,19 +76,37 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
   // with a saturation that suits it. Travel and spin advance continuously at
   // the slider speeds, wrapping at the sponge's repeat period.
   double _mengerTravel = 1.0;
-  double _mengerTravelSpeed = 1.0; // units per second
+  double _mengerTravelSpeed = 1.22; // units per second
   double _mengerSpin = 0.0;
-  double _mengerSpinSpeed = 0.25; // radians per second
-  double _mengerHoleSize = -0.01;
-  double _mengerLightHue = 82.22;
-  double _mengerLightIntensity = 1.6;
+  double _mengerSpinSpeed = 0.30; // radians per second
+  double _mengerHoleSize = -0.02;
+  double _mengerLightHue = 153.94;
+  double _mengerLightIntensity = 0.25;
   double _mengerLightHeight = 0.51;
-  double _mengerGlowHue = 200.0;
+  double _mengerGlowHue = 134.60;
   double _mengerGlowIntensity = 8.59;
-  double _mengerFogHue = 220.0;
-  double _mengerFogBrightness = 6.82;
-  double _mengerGrade = 0.48;
-  double _mengerReflection = 0.7;
+  double _mengerFogHue = 259.43;
+  double _mengerFogBrightness = 3.15;
+  double _mengerGrade = 0.59;
+  double _mengerReflection = 1.44;
+
+  // The 5x5 shape grid: metallic ascends along +X, roughness along +Z. Each
+  // shape tumbles around its own random axis at its own rate, scaled by the
+  // shared spin slider.
+  static const int _gridSize = 5;
+  static const double _gridSpacing = 1.5;
+  final List<Node> _shapeNodes = [];
+  final List<vm.Vector3> _shapePositions = [];
+  final List<vm.Vector3> _shapeAxes = [];
+  final List<double> _shapeAngles = [];
+  final List<double> _shapeRates = [];
+  double _shapeSpinSpeed = 1.0; // radians per second, per-shape scaled
+  double _cameraDistance = 8.0;
+
+  // Optional detached "quake" fly camera, as in the DICOM example.
+  bool _freeCamera = false;
+  final QuakeCamera _freeCam = QuakeCamera();
+  double _elapsedSeconds = 0.0;
 
   @override
   void initState() {
@@ -98,31 +122,98 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
     _mengerSky = menger..sampledEnvironment = _sampledEnvironment;
     _applySkyType(_skyType);
 
-    // Left: a smooth metallic sphere mirrors the baked environment (specular).
-    scene.add(
-      Node(
-        mesh: Mesh(
-          SphereGeometry(radius: 1.0),
-          PhysicallyBasedMaterial()
-            ..metallicFactor = 1.0
-            ..roughnessFactor = 0.08,
-        ),
-      )..localTransform = vm.Matrix4.translationValues(-1.5, 0, 0),
-    );
-    // Right: a matte sphere lit by the sky's diffuse irradiance (the SH term).
-    scene.add(
-      Node(
-        mesh: Mesh(
-          SphereGeometry(radius: 1.0),
-          PhysicallyBasedMaterial()
-            ..metallicFactor = 0.0
-            ..roughnessFactor = 1.0
-            ..baseColorFactor = vm.Vector4(0.85, 0.85, 0.85, 1.0),
-        ),
-      )..localTransform = vm.Matrix4.translationValues(1.5, 0, 0),
-    );
+    _buildShapeGrid();
 
     setState(() => loaded = true);
+  }
+
+  // A random primitive, roughly matched in visual size.
+  MeshGeometry _randomShape(Random rng) => switch (rng.nextInt(6)) {
+    0 => SphereGeometry(radius: 0.45),
+    1 => CuboidGeometry(vm.Vector3(0.7, 0.7, 0.7)),
+    2 => CylinderGeometry(bottomRadius: 0.35, topRadius: 0.35, height: 0.8),
+    3 => CapsuleGeometry(radius: 0.28, height: 0.5),
+    4 => TorusGeometry(radius: 0.35, tubeRadius: 0.15),
+    _ => WedgeGeometry(vm.Vector3(0.7, 0.7, 0.7)),
+  };
+
+  void _buildShapeGrid() {
+    // Fixed seed so the assortment is stable across runs.
+    final rng = Random(1337);
+    for (var ix = 0; ix < _gridSize; ix++) {
+      for (var iz = 0; iz < _gridSize; iz++) {
+        final node = Node(
+          mesh: Mesh(
+            _randomShape(rng),
+            PhysicallyBasedMaterial()
+              ..baseColorFactor = vm.Vector4(0.85, 0.85, 0.85, 1.0)
+              ..metallicFactor = ix / (_gridSize - 1)
+              ..roughnessFactor = iz / (_gridSize - 1),
+          ),
+        );
+        _shapePositions.add(
+          vm.Vector3(
+            (ix - (_gridSize - 1) / 2) * _gridSpacing,
+            0,
+            (iz - (_gridSize - 1) / 2) * _gridSpacing,
+          ),
+        );
+        var axis = vm.Vector3(
+          rng.nextDouble() * 2 - 1,
+          rng.nextDouble() * 2 - 1,
+          rng.nextDouble() * 2 - 1,
+        );
+        if (axis.length2 < 1e-3) axis = vm.Vector3(0, 1, 0);
+        _shapeAxes.add(axis..normalize());
+        _shapeAngles.add(rng.nextDouble() * 2 * pi);
+        _shapeRates.add(0.5 + rng.nextDouble());
+        _shapeNodes.add(node);
+        scene.add(node);
+      }
+    }
+    _updateShapeTransforms();
+  }
+
+  void _updateShapeTransforms() {
+    for (var i = 0; i < _shapeNodes.length; i++) {
+      _shapeNodes[i].localTransform = vm.Matrix4.translation(_shapePositions[i])
+        ..rotate(_shapeAxes[i], _shapeAngles[i]);
+    }
+  }
+
+  void _tickShapes(double deltaSeconds) {
+    if (_shapeSpinSpeed == 0.0) return;
+    for (var i = 0; i < _shapeAngles.length; i++) {
+      _shapeAngles[i] =
+          (_shapeAngles[i] + _shapeRates[i] * _shapeSpinSpeed * deltaSeconds) %
+          (2 * pi);
+    }
+    _updateShapeTransforms();
+  }
+
+  PerspectiveCamera _orbitCamera(double seconds) {
+    final t = seconds * 0.25;
+    return PerspectiveCamera(
+      position: vm.Vector3(
+        sin(t) * _cameraDistance,
+        _cameraDistance * 0.4,
+        cos(t) * _cameraDistance,
+      ),
+      target: vm.Vector3(0, 0, 0),
+    );
+  }
+
+  // Toggles the detached fly camera. Turning it on adopts the current orbit
+  // pose so the view does not jump; turning it off drops back to the orbit.
+  void _toggleFreeCamera() {
+    setState(() {
+      _freeCamera = !_freeCamera;
+      if (_freeCamera) _freeCam.syncTo(_orbitCamera(_elapsedSeconds));
+      _freeCam
+        ..enabled = _freeCamera
+        ..releaseKeys()
+        ..move(_elapsedSeconds); // reset the frame clock without moving
+    });
   }
 
   @override
@@ -261,6 +352,16 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
       );
     }
 
+    // Scene controls shown for every sky.
+    final common = [
+      slider('Shape spin', _shapeSpinSpeed, 0, 4, (v) {
+        _shapeSpinSpeed = v;
+      }),
+      slider('Camera distance', _cameraDistance, 3, 20, (v) {
+        _cameraDistance = v;
+      }),
+    ];
+
     if (_skyType != _SkyType.fmatMenger) {
       return [
         slider('Sun elevation', _sunElevation, -0.3, 1.4, (v) {
@@ -272,6 +373,7 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
         slider('Sun sharpness', _sunSharpness, 16, 2000, (v) {
           _sunSharpness = v;
         }),
+        ...common,
       ];
     }
     return [
@@ -311,6 +413,7 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
       slider('Reflection', _mengerReflection, 0, 2, (v) {
         _mengerReflection = v;
       }),
+      ...common,
     ];
   }
 
@@ -319,117 +422,162 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
     if (!loaded) {
       return const Center(child: CircularProgressIndicator());
     }
-    return Stack(
-      children: [
-        Positioned.fill(
-          child: SceneView(
-            scene,
-            cameraBuilder: (elapsed) {
-              final t = elapsed.inMicroseconds / 1e6 * 0.25;
-              return PerspectiveCamera(
-                position: vm.Vector3(sin(t) * 6, 2, cos(t) * 6),
-                target: vm.Vector3(0, 0, 0),
-              );
-            },
-            onTick: (elapsed, deltaSeconds) {
-              exampleSettings.applyTo(scene);
-              _tickMengerSky(deltaSeconds);
-            },
-          ),
-        ),
-        Positioned(
-          right: 16,
-          top: 16,
-          child: LightingPanel(
-            scene: scene,
-            selector: _environmentSelector,
-            manageSkybox: false,
-            initialEnvironmentId: 'helipad',
-            onEnvironmentResolved: _onEnvironmentResolved,
-          ),
-        ),
-        Positioned(
-          left: 16,
-          right: 16,
-          bottom: 16,
-          child: Card(
-            color: Colors.black54,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Row(
-                    children: [
-                      const Text('Sky:', style: TextStyle(color: Colors.white)),
-                      const SizedBox(width: 8),
-                      DropdownButton<_SkyType>(
-                        value: _skyType,
-                        dropdownColor: Colors.black87,
-                        style: const TextStyle(color: Colors.white),
-                        items: [
-                          for (final type in _SkyType.values)
-                            DropdownMenuItem(
-                              value: type,
-                              child: Text(type.label),
-                            ),
-                        ],
-                        onChanged: (type) => setState(() {
-                          if (type != null) _applySkyType(type);
-                        }),
-                      ),
-                    ],
-                  ),
-                  Row(
-                    children: [
-                      const Text(
-                        'Lighting refresh:',
-                        style: TextStyle(color: Colors.white),
-                      ),
-                      const SizedBox(width: 8),
-                      DropdownButton<SkyEnvironmentRefresh>(
-                        value:
-                            _skyEnvironment?.refresh ??
-                            SkyEnvironmentRefresh.manual,
-                        dropdownColor: Colors.black87,
-                        style: const TextStyle(color: Colors.white),
-                        items: const [
-                          DropdownMenuItem(
-                            value: SkyEnvironmentRefresh.manual,
-                            child: Text('Manual'),
-                          ),
-                          DropdownMenuItem(
-                            value: SkyEnvironmentRefresh.interval,
-                            child: Text('Interval (1s)'),
-                          ),
-                          DropdownMenuItem(
-                            value: SkyEnvironmentRefresh.everyFrame,
-                            child: Text('Every frame'),
-                          ),
-                        ],
-                        onChanged: (mode) => setState(() {
-                          if (mode != null) _skyEnvironment?.refresh = mode;
-                        }),
-                      ),
-                      const SizedBox(width: 16),
-                      ElevatedButton(
-                        onPressed: () => _skyEnvironment?.invalidate(),
-                        child: const Text('Re-bake lighting'),
-                      ),
-                    ],
-                  ),
-                  Wrap(
-                    children: [
-                      for (final row in _parameterRows())
-                        SizedBox(width: 380, child: row),
-                    ],
-                  ),
-                ],
+    return Focus(
+      autofocus: true,
+      onKeyEvent: _freeCam.onKeyEvent,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: GestureDetector(
+              onPanUpdate: (d) {
+                if (_freeCamera) _freeCam.look(d.delta);
+              },
+              child: SceneView(
+                scene,
+                cameraBuilder: (elapsed) => _freeCamera
+                    ? _freeCam.camera
+                    : _orbitCamera(elapsed.inMicroseconds / 1e6),
+                onTick: (elapsed, deltaSeconds) {
+                  exampleSettings.applyTo(scene);
+                  _elapsedSeconds = elapsed.inMicroseconds / 1e6;
+                  if (_freeCamera) {
+                    _freeCam.move(_elapsedSeconds);
+                  } else {
+                    // Keep the free camera glued to the orbit pose so
+                    // toggling it on never jumps.
+                    _freeCam.syncTo(_orbitCamera(_elapsedSeconds));
+                  }
+                  _tickMengerSky(deltaSeconds);
+                  _tickShapes(deltaSeconds);
+                },
               ),
             ),
           ),
-        ),
-      ],
+          Positioned(
+            right: 16,
+            top: 16,
+            child: LightingPanel(
+              scene: scene,
+              selector: _environmentSelector,
+              manageSkybox: false,
+              initialEnvironmentId: 'field',
+              initialExposure: 1.63,
+              initialIblIntensity: 1.14,
+              onEnvironmentResolved: _onEnvironmentResolved,
+            ),
+          ),
+          Positioned(
+            left: 16,
+            right: 16,
+            bottom: 16,
+            child: Card(
+              color: Colors.black54,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        const Text(
+                          'Sky:',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                        const SizedBox(width: 8),
+                        DropdownButton<_SkyType>(
+                          value: _skyType,
+                          dropdownColor: Colors.black87,
+                          style: const TextStyle(color: Colors.white),
+                          items: [
+                            for (final type in _SkyType.values)
+                              DropdownMenuItem(
+                                value: type,
+                                child: Text(type.label),
+                              ),
+                          ],
+                          onChanged: (type) => setState(() {
+                            if (type != null) _applySkyType(type);
+                          }),
+                        ),
+                      ],
+                    ),
+                    Row(
+                      children: [
+                        const Text(
+                          'Lighting refresh:',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                        const SizedBox(width: 8),
+                        DropdownButton<SkyEnvironmentRefresh>(
+                          value:
+                              _skyEnvironment?.refresh ??
+                              SkyEnvironmentRefresh.manual,
+                          dropdownColor: Colors.black87,
+                          style: const TextStyle(color: Colors.white),
+                          items: const [
+                            DropdownMenuItem(
+                              value: SkyEnvironmentRefresh.manual,
+                              child: Text('Manual'),
+                            ),
+                            DropdownMenuItem(
+                              value: SkyEnvironmentRefresh.interval,
+                              child: Text('Interval (1s)'),
+                            ),
+                            DropdownMenuItem(
+                              value: SkyEnvironmentRefresh.everyFrame,
+                              child: Text('Every frame'),
+                            ),
+                          ],
+                          onChanged: (mode) => setState(() {
+                            if (mode != null) _skyEnvironment?.refresh = mode;
+                          }),
+                        ),
+                        const SizedBox(width: 16),
+                        ElevatedButton(
+                          onPressed: () => _skyEnvironment?.invalidate(),
+                          child: const Text('Re-bake lighting'),
+                        ),
+                        const SizedBox(width: 16),
+                        ElevatedButton.icon(
+                          onPressed: _toggleFreeCamera,
+                          icon: Icon(
+                            _freeCamera
+                                ? Icons.videocam
+                                : Icons.videocam_outlined,
+                          ),
+                          label: Text(
+                            _freeCamera ? 'Quake camera' : 'Orbit camera',
+                          ),
+                        ),
+                        if (_freeCamera) ...[
+                          const SizedBox(width: 12),
+                          const Text(
+                            'WASD move · QE up/down · drag to look · '
+                            'shift to boost',
+                            style: TextStyle(
+                              color: Colors.white70,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    Wrap(
+                      children: [
+                        for (final row in _parameterRows())
+                          SizedBox(width: 380, child: row),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/examples/flutter_app/lib/example_skybox.dart
+++ b/examples/flutter_app/lib/example_skybox.dart
@@ -84,7 +84,7 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
   double _mengerLightIntensity = 0.25;
   double _mengerLightHeight = 0.51;
   double _mengerGlowHue = 134.60;
-  double _mengerGlowIntensity = 8.59;
+  double _mengerGlowIntensity = 1.85;
   double _mengerFogHue = 259.43;
   double _mengerFogBrightness = 3.15;
   double _mengerGrade = 0.59;
@@ -101,7 +101,7 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
   final List<double> _shapeAngles = [];
   final List<double> _shapeRates = [];
   double _shapeSpinSpeed = 1.0; // radians per second, per-shape scaled
-  double _cameraDistance = 8.0;
+  double _cameraDistance = 10.14;
 
   // Optional detached "quake" fly camera, as in the DICOM example.
   bool _freeCamera = false;
@@ -462,7 +462,7 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
               manageSkybox: false,
               initialEnvironmentId: 'field',
               initialExposure: 1.63,
-              initialIblIntensity: 1.14,
+              initialIblIntensity: 1.06,
               onEnvironmentResolved: _onEnvironmentResolved,
             ),
           ),

--- a/examples/flutter_app/lib/example_skybox.dart
+++ b/examples/flutter_app/lib/example_skybox.dart
@@ -12,7 +12,10 @@
 // assets/menger_sky.fmat is a second, much heavier sky (a raymarched Menger
 // sponge interior) driven the same way; its light, glow, and fog parameters
 // change the emitted light dramatically, so re-baking visibly relights the
-// spheres.
+// spheres. It also declares `requires: [environment]` and reflects a
+// downloaded environment map (Helipad by default, selectable from the
+// lighting panel) through `sampledEnvironment`, while its own bake keeps
+// driving the scene lighting.
 
 import 'dart:math';
 
@@ -20,7 +23,9 @@ import 'package:flutter/material.dart' hide Material;
 import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
+import 'environment_menu.dart';
 import 'example_settings.dart';
+import 'lighting_panel.dart';
 
 class ExampleSkybox extends StatefulWidget {
   const ExampleSkybox({super.key});
@@ -47,8 +52,14 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
   PreprocessedSky? _mengerSky;
   GradientSkySource? _gradientSky;
   PhysicalSkySource? _physicalSky;
-  _SkyType _skyType = _SkyType.fmatGradient;
+  _SkyType _skyType = _SkyType.fmatMenger;
   SkyEnvironment? _skyEnvironment;
+
+  // The lighting panel's environment selection feeds the Menger sky's
+  // reflections through sampledEnvironment (the scene's own environment is
+  // owned by the sky bake).
+  final EnvironmentSelector _environmentSelector = EnvironmentSelector();
+  EnvironmentMap? _studioEnvironment;
 
   // Sun controls, surfaced as sliders.
   double _sunElevation = 0.5; // radians above the horizon
@@ -56,18 +67,22 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
   double _sunSharpness = 400.0; // higher = tighter sun disk
 
   // Menger sky controls. Hues are in degrees; colors are derived per emitter
-  // with a saturation that suits it.
+  // with a saturation that suits it. Travel and spin advance continuously at
+  // the slider speeds, wrapping at the sponge's repeat period.
   double _mengerTravel = 1.0;
-  double _mengerSpin = 0.5;
-  double _mengerHoleSize = 0.03;
-  double _mengerLightHue = 37.0;
+  double _mengerTravelSpeed = 1.0; // units per second
+  double _mengerSpin = 0.0;
+  double _mengerSpinSpeed = 0.25; // radians per second
+  double _mengerHoleSize = -0.01;
+  double _mengerLightHue = 82.22;
   double _mengerLightIntensity = 1.6;
-  double _mengerLightHeight = 1.0;
+  double _mengerLightHeight = 0.51;
   double _mengerGlowHue = 200.0;
-  double _mengerGlowIntensity = 2.0;
+  double _mengerGlowIntensity = 8.59;
   double _mengerFogHue = 220.0;
-  double _mengerFogBrightness = 2.5;
-  double _mengerGrade = 0.5;
+  double _mengerFogBrightness = 6.82;
+  double _mengerGrade = 0.48;
+  double _mengerReflection = 0.7;
 
   @override
   void initState() {
@@ -80,7 +95,7 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
     final menger = await loadFmatSky('assets/menger_sky.fmat');
     if (!mounted) return;
     _fmatSky = sky;
-    _mengerSky = menger;
+    _mengerSky = menger..sampledEnvironment = _sampledEnvironment;
     _applySkyType(_skyType);
 
     // Left: a smooth metallic sphere mirrors the baked environment (specular).
@@ -138,9 +153,22 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
     scene.skybox = Skybox(source);
     _skyEnvironment = SkyEnvironment(
       source,
-      refresh: _skyEnvironment?.refresh ?? SkyEnvironmentRefresh.manual,
+      refresh: _skyEnvironment?.refresh ?? SkyEnvironmentRefresh.everyFrame,
     );
     scene.skyEnvironment = _skyEnvironment;
+  }
+
+  // The Menger sky reflects the map picked in the lighting panel. The scene's
+  // environment can't carry it (each sky bake overwrites it), so the resolved
+  // map goes to the sky source directly; null falls back to the same studio
+  // environment the renderer defaults to. Kept in a field because the panel's
+  // initial download can finish before the sky loads (or after).
+  EnvironmentMap? _sampledEnvironment;
+
+  void _onEnvironmentResolved(EnvironmentMap? map) {
+    _sampledEnvironment =
+        map ?? (_studioEnvironment ??= EnvironmentMap.studio());
+    _mengerSky?.sampledEnvironment = _sampledEnvironment;
   }
 
   // A slider hue as a light color, with a per-emitter saturation.
@@ -190,8 +218,23 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
           ..setFloat('glow_intensity', _mengerGlowIntensity)
           ..setVec3('fog_color', _hueColor(_mengerFogHue, 0.3))
           ..setFloat('fog_brightness', _mengerFogBrightness)
-          ..setFloat('grade', _mengerGrade);
+          ..setFloat('grade', _mengerGrade)
+          ..setFloat('reflection', _mengerReflection);
     }
+  }
+
+  // Advances the Menger sky's travel and spin at the slider speeds. Both
+  // wrap at the field's period (the sponge repeats every 3 units, rotation
+  // every full turn) so the march never runs into float precision.
+  void _tickMengerSky(double deltaSeconds) {
+    if (_skyType != _SkyType.fmatMenger) return;
+    final sky = _mengerSky;
+    if (sky == null) return;
+    _mengerTravel = (_mengerTravel + _mengerTravelSpeed * deltaSeconds) % 3.0;
+    _mengerSpin = (_mengerSpin + _mengerSpinSpeed * deltaSeconds) % (2 * pi);
+    sky.parameters
+      ..setFloat('travel', _mengerTravel)
+      ..setFloat('spin', _mengerSpin);
   }
 
   // One slider per parameter of the active sky. Each one pushes the new
@@ -232,11 +275,11 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
       ];
     }
     return [
-      slider('Travel', _mengerTravel, 0, 60, (v) {
-        _mengerTravel = v;
+      slider('Travel speed', _mengerTravelSpeed, 0, 6, (v) {
+        _mengerTravelSpeed = v;
       }),
-      slider('Spin', _mengerSpin, -pi, pi, (v) {
-        _mengerSpin = v;
+      slider('Spin speed', _mengerSpinSpeed, -2, 2, (v) {
+        _mengerSpinSpeed = v;
       }),
       slider('Hole size', _mengerHoleSize, -0.02, 0.1, (v) {
         _mengerHoleSize = v;
@@ -265,6 +308,9 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
       slider('Grade', _mengerGrade, 0, 1, (v) {
         _mengerGrade = v;
       }),
+      slider('Reflection', _mengerReflection, 0, 2, (v) {
+        _mengerReflection = v;
+      }),
     ];
   }
 
@@ -285,7 +331,21 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
                 target: vm.Vector3(0, 0, 0),
               );
             },
-            onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+            onTick: (elapsed, deltaSeconds) {
+              exampleSettings.applyTo(scene);
+              _tickMengerSky(deltaSeconds);
+            },
+          ),
+        ),
+        Positioned(
+          right: 16,
+          top: 16,
+          child: LightingPanel(
+            scene: scene,
+            selector: _environmentSelector,
+            manageSkybox: false,
+            initialEnvironmentId: 'helipad',
+            onEnvironmentResolved: _onEnvironmentResolved,
           ),
         ),
         Positioned(

--- a/examples/flutter_app/lib/example_skybox.dart
+++ b/examples/flutter_app/lib/example_skybox.dart
@@ -108,6 +108,9 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
   final QuakeCamera _freeCam = QuakeCamera();
   double _elapsedSeconds = 0.0;
 
+  // Whether the bottom controls card shows more than its header row.
+  bool _controlsExpanded = true;
+
   @override
   void initState() {
     super.initState();
@@ -502,75 +505,92 @@ class _ExampleSkyboxState extends State<ExampleSkybox> {
                             if (type != null) _applySkyType(type);
                           }),
                         ),
+                        const Spacer(),
+                        IconButton(
+                          tooltip: _controlsExpanded
+                              ? 'Collapse controls'
+                              : 'Expand controls',
+                          icon: Icon(
+                            _controlsExpanded
+                                ? Icons.keyboard_arrow_down
+                                : Icons.keyboard_arrow_up,
+                            color: Colors.white,
+                          ),
+                          onPressed: () => setState(
+                            () => _controlsExpanded = !_controlsExpanded,
+                          ),
+                        ),
                       ],
                     ),
-                    Row(
-                      children: [
-                        const Text(
-                          'Lighting refresh:',
-                          style: TextStyle(color: Colors.white),
-                        ),
-                        const SizedBox(width: 8),
-                        DropdownButton<SkyEnvironmentRefresh>(
-                          value:
-                              _skyEnvironment?.refresh ??
-                              SkyEnvironmentRefresh.manual,
-                          dropdownColor: Colors.black87,
-                          style: const TextStyle(color: Colors.white),
-                          items: const [
-                            DropdownMenuItem(
-                              value: SkyEnvironmentRefresh.manual,
-                              child: Text('Manual'),
+                    if (_controlsExpanded)
+                      Row(
+                        children: [
+                          const Text(
+                            'Lighting refresh:',
+                            style: TextStyle(color: Colors.white),
+                          ),
+                          const SizedBox(width: 8),
+                          DropdownButton<SkyEnvironmentRefresh>(
+                            value:
+                                _skyEnvironment?.refresh ??
+                                SkyEnvironmentRefresh.manual,
+                            dropdownColor: Colors.black87,
+                            style: const TextStyle(color: Colors.white),
+                            items: const [
+                              DropdownMenuItem(
+                                value: SkyEnvironmentRefresh.manual,
+                                child: Text('Manual'),
+                              ),
+                              DropdownMenuItem(
+                                value: SkyEnvironmentRefresh.interval,
+                                child: Text('Interval (1s)'),
+                              ),
+                              DropdownMenuItem(
+                                value: SkyEnvironmentRefresh.everyFrame,
+                                child: Text('Every frame'),
+                              ),
+                            ],
+                            onChanged: (mode) => setState(() {
+                              if (mode != null) _skyEnvironment?.refresh = mode;
+                            }),
+                          ),
+                          const SizedBox(width: 16),
+                          ElevatedButton(
+                            onPressed: () => _skyEnvironment?.invalidate(),
+                            child: const Text('Re-bake lighting'),
+                          ),
+                          const SizedBox(width: 16),
+                          ElevatedButton.icon(
+                            onPressed: _toggleFreeCamera,
+                            icon: Icon(
+                              _freeCamera
+                                  ? Icons.videocam
+                                  : Icons.videocam_outlined,
                             ),
-                            DropdownMenuItem(
-                              value: SkyEnvironmentRefresh.interval,
-                              child: Text('Interval (1s)'),
+                            label: Text(
+                              _freeCamera ? 'Quake camera' : 'Orbit camera',
                             ),
-                            DropdownMenuItem(
-                              value: SkyEnvironmentRefresh.everyFrame,
-                              child: Text('Every frame'),
+                          ),
+                          if (_freeCamera) ...[
+                            const SizedBox(width: 12),
+                            const Text(
+                              'WASD move · QE up/down · drag to look · '
+                              'shift to boost',
+                              style: TextStyle(
+                                color: Colors.white70,
+                                fontSize: 12,
+                              ),
                             ),
                           ],
-                          onChanged: (mode) => setState(() {
-                            if (mode != null) _skyEnvironment?.refresh = mode;
-                          }),
-                        ),
-                        const SizedBox(width: 16),
-                        ElevatedButton(
-                          onPressed: () => _skyEnvironment?.invalidate(),
-                          child: const Text('Re-bake lighting'),
-                        ),
-                        const SizedBox(width: 16),
-                        ElevatedButton.icon(
-                          onPressed: _toggleFreeCamera,
-                          icon: Icon(
-                            _freeCamera
-                                ? Icons.videocam
-                                : Icons.videocam_outlined,
-                          ),
-                          label: Text(
-                            _freeCamera ? 'Quake camera' : 'Orbit camera',
-                          ),
-                        ),
-                        if (_freeCamera) ...[
-                          const SizedBox(width: 12),
-                          const Text(
-                            'WASD move · QE up/down · drag to look · '
-                            'shift to boost',
-                            style: TextStyle(
-                              color: Colors.white70,
-                              fontSize: 12,
-                            ),
-                          ),
                         ],
-                      ],
-                    ),
-                    Wrap(
-                      children: [
-                        for (final row in _parameterRows())
-                          SizedBox(width: 380, child: row),
-                      ],
-                    ),
+                      ),
+                    if (_controlsExpanded)
+                      Wrap(
+                        children: [
+                          for (final row in _parameterRows())
+                            SizedBox(width: 380, child: row),
+                        ],
+                      ),
                   ],
                 ),
               ),

--- a/examples/flutter_app/lib/lighting_panel.dart
+++ b/examples/flutter_app/lib/lighting_panel.dart
@@ -67,6 +67,7 @@ class LightingPanel extends StatefulWidget {
 
 class _LightingPanelState extends State<LightingPanel> {
   late bool _showSkybox = widget.showSkybox;
+  bool _expanded = true;
   final EnvironmentSkySource _skySource = EnvironmentSkySource();
   late double _exposure = widget.initialExposure;
   late double _environmentIntensity = widget.initialIblIntensity;
@@ -147,90 +148,110 @@ class _LightingPanelState extends State<LightingPanel> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            EnvironmentMenu(
-              active: widget.selector.active,
-              loading: widget.selector.loading,
-              onSelected: _selectEnvironment,
+            Row(
+              children: [
+                Expanded(
+                  child: EnvironmentMenu(
+                    active: widget.selector.active,
+                    loading: widget.selector.loading,
+                    onSelected: _selectEnvironment,
+                  ),
+                ),
+                IconButton(
+                  tooltip: _expanded ? 'Collapse' : 'Expand',
+                  visualDensity: VisualDensity.compact,
+                  icon: Icon(
+                    _expanded
+                        ? Icons.keyboard_arrow_up
+                        : Icons.keyboard_arrow_down,
+                    color: Colors.white,
+                    size: 18,
+                  ),
+                  onPressed: () => setState(() => _expanded = !_expanded),
+                ),
+              ],
             ),
-            const SizedBox(height: 4),
-            if (widget.manageSkybox) ...[
-              Row(
-                children: [
-                  const Expanded(
-                    child: Text(
-                      'Skybox',
-                      style: TextStyle(color: Colors.white, fontSize: 12),
+            if (_expanded) ...[
+              const SizedBox(height: 4),
+              if (widget.manageSkybox) ...[
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Text(
+                        'Skybox',
+                        style: TextStyle(color: Colors.white, fontSize: 12),
+                      ),
                     ),
-                  ),
-                  Switch(
-                    value: _showSkybox,
-                    onChanged: (value) => setState(() {
-                      _showSkybox = value;
-                      _applySkybox();
-                    }),
-                  ),
-                ],
+                    Switch(
+                      value: _showSkybox,
+                      onChanged: (value) => setState(() {
+                        _showSkybox = value;
+                        _applySkybox();
+                      }),
+                    ),
+                  ],
+                ),
+                LabeledSlider(
+                  label: 'Sky blur',
+                  value: _skySource.blurriness,
+                  min: 0.0,
+                  max: 1.0,
+                  onChanged: _showSkybox
+                      ? (value) => setState(() => _skySource.blurriness = value)
+                      : null,
+                ),
+              ],
+              LabeledSlider(
+                label: 'Exposure',
+                value: _exposure,
+                min: 0.1,
+                max: 8.0,
+                onChanged: (value) => setState(() {
+                  _exposure = value;
+                  widget.scene.exposure = value;
+                }),
               ),
               LabeledSlider(
-                label: 'Sky blur',
-                value: _skySource.blurriness,
+                label: 'IBL intensity',
+                value: _environmentIntensity,
                 min: 0.0,
-                max: 1.0,
-                onChanged: _showSkybox
-                    ? (value) => setState(() => _skySource.blurriness = value)
-                    : null,
+                max: 4.0,
+                onChanged: (value) => setState(() {
+                  _environmentIntensity = value;
+                  widget.scene.environmentIntensity = value;
+                }),
+              ),
+              LabeledSlider(
+                label: 'Env rotation X',
+                value: _envRotationX,
+                min: -180.0,
+                max: 180.0,
+                onChanged: (value) => setState(() {
+                  _envRotationX = value;
+                  _applyEnvironmentRotation();
+                }),
+              ),
+              LabeledSlider(
+                label: 'Env rotation Y',
+                value: _envRotationY,
+                min: -180.0,
+                max: 180.0,
+                onChanged: (value) => setState(() {
+                  _envRotationY = value;
+                  _applyEnvironmentRotation();
+                }),
+              ),
+              LabeledSlider(
+                label: 'Env rotation Z',
+                value: _envRotationZ,
+                min: -180.0,
+                max: 180.0,
+                onChanged: (value) => setState(() {
+                  _envRotationZ = value;
+                  _applyEnvironmentRotation();
+                }),
               ),
             ],
-            LabeledSlider(
-              label: 'Exposure',
-              value: _exposure,
-              min: 0.1,
-              max: 8.0,
-              onChanged: (value) => setState(() {
-                _exposure = value;
-                widget.scene.exposure = value;
-              }),
-            ),
-            LabeledSlider(
-              label: 'IBL intensity',
-              value: _environmentIntensity,
-              min: 0.0,
-              max: 4.0,
-              onChanged: (value) => setState(() {
-                _environmentIntensity = value;
-                widget.scene.environmentIntensity = value;
-              }),
-            ),
-            LabeledSlider(
-              label: 'Env rotation X',
-              value: _envRotationX,
-              min: -180.0,
-              max: 180.0,
-              onChanged: (value) => setState(() {
-                _envRotationX = value;
-                _applyEnvironmentRotation();
-              }),
-            ),
-            LabeledSlider(
-              label: 'Env rotation Y',
-              value: _envRotationY,
-              min: -180.0,
-              max: 180.0,
-              onChanged: (value) => setState(() {
-                _envRotationY = value;
-                _applyEnvironmentRotation();
-              }),
-            ),
-            LabeledSlider(
-              label: 'Env rotation Z',
-              value: _envRotationZ,
-              min: -180.0,
-              max: 180.0,
-              onChanged: (value) => setState(() {
-                _envRotationZ = value;
-                _applyEnvironmentRotation();
-              }),
-            ),
           ],
         ),
       ),

--- a/examples/flutter_app/lib/lighting_panel.dart
+++ b/examples/flutter_app/lib/lighting_panel.dart
@@ -21,6 +21,8 @@ class LightingPanel extends StatefulWidget {
     required this.scene,
     required this.selector,
     this.showSkybox = true,
+    this.manageSkybox = true,
+    this.onEnvironmentResolved,
     this.initialEnvironmentId,
     this.initialSkyBlur = 0.0,
     this.initialExposure = 1.0,
@@ -33,6 +35,16 @@ class LightingPanel extends StatefulWidget {
 
   /// Whether the skybox starts enabled.
   final bool showSkybox;
+
+  /// Whether the panel owns the scene's skybox (the toggle plus sky blur).
+  /// Pass false when the example manages its own skybox; the panel then
+  /// never touches `scene.skybox` and hides those controls.
+  final bool manageSkybox;
+
+  /// Called with the resolved [EnvironmentMap] after each successful
+  /// selection (null means the renderer's built-in studio default), including
+  /// the [initialEnvironmentId] load.
+  final void Function(EnvironmentMap? map)? onEnvironmentResolved;
 
   /// The [ExampleEnvironment.id] to select at startup, or null to keep the
   /// selector's current environment. Loads (from the cache when possible)
@@ -69,7 +81,7 @@ class _LightingPanelState extends State<LightingPanel> {
     widget.scene.exposure = _exposure;
     widget.scene.environmentIntensity = _environmentIntensity;
     _applyEnvironmentRotation();
-    _applySkybox();
+    if (widget.manageSkybox) _applySkybox();
     widget.selector.addListener(_onSelectorChanged);
     final environmentId = widget.initialEnvironmentId;
     if (environmentId != null && widget.selector.active.id != environmentId) {
@@ -110,7 +122,8 @@ class _LightingPanelState extends State<LightingPanel> {
 
   Future<void> _selectEnvironment(ExampleEnvironment environment) async {
     try {
-      await widget.selector.select(environment, widget.scene);
+      final map = await widget.selector.select(environment, widget.scene);
+      widget.onEnvironmentResolved?.call(map);
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.maybeOf(context)?.showSnackBar(
@@ -140,32 +153,34 @@ class _LightingPanelState extends State<LightingPanel> {
               onSelected: _selectEnvironment,
             ),
             const SizedBox(height: 4),
-            Row(
-              children: [
-                const Expanded(
-                  child: Text(
-                    'Skybox',
-                    style: TextStyle(color: Colors.white, fontSize: 12),
+            if (widget.manageSkybox) ...[
+              Row(
+                children: [
+                  const Expanded(
+                    child: Text(
+                      'Skybox',
+                      style: TextStyle(color: Colors.white, fontSize: 12),
+                    ),
                   ),
-                ),
-                Switch(
-                  value: _showSkybox,
-                  onChanged: (value) => setState(() {
-                    _showSkybox = value;
-                    _applySkybox();
-                  }),
-                ),
-              ],
-            ),
-            LabeledSlider(
-              label: 'Sky blur',
-              value: _skySource.blurriness,
-              min: 0.0,
-              max: 1.0,
-              onChanged: _showSkybox
-                  ? (value) => setState(() => _skySource.blurriness = value)
-                  : null,
-            ),
+                  Switch(
+                    value: _showSkybox,
+                    onChanged: (value) => setState(() {
+                      _showSkybox = value;
+                      _applySkybox();
+                    }),
+                  ),
+                ],
+              ),
+              LabeledSlider(
+                label: 'Sky blur',
+                value: _skySource.blurriness,
+                min: 0.0,
+                max: 1.0,
+                onChanged: _showSkybox
+                    ? (value) => setState(() => _skySource.blurriness = value)
+                    : null,
+              ),
+            ],
             LabeledSlider(
               label: 'Exposure',
               value: _exposure,

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -67,6 +67,22 @@ final Map<String, ExampleSettings Function()> settingsDefaults = {
     ..chromaticAberration.enabled = true
     ..chromaticAberration.intensity = 0.14
     ..vignette.enabled = true,
+  // The Menger sky's look: no key light (the sky's emitters and the baked
+  // environment carry it), a bright cool saturated grade, bloom for the neon
+  // bracing, and a lens treatment.
+  'Custom Skybox': () => ExampleSettings()
+    ..directionalLightEnabled = false
+    ..colorGrading.enabled = true
+    ..colorGrading.brightness = 1.15
+    ..colorGrading.contrast = 1.07
+    ..colorGrading.saturation = 1.19
+    ..colorGrading.temperature = -0.37
+    ..colorGrading.tint = -0.05
+    ..bloom.enabled = true
+    ..bloom.threshold = 1.35
+    ..chromaticAberration.enabled = true
+    ..chromaticAberration.intensity = 0.32
+    ..vignette.enabled = true,
 };
 
 class MyApp extends StatefulWidget {

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 0.19.0
 
+* `.fmat` skies declaring `requires: [environment]` now sample through a
+  generated `SampleEnvironment(direction, roughness)` helper that binds every
+  radiance layout correctly (the roughness-mip cube layout previously sampled
+  black), and `ShaderSkySource.sampledEnvironment` pins the environment such a
+  sky samples, so a sky that drives scene lighting through `SkyEnvironment`
+  can reflect a fixed map instead of its own bake.
+
 * The lit shader reads both cross-fade environments' diffuse SH through a
   single `sh_coefficients` sampler (a 9x2 composite row per environment during
   a cross-fade), dropping the fragment sampler count from 16 to 15. Skinned

--- a/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
@@ -352,7 +352,7 @@ String _emitSkyGlsl(FmatMaterial material) {
     sb.writeln('$kMaterialParamsInstance;');
     sb.writeln();
   }
-  if (uniforms.isNotEmpty || samplers.isNotEmpty) {
+  if (uniforms.isNotEmpty || samplers.isNotEmpty || material.useEnvironment) {
     // Same keep-alive as the surface fragment shader; see
     // _fragmentKeepAliveTerm.
     sb.writeln('uniform $kFragmentKeepAliveBlock { vec4 keep_alive; }');
@@ -367,13 +367,19 @@ String _emitSkyGlsl(FmatMaterial material) {
 
   if (material.useEnvironment) {
     sb.writeln(
-      '// The scene environment\'s prefiltered-radiance atlas, bound by the',
+      '// The environment\'s prefiltered radiance, bound by the engine in',
     );
     sb.writeln(
-      '// engine. Sample with SamplePrefilteredRadiance(prefiltered_radiance,',
+      '// whichever layout it uses (2D equirect or cube). Sample through',
     );
-    sb.writeln('// direction, roughness).');
+    sb.writeln('// SampleEnvironment(direction, roughness).');
     sb.writeln('uniform sampler2D prefiltered_radiance;');
+    sb.writeln('uniform samplerCube prefiltered_radiance_cube;');
+    sb.writeln();
+    sb.writeln('vec3 SampleEnvironment(vec3 direction, float roughness) {');
+    sb.writeln('  return SampleRadianceEnv(prefiltered_radiance,');
+    sb.writeln('      prefiltered_radiance_cube, direction, roughness);');
+    sb.writeln('}');
     sb.writeln();
   }
 
@@ -390,7 +396,15 @@ String _emitSkyGlsl(FmatMaterial material) {
   sb.writeln('void main() {');
   sb.writeln('  // Linear HDR radiance, premultiplied alpha (opaque sky).');
   sb.writeln('  frag_color = vec4(Sky(normalize(v_ray)), 1.0);');
-  final keepAlive = _fragmentKeepAliveTerm(material, uniforms, samplers);
+  var keepAlive = _fragmentKeepAliveTerm(material, uniforms, samplers);
+  // A sky that requires the environment but never calls SampleEnvironment
+  // would let the compiler strip the radiance samplers and layout block the
+  // engine binds unconditionally; a zero-multiplied sample keeps them live.
+  if (material.useEnvironment &&
+      !RegExp(r'\bSampleEnvironment\b').hasMatch(material.fragmentSource)) {
+    const envTerm = 'SampleEnvironment(vec3(0.0, 1.0, 0.0), 1.0).x';
+    keepAlive = keepAlive == null ? envTerm : '($keepAlive + $envTerm)';
+  }
   if (keepAlive != null) {
     sb.writeln(
       '  frag_color.r += '

--- a/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/hot_reload/hot_reloadable_fmat.dart';
+import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/environment.dart';
 import 'package:flutter_scene/src/material/material_parameters.dart';
 import 'package:flutter_scene/src/skybox.dart';
@@ -63,25 +64,22 @@ class PreprocessedSky extends ShaderSkySource implements HotReloadableFmat {
     parameters.bind(pass, fragmentShader, transientsBuffer);
     // Zero keep-alive, mirroring PreprocessedMaterial; the generated sky
     // references every declared parameter resource through it so none can be
-    // optimized out.
-    if (parameters.hasAnyParameters) {
+    // optimized out. Environment skies always declare the block (it keeps
+    // the radiance samplers live even when the author never samples them).
+    if (parameters.hasAnyParameters || useEnvironment) {
       pass.bindUniform(
         fragmentShader.getUniformSlot('FragmentKeepAlive'),
         transientsBuffer.emplace(_zeroKeepAlive),
       );
     }
-    // A `requires: [environment]` sky samples the scene's prefiltered
-    // radiance, bound the same way the standard material binds it.
+    // A `requires: [environment]` sky samples the prefiltered radiance
+    // through SampleEnvironment, bound the same way the standard material
+    // binds it (both layout samplers plus the layout selector block).
     if (useEnvironment) {
-      pass.bindTexture(
-        fragmentShader.getUniformSlot('prefiltered_radiance'),
-        environment.prefilteredRadianceTexture,
-        sampler: gpu.SamplerOptions(
-          minFilter: gpu.MinMagFilter.linear,
-          magFilter: gpu.MinMagFilter.linear,
-          widthAddressMode: gpu.SamplerAddressMode.repeat,
-          heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
-        ),
+      EngineLightingUniforms.bindPrefilteredRadiance(
+        pass,
+        fragmentShader,
+        sampledEnvironment ?? environment,
       );
     }
   }

--- a/packages/flutter_scene/lib/src/render/sky_bake.dart
+++ b/packages/flutter_scene/lib/src/render/sky_bake.dart
@@ -241,8 +241,9 @@ void _projectSh(gpu.Texture equirect, gpu.Texture sh) {
 /// see [prefilterEquirectRadiance]) and the 9-texel diffuse SH coefficient
 /// texture, all in one call. [noEnvironment] is passed to the sky fragment's
 /// bind for any `useEnvironment` samplers (a sky baked into the environment
-/// cannot sample the environment it is producing). For a bake spread across
-/// frames, use [SkyBakeJob].
+/// cannot sample the environment it is producing; a source with a fixed
+/// `sampledEnvironment` override still samples that override). For a bake
+/// spread across frames, use [SkyBakeJob].
 ({gpu.Texture atlas, gpu.Texture sh}) bakeSkyEnvironment(
   ShaderSkySource source,
   EnvironmentMap noEnvironment, {

--- a/packages/flutter_scene/lib/src/skybox.dart
+++ b/packages/flutter_scene/lib/src/skybox.dart
@@ -107,6 +107,18 @@ class ShaderSkySource extends SkySource {
   /// (`prefiltered_radiance`, `brdf_lut`) when the shader declares them.
   bool useEnvironment;
 
+  /// The environment a [useEnvironment] shader samples, overriding the
+  /// scene's.
+  ///
+  /// Null (the default) samples the scene's active environment. Set a fixed
+  /// map when this same sky drives the scene's lighting through a
+  /// `SkyEnvironment`: the scene's environment then holds the sky's own
+  /// bake, and without an override the bake pass substitutes an empty
+  /// environment (a sky cannot sample the environment it is producing). A
+  /// fixed override is safe there, so both the background draw and the bake
+  /// sample it.
+  EnvironmentMap? sampledEnvironment;
+
   final Map<String, ByteData> _uniformBlocks = {};
   final Map<String, _SkyTexture> _textures = {};
 
@@ -176,7 +188,7 @@ class ShaderSkySource extends SkySource {
       EngineLightingUniforms.bindPrefilteredRadiance(
         pass,
         fragmentShader,
-        environment,
+        sampledEnvironment ?? environment,
       );
       pass.bindTexture(
         fragmentShader.getUniformSlot('brdf_lut'),

--- a/packages/flutter_scene/test/fmat_test.dart
+++ b/packages/flutter_scene/test/fmat_test.dart
@@ -550,17 +550,29 @@ sky { vec3 Sky(vec3 d) { return vec3(0.0); } }
 material { name: "EnvSky", requires: [environment] }
 sky {
   vec3 Sky(vec3 direction) {
-    return SamplePrefilteredRadiance(prefiltered_radiance, direction, 0.5);
+    return SampleEnvironment(direction, 0.5);
   }
 }
 ''';
 
-    test('requires: [environment] declares and records the atlas', () {
+    test('requires: [environment] declares and records the samplers', () {
       final m = parseFmat(envSky);
       expect(m.useEnvironment, isTrue);
       final glsl = emitFragmentGlsl(m);
       expect(glsl, contains('uniform sampler2D prefiltered_radiance;'));
+      expect(glsl, contains('uniform samplerCube prefiltered_radiance_cube;'));
+      expect(glsl, contains('vec3 SampleEnvironment('));
       expect(buildSidecar(m)['use_environment'], isTrue);
+    });
+
+    test('an unsampled environment stays live through the keep-alive', () {
+      final m = parseFmat('''
+material { name: "EnvSky", requires: [environment] }
+sky { vec3 Sky(vec3 direction) { return vec3(0.0); } }
+''');
+      final glsl = emitFragmentGlsl(m);
+      expect(glsl, contains('uniform FragmentKeepAlive'));
+      expect(glsl, contains('SampleEnvironment(vec3(0.0, 1.0, 0.0), 1.0).x'));
     });
 
     test('skies without requires do not declare the atlas', () {


### PR DESCRIPTION
The custom skybox example gets a second, much heavier `.fmat` sky, a raymarched Menger sponge interior adapted from Shane's "Menger Sponge Variation" (used and modified under its CC BY-NC-SA 3.0 license, with attribution and the list of changes in the shader header). The viewer drifts and rotates through the lattice at slider-controlled speeds, and the point light, neon bracing glow, fog, hole size, reflections, and color grade are all typed parameters, so the sky's emitted light can be reshaped live to show the sky-driven environment re-baking.

Engine side, sky `.fmat`s declaring `requires: [environment]` now compile a generated `SampleEnvironment(direction, roughness)` helper, and `PreprocessedSky` binds both radiance layouts plus the layout selector block (the roughness-mip cube layout previously sampled black), with a keep-alive term protecting the samplers when the author never calls the helper. A new `ShaderSkySource.sampledEnvironment` pins the environment such a sky samples, so a sky that drives scene lighting through `SkyEnvironment` reflects a fixed map instead of its own bake. The sponge uses this to reflect an environment downloaded through the shared lighting panel (Field by default), and that map feeds both the visible sky and the lighting bake.

The lit content is a 5x5 grid of randomly tumbling primitives, metallic ascending along one axis and roughness along the other, so the baked environment's specular and diffuse response is visible in one view. The example also gains sliders for shape spin and camera distance, an optional quake fly camera matching the DICOM Volume example, per-example post-processing defaults (no key light, a cool grade, bloom for the neon bracing, chromatic aberration, vignette), and collapsible control panels. The shared lighting panel gains a collapse chevron plus a mode that leaves the scene's skybox alone for examples that manage their own.
