### PR TITLE
Keep authored TRS so mirrored bones survive animation blending

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 0.20.0
 
+* Animation blending no longer flattens rigs with mirrored bones. Recovering
+  the bind pose from the composed matrix put a mirrored axis's negative
+  scale on X, so weighted blends faded the bone through zero scale and the
+  attached geometry collapsed until the blend finished. Nodes built from
+  TRS transforms (both importers, `.fscene` documents, and scene hot
+  reload) now keep the authored decomposition and blending anchors to it.
+
 * Imported materials keep their source names. `Material` gained a `name`
   field (empty when unnamed), and both import paths set it from the glTF
   material name, so materials can be looked up after loading. `.fscene`

--- a/packages/flutter_scene/lib/src/animation/animation_player.dart
+++ b/packages/flutter_scene/lib/src/animation/animation_player.dart
@@ -29,7 +29,7 @@ class AnimationPlayer {
     // will mutate.
     for (final binding in clip._bindings) {
       _targetTransforms[binding.node] = AnimationTransforms(
-        bindPose: DecomposedTransform.fromMatrix(binding.node.localTransform),
+        bindPose: _bindPoseOf(binding.node),
       );
     }
 
@@ -58,10 +58,18 @@ class AnimationPlayer {
       clip.rebind(newRoot, animation: byName[clip._animation.name]);
       for (final binding in clip._bindings) {
         _targetTransforms[binding.node] = AnimationTransforms(
-          bindPose: DecomposedTransform.fromMatrix(binding.node.localTransform),
+          bindPose: _bindPoseOf(binding.node),
         );
       }
     }
+  }
+
+  /// Prefers the node's authored decomposition over decomposing the
+  /// matrix, which would move a mirrored axis's negative scale onto X and
+  /// make blends on mirrored bones fade through zero scale.
+  static DecomposedTransform _bindPoseOf(Node node) {
+    return node.localTransformTrs?.clone() ??
+        DecomposedTransform.fromMatrix(node.localTransform);
   }
 
   /// Advances all registered clips by [deltaSeconds] and applies their
@@ -90,11 +98,12 @@ class AnimationPlayer {
       clip.applyToBindings(_targetTransforms, weightMultiplier);
     }
 
-    // Apply the animated pose to the bound joints.
+    // Apply the animated pose to the bound joints, keeping the
+    // decomposition so a later rebind anchors to consistent scale signs.
     for (final entry in _targetTransforms.entries) {
       final node = entry.key;
       final transforms = entry.value;
-      node.localTransform = transforms.animatedPose.toMatrix4();
+      node.setLocalTransformTrs(transforms.animatedPose);
     }
   }
 }

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -17,6 +17,25 @@ import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/node.dart';
 import 'package:flutter_scene/src/skin.dart';
 
+/// Applies [spec] to [node]'s local transform. A TRS spec keeps its
+/// authored decomposition; recovering it from the composed matrix puts a
+/// mirrored axis's negative scale on X, which breaks animation blending
+/// on mirrored bones. Also used by scene hot reload.
+void applyTransformSpec(Node node, TransformSpec spec) {
+  switch (spec) {
+    case TrsTransform(:final translation, :final rotation, :final scale):
+      node.setLocalTransformTrs(
+        engine.DecomposedTransform(
+          translation: translation.clone(),
+          rotation: rotation.clone(),
+          scale: scale.clone(),
+        ),
+      );
+    case MatrixTransform(:final matrix):
+      node.localTransform = matrix.clone();
+  }
+}
+
 /// Returns a registry preloaded with the built-in component codecs.
 FsceneComponentRegistry defaultComponentRegistry() {
   final registry = FsceneComponentRegistry();
@@ -90,12 +109,13 @@ Node _realizeWith(
   final nodes = <LocalId, Node>{};
   for (final spec in document.nodes.values) {
     final node = tagNodeId(
-      Node(name: spec.name, localTransform: spec.transform.toMatrix4())
+      Node(name: spec.name)
         ..layers = spec.layers
         ..excludeFromWindingParity = spec.excludeFromWindingParity
         ..visible = spec.visible,
       spec.id,
     );
+    applyTransformSpec(node, spec.transform);
     final instance = spec.instance;
     if (instance != null) {
       if (instance.load == LoadPolicy.lazy) {
@@ -233,10 +253,17 @@ NodeSpec _serializeNode(
   }
 
   final lazyInstance = lazyInstanceOf(node);
+  final trs = node.localTransformTrs;
   final spec = NodeSpec(
     id: ids[node]!,
     name: node.name,
-    transform: MatrixTransform(node.localTransform.clone()),
+    transform: trs != null
+        ? TrsTransform(
+            translation: trs.translation.clone(),
+            rotation: trs.rotation.clone(),
+            scale: trs.scale.clone(),
+          )
+        : MatrixTransform(node.localTransform.clone()),
     components: components,
     layers: node.layers,
     skin: _serializeSkin(node.skin, document, context, ids),

--- a/packages/flutter_scene/lib/src/fscene/reload/reload.dart
+++ b/packages/flutter_scene/lib/src/fscene/reload/reload.dart
@@ -70,13 +70,15 @@ Future<SceneDiff> reloadScene(
   // then attach those still without a parent under their document parent.
   for (final id in diff.added) {
     final spec = newDocument.nodes[id]!;
-    live[id] = tagNodeId(
-      Node(name: spec.name, localTransform: spec.transform.toMatrix4())
+    final node = tagNodeId(
+      Node(name: spec.name)
         ..layers = spec.layers
         ..excludeFromWindingParity = spec.excludeFromWindingParity
         ..visible = spec.visible,
       id,
     );
+    applyTransformSpec(node, spec.transform);
+    live[id] = node;
   }
   for (final id in diff.added) {
     final spec = newDocument.nodes[id]!;
@@ -97,7 +99,7 @@ Future<SceneDiff> reloadScene(
     final node = live[change.id]!;
     final spec = newDocument.nodes[change.id]!;
     if (change.transform) {
-      node.localTransform = spec.transform.toMatrix4();
+      applyTransformSpec(node, spec.transform);
       node.excludeFromWindingParity = spec.excludeFromWindingParity;
     }
     if (change.name) node.name = spec.name;
@@ -130,19 +132,23 @@ Future<SceneDiff> reloadScene(
 
   // 5. Rebuild and re-bind animations. Clips created from the old animations
   // keep playing (matched by name); rest poses come from the document so a
-  // node frozen mid-playback is not captured at its animated pose.
+  // node frozen mid-playback is not captured at its animated pose. Applying
+  // the transform specs directly (rather than via `restPoseOf` matrices)
+  // keeps authored TRS decompositions for the rebound bind poses.
   if (diff.animationsChanged) {
+    for (final spec in newDocument.animations.values) {
+      for (final channel in spec.channels) {
+        final node = live[channel.target];
+        final nodeSpec = newDocument.nodes[channel.target];
+        if (node == null || nodeSpec == null) continue;
+        applyTransformSpec(node, nodeSpec.transform);
+      }
+    }
     final animations = [
       for (final spec in newDocument.animations.values)
         buildAnimation(newDocument, spec, live),
     ].whereType<Animation>().toList();
-    liveRoot.reloadParsedAnimations(
-      animations,
-      restPoseOf: (node) {
-        final id = nodeFsceneId(node);
-        return id == null ? null : newDocument.nodes[id]?.transform.toMatrix4();
-      },
-    );
+    liveRoot.reloadParsedAnimations(animations);
   }
 
   return diff;

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -92,6 +92,7 @@ base class Node implements SceneGraph {
   bool raycastable = true;
 
   Matrix4 _localTransform;
+  DecomposedTransform? _localTransformTrs;
 
   /// The transform of this node relative to its parent: position,
   /// rotation, and scale.
@@ -103,6 +104,25 @@ base class Node implements SceneGraph {
   Matrix4 get localTransform => _localTransform;
   set localTransform(Matrix4 value) {
     _localTransform = value;
+    _localTransformTrs = null;
+    markTransformDirty();
+  }
+
+  /// The authored decomposition of [localTransform], when known.
+  ///
+  /// A matrix decompose puts a mirror's negative sign on the X scale no
+  /// matter which axis the source mirrored, so animation blends anchored
+  /// to a re-decomposed bind pose fade mirrored bones through zero scale.
+  /// Importers record the authored decomposition here and blending
+  /// anchors to it. Cleared when [localTransform] is assigned a matrix.
+  @internal
+  DecomposedTransform? get localTransformTrs => _localTransformTrs;
+
+  /// Sets [localTransform] from [trs], keeping the decomposition.
+  @internal
+  void setLocalTransformTrs(DecomposedTransform trs) {
+    _localTransform = trs.toMatrix4();
+    _localTransformTrs = trs;
     markTransformDirty();
   }
 
@@ -804,6 +824,7 @@ base class Node implements SceneGraph {
       mesh: mesh?.clone(),
     );
     result.isJoint = isJoint;
+    result._localTransformTrs = _localTransformTrs?.clone();
     // Preserve the coordinate-convention flag so a cloned scene root's
     // handedness flip is still excluded from winding parity (otherwise the
     // clone renders with reversed cull winding: see-through, inverted geometry).

--- a/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:vector_math/vector_math.dart';
 import 'package:flutter_scene/src/importer/gltf.dart';
 
+import '../animation.dart';
 import '../components/component.dart';
 import '../components/directional_light_component.dart';
 import '../components/point_light_component.dart';
@@ -205,7 +206,21 @@ void _populateNode({
   required List<Texture2D> textures,
 }) {
   engineNode.name = resolveGltfNodeName(gltfNode.name, index);
-  engineNode.localTransform = _localTransformFor(gltfNode);
+  final matrix = gltfNode.matrix;
+  if (matrix != null) {
+    engineNode.localTransform = matrix.clone();
+  } else {
+    // Keep the authored TRS. Recovering it from the composed matrix puts
+    // a mirrored bone's negative scale on the wrong axis, which breaks
+    // animation blending.
+    engineNode.setLocalTransformTrs(
+      DecomposedTransform(
+        translation: gltfNode.translation?.clone() ?? Vector3.zero(),
+        rotation: gltfNode.rotation?.clone() ?? Quaternion.identity(),
+        scale: gltfNode.scale?.clone() ?? Vector3(1.0, 1.0, 1.0),
+      ),
+    );
+  }
 
   if (gltfNode.mesh != null) {
     final gltfMesh = doc.meshes[gltfNode.mesh!];
@@ -292,16 +307,6 @@ Component? _buildLightComponent(GltfPunctualLight light) {
       debugPrint('Skipping unsupported KHR_lights_punctual type ${light.type}');
       return null;
   }
-}
-
-Matrix4 _localTransformFor(GltfNode n) {
-  if (n.matrix != null) return n.matrix!.clone();
-  final t = n.translation ?? Vector3.zero();
-  final r = n.rotation ?? Quaternion.identity();
-  final s = n.scale ?? Vector3(1.0, 1.0, 1.0);
-  // T * R * S
-  final m = Matrix4.compose(t, r, s);
-  return m;
 }
 
 /// Returns the binary buffer that backs the document's bufferViews.

--- a/packages/flutter_scene/test/animation_mirrored_bone_test.dart
+++ b/packages/flutter_scene/test/animation_mirrored_bone_test.dart
@@ -1,0 +1,113 @@
+/// Regression coverage for animation blending on rigs with mirrored bones
+/// (issue #249). A bind pose recovered with `Matrix4.decompose` puts a
+/// mirror's negative scale on X no matter which axis the source mirrored,
+/// so weighted blends faded mirrored bones through zero scale (the model
+/// collapsed flat mid-blend). Importers now record the authored TRS
+/// decomposition on the node and blending anchors to it.
+library;
+
+import 'package:flutter_scene/scene.dart';
+// The channel/resolver data model and TRS plumbing are internal; tests
+// reach them directly.
+// ignore: implementation_imports
+import 'package:flutter_scene/src/animation.dart'
+    show AnimationChannel, BindKey, DecomposedTransform, PropertyResolver;
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// A root node with a single child bone whose authored rest pose mirrors
+/// the Y axis, the way a rig mirrors one side's bones onto the other.
+(Node, Node) _rigWithMirroredBone() {
+  final rig = Node(name: 'rig');
+  final bone = Node(name: 'bone');
+  bone.setLocalTransformTrs(
+    DecomposedTransform(
+      translation: Vector3.zero(),
+      rotation: Quaternion.identity(),
+      scale: Vector3(1, -1, 1),
+    ),
+  );
+  rig.add(bone);
+  return (rig, bone);
+}
+
+/// A 1-second animation with a single scale channel on 'bone' holding
+/// [scale] for the whole timeline.
+Animation _constantScaleAnimation(String name, Vector3 scale) {
+  final resolver = PropertyResolver.makeScaleTimeline(
+    [0.0, 1.0],
+    [scale, scale],
+  );
+  final channel = AnimationChannel(
+    bindTarget: BindKey(nodeName: 'bone'),
+    resolver: resolver,
+  );
+  return Animation(name: name, channels: [channel]);
+}
+
+void main() {
+  test('half-weight blend keeps a mirrored bone solid', () {
+    final (rig, bone) = _rigWithMirroredBone();
+    final clip = rig.createAnimationClip(
+      _constantScaleAnimation('a', Vector3(1, -1, 1)),
+    );
+    clip.weight = 0.5;
+
+    rig.scenePrePass(1 / 60);
+
+    // Before the fix the bind pose decomposed to scale (-1, 1, 1), the
+    // keyframe ratio came out (-1, -1, 1), and the half-weight lerp landed
+    // on (0, 0, 1), flattening the bone.
+    final scale = bone.localTransformTrs!.scale;
+    expect(scale.x, closeTo(1, 1e-6));
+    expect(scale.y, closeTo(-1, 1e-6));
+    expect(scale.z, closeTo(1, 1e-6));
+    expect(bone.localTransform.determinant(), closeTo(-1, 1e-6));
+  });
+
+  test('full-weight scale reaches the keyframe exactly', () {
+    final (rig, bone) = _rigWithMirroredBone();
+    rig.createAnimationClip(_constantScaleAnimation('a', Vector3(2, -2, 2)));
+
+    rig.scenePrePass(1 / 60);
+
+    final scale = bone.localTransformTrs!.scale;
+    expect(scale.x, closeTo(2, 1e-6));
+    expect(scale.y, closeTo(-2, 1e-6));
+    expect(scale.z, closeTo(2, 1e-6));
+  });
+
+  test('crossfading two clips never collapses a mirrored bone', () {
+    final (rig, bone) = _rigWithMirroredBone();
+    final a = rig.createAnimationClip(
+      _constantScaleAnimation('a', Vector3(1, -1, 1)),
+    );
+    final b = rig.createAnimationClip(
+      _constantScaleAnimation('b', Vector3(2, -2, 2)),
+    );
+
+    for (var t = 0.0; t <= 1.0; t += 0.1) {
+      a.weight = 1.0 - t;
+      b.weight = t;
+      rig.scenePrePass(1 / 60);
+      expect(
+        bone.localTransform.determinant(),
+        lessThan(-0.5),
+        reason: 'bone flattened at crossfade t=$t',
+      );
+    }
+  });
+
+  test('cloned nodes keep the authored decomposition', () {
+    final (rig, _) = _rigWithMirroredBone();
+    final clonedBone = rig.clone().getChildByName('bone')!;
+    final scale = clonedBone.localTransformTrs!.scale;
+    expect(scale.y, closeTo(-1, 1e-6));
+  });
+
+  test('assigning a raw matrix clears the authored decomposition', () {
+    final (_, bone) = _rigWithMirroredBone();
+    bone.localTransform = Matrix4.identity();
+    expect(bone.localTransformTrs, isNull);
+  });
+}

--- a/packages/flutter_scene/test/fscene/realize_test.dart
+++ b/packages/flutter_scene/test/fscene/realize_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_scene/src/fscene/realize/realize.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
 
 // A tagged component plus its codec, for the registry-extensibility test.
 class _TagComponent extends Component {
@@ -140,6 +141,32 @@ void main() {
       final lightSpec = sunSpec.components.single;
       expect(lightSpec.type, 'directionalLight');
       expect((lightSpec.properties['intensity'] as DoubleValue).value, 5.0);
+    });
+
+    test('round-trips a TRS transform without matrix decomposition', () {
+      // A mirrored-axis scale must survive as authored; recovering it from
+      // the composed matrix would move the negative sign to X and break
+      // animation blending on mirrored bones.
+      final doc = SceneDocument();
+      doc.createNode(
+        name: 'mirrored',
+        root: true,
+        transform: TrsTransform(
+          translation: Vector3(1, 2, 3),
+          scale: Vector3(1, -1, 1),
+        ),
+      );
+
+      final root = realizeScene(doc);
+      final node = root.children.single;
+      final trs = node.localTransformTrs!;
+      expect(trs.scale.y, -1);
+      expect(trs.translation, Vector3(1, 2, 3));
+
+      final back = serializeScene(root);
+      final spec = back.rootNodes.single.transform as TrsTransform;
+      expect(spec.scale.y, -1);
+      expect(spec.translation, Vector3(1, 2, 3));
     });
   });
 


### PR DESCRIPTION
Resolves #249.

Blending anchors each animated bone to a decomposed bind pose. Recovering that pose from the composed local matrix puts a mirrored bone's negative scale on X no matter which axis the rig mirrored, so the keyframe-to-bind scale ratio went negative and weighted blends faded the bone through zero scale, flattening it and everything attached until the blend finished.

Nodes built from TRS transforms now record the authored decomposition (both importers, .fscene realization, scene hot reload, and clones), the animation player prefers it over decomposing the matrix, and serializing a scene emits the kept TRS instead of a baked matrix. The animated write-back keeps the pose decomposition too, so rebinds stay sign-consistent.

Covered by new blend regression tests (half-weight hold, crossfade sweep, clone, matrix reassignment) and a TRS serialize round trip.