### PR TITLE
remove inheriting impellers mediump sampler for shaders

### DIFF
--- a/packages/flutter_scene/shaders/pbr.glsl
+++ b/packages/flutter_scene/shaders/pbr.glsl
@@ -1,4 +1,3 @@
-#include <impeller/constants.glsl>
 
 const float kPi = 3.14159265358979323846;
 


### PR DESCRIPTION
fixes #234 

as far as i can see the #include <impeller/constants.glsl> is not really used, but makes shaders inherit its precision mediump sampler2D. Which compiles with relaxed precision and some GPUs then read the shadow depth at fp16. Like on a Pixel 8 Mali Gpu. On Vulkan

But I'm not sure if it serves any other purpose.

before after removal:

<img width="2048" height="921" alt="grafik" src="https://github.com/user-attachments/assets/8266dfac-cf6e-449a-a65d-a3485fabaed4" />

<img width="2048" height="863" alt="grafik" src="https://github.com/user-attachments/assets/b1099c06-45c2-403d-9c17-5938a940085c" />

