### PR TITLE
Preserve glTF material names on import

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.20.0
+
+* Imported materials keep their source names. `Material` gained a `name`
+  field (empty when unnamed), and both import paths set it from the glTF
+  material name, so materials can be looked up after loading. `.fscene`
+  documents store it as an optional `name` on material resources.
+
 ## 0.19.0
 
 * Steady-state frame allocations cut sharply. Every fullscreen pass (bloom,

--- a/packages/flutter_scene/lib/src/fscene/compose/compose.dart
+++ b/packages/flutter_scene/lib/src/fscene/compose/compose.dart
@@ -526,6 +526,7 @@ ResourceSpec _remapResource(ResourceSpec r, LocalId Function(LocalId) remap) =>
       MaterialResource() => MaterialResource(
         remap(r.id),
         type: r.type,
+        name: r.name,
         properties: _remapProperties(r.properties, remap),
         asset: r.asset,
       ),

--- a/packages/flutter_scene/lib/src/fscene/json/fscene_json.dart
+++ b/packages/flutter_scene/lib/src/fscene/json/fscene_json.dart
@@ -371,10 +371,16 @@ Object _encodeResource(ResourceSpec r, String Function(LocalId) idKey) {
         if (filter != 'linear') 'filter': filter,
         if (wrap != 'clampToEdge') 'wrap': wrap,
       };
-    case MaterialResource(:final type, :final properties, :final asset):
+    case MaterialResource(
+      :final type,
+      :final name,
+      :final properties,
+      :final asset,
+    ):
       return {
         'kind': 'material',
         'type': type,
+        if (name.isNotEmpty) 'name': name,
         if (asset != null) 'ref': asset.key,
         if (properties.isNotEmpty)
           'properties': {
@@ -734,6 +740,7 @@ ResourceSpec _decodeResource(LocalId id, Map<String, dynamic> json) {
       return MaterialResource(
         id,
         type: json['type'] as String,
+        name: json['name'] as String? ?? '',
         asset: json['ref'] != null ? AssetRef(json['ref'] as String) : null,
         properties: _decodeProperties(json['properties']),
       );

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_copy.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_copy.dart
@@ -72,7 +72,12 @@ LocalId copyResourceInto(
           wrap: wrap,
         ),
       );
-    case MaterialResource(:final type, :final properties, :final asset):
+    case MaterialResource(
+      :final type,
+      :final name,
+      :final properties,
+      :final asset,
+    ):
       for (final value in properties.values) {
         if (value is! ResourceRefValue) continue;
         final referenced = source.resource(value.id);
@@ -85,6 +90,7 @@ LocalId copyResourceInto(
         MaterialResource(
           resourceId,
           type: type,
+          name: name,
           properties: Map<String, PropertyValue>.of(properties),
           asset: asset,
         ),

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -229,7 +229,7 @@ class ResourceRealizer {
     if (asset == null) {
       debugPrint('fscene: fmat material ${res.id} has no asset; using unlit');
       _materials[res.id] = tagResourceOrigin(
-        _unlit(res.properties),
+        _unlit(res.properties)..name = res.name,
         document,
         res.id,
       );
@@ -237,6 +237,7 @@ class ResourceRealizer {
     }
     try {
       final material = await loadFmatMaterial(asset.key, bundle: bundle);
+      material.name = res.name;
       // Apply the document's parameter overrides (scalars, vectors, colors,
       // and texture-resource references) over the sidecar defaults.
       applyFmatParameterOverrides(
@@ -248,7 +249,7 @@ class ResourceRealizer {
     } catch (e) {
       debugPrint('fscene: failed to load fmat ${res.id} ("${asset.key}"): $e');
       _materials[res.id] = tagResourceOrigin(
-        _unlit(res.properties),
+        _unlit(res.properties)..name = res.name,
         document,
         res.id,
       );
@@ -403,6 +404,10 @@ class ResourceRealizer {
     if (res is! MaterialResource) {
       throw FsceneFormatException('Resource $id is not a material');
     }
+    return _materialForType(res)..name = res.name;
+  }
+
+  Material _materialForType(MaterialResource res) {
     switch (res.type) {
       case 'unlit':
         return _unlit(res.properties);

--- a/packages/flutter_scene/lib/src/fscene/specs.dart
+++ b/packages/flutter_scene/lib/src/fscene/specs.dart
@@ -391,12 +391,16 @@ class MaterialResource extends ResourceSpec {
   MaterialResource(
     super.id, {
     required this.type,
+    this.name = '',
     Map<String, PropertyValue>? properties,
     this.asset,
   }) : properties = properties ?? {};
 
   /// The material kind (`physicallyBased`, `unlit`, `fmat`, ...).
   final String type;
+
+  /// The material's name, empty when the source asset left it unnamed.
+  final String name;
 
   /// Typed material parameters (factors, texture refs, alpha mode, ...).
   final Map<String, PropertyValue> properties;

--- a/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
+++ b/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
@@ -545,6 +545,7 @@ LocalId _buildMaterial(
           MaterialResource(
             document.newId(),
             type: 'unlit',
+            name: material.name ?? '',
             properties: properties,
           ),
         )
@@ -590,6 +591,7 @@ LocalId _buildMaterial(
         MaterialResource(
           document.newId(),
           type: 'physicallyBased',
+          name: material.name ?? '',
           properties: properties,
         ),
       )

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -159,6 +159,12 @@ abstract class Material {
     return Future<void>.value();
   }
 
+  /// The name of this material, used for identification.
+  ///
+  /// The importers set it from the source asset's material name; empty when
+  /// the source material is unnamed or the material was created directly.
+  String name = '';
+
   /// Whether to render both faces of triangles drawn with this material
   /// (glTF's `material.doubleSided`). When true, [bind] disables back-face
   /// culling so the geometry is visible from both sides; otherwise back faces

--- a/packages/flutter_scene/lib/src/runtime_importer/material_builder.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/material_builder.dart
@@ -15,6 +15,7 @@ Material buildMaterial(GltfMaterial? gm, List<Texture2D> textures) {
   }
   if (gm.unlit) {
     final m = UnlitMaterial();
+    m.name = gm.name ?? '';
     final pbr = gm.pbrMetallicRoughness;
     if (pbr != null) {
       m.baseColorFactor = _vec4(pbr.baseColorFactor);
@@ -25,6 +26,7 @@ Material buildMaterial(GltfMaterial? gm, List<Texture2D> textures) {
     return m;
   }
   final m = PhysicallyBasedMaterial();
+  m.name = gm.name ?? '';
   final pbr = gm.pbrMetallicRoughness;
   if (pbr != null) {
     m.baseColorFactor = _vec4(pbr.baseColorFactor);

--- a/packages/flutter_scene/test/material_name_test.dart
+++ b/packages/flutter_scene/test/material_name_test.dart
@@ -1,0 +1,84 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/importer/gltf.dart';
+import 'package:flutter_scene/src/importer/src/fscene_emitter/fscene_emitter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Coverage for material-name preservation (#248): glTF material.name is
+// parsed, Material carries a name, the offline importer stores it on the
+// MaterialResource, and the .fscene codec round-trips it.
+//
+// The middle of the chain (buildMaterial and the realizer setting the name on
+// a real PhysicallyBasedMaterial / UnlitMaterial) constructs engine materials,
+// which need a Flutter GPU context the headless test harness doesn't provide,
+// the same boundary noted in material_double_sided_test.dart.
+
+void main() {
+  group('Material.name field', () {
+    test('defaults to empty', () {
+      expect(ShaderMaterial().name, isEmpty);
+    });
+
+    test('is settable', () {
+      expect((ShaderMaterial()..name = 'Steel').name, 'Steel');
+    });
+  });
+
+  group('glTF parser reads material.name', () {
+    test('present', () {
+      final doc = parseGltfJson(<String, Object?>{
+        'materials': [
+          <String, Object?>{'name': 'Steel'},
+        ],
+      });
+      expect(doc.materials.single.name, 'Steel');
+    });
+
+    test('null when omitted', () {
+      final doc = parseGltfJson(<String, Object?>{
+        'materials': [<String, Object?>{}],
+      });
+      expect(doc.materials.single.name, isNull);
+    });
+  });
+
+  group('offline importer keeps material names', () {
+    test('emitter stores the glTF name on the MaterialResource', () {
+      final doc = parseGltfJson(<String, Object?>{
+        'materials': [
+          <String, Object?>{'name': 'Steel'},
+          <String, Object?>{
+            'name': 'Glow',
+            'extensions': <String, Object?>{
+              'KHR_materials_unlit': <String, Object?>{},
+            },
+          },
+          <String, Object?>{},
+        ],
+      });
+      final document = buildSceneDocument(doc, Uint8List(0));
+      final names = [
+        for (final r in document.resources.values)
+          if (r is MaterialResource) r.name,
+      ];
+      expect(names, ['Steel', 'Glow', '']);
+    });
+
+    test('.fscene codec round-trips the name', () {
+      final doc = SceneDocument();
+      final named = doc.addResource(
+        MaterialResource(doc.newId(), type: 'physicallyBased', name: 'Steel'),
+      );
+      final unnamed = doc.addResource(
+        MaterialResource(doc.newId(), type: 'unlit'),
+      );
+      final back = readFscene(writeFscene(doc));
+      expect((back.resource(named.id) as MaterialResource).name, 'Steel');
+      expect((back.resource(unnamed.id) as MaterialResource).name, isEmpty);
+    });
+  });
+}

--- a/packages/flutter_scene_editor_core/lib/src/builtin_commands.dart
+++ b/packages/flutter_scene_editor_core/lib/src/builtin_commands.dart
@@ -989,6 +989,7 @@ final setMaterialProperties = CommandEntry(
     final merged = MaterialResource(
       existing.id,
       type: existing.type,
+      name: existing.name,
       properties: {
         ...existing.properties,
         ...optionalPropertyMap(params, 'properties'),

--- a/packages/flutter_scene_editor_core/lib/src/graft.dart
+++ b/packages/flutter_scene_editor_core/lib/src/graft.dart
@@ -175,6 +175,7 @@ ResourceSpec _copyResource(ResourceSpec r, _Remap remap) => switch (r) {
   MaterialResource m => MaterialResource(
     remap(m.id),
     type: m.type,
+    name: m.name,
     properties: {
       for (final e in m.properties.entries) e.key: _copyValue(e.value, remap),
     },


### PR DESCRIPTION
Resolves #248.

Both import paths parsed the glTF material name and then dropped it, so finding a specific material after loading meant matching on node structure. `Material` now carries a `name` field, the runtime GLB importer and the offline `.fscene` importer copy it from the source material, and `.fscene` documents store it as an optional `name` on material resources (round-tripped by the codec and preserved by copy, compose, and the editor commands that rebuild material resources).
