### PR TITLE
Release flutter_scene_rapier 0.2.2

### DIFF
--- a/packages/flutter_scene_rapier/CHANGELOG.md
+++ b/packages/flutter_scene_rapier/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+* Requires flutter_scene 0.19.0.
+* No native changes; this release reuses the 0.1.0 prebuilt binaries and wasm.
+
 ## 0.2.1
 
 * Requires flutter_scene 0.18.0.

--- a/packages/flutter_scene_rapier/pubspec.yaml
+++ b/packages/flutter_scene_rapier/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_scene_rapier
 description: Rapier 3D physics backend for flutter_scene. Implements the abstract physics contract from flutter_scene against Rapier via FFI.
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
-version: 0.2.1
+version: 0.2.2
 
 topics:
   - physics


### PR DESCRIPTION
Bumps `flutter_scene_rapier` to 0.2.2 to require `flutter_scene: ^0.19.0` (the constraint widen itself landed with the 0.19.0 release prep in #243). The published 0.2.1 pins `^0.18.0`, which excludes the just-published flutter_scene 0.19.0, so rapier users can't upgrade until this ships.

No native changes: `native/src` is unchanged since 0.1.0, so this reuses the 0.1.0 prebuilt binaries and wasm (`native_binaries.json` and `wasm_release.dart` keep pointing at the `flutter_scene_rapier-0.1.0` release, same as 0.2.0 and 0.2.1 did). Pure-Dart release, no cross-build needed.

Dry-run clean apart from the expected uncommitted-files warning before this commit (archive includes `native/` + `native_binaries.json`, `hook/` has only `build.dart`), and the package analyzes clean against flutter_scene 0.19.0.
