### PR TITLE
Skip redundant engine-lighting binds across same-pipeline draws

### DIFF
--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -143,6 +143,11 @@ class EngineLightingUniforms {
     TransientWriter transientsBuffer,
     Lighting lighting,
   ) {
+    // Frame-constant per (pass, shader, lighting); see the bind memo above.
+    if (_memoPassIs(pass) && identical(_fogMemo[shader], lighting)) {
+      return;
+    }
+    _fogMemo[shader] = lighting;
     final fog = lighting.fog;
     final buffer = Float32List(24);
     if (fog != null && fog.enabled && fog.mode != FogMode.none) {
@@ -286,6 +291,33 @@ class EngineLightingUniforms {
     );
   }
 
+  // Pass-scoped memo for the engine-constant bind set. Bindings persist
+  // across draws within a pass, and the lighting samplers plus the fog block
+  // are identical for a given (pass, shader, lighting, environment), so
+  // re-issuing them per item only burns main-thread time (each bind marshals
+  // its slot name across the FFI). The scene encoder invalidates the memo
+  // whenever it clears the pass's bindings (on pipeline changes), keeping the
+  // skip exactly as safe as re-binding.
+  static gpu.RenderPass? _memoPass;
+  static final Map<gpu.Shader, (Lighting, EnvironmentMap)> _texturesMemo = {};
+  static final Map<gpu.Shader, Lighting> _fogMemo = {};
+
+  /// Forgets all memoized bindings; the encoder calls this whenever it clears
+  /// the render pass's bindings.
+  static void invalidateBindMemo() {
+    _memoPass = null;
+    _texturesMemo.clear();
+    _fogMemo.clear();
+  }
+
+  static bool _memoPassIs(gpu.RenderPass pass) {
+    if (identical(pass, _memoPass)) return true;
+    _memoPass = pass;
+    _texturesMemo.clear();
+    _fogMemo.clear();
+    return false;
+  }
+
   /// Binds the engine image-based-lighting and shadow samplers
   /// (`prefiltered_radiance`, `brdf_lut`, `shadow_map`) on [shader].
   static void bindEngineTextures(
@@ -294,6 +326,15 @@ class EngineLightingUniforms {
     Lighting lighting,
     EnvironmentMap env,
   ) {
+    if (_memoPassIs(pass)) {
+      final previous = _texturesMemo[shader];
+      if (previous != null &&
+          identical(previous.$1, lighting) &&
+          identical(previous.$2, env)) {
+        return;
+      }
+    }
+    _texturesMemo[shader] = (lighting, env);
     bindPrefilteredRadiance(pass, shader, env);
     pass.bindTexture(
       shader.getUniformSlot('brdf_lut'),

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -8,6 +8,7 @@ import 'package:flutter_scene/src/geometry/geometry.dart';
 import 'package:flutter_scene/src/geometry/vertex_layout.dart';
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/render/instance_packing.dart';
 import 'package:flutter_scene/src/render/lod.dart';
 import 'package:flutter_scene/src/render/render_scene.dart';
@@ -352,7 +353,19 @@ base class SceneEncoder {
     bool windingFlipped,
     double fade,
   ) {
-    _renderPass.clearBindings();
+    // Bindings persist across draws within a pass, and every draw binds its
+    // full slot set, so clearing is only needed when the pipeline (and with
+    // it the shaders' slot layouts) changes; a stale entry from a different
+    // layout could otherwise leak into the next command. Opaque draws are
+    // pipeline-sorted, so same-pipeline runs skip the clear, which lets the
+    // per-draw engine-lighting rebind be skipped too (see
+    // EngineLightingUniforms); each bind marshals its slot name across the
+    // FFI, and re-issuing the full set per item dominated main-thread frame
+    // time in draw-heavy scenes.
+    if (!identical(_boundPipeline, pipeline)) {
+      _renderPass.clearBindings();
+      EngineLightingUniforms.invalidateBindMemo();
+    }
     _bindPipeline(pipeline);
     // The material reads its cross-fade coverage from this transient field as
     // it binds; reset for every draw so a shared material does not leak a


### PR DESCRIPTION
Render-pass bindings persist across draws, and every draw binds its full slot set, so the scene encoder now clears bindings only when the pipeline (and with it the shaders' slot layouts) changes instead of before every draw. Opaque draws are already pipeline-sorted, so same-pipeline runs keep their bindings.

That lets the engine-constant lighting set (ten IBL, shadow, SH, punctual, and occlusion samplers plus the radiance-layout and fog uniform blocks) bind once per pipeline run instead of once per item. A pass-scoped memo in EngineLightingUniforms keyed on the pass, shader, lighting, and environment skips identical re-binds, and the encoder invalidates it whenever it clears bindings, so the skip is exactly as safe as re-binding was.

Each bind marshals its slot name across the FFI, and re-issuing the full set per item dominated main-thread frame time in draw-heavy scenes. In a 100-tile streaming scene on Metal, frame build time drops from 13.0 ms to 5.7 ms average (p95 15.3 ms to 6.3 ms) with identical output. The web shim already keeps uniform and texture records across draws, so behavior is unchanged there.

The remaining per-draw cost is the name-string marshal inside each bind call itself, which needs a bind-by-handle API upstream in flutter_gpu (left as a TODO in the encoder).