### PR TITLE
Add automatic exposure with eye adaptation

### DIFF
--- a/examples/flutter_app/lib/example_auto_exposure.dart
+++ b/examples/flutter_app/lib/example_auto_exposure.dart
@@ -1,0 +1,403 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_overlay.dart';
+import 'example_panel.dart';
+import 'example_settings.dart';
+
+/// Demonstrates auto exposure (eye adaptation): the camera walks out of a
+/// dim room into bright sunlight and back, and the metered exposure factor
+/// eases the image toward a consistent brightness in both. A tuning panel
+/// exposes the settings; toggle it off mid-walk to see the raw range the
+/// meter is covering.
+class ExampleAutoExposure extends StatefulWidget {
+  const ExampleAutoExposure({super.key});
+
+  @override
+  ExampleAutoExposureState createState() => ExampleAutoExposureState();
+}
+
+class ExampleAutoExposureState extends State<ExampleAutoExposure> {
+  final Scene scene = Scene();
+
+  // The walk path: camera z from deep inside the room to well outside.
+  static const double _insideZ = -3.2;
+  static const double _outsideZ = 11.0;
+
+  bool _autoWalk = true;
+  double _walk = 0.0; // 0 inside, 1 outside.
+  Camera _camera = PerspectiveCamera(
+    position: vm.Vector3(0, 1.7, _insideZ),
+    target: vm.Vector3(0, 1.5, _insideZ + 6),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+
+    // A dim image-based-lighting bed so the room interior reads dark; the
+    // sunlight (the shared directional light, boosted for this example) and
+    // the bright gradient sky carry the outdoors.
+    scene.environmentIntensity = 0.25;
+    scene.skybox = Skybox(
+      GradientSkySource(
+        // Matches the shared light's default azimuth/elevation, so the sky
+        // reads as the source of the sunlight (the disk sits behind the
+        // camera on this path).
+        sunDirection: vm.Vector3(-0.47, 0.82, -0.33),
+      ),
+    );
+
+    scene.autoExposure.enabled = true;
+
+    _buildWorld();
+  }
+
+  void _buildWorld() {
+    Node box(
+      vm.Vector3 center,
+      vm.Vector3 size,
+      vm.Vector4 color, {
+      double roughness = 0.85,
+    }) {
+      return Node(
+        mesh: Mesh(
+          CuboidGeometry(size),
+          PhysicallyBasedMaterial()
+            ..baseColorFactor = color
+            ..roughnessFactor = roughness
+            ..metallicFactor = 0.0,
+        ),
+      )..localTransform = vm.Matrix4.translation(center);
+    }
+
+    // Sunlit ground.
+    scene.add(
+      Node(
+        mesh: Mesh(
+          PlaneGeometry(width: 60, depth: 60),
+          PhysicallyBasedMaterial()
+            ..baseColorFactor = vm.Vector4(0.45, 0.42, 0.35, 1.0)
+            ..roughnessFactor = 0.9
+            ..metallicFactor = 0.0,
+        ),
+      ),
+    );
+
+    // The room: an 8x8 shell with a doorway in the +z wall. The walls block
+    // the sun, so the interior is lit only by the dim environment.
+    final wallColor = vm.Vector4(0.62, 0.60, 0.57, 1.0);
+    scene.add(box(vm.Vector3(0, 2, -4), vm.Vector3(8, 4, 0.3), wallColor));
+    scene.add(box(vm.Vector3(-4, 2, 0), vm.Vector3(0.3, 4, 8), wallColor));
+    scene.add(box(vm.Vector3(4, 2, 0), vm.Vector3(0.3, 4, 8), wallColor));
+    scene.add(
+      box(vm.Vector3(0, 4.15, 0), vm.Vector3(8.6, 0.3, 8.6), wallColor),
+    );
+    // The doorway wall: two segments beside a 2-wide opening and a lintel
+    // above it.
+    scene.add(box(vm.Vector3(-2.5, 2, 4), vm.Vector3(3, 4, 0.3), wallColor));
+    scene.add(box(vm.Vector3(2.5, 2, 4), vm.Vector3(3, 4, 0.3), wallColor));
+    scene.add(box(vm.Vector3(0, 3.4, 4), vm.Vector3(2, 1.2, 0.3), wallColor));
+
+    // Furniture inside, so the dark half of the walk has a subject to
+    // recover detail on.
+    scene.add(
+      Node(
+        mesh: Mesh(
+          SphereGeometry(radius: 0.7),
+          PhysicallyBasedMaterial()
+            ..baseColorFactor = vm.Vector4(0.75, 0.72, 0.68, 1.0)
+            ..roughnessFactor = 0.5
+            ..metallicFactor = 0.0,
+        ),
+      )..localTransform = vm.Matrix4.translation(vm.Vector3(-1.6, 0.7, -1.6)),
+    );
+    scene.add(
+      box(
+        vm.Vector3(1.7, 0.6, -2.2),
+        vm.Vector3(1.2, 1.2, 1.2),
+        vm.Vector4(0.30, 0.45, 0.70, 1.0),
+        roughness: 0.4,
+      ),
+    );
+
+    // Landmarks outside along the path.
+    final palette = <vm.Vector4>[
+      vm.Vector4(0.90, 0.30, 0.25, 1.0),
+      vm.Vector4(0.95, 0.70, 0.20, 1.0),
+      vm.Vector4(0.30, 0.75, 0.40, 1.0),
+      vm.Vector4(0.65, 0.35, 0.85, 1.0),
+    ];
+    for (var i = 0; i < palette.length; i++) {
+      final side = i.isEven ? -1.0 : 1.0;
+      final z = 7.0 + i * 2.5;
+      scene.add(
+        Node(
+            mesh: Mesh(
+              i.isEven
+                  ? SphereGeometry(radius: 0.8)
+                  : CuboidGeometry(vm.Vector3(1.3, 1.5, 1.3)),
+              PhysicallyBasedMaterial()
+                ..baseColorFactor = palette[i]
+                ..roughnessFactor = 0.45
+                ..metallicFactor = 0.0,
+            ),
+          )
+          ..localTransform = vm.Matrix4.translation(
+            vm.Vector3(side * (2.5 + i * 0.6), i.isEven ? 0.8 : 0.75, z),
+          ),
+      );
+    }
+  }
+
+  void _updateCamera() {
+    final z = _insideZ + (_outsideZ - _insideZ) * _walk;
+    _camera = PerspectiveCamera(
+      position: vm.Vector3(0, 1.7, z),
+      target: vm.Vector3(0, 1.5, z + 6),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: SceneView(
+            scene,
+            cameraBuilder: (elapsed) => _camera,
+            onTick: (elapsed, deltaSeconds) {
+              if (_autoWalk) {
+                final t = elapsed.inMicroseconds / 1e6;
+                // Ease-in-out ping-pong with a hold at each end, so the
+                // adaptation is visible both mid-walk and at rest.
+                _walk = 0.5 - 0.5 * cos(t * 0.45);
+              }
+              _updateCamera();
+              exampleSettings.applyTo(scene);
+            },
+          ),
+        ),
+        ExampleOverlay.bottomRightPanel(
+          paired: true,
+          child: _AutoExposurePanel(
+            settings: scene.autoExposure,
+            onChanged: () => setState(() {}),
+          ),
+        ),
+        ExampleOverlay.bottomLeftPanel(
+          paired: true,
+          child: _WalkPanel(
+            autoWalk: _autoWalk,
+            walk: _walk,
+            onAutoWalkChanged: (v) => setState(() => _autoWalk = v),
+            onWalkChanged: (v) => setState(() {
+              _autoWalk = false;
+              _walk = v;
+            }),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// The auto exposure tuning panel: sliders that mutate the scene's
+// AutoExposureSettings live, plus a snap button exercising reset().
+class _AutoExposurePanel extends StatelessWidget {
+  const _AutoExposurePanel({required this.settings, required this.onChanged});
+
+  final AutoExposureSettings settings;
+  final VoidCallback onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return ExamplePanelCard(
+      icon: Icons.exposure,
+      title: 'Auto exposure',
+      width: 340,
+      maxBodyHeight: 520,
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text('Enabled', style: TextStyle(color: Colors.white)),
+              ),
+              Switch(
+                value: settings.enabled,
+                onChanged: (v) {
+                  settings.enabled = v;
+                  onChanged();
+                },
+              ),
+            ],
+          ),
+          _SliderRow(
+            label: 'Strength',
+            value: settings.strength,
+            min: 0,
+            max: 1,
+            onChanged: (v) {
+              settings.strength = v;
+              onChanged();
+            },
+          ),
+          _SliderRow(
+            label: 'Compensation',
+            value: settings.compensation,
+            min: -3,
+            max: 3,
+            onChanged: (v) {
+              settings.compensation = v;
+              onChanged();
+            },
+          ),
+          _SliderRow(
+            label: 'Min EV',
+            value: settings.minEv,
+            min: -4,
+            max: 0,
+            onChanged: (v) {
+              settings.minEv = v;
+              onChanged();
+            },
+          ),
+          _SliderRow(
+            label: 'Max EV',
+            value: settings.maxEv,
+            min: 0,
+            max: 4,
+            onChanged: (v) {
+              settings.maxEv = v;
+              onChanged();
+            },
+          ),
+          _SliderRow(
+            label: 'Speed up',
+            value: settings.speedUp,
+            min: 0.1,
+            max: 8,
+            onChanged: (v) {
+              settings.speedUp = v;
+              onChanged();
+            },
+          ),
+          _SliderRow(
+            label: 'Speed down',
+            value: settings.speedDown,
+            min: 0.1,
+            max: 8,
+            onChanged: (v) {
+              settings.speedDown = v;
+              onChanged();
+            },
+          ),
+          const SizedBox(height: 4),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: OutlinedButton.icon(
+              onPressed: () {
+                settings.reset();
+                onChanged();
+              },
+              icon: const Icon(Icons.center_focus_strong, size: 18),
+              label: const Text('Snap adaptation'),
+              style: OutlinedButton.styleFrom(foregroundColor: Colors.white),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// Walk controls: an automatic in-and-out stroll, or a manual scrub between
+// the room and the daylight.
+class _WalkPanel extends StatelessWidget {
+  const _WalkPanel({
+    required this.autoWalk,
+    required this.walk,
+    required this.onAutoWalkChanged,
+    required this.onWalkChanged,
+  });
+
+  final bool autoWalk;
+  final double walk;
+  final ValueChanged<bool> onAutoWalkChanged;
+  final ValueChanged<double> onWalkChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return ExamplePanelCard(
+      icon: Icons.directions_walk,
+      title: 'Camera walk',
+      width: 300,
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text('Auto walk', style: TextStyle(color: Colors.white)),
+              ),
+              Switch(value: autoWalk, onChanged: onAutoWalkChanged),
+            ],
+          ),
+          _SliderRow(
+            label: 'Position',
+            value: walk,
+            min: 0,
+            max: 1,
+            onChanged: onWalkChanged,
+          ),
+          const Padding(
+            padding: EdgeInsets.only(top: 4),
+            child: Text(
+              'Left is inside the room, right is out in the sun.',
+              style: TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SliderRow extends StatelessWidget {
+  const _SliderRow({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 120,
+          child: Text(
+            '$label: ${value.toStringAsFixed(2)}',
+            style: const TextStyle(color: Colors.white),
+          ),
+        ),
+        Expanded(
+          child: Slider(value: value, min: min, max: max, onChanged: onChanged),
+        ),
+      ],
+    );
+  }
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene_box3d/flutter_scene_box3d.dart'
 import 'package:example_app/example_animation.dart';
 
 import 'example_accessibility.dart';
+import 'example_auto_exposure.dart';
 import 'example_cuboid.dart';
 import 'example_dicom.dart';
 import 'example_lights.dart';
@@ -51,6 +52,9 @@ void main() {
 /// (see [resetExampleSettings]), so tuning one scene never leaks into
 /// another.
 final Map<String, ExampleSettings Function()> settingsDefaults = {
+  // A strong sun for the adaptation walk: the outdoor half of the path
+  // should overexpose while the meter is adapted to the room.
+  'Auto Exposure': () => ExampleSettings()..lightIntensity = 7.0,
   // A cinematic grade for the dark materialize stage: no key light (the
   // effect's own emissives and the environment carry it), bloom for the hot
   // seam and shard glows, and a subtle lens treatment.
@@ -120,6 +124,7 @@ class _MyAppState extends State<MyApp> {
       'Instancing': (context) => const ExampleInstancing(),
       'Geometry LOD': (context) => const ExampleLod(),
       'Screen-space Reflections': (context) => const ExampleSsr(),
+      'Auto Exposure': (context) => const ExampleAutoExposure(),
       'Navigation Route': (context) => const ExampleNavRoute(),
       'Toon': (context) => const ExampleToon(),
       'Toon (.fmat)': (context) => const ExampleToonFmat(),

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -393,6 +393,20 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
     );
     return (scene: scene, camera: _camera());
   }),
+  // Auto exposure pinned at its upper clamp: the mostly-empty background
+  // meters far below the reference luminance, so the adapted factor lands on
+  // exp2(maxEv) on the first (snapped) frame and holds there on every later
+  // frame, deterministically brightening the dimly-lit cuboid. Covers the
+  // whole chain (seed, downsample, adaptation, resolve composite) with a
+  // clamp-pinned value that is robust to small cross-backend metering
+  // differences.
+  SmokeScene('auto_exposure', () {
+    final scene = Scene();
+    scene.environmentIntensity = 0.4;
+    scene.autoExposure.enabled = true;
+    scene.add(_cuboid(vm.Vector4(0.30, 0.60, 0.85, 1.0), 0.0, 0.5));
+    return (scene: scene, camera: _camera());
+  }),
   // A procedural anisotropic splat cloud (degree-1 SH) composited around an
   // opaque cuboid, with a crop box carving one side. One scene covers the
   // splat path across backends, the vertex-stage data texture fetch, the EWA

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -395,9 +395,9 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
   }),
   // Auto exposure pinned at its upper clamp: the mostly-empty background
   // meters far below the reference luminance, so the adapted factor lands on
-  // exp2(maxEv) on the first (snapped) frame and holds there on every later
-  // frame, deterministically brightening the dimly-lit cuboid. Covers the
-  // whole chain (seed, downsample, adaptation, resolve composite) with a
+  // exp2(maxEv) during the startup snap frames and holds there on every
+  // later frame, deterministically brightening the dimly-lit cuboid. Covers
+  // the whole chain (seed, downsample, adaptation, resolve composite) with a
   // clamp-pinned value that is robust to small cross-backend metering
   // differences.
   SmokeScene('auto_exposure', () {

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -7,6 +7,17 @@
   TRS transforms (both importers, `.fscene` documents, and scene hot
   reload) now keep the authored decomposition and blending anchors to it.
 
+* Automatic exposure (eye adaptation). `Scene.autoExposure` meters the
+  average luminance of the rendered HDR image each frame and eases a
+  correction factor toward it, so the image brightens in dark surroundings
+  and darkens in bright ones. The factor multiplies on top of
+  `Scene.exposure`, which stays the artistic base. Settings cover the
+  correction strength, EV compensation, EV clamps relative to the base
+  exposure, asymmetric adaptation speeds, and a `reset()` snap for camera
+  cuts. Metering runs entirely on the GPU (a log-luminance downsample chain
+  and a one-pixel adaptation state), so it works on every backend with no
+  readback.
+
 * Imported materials keep their source names. `Material` gained a `name`
   field (empty when unnamed), and both import paths set it from the glTF
   material name, so materials can be looked up after loading. `.fscene`

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -84,6 +84,7 @@ export 'src/importer/scene_registry.dart'
 
 export 'src/ambient_occlusion.dart'
     show AmbientOcclusionSettings, SpecularAmbientOcclusionMode;
+export 'src/auto_exposure.dart' show AutoExposureSettings;
 export 'src/depth_of_field.dart' show DepthOfField, DepthOfFieldQuality;
 export 'src/fog.dart' show Fog, FogMode;
 export 'src/god_rays.dart' show GodRaysSettings;

--- a/packages/flutter_scene/lib/src/auto_exposure.dart
+++ b/packages/flutter_scene/lib/src/auto_exposure.dart
@@ -1,0 +1,101 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart' show internal;
+
+/// The mid-gray scene luminance the meter drives the image toward, before
+/// the scene's base exposure is applied.
+const double kAutoExposureReferenceLuminance = 0.18;
+
+/// Automatic exposure (eye adaptation) settings for a [Scene].
+///
+/// Reachable through `Scene.autoExposure`. When enabled, the engine meters
+/// the average luminance of the rendered HDR image each frame and eases a
+/// correction factor toward it, so the image brightens in dark surroundings
+/// and darkens in bright ones, like eyes adjusting. The factor multiplies on
+/// top of `Scene.exposure`, which stays the artistic base (a value derived
+/// from `Scene.physicalCameraExposure` keeps working unchanged); the final
+/// multiplier applied to the HDR color is `exposure * factor`.
+///
+/// Metering runs entirely on the GPU (a luminance downsample chain feeding a
+/// one-pixel adaptation state), so enabling it adds no readback and works on
+/// every backend.
+///
+/// Disabled by default; a fresh scene meters nothing and renders with
+/// [Scene.exposure] alone.
+/// {@category Rendering}
+class AutoExposureSettings {
+  /// Whether auto exposure runs. Off by default. When false the scene adds
+  /// no metering passes and the image is unaffected.
+  bool enabled = false;
+
+  /// How strongly the metered error is corrected, from `0` (no correction)
+  /// to `1` (full correction to the metering target). Partial correction
+  /// preserves some of the scene's natural brightness variation, which
+  /// usually reads better than a fully flattened image.
+  double strength = 0.55;
+
+  /// Exposure compensation in EV stops, applied to the metering target.
+  /// `0` is neutral; `+1` doubles the target brightness, `-1` halves it.
+  double compensation = 0.0;
+
+  /// The lowest the correction may go, in EV stops relative to the base
+  /// exposure. `-1` (the default) lets bright scenes be darkened to half.
+  double minEv = -1.0;
+
+  /// The highest the correction may go, in EV stops relative to the base
+  /// exposure. `1.3` (the default) lets dark scenes be brightened to about
+  /// 2.5x.
+  double maxEv = 1.3;
+
+  /// Adaptation rate while the scene gets brighter (the correction falls),
+  /// in blends per second. Adapting to brightness is faster than adapting
+  /// to darkness by default, matching how eyes behave.
+  double speedUp = 3.0;
+
+  /// Adaptation rate while the scene gets darker (the correction rises),
+  /// in blends per second.
+  double speedDown = 1.0;
+
+  /// Snaps the adaptation to the metered target on the next frame, skipping
+  /// the eased transition. Call on camera cuts and teleports so the new shot
+  /// does not visibly ramp from the previous shot's adaptation.
+  void reset() => _resetPending = true;
+
+  bool _resetPending = false;
+
+  /// Consumes a pending [reset] request. Called once per metered frame by
+  /// the auto exposure render pass.
+  @internal
+  bool takeResetRequest() {
+    final pending = _resetPending;
+    _resetPending = false;
+    return pending;
+  }
+}
+
+/// The correction factor auto exposure eases toward for a metered mean
+/// log-luminance, mirroring the adaptation shader's curve so it can be unit
+/// tested without a GPU.
+double autoExposureTargetFactor({
+  required double meanLogLuminance,
+  required AutoExposureSettings settings,
+}) {
+  final meanLuminance = math.max(math.exp(meanLogLuminance), 1e-6);
+  final target =
+      math.pow(
+        kAutoExposureReferenceLuminance / meanLuminance,
+        settings.strength,
+      ) *
+      _exp2(settings.compensation);
+  return target.clamp(_exp2(settings.minEv), _exp2(settings.maxEv));
+}
+
+/// The blend weight toward the target after [deltaSeconds] at [speed] blends
+/// per second, the exponential-ease step mirrored from the adaptation
+/// shader. `0` holds the previous value, `1` lands on the target.
+double autoExposureBlend({
+  required double deltaSeconds,
+  required double speed,
+}) => 1.0 - math.exp(-deltaSeconds * speed);
+
+double _exp2(double ev) => math.pow(2.0, ev).toDouble();

--- a/packages/flutter_scene/lib/src/render/auto_exposure_pass.dart
+++ b/packages/flutter_scene/lib/src/render/auto_exposure_pass.dart
@@ -33,10 +33,22 @@ class AutoExposureState {
   gpu.Texture? _b;
   int _current = 0;
 
-  /// Whether the adaptation state holds a value from a previous frame.
-  /// False on the first metered frame, which snaps to the target instead
-  /// of easing from uninitialized memory.
-  bool seeded = false;
+  // Remaining startup frames that snap to the target instead of easing.
+  // Two, not one: easing must never start from uninitialized memory, and
+  // the first rendered frame is not always representative either (the web
+  // backend re-bakes a degenerate cold-context environment after the first
+  // present, so frame one can meter junk-bright there). The second snap
+  // lands on the first trustworthy frame; on backends whose first frame is
+  // already good both snaps compute the same value.
+  int _startupSnapFrames = 2;
+
+  /// Whether this frame should snap to the target instead of easing, and
+  /// consumes one startup-snap frame when so.
+  bool takeStartupSnap() {
+    if (_startupSnapFrames == 0) return false;
+    _startupSnapFrames--;
+    return true;
+  }
 
   final Stopwatch _clock = Stopwatch()..start();
 
@@ -174,7 +186,8 @@ class AutoExposurePass extends RenderGraphPass {
     // simultaneous views meter into one shared factor (the later view wins,
     // with a near-zero dt); per-view state needs a keyed state map.
     final dt = _state.takeDeltaSeconds();
-    final snap = !_state.seeded || _settings.takeResetRequest();
+    final startupSnap = _state.takeStartupSnap();
+    final snap = _settings.takeResetRequest() || startupSnap;
     final info = Float32List(8)
       ..[0] = _settings.strength
       ..[1] = _exp2(_settings.compensation)
@@ -204,7 +217,6 @@ class AutoExposurePass extends RenderGraphPass {
 
     context.blackboard.set(kAutoExposureFactorBlackboardKey, _state.next);
     _state.flip();
-    _state.seeded = true;
   }
 
   void _draw({

--- a/packages/flutter_scene/lib/src/render/auto_exposure_pass.dart
+++ b/packages/flutter_scene/lib/src/render/auto_exposure_pass.dart
@@ -1,0 +1,250 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
+
+import 'package:flutter_scene/src/auto_exposure.dart';
+import 'package:flutter_scene/src/render/render_graph.dart';
+import 'package:flutter_scene/src/render/scene_pass.dart';
+import 'package:flutter_scene/src/shaders.dart';
+import 'package:flutter_scene/src/render/frame_transients.dart';
+import 'package:flutter_scene/src/scene_encoder.dart' show resolvePipeline;
+
+/// Render-graph blackboard key for the 1x1 adapted exposure-factor texture
+/// [AutoExposurePass] produces. The resolve pass samples it and multiplies
+/// the factor with the scene's base exposure.
+const String kAutoExposureFactorBlackboardKey = 'auto_exposure_factor';
+
+// Side length of the metering seed grid. Fixed so the metering cost is
+// resolution-independent and the halving chain to 1x1 stays exact.
+const int _kMeterSize = 64;
+
+// RGBA16F everywhere; single-channel float formats are not renderable on
+// every backend (bloom's format choice is the precedent).
+const gpu.PixelFormat _format = gpu.PixelFormat.r16g16b16a16Float;
+
+/// Cross-frame state for auto exposure: the persistent ping-pong pair of
+/// 1x1 adapted-factor textures and the adaptation clock. Owned by the
+/// scene, created when auto exposure is first enabled and dropped when it
+/// is disabled (re-enabling starts fresh and snaps, like the first frame).
+class AutoExposureState {
+  gpu.Texture? _a;
+  gpu.Texture? _b;
+  int _current = 0;
+
+  /// Whether the adaptation state holds a value from a previous frame.
+  /// False on the first metered frame, which snaps to the target instead
+  /// of easing from uninitialized memory.
+  bool seeded = false;
+
+  final Stopwatch _clock = Stopwatch()..start();
+
+  /// The 1x1 holding the previous frame's adapted factor.
+  gpu.Texture get previous => _texture(_current);
+
+  /// The 1x1 the adaptation pass writes this frame.
+  gpu.Texture get next => _texture(1 - _current);
+
+  /// Swaps [previous] and [next] after a metered frame.
+  void flip() => _current = 1 - _current;
+
+  /// Seconds since the last metered frame, clamped so a hitch or a pause
+  /// does not step the adaptation by a huge dt. Zero on the first call.
+  double takeDeltaSeconds() {
+    final dt = _clock.elapsedMicroseconds / 1e6;
+    _clock.reset();
+    return dt.clamp(0.0, 0.25);
+  }
+
+  gpu.Texture _texture(int index) {
+    final existing = index == 0 ? _a : _b;
+    if (existing != null) return existing;
+    final texture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.devicePrivate,
+      1,
+      1,
+      format: _format,
+      enableRenderTargetUsage: true,
+      enableShaderReadUsage: true,
+    );
+    if (index == 0) {
+      _a = texture;
+    } else {
+      _b = texture;
+    }
+    return texture;
+  }
+}
+
+/// Meters the HDR scene color and eases the adapted exposure factor toward
+/// it, publishing the 1x1 factor texture under
+/// [kAutoExposureFactorBlackboardKey] for [ResolvePass] to sample.
+///
+/// Three stages, all plain render passes (no compute, no readback, so it
+/// runs on the WebGL2 backend): a seed draw samples the scene into a
+/// [_kMeterSize]-square grid of center-weighted log-luminance samples, a
+/// halving chain of copy draws averages the grid down to 1x1 (the
+/// geometric-mean "log-average" meter), and a 1x1 adaptation draw blends
+/// the persistent state toward the metered target.
+class AutoExposurePass extends RenderGraphPass {
+  AutoExposurePass({
+    required AutoExposureSettings settings,
+    required AutoExposureState state,
+  }) : _settings = settings,
+       _state = state;
+
+  final AutoExposureSettings _settings;
+  final AutoExposureState _state;
+
+  static final gpu.Shader _vertexShader =
+      baseShaderLibrary['FullscreenVertex']!;
+  static final gpu.Shader _seedShader =
+      baseShaderLibrary['AutoExposureSeedFragment']!;
+  static final gpu.Shader _downsampleShader =
+      baseShaderLibrary['CopyFragment']!;
+  static final gpu.Shader _adaptShader =
+      baseShaderLibrary['AutoExposureAdaptFragment']!;
+
+  // Two triangles of NDC positions covering the screen (6 vec2s).
+  static final gpu.DeviceBuffer _quadBuffer = gpu.gpuContext
+      .createDeviceBufferWithCopy(
+        ByteData.sublistView(
+          Float32List.fromList(<double>[
+            -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, //
+            -1.0, 1.0, 1.0, -1.0, 1.0, 1.0, //
+          ]),
+        ),
+      );
+  static final gpu.BufferView _quadView = gpu.BufferView(
+    _quadBuffer,
+    offsetInBytes: 0,
+    lengthInBytes: 6 * 2 * 4,
+  );
+
+  @override
+  String get name => 'AutoExposurePass';
+
+  @override
+  void execute(RenderGraphContext context) {
+    final scene = context.blackboard.require<gpu.Texture>(
+      kSceneColorBlackboardKey,
+    );
+
+    // Seed the metering grid from the scene color.
+    var metered = context.texturePool.acquire(
+      TransientTextureDescriptor.color(
+        width: _kMeterSize,
+        height: _kMeterSize,
+        format: _format,
+        debugName: 'auto_exposure_seed',
+      ),
+    );
+    _draw(
+      shader: _seedShader,
+      sourceSlot: 'scene_color',
+      source: scene,
+      target: metered,
+    );
+
+    // Average down to 1x1. Each level halves exactly, so one bilinear tap
+    // at the texel center is a precise 2x2 box average.
+    for (var size = _kMeterSize ~/ 2; size >= 1; size ~/= 2) {
+      final level = context.texturePool.acquire(
+        TransientTextureDescriptor.color(
+          width: size,
+          height: size,
+          format: _format,
+          debugName: 'auto_exposure_$size',
+        ),
+      );
+      _draw(
+        shader: _downsampleShader,
+        sourceSlot: 'source_texture',
+        source: metered,
+        target: level,
+      );
+      metered = level;
+    }
+
+    // Ease the persistent adaptation state toward the metered target. The
+    // first metered frame (and a requested reset) snaps instead, so the
+    // image never visibly ramps in from a stale or uninitialized factor.
+    // TODO(auto-exposure): the adaptation state is per scene, so multiple
+    // simultaneous views meter into one shared factor (the later view wins,
+    // with a near-zero dt); per-view state needs a keyed state map.
+    final dt = _state.takeDeltaSeconds();
+    final snap = !_state.seeded || _settings.takeResetRequest();
+    final info = Float32List(8)
+      ..[0] = _settings.strength
+      ..[1] = _exp2(_settings.compensation)
+      ..[2] = _exp2(_settings.minEv)
+      ..[3] = _exp2(_settings.maxEv)
+      ..[4] = autoExposureBlend(deltaSeconds: dt, speed: _settings.speedUp)
+      ..[5] = autoExposureBlend(deltaSeconds: dt, speed: _settings.speedDown)
+      ..[6] = snap ? 1.0 : 0.0;
+    _draw(
+      shader: _adaptShader,
+      sourceSlot: 'metered',
+      source: metered,
+      target: _state.next,
+      bind: (renderPass) {
+        renderPass.bindUniform(
+          _adaptShader.getUniformSlot('AutoExposureAdaptInfo'),
+          context.transientsBuffer.emplace(ByteData.sublistView(info)),
+        );
+        renderPass.bindTexture(
+          _adaptShader.getUniformSlot('previous_adapted'),
+          _state.previous,
+          sampler: _nearestClamp,
+        );
+      },
+      sampler: _nearestClamp,
+    );
+
+    context.blackboard.set(kAutoExposureFactorBlackboardKey, _state.next);
+    _state.flip();
+    _state.seeded = true;
+  }
+
+  void _draw({
+    required gpu.Shader shader,
+    required String sourceSlot,
+    required gpu.Texture source,
+    required gpu.Texture target,
+    void Function(gpu.RenderPass renderPass)? bind,
+    gpu.SamplerOptions? sampler,
+  }) {
+    final commandBuffer = gpu.gpuContext.createCommandBuffer();
+    final renderPass = commandBuffer.createRenderPass(
+      gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: target)),
+    );
+    renderPass.bindPipeline(resolvePipeline(_vertexShader, shader));
+    renderPass.setColorBlendEnable(false);
+    bindVertexBufferCompat(renderPass, _quadView, 6);
+    renderPass.bindTexture(
+      shader.getUniformSlot(sourceSlot),
+      source,
+      sampler: sampler ?? _linearClamp,
+    );
+    bind?.call(renderPass);
+    drawCompat(renderPass, 6);
+    rendererSubmissions.submit(commandBuffer);
+  }
+
+  static double _exp2(double ev) => math.pow(2.0, ev).toDouble();
+
+  static final gpu.SamplerOptions _linearClamp = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.linear,
+    magFilter: gpu.MinMagFilter.linear,
+    widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+    heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  );
+
+  static final gpu.SamplerOptions _nearestClamp = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.nearest,
+    magFilter: gpu.MinMagFilter.nearest,
+    widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+    heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+  );
+}

--- a/packages/flutter_scene/lib/src/render/resolve_pass.dart
+++ b/packages/flutter_scene/lib/src/render/resolve_pass.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/src/gpu/render_pass_compat.dart';
 
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/post_process/post_process.dart';
+import 'package:flutter_scene/src/render/auto_exposure_pass.dart';
 import 'package:flutter_scene/src/render/bloom_pass.dart';
 import 'package:flutter_scene/src/render/render_graph.dart';
 import 'package:flutter_scene/src/render/resolve_info.dart';
@@ -116,6 +117,22 @@ class ResolvePass extends RenderGraphPass {
       sampler: gpu.SamplerOptions(
         minFilter: gpu.MinMagFilter.linear,
         magFilter: gpu.MinMagFilter.linear,
+        widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
+        heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
+      ),
+    );
+    // The adapted auto exposure factor is present only when
+    // AutoExposurePass ran this frame; otherwise the white placeholder
+    // supplies a neutral 1.0.
+    final exposureFactor =
+        context.blackboard.get<gpu.Texture>(kAutoExposureFactorBlackboardKey) ??
+        Material.getWhitePlaceholderTexture();
+    renderPass.bindTexture(
+      _fragmentShader.getUniformSlot('exposure_factor'),
+      exposureFactor,
+      sampler: gpu.SamplerOptions(
+        minFilter: gpu.MinMagFilter.nearest,
+        magFilter: gpu.MinMagFilter.nearest,
         widthAddressMode: gpu.SamplerAddressMode.clampToEdge,
         heightAddressMode: gpu.SamplerAddressMode.clampToEdge,
       ),

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene/src/render/frame_transients.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:vector_math/vector_math.dart' show Matrix3, Ray;
 import 'ambient_occlusion.dart';
+import 'auto_exposure.dart';
 import 'camera.dart';
 import 'components/camera_component.dart';
 import 'components/directional_light_component.dart';
@@ -25,6 +26,7 @@ import 'environment_settings.dart';
 import 'environment_volume.dart';
 import 'post_process/post_effect.dart';
 import 'post_process/post_process.dart';
+import 'render/auto_exposure_pass.dart';
 import 'render/bloom_pass.dart';
 import 'render/custom_render_pass.dart';
 import 'render/depth_prepass.dart';
@@ -695,6 +697,17 @@ base class Scene implements SceneGraph {
   /// the camera depth prepass, which it forces while enabled); skipped
   /// otherwise.
   final DepthOfField depthOfField = DepthOfField();
+
+  /// Automatic exposure (eye adaptation). Off by default; set
+  /// [AutoExposureSettings.enabled] to turn it on. Meters the rendered HDR
+  /// image on the GPU each frame and eases a correction factor the resolve
+  /// multiplies with [exposure], so [exposure] stays the artistic base.
+  final AutoExposureSettings autoExposure = AutoExposureSettings();
+
+  // Cross-frame auto exposure adaptation state (the persistent 1x1 factor
+  // ping-pong), created the first enabled frame and dropped when disabled,
+  // so re-enabling starts fresh and snaps to the metered target.
+  AutoExposureState? _autoExposureState;
 
   // Cross-frame cache for the directional light's shadow tiles, created the
   // first frame any visible caster is `shadowStatic` and dropped when none
@@ -1486,6 +1499,21 @@ base class Scene implements SceneGraph {
           time: postTime,
         ),
       );
+    }
+
+    // Auto exposure meters the HDR image the resolve will consume, after
+    // depth of field and the custom effects republish the scene color and
+    // before bloom (bloom feeds off the exposure-independent HDR color and
+    // its own contribution should not drive the metering).
+    if (autoExposure.enabled) {
+      graph.addPass(
+        AutoExposurePass(
+          settings: autoExposure,
+          state: _autoExposureState ??= AutoExposureState(),
+        ),
+      );
+    } else {
+      _autoExposureState = null;
     }
 
     // Bloom runs in HDR before the resolve, which composites it back in.

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -131,6 +131,14 @@
     "type": "fragment",
     "file": "shaders/flutter_scene_prefilter_radiance_cube.frag"
   },
+  "AutoExposureSeedFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_auto_exposure_seed.frag"
+  },
+  "AutoExposureAdaptFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_auto_exposure_adapt.frag"
+  },
   "BloomThresholdFragment": {
     "type": "fragment",
     "file": "shaders/flutter_scene_bloom_threshold.frag"

--- a/packages/flutter_scene/shaders/flutter_scene_auto_exposure_adapt.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_auto_exposure_adapt.frag
@@ -1,0 +1,49 @@
+// Auto exposure adaptation: turns the metered mean log-luminance into a
+// clamped exposure-correction factor and eases the persistent one-pixel
+// adaptation state toward it. The eased factor is what the resolve pass
+// multiplies with the scene's base exposure. Mirrored in Dart by
+// autoExposureTargetFactor/autoExposureBlend for unit testing; keep the
+// curves in sync.
+
+uniform AutoExposureAdaptInfo {
+  // The strength exponent applied to the correction toward the reference.
+  float strength;
+  // exp2 of the EV compensation, min, and max settings.
+  float compensation_factor;
+  float min_factor;
+  float max_factor;
+  // Precomputed 1 - exp(-dt * speed) blend weights for a falling factor
+  // (scene got brighter) and a rising one (scene got darker).
+  float blend_up;
+  float blend_down;
+  // 1.0 -> land on the target immediately (first frame or reset()).
+  float snap;
+  float _pad0;
+}
+adapt_info;
+
+// 1x1 metered result: (weight * mean log-luminance, weight, 0, 1).
+uniform sampler2D metered;
+// 1x1 previous adapted factor in r.
+uniform sampler2D previous_adapted;
+
+out vec4 frag_color;
+
+const float kReferenceLuminance = 0.18;
+
+void main() {
+  vec2 m = texture(metered, vec2(0.5, 0.5)).rg;
+  float mean_luminance = max(exp(m.x / max(m.y, 1e-6)), 1e-6);
+  float target = pow(kReferenceLuminance / mean_luminance,
+                     adapt_info.strength) *
+                 adapt_info.compensation_factor;
+  target = clamp(target, adapt_info.min_factor, adapt_info.max_factor);
+
+  float previous = texture(previous_adapted, vec2(0.5, 0.5)).r;
+  float blend =
+      target < previous ? adapt_info.blend_up : adapt_info.blend_down;
+  float adapted =
+      adapt_info.snap > 0.5 ? target : mix(previous, target, blend);
+
+  frag_color = vec4(adapted, 0.0, 0.0, 1.0);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_auto_exposure_seed.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_auto_exposure_seed.frag
@@ -1,0 +1,28 @@
+// Auto exposure metering seed: samples the linear HDR scene color into a
+// small grid of center-weighted log-luminance samples. Each texel stores
+// (weight * log-luminance, weight, 0, 1); the plain-average downsample
+// chain reduces both channels together, and the adaptation pass divides
+// them back out, so the result is the weighted geometric mean luminance.
+
+uniform sampler2D scene_color;
+
+in vec2 v_uv;
+
+out vec4 frag_color;
+
+void main() {
+  // The scene color is premultiplied; meter the un-premultiplied radiance
+  // so translucent coverage does not read as darkness. Empty background
+  // (alpha 0) meters as black.
+  vec4 s = texture(scene_color, v_uv);
+  vec3 color = s.a > 0.0 ? s.rgb / s.a : vec3(0.0);
+  float luminance = dot(color, vec3(0.2126, 0.7152, 0.0722));
+  float log_luminance = log(max(luminance, 1e-4));
+
+  // Center-weighted metering: the middle of the frame counts four times as
+  // much as the corners, so bright skies and dark floor edges pull the
+  // adaptation around less than the subject.
+  float w = 1.0 - 0.75 * smoothstep(0.2, 0.7, length(v_uv - 0.5));
+
+  frag_color = vec4(log_luminance * w, w, 0.0, 1.0);
+}

--- a/packages/flutter_scene/shaders/flutter_scene_resolve.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_resolve.frag
@@ -56,6 +56,10 @@ resolve_info;
 
 uniform sampler2D scene_color;
 uniform sampler2D bloom_color;
+// 1x1 auto exposure correction factor in r, produced by the adaptation
+// pass. A white placeholder (factor 1.0) fills the slot when auto exposure
+// is disabled.
+uniform sampler2D exposure_factor;
 
 in vec2 v_uv;
 
@@ -133,7 +137,7 @@ void main() {
     color += texture(bloom_color, uv).rgb * resolve_info.bloom_intensity;
   }
 
-  color *= resolve_info.exposure;
+  color *= resolve_info.exposure * texture(exposure_factor, vec2(0.5, 0.5)).r;
   if (resolve_info.grading_enabled > 0.5) {
     color = ApplyColorGrading(color);
   }

--- a/packages/flutter_scene/test/auto_exposure_test.dart
+++ b/packages/flutter_scene/test/auto_exposure_test.dart
@@ -1,0 +1,125 @@
+import 'dart:math' as math;
+
+import 'package:flutter_scene/src/auto_exposure.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AutoExposureSettings', () {
+    test('defaults', () {
+      final settings = AutoExposureSettings();
+      expect(settings.enabled, isFalse);
+      expect(settings.strength, 0.55);
+      expect(settings.compensation, 0.0);
+      expect(settings.minEv, -1.0);
+      expect(settings.maxEv, 1.3);
+      expect(settings.speedUp, 3.0);
+      expect(settings.speedDown, 1.0);
+    });
+
+    test('reset is a one-shot request', () {
+      final settings = AutoExposureSettings();
+      expect(settings.takeResetRequest(), isFalse);
+      settings.reset();
+      expect(settings.takeResetRequest(), isTrue);
+      expect(settings.takeResetRequest(), isFalse);
+    });
+  });
+
+  group('autoExposureTargetFactor', () {
+    test('a scene metering at the reference needs no correction', () {
+      final factor = autoExposureTargetFactor(
+        meanLogLuminance: math.log(kAutoExposureReferenceLuminance),
+        settings: AutoExposureSettings(),
+      );
+      expect(factor, closeTo(1.0, 1e-9));
+    });
+
+    test('full strength fully corrects to the reference', () {
+      final settings = AutoExposureSettings()..strength = 1.0;
+      const luminance = 0.09;
+      final factor = autoExposureTargetFactor(
+        meanLogLuminance: math.log(luminance),
+        settings: settings,
+      );
+      expect(
+        factor,
+        closeTo(kAutoExposureReferenceLuminance / luminance, 1e-9),
+      );
+    });
+
+    test('partial strength corrects partially', () {
+      final settings = AutoExposureSettings()..strength = 0.5;
+      const luminance = 0.045; // Two stops under the reference.
+      final factor = autoExposureTargetFactor(
+        meanLogLuminance: math.log(luminance),
+        settings: settings,
+      );
+      // Half of a 4x correction in log space is 2x.
+      expect(factor, closeTo(2.0, 1e-9));
+    });
+
+    test('compensation shifts the target in stops', () {
+      final base = AutoExposureSettings()..maxEv = 10.0;
+      final compensated = AutoExposureSettings()
+        ..maxEv = 10.0
+        ..compensation = 1.0;
+      final logLuminance = math.log(0.09);
+      expect(
+        autoExposureTargetFactor(
+          meanLogLuminance: logLuminance,
+          settings: compensated,
+        ),
+        closeTo(
+          2.0 *
+              autoExposureTargetFactor(
+                meanLogLuminance: logLuminance,
+                settings: base,
+              ),
+          1e-9,
+        ),
+      );
+    });
+
+    test('a dark scene clamps to maxEv', () {
+      final factor = autoExposureTargetFactor(
+        meanLogLuminance: math.log(1e-4),
+        settings: AutoExposureSettings(),
+      );
+      expect(factor, closeTo(math.pow(2.0, 1.3), 1e-9));
+    });
+
+    test('a bright scene clamps to minEv', () {
+      final factor = autoExposureTargetFactor(
+        meanLogLuminance: math.log(50.0),
+        settings: AutoExposureSettings(),
+      );
+      expect(factor, closeTo(0.5, 1e-9));
+    });
+  });
+
+  group('autoExposureBlend', () {
+    test('zero dt holds the previous value', () {
+      expect(autoExposureBlend(deltaSeconds: 0.0, speed: 3.0), 0.0);
+    });
+
+    test('a long step converges on the target', () {
+      expect(
+        autoExposureBlend(deltaSeconds: 10.0, speed: 3.0),
+        closeTo(1.0, 1e-9),
+      );
+    });
+
+    test('matches the exponential ease', () {
+      expect(
+        autoExposureBlend(deltaSeconds: 1 / 60, speed: 3.0),
+        closeTo(1.0 - math.exp(-3.0 / 60), 1e-12),
+      );
+    });
+
+    test('a faster speed blends further per step', () {
+      final up = autoExposureBlend(deltaSeconds: 1 / 60, speed: 3.0);
+      final down = autoExposureBlend(deltaSeconds: 1 / 60, speed: 1.0);
+      expect(up, greaterThan(down));
+    });
+  });
+}


### PR DESCRIPTION
Adds automatic exposure (eye adaptation). `Scene.autoExposure` meters the average luminance of the rendered HDR image on the GPU each frame and eases a correction factor toward it, so the image brightens in dark surroundings and darkens in bright ones. The factor multiplies on top of `Scene.exposure`, which stays the artistic base. Settings cover correction strength, EV compensation, EV clamps relative to the base exposure, asymmetric adaptation speeds, and a `reset()` snap for camera cuts.

Metering is a log-luminance downsample chain of plain render passes feeding a persistent one-pixel adaptation state, so there is no compute and no readback and it runs on every backend, including WebGL2.

Includes an Auto Exposure example page (a camera walk from a dim room into bright sunlight), an `auto_exposure` smoke scene, and unit tests mirroring the adaptation math.