### PR TITLE
Add a declarative scene widget API, KHR_materials_variants support, and a product configurator example

### DIFF
--- a/examples/flutter_app/lib/example_animation.dart
+++ b/examples/flutter_app/lib/example_animation.dart
@@ -9,6 +9,15 @@ import 'example_panel.dart';
 import 'example_settings.dart';
 import 'lighting_panel.dart';
 
+/// Skeletal animation blending, driven through the declarative API.
+///
+/// The model and its animation state are declared in `build()`: a
+/// [SceneModel] mounts dash.glb as a child of the app-owned [Scene] (the
+/// mixed mode, so the shared lighting panel keeps mutating the scene
+/// imperatively), and each blend slider just rebuilds with new
+/// [SceneAnimationSpec] weights. The widget diffs the specs onto the
+/// underlying clips as plain property writes, so dragging a slider costs a
+/// field write per frame and the blending itself runs engine-side.
 class ExampleAnimation extends StatefulWidget {
   const ExampleAnimation({super.key});
 
@@ -17,71 +26,21 @@ class ExampleAnimation extends StatefulWidget {
 }
 
 class ExampleAnimationState extends State<ExampleAnimation> {
-  Scene scene = Scene();
-  bool loaded = false;
-  AnimationClip? idleClip;
-  AnimationClip? runClip;
-  AnimationClip? walkClip;
+  final Scene scene = Scene();
 
-  @override
-  void initState() {
-    super.initState();
-    _load();
-  }
-
-  Future<void> _load() async {
-    // The scene hot reloads in place. The clips below are held by reference and
-    // re-bound automatically across a reload (their playback state and the
-    // slider bindings survive), so no reload callback is needed.
-    final modelNode = await loadScene('assets_src/dash.glb');
-    if (!mounted) {
-      return;
-    }
-
-    for (final animation in modelNode.parsedAnimations) {
-      debugPrint('Animation: ${animation.name}');
-    }
-
-    scene.add(modelNode);
-
-    idleClip =
-        modelNode.createAnimationClip(modelNode.findAnimationByName('Idle')!)
-          ..loop = true
-          ..play();
-    walkClip =
-        modelNode.createAnimationClip(modelNode.findAnimationByName('Walk')!)
-          ..loop = true
-          ..weight = 0
-          ..play();
-    runClip =
-        modelNode.createAnimationClip(modelNode.findAnimationByName('Run')!)
-          ..loop = true
-          ..weight = 0
-          ..play();
-
-    debugPrint('Scene loaded.');
-    if (!mounted) {
-      return;
-    }
-    setState(() {
-      loaded = true;
-    });
-  }
+  double _idleWeight = 1.0;
+  double _walkWeight = 0.0;
+  double _runWeight = 0.0;
+  double _speed = 1.0;
 
   @override
   void dispose() {
-    // Optional: the scene is dropped with this State. `Node.fromAsset` caches
-    // the imported model template (shared across clones), so its GPU resources
-    // persist for the session regardless.
     scene.removeAll();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    if (!loaded) {
-      return const Center(child: CircularProgressIndicator());
-    }
     return Stack(
       children: [
         Positioned.fill(
@@ -100,21 +59,38 @@ class ExampleAnimationState extends State<ExampleAnimation> {
               );
             },
             onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+            children: [
+              SceneModel(
+                'assets_src/dash.glb',
+                animations: [
+                  SceneAnimationSpec(
+                    'Idle',
+                    weight: _idleWeight,
+                    speed: _speed,
+                  ),
+                  SceneAnimationSpec(
+                    'Walk',
+                    weight: _walkWeight,
+                    speed: _speed,
+                  ),
+                  SceneAnimationSpec('Run', weight: _runWeight, speed: _speed),
+                ],
+              ),
+            ],
           ),
         ),
         // Animation weights are grouped in a side panel instead of occupying
         // the entire scene width as unlabeled sliders.
-        if (idleClip != null)
-          ExampleOverlay.bottomLeftPanel(child: _buildControls()),
+        ExampleOverlay.bottomLeftPanel(child: _buildControls()),
       ],
     );
   }
 
   Widget _buildControls() {
-    final clips = <(String, AnimationClip)>[
-      ('Idle weight', idleClip!),
-      ('Walk weight', walkClip!),
-      ('Run weight', runClip!),
+    final weights = <(String, double, void Function(double))>[
+      ('Idle weight', _idleWeight, (v) => _idleWeight = v),
+      ('Walk weight', _walkWeight, (v) => _walkWeight = v),
+      ('Run weight', _runWeight, (v) => _runWeight = v),
     ];
     return ExamplePanelCard(
       icon: Icons.animation,
@@ -125,24 +101,20 @@ class ExampleAnimationState extends State<ExampleAnimation> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          for (final (label, clip) in clips)
+          for (final (label, value, apply) in weights)
             LabeledSlider(
               label: label,
-              value: clip.weight,
+              value: value,
               min: 0,
               max: 1,
-              onChanged: (value) => setState(() => clip.weight = value),
+              onChanged: (v) => setState(() => apply(v)),
             ),
           LabeledSlider(
             label: 'Playback speed',
-            value: walkClip!.playbackTimeScale,
+            value: _speed,
             min: -2,
             max: 2,
-            onChanged: (value) => setState(() {
-              idleClip!.playbackTimeScale = value;
-              walkClip!.playbackTimeScale = value;
-              runClip!.playbackTimeScale = value;
-            }),
+            onChanged: (v) => setState(() => _speed = v),
           ),
         ],
       ),

--- a/examples/flutter_app/lib/example_animation.dart
+++ b/examples/flutter_app/lib/example_animation.dart
@@ -59,6 +59,10 @@ class ExampleAnimationState extends State<ExampleAnimation> {
               );
             },
             onTick: (elapsed, deltaSeconds) => exampleSettings.applyTo(scene),
+            // Gating on a loadingBuilder holds the reveal until the
+            // declarative model below has loaded.
+            loadingBuilder: (context, progress) =>
+                const Center(child: CircularProgressIndicator()),
             children: [
               SceneModel(
                 'assets_src/dash.glb',

--- a/examples/flutter_app/lib/example_configurator.dart
+++ b/examples/flutter_app/lib/example_configurator.dart
@@ -10,10 +10,17 @@ import 'environment_menu.dart';
 /// A product configurator built entirely with the declarative scene API.
 ///
 /// The scene is described in `build()`: a [SceneView.declarative] owns the
-/// scene, a [SceneModel] mounts the downloaded shoe, and tapping a swatch
-/// just calls setState with a new variant name. The engine's
-/// KHR_materials_variants support swaps the mapped materials in place, so
-/// switching is instant (no reload, no re-upload).
+/// scene, a [SceneModel] mounts the downloaded shoe on a turntable, and
+/// tapping a swatch just calls setState with a new variant name. The
+/// engine's KHR_materials_variants support swaps the mapped materials in
+/// place, so switching is instant (no reload, no re-upload).
+///
+/// The lighting is a small showroom rig that reacts to the selected
+/// colorway: a shadow-casting key spot over a glossy pedestal, two rim
+/// lights behind the shoe, and an emissive floor ring. The rig's structure
+/// is declared once; the color transitions run engine-side in [Component]s
+/// that ease toward targets each frame, so nothing rebuilds per frame
+/// ("rebuild for structure, mutate for motion").
 ///
 /// The model (MaterialsVariantsShoe, (c) Shopify, CC BY 4.0) is downloaded
 /// live from the Khronos glTF-Sample-Assets repository through the example
@@ -30,18 +37,156 @@ const String _kShoeUrl =
     'Models/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb';
 const int _kShoeSizeBytes = 7833592;
 
-/// The shoe's declared variants with swatch colors for the chips.
-const List<({String name, String label, Color swatch})> _kColorways = [
-  (name: 'midnight', label: 'Midnight', swatch: Color(0xff2b3a67)),
-  (name: 'beach', label: 'Beach', swatch: Color(0xffe8b89d)),
-  (name: 'street', label: 'Street', swatch: Color(0xff9ba0a8)),
+/// The shoe's declared variants, with swatch colors for the chips and the
+/// accent colors the lighting rig glides to.
+const List<
+  ({String name, String label, Color swatch, Color rimLeft, Color rimRight})
+>
+_kColorways = [
+  (
+    name: 'midnight',
+    label: 'Midnight',
+    swatch: Color(0xff2b3a67),
+    rimLeft: Color(0xff3d7bff), // electric blue
+    rimRight: Color(0xff8a4dff), // violet
+  ),
+  (
+    name: 'beach',
+    label: 'Beach',
+    swatch: Color(0xffe8b89d),
+    rimLeft: Color(0xffff7a52), // coral
+    rimRight: Color(0xffffc266), // amber
+  ),
+  (
+    name: 'street',
+    label: 'Street',
+    swatch: Color(0xff9ba0a8),
+    rimLeft: Color(0xff2effd4), // cyan
+    rimRight: Color(0xffff40b0), // magenta
+  ),
 ];
+
+vm.Vector3 _colorToVec3(Color color) => vm.Vector3(color.r, color.g, color.b);
+
+/// Spins the owning node about its Y axis, the product turntable.
+class _TurntableComponent extends Component {
+  _TurntableComponent(this.radiansPerSecond);
+
+  final double radiansPerSecond;
+
+  @override
+  void update(double deltaSeconds) {
+    node.localTransform =
+        node.localTransform *
+        vm.Matrix4.rotationY(radiansPerSecond * deltaSeconds);
+  }
+}
+
+/// Eases a [PointLight]'s color toward [target] each frame, engine-side, so
+/// colorway changes fade smoothly without any widget rebuilding per frame.
+class _ColorGlideComponent extends Component {
+  _ColorGlideComponent(this.light, this.target);
+
+  final PointLight light;
+  vm.Vector3 target;
+
+  @override
+  void update(double deltaSeconds) {
+    final blend = 1.0 - exp(-deltaSeconds * 6.0);
+    light.color.setFrom(light.color + (target - light.color) * blend);
+  }
+}
+
+/// Eases an [UnlitMaterial]'s color toward [target] with a gentle pulse, for
+/// the emissive floor ring.
+class _RingPulseComponent extends Component {
+  _RingPulseComponent(this.material, this.target);
+
+  final UnlitMaterial material;
+  vm.Vector3 target;
+
+  final vm.Vector3 _eased = vm.Vector3.zero();
+  double _elapsed = 0;
+
+  @override
+  void update(double deltaSeconds) {
+    _elapsed += deltaSeconds;
+    final blend = 1.0 - exp(-deltaSeconds * 6.0);
+    _eased.setFrom(_eased + (target - _eased) * blend);
+    final pulse = 0.8 + 0.2 * sin(_elapsed * 1.8);
+    material.baseColorFactor = vm.Vector4(
+      _eased.x * pulse,
+      _eased.y * pulse,
+      _eased.z * pulse,
+      1.0,
+    );
+  }
+}
 
 class ExampleConfiguratorState extends State<ExampleConfigurator> {
   Uint8List? _modelBytes;
   Object? _downloadError;
   int _downloadedBytes = 0;
   String _variant = _kColorways.first.name;
+
+  // The lighting rig and set dressing. Engine objects and components are
+  // created once and kept stable across rebuilds (scene widgets identity-diff
+  // them); swatch taps only retarget the glide components.
+  late final SpotLight _keyLight = SpotLight(
+    color: vm.Vector3(1.0, 0.96, 0.9),
+    intensity: 65.0,
+    range: 30.0,
+    direction: vm.Vector3(-1.3, -3.0, 1.9).normalized(),
+    innerConeAngle: 12 * pi / 180,
+    outerConeAngle: 38 * pi / 180,
+    castsShadow: true,
+    shadowSoftness: 2.0,
+  );
+  late final PointLight _rimLeftLight = PointLight(
+    color: _colorToVec3(_kColorways.first.rimLeft),
+    intensity: 9.0,
+    range: 14.0,
+  );
+  late final PointLight _rimRightLight = PointLight(
+    color: _colorToVec3(_kColorways.first.rimRight),
+    intensity: 7.0,
+    range: 14.0,
+  );
+  late final PointLight _fillLight = PointLight(
+    color: vm.Vector3(0.5, 0.6, 0.8),
+    intensity: 2.5,
+    range: 12.0,
+  );
+  late final _ColorGlideComponent _rimLeftGlide = _ColorGlideComponent(
+    _rimLeftLight,
+    _colorToVec3(_kColorways.first.rimLeft),
+  );
+  late final _ColorGlideComponent _rimRightGlide = _ColorGlideComponent(
+    _rimRightLight,
+    _colorToVec3(_kColorways.first.rimRight),
+  );
+  late final UnlitMaterial _ringMaterial = UnlitMaterial();
+  late final _RingPulseComponent _ringPulse = _RingPulseComponent(
+    _ringMaterial,
+    _colorToVec3(_kColorways.first.rimLeft),
+  );
+  late final _TurntableComponent _turntable = _TurntableComponent(0.45);
+  late final Geometry _pedestalGeometry = CylinderGeometry(
+    bottomRadius: 1.75,
+    topRadius: 1.6,
+    height: 0.12,
+    radialSegments: 64,
+  );
+  late final PhysicallyBasedMaterial _pedestalMaterial =
+      PhysicallyBasedMaterial()
+        ..baseColorFactor = vm.Vector4(0.045, 0.045, 0.055, 1.0)
+        ..metallicFactor = 0.85
+        ..roughnessFactor = 0.32;
+  late final Geometry _ringGeometry = RingGeometry(
+    innerRadius: 1.72,
+    outerRadius: 1.86,
+    segments: 96,
+  );
 
   @override
   void initState() {
@@ -71,6 +216,17 @@ class ExampleConfiguratorState extends State<ExampleConfigurator> {
     }
   }
 
+  void _selectColorway(
+    ({String name, String label, Color swatch, Color rimLeft, Color rimRight})
+    colorway,
+  ) {
+    setState(() => _variant = colorway.name);
+    // Retarget the engine-side glides; they ease over the next frames.
+    _rimLeftGlide.target = _colorToVec3(colorway.rimLeft);
+    _rimRightGlide.target = _colorToVec3(colorway.rimRight);
+    _ringPulse.target = _colorToVec3(colorway.rimLeft);
+  }
+
   @override
   Widget build(BuildContext context) {
     final bytes = _modelBytes;
@@ -80,22 +236,62 @@ class ExampleConfiguratorState extends State<ExampleConfigurator> {
     return Stack(
       children: [
         SceneView.declarative(
-          exposure: 1.2,
+          // Dimmed studio environment so the rig's key and rim lights carry
+          // the image.
+          environmentIntensity: 0.32,
+          exposure: 1.45,
           cameraBuilder: (elapsed) {
-            // A slow orbit around the shoe; the scene itself never rebuilds
-            // for camera motion.
-            final t = elapsed.inMicroseconds / 1e6 * 0.35;
+            // A fixed product-shot framing with a slow breathing sway; the
+            // turntable provides the rotation.
+            final t = elapsed.inMicroseconds / 1e6;
+            final yaw = pi * 0.94 + sin(t * 0.22) * 0.10;
             return PerspectiveCamera(
-              position: vm.Vector3(sin(t) * 2.8, 1.1, cos(t) * 2.8),
-              target: vm.Vector3(0, 0.55, 0),
-              fovRadiansY: 35 * pi / 180,
+              position: vm.Vector3(sin(yaw) * 3.1, 1.45, cos(yaw) * 3.1),
+              target: vm.Vector3(0, 0.52, 0),
+              fovRadiansY: 31 * pi / 180,
             );
           },
           children: [
+            // Key light: warm, shadow casting, above front-left.
+            SceneNode(
+              position: vm.Vector3(1.3, 3.3, -1.9),
+              components: [SpotLightComponent(_keyLight)],
+            ),
+            // Colorway rim lights behind the shoe; their colors glide when
+            // the selection changes.
+            SceneNode(
+              position: vm.Vector3(-2.7, 1.3, 2.3),
+              components: [PointLightComponent(_rimLeftLight), _rimLeftGlide],
+            ),
+            SceneNode(
+              position: vm.Vector3(2.7, 1.0, 2.1),
+              components: [PointLightComponent(_rimRightLight), _rimRightGlide],
+            ),
+            // Faint cool fill from the camera side.
+            SceneNode(
+              position: vm.Vector3(0, 0.7, -3.4),
+              components: [PointLightComponent(_fillLight)],
+            ),
+            // Glossy pedestal that catches the key shadow and rim
+            // reflections.
+            SceneMesh(
+              geometry: _pedestalGeometry,
+              material: _pedestalMaterial,
+              position: vm.Vector3(0, -0.06, 0),
+            ),
+            // Emissive floor ring pulsing in the colorway accent.
+            SceneMesh(
+              geometry: _ringGeometry,
+              material: _ringMaterial,
+              position: vm.Vector3(0, 0.004, 0),
+              components: [_ringPulse],
+            ),
+            // The shoe, on a turntable.
             SceneModel.from(
               MemoryModelSource(bytes, key: _kShoeUrl),
               variant: _variant,
               scale: vm.Vector3.all(8.0),
+              components: [_turntable],
             ),
           ],
         ),
@@ -160,7 +356,7 @@ class ExampleConfiguratorState extends State<ExampleConfigurator> {
                       color: colorway.swatch,
                       label: colorway.label,
                       selected: _variant == colorway.name,
-                      onTap: () => setState(() => _variant = colorway.name),
+                      onTap: () => _selectColorway(colorway),
                     ),
                   ),
               ],

--- a/examples/flutter_app/lib/example_configurator.dart
+++ b/examples/flutter_app/lib/example_configurator.dart
@@ -1,0 +1,233 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart' hide BoxShape;
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'environment_menu.dart';
+
+/// A product configurator built entirely with the declarative scene API.
+///
+/// The scene is described in `build()`: a [SceneView.declarative] owns the
+/// scene, a [SceneModel] mounts the downloaded shoe, and tapping a swatch
+/// just calls setState with a new variant name. The engine's
+/// KHR_materials_variants support swaps the mapped materials in place, so
+/// switching is instant (no reload, no re-upload).
+///
+/// The model (MaterialsVariantsShoe, (c) Shopify, CC BY 4.0) is downloaded
+/// live from the Khronos glTF-Sample-Assets repository through the example
+/// resource cache, so nothing is bundled with the app.
+class ExampleConfigurator extends StatefulWidget {
+  const ExampleConfigurator({super.key});
+
+  @override
+  State<ExampleConfigurator> createState() => ExampleConfiguratorState();
+}
+
+const String _kShoeUrl =
+    'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/'
+    'Models/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb';
+const int _kShoeSizeBytes = 7833592;
+
+/// The shoe's declared variants with swatch colors for the chips.
+const List<({String name, String label, Color swatch})> _kColorways = [
+  (name: 'midnight', label: 'Midnight', swatch: Color(0xff2b3a67)),
+  (name: 'beach', label: 'Beach', swatch: Color(0xffe8b89d)),
+  (name: 'street', label: 'Street', swatch: Color(0xff9ba0a8)),
+];
+
+class ExampleConfiguratorState extends State<ExampleConfigurator> {
+  Uint8List? _modelBytes;
+  Object? _downloadError;
+  int _downloadedBytes = 0;
+  String _variant = _kColorways.first.name;
+
+  @override
+  void initState() {
+    super.initState();
+    _download();
+  }
+
+  Future<void> _download() async {
+    setState(() {
+      _downloadError = null;
+      _downloadedBytes = 0;
+    });
+    try {
+      final bytes = await fetchResource(
+        _kShoeUrl,
+        expectedSize: _kShoeSizeBytes,
+        onChunk: (chunk) {
+          if (!mounted) return;
+          setState(() => _downloadedBytes += chunk);
+        },
+      );
+      if (!mounted) return;
+      setState(() => _modelBytes = bytes);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _downloadError = e);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bytes = _modelBytes;
+    if (bytes == null) {
+      return _buildDownloadGate();
+    }
+    return Stack(
+      children: [
+        SceneView.declarative(
+          exposure: 1.2,
+          cameraBuilder: (elapsed) {
+            // A slow orbit around the shoe; the scene itself never rebuilds
+            // for camera motion.
+            final t = elapsed.inMicroseconds / 1e6 * 0.35;
+            return PerspectiveCamera(
+              position: vm.Vector3(sin(t) * 2.8, 1.1, cos(t) * 2.8),
+              target: vm.Vector3(0, 0.55, 0),
+              fovRadiansY: 35 * pi / 180,
+            );
+          },
+          children: [
+            SceneModel.from(
+              MemoryModelSource(bytes, key: _kShoeUrl),
+              variant: _variant,
+              scale: vm.Vector3.all(8.0),
+            ),
+          ],
+        ),
+        _buildSwatchBar(),
+        _buildAttribution(),
+      ],
+    );
+  }
+
+  Widget _buildDownloadGate() {
+    final error = _downloadError;
+    if (error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Download failed'),
+            const SizedBox(height: 8),
+            Text('$error', style: const TextStyle(fontSize: 11)),
+            const SizedBox(height: 12),
+            FilledButton(onPressed: _download, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+    final progress = (_downloadedBytes / _kShoeSizeBytes).clamp(0.0, 1.0);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(width: 220, child: LinearProgressIndicator(value: progress)),
+          const SizedBox(height: 12),
+          Text(
+            'Downloading shoe model '
+            '(${(_downloadedBytes / (1024 * 1024)).toStringAsFixed(1)} / '
+            '${(_kShoeSizeBytes / (1024 * 1024)).toStringAsFixed(1)} MB)',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSwatchBar() {
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 40),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: const Color(0xaa000000),
+            borderRadius: BorderRadius.circular(24),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final colorway in _kColorways)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 6),
+                    child: _Swatch(
+                      color: colorway.swatch,
+                      label: colorway.label,
+                      selected: _variant == colorway.name,
+                      onTap: () => setState(() => _variant = colorway.name),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAttribution() {
+    return const Align(
+      alignment: Alignment.bottomRight,
+      child: Padding(
+        padding: EdgeInsets.all(8),
+        child: Text(
+          'Shoe model (c) Shopify, CC BY 4.0',
+          style: TextStyle(fontSize: 10, color: Color(0x88ffffff)),
+        ),
+      ),
+    );
+  }
+}
+
+class _Swatch extends StatelessWidget {
+  const _Swatch({
+    required this.color,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final Color color;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: selected ? Colors.white : Colors.white24,
+                width: selected ? 3 : 1,
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 11,
+              color: selected ? Colors.white : Colors.white70,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/flutter_app/lib/example_configurator.dart
+++ b/examples/flutter_app/lib/example_configurator.dart
@@ -37,12 +37,19 @@ const String _kShoeUrl =
     'Models/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb';
 const int _kShoeSizeBytes = 7833592;
 
+/// A colorway pairing the shoe's declared variant with swatch and lighting
+/// accent colors.
+typedef _Colorway = ({
+  String name,
+  String label,
+  Color swatch,
+  Color rimLeft,
+  Color rimRight,
+});
+
 /// The shoe's declared variants, with swatch colors for the chips and the
 /// accent colors the lighting rig glides to.
-const List<
-  ({String name, String label, Color swatch, Color rimLeft, Color rimRight})
->
-_kColorways = [
+const List<_Colorway> _kColorways = [
   (
     name: 'midnight',
     label: 'Midnight',
@@ -76,9 +83,9 @@ class _TurntableComponent extends Component {
 
   @override
   void update(double deltaSeconds) {
-    node.localTransform =
-        node.localTransform *
-        vm.Matrix4.rotationY(radiansPerSecond * deltaSeconds);
+    // In place, so the per-frame path allocates nothing.
+    node.localTransform.rotateY(radiansPerSecond * deltaSeconds);
+    node.markTransformDirty();
   }
 }
 
@@ -92,8 +99,12 @@ class _ColorGlideComponent extends Component {
 
   @override
   void update(double deltaSeconds) {
+    // Component-wise in place, so the per-frame path allocates nothing.
     final blend = 1.0 - exp(-deltaSeconds * 6.0);
-    light.color.setFrom(light.color + (target - light.color) * blend);
+    final color = light.color;
+    color.x += (target.x - color.x) * blend;
+    color.y += (target.y - color.y) * blend;
+    color.z += (target.z - color.z) * blend;
   }
 }
 
@@ -112,9 +123,11 @@ class _RingPulseComponent extends Component {
   void update(double deltaSeconds) {
     _elapsed += deltaSeconds;
     final blend = 1.0 - exp(-deltaSeconds * 6.0);
-    _eased.setFrom(_eased + (target - _eased) * blend);
+    _eased.x += (target.x - _eased.x) * blend;
+    _eased.y += (target.y - _eased.y) * blend;
+    _eased.z += (target.z - _eased.z) * blend;
     final pulse = 0.8 + 0.2 * sin(_elapsed * 1.8);
-    material.baseColorFactor = vm.Vector4(
+    material.baseColorFactor.setValues(
       _eased.x * pulse,
       _eased.y * pulse,
       _eased.z * pulse,
@@ -216,10 +229,7 @@ class ExampleConfiguratorState extends State<ExampleConfigurator> {
     }
   }
 
-  void _selectColorway(
-    ({String name, String label, Color swatch, Color rimLeft, Color rimRight})
-    colorway,
-  ) {
+  void _selectColorway(_Colorway colorway) {
     setState(() => _variant = colorway.name);
     // Retarget the engine-side glides; they ease over the next frames.
     _rimLeftGlide.target = _colorToVec3(colorway.rimLeft);
@@ -252,7 +262,7 @@ class ExampleConfiguratorState extends State<ExampleConfigurator> {
             );
           },
           children: [
-            // Key light: warm, shadow casting, above front-left.
+            // Warm shadow-casting key light above front-left.
             SceneNode(
               position: vm.Vector3(1.3, 3.3, -1.9),
               components: [SpotLightComponent(_keyLight)],
@@ -326,7 +336,7 @@ class ExampleConfiguratorState extends State<ExampleConfigurator> {
           const SizedBox(height: 12),
           Text(
             'Downloading shoe model '
-            '(${(_downloadedBytes / (1024 * 1024)).toStringAsFixed(1)} / '
+            '(${(_downloadedBytes / (1024 * 1024)).toStringAsFixed(1)} of '
             '${(_kShoeSizeBytes / (1024 * 1024)).toStringAsFixed(1)} MB)',
           ),
         ],

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:example_app/example_animation.dart';
 
 import 'example_accessibility.dart';
 import 'example_auto_exposure.dart';
+import 'example_configurator.dart';
 import 'example_cuboid.dart';
 import 'example_dicom.dart';
 import 'example_lights.dart';
@@ -116,6 +117,7 @@ class _MyAppState extends State<MyApp> {
       'Animation': (context) => const ExampleAnimation(),
       'Flutter Logo': (context) => const ExampleLogo(),
       'Cuboid': (context) => const ExampleCuboid(),
+      'Configurator': (context) => const ExampleConfigurator(),
       'Lights': (context) => const ExampleLights(),
       'Spot Shadow': (context) => const ExampleSpotShadow(),
       'Sprites': (context) => const ExampleSprites(),

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -14,8 +14,13 @@
   declarative tree, `SceneSubtree` mounts declarative children under any
   node of an app-owned scene (both `SceneView` constructors take
   `children`), and `SceneNodeController` hands imperative code the
-  widget-managed node. The imperative API is unchanged and remains fully
-  supported.
+  widget-managed node. Gated views (`loading`/`warmUp`) hold their reveal
+  until declarative models finish loading, asset-sourced models
+  participate in asset hot reload, template clones carry importer-attached
+  components (punctual lights) through the new `Component.cloneFor` hook,
+  and removing an animation spec fully unregisters its clip
+  (`AnimationPlayer.removeClip`). The imperative API is unchanged and
+  remains fully supported.
 
 * Declarative animation control and shared model templates. `SceneModel`
   gained `animations`, a list of `SceneAnimationSpec`s declaring which
@@ -31,14 +36,19 @@
 
 * `KHR_materials_variants` support in both import paths. Models
   declaring material variants get a `MaterialsVariantsComponent` (found
-  via `MaterialsVariantsComponent.of(root)`) with the declared names;
+  via `MaterialsVariantsComponent.of(root)`, or `allOf` for multi-root
+  documents) with the declared names;
   `select(name)` swaps the mapped primitives' materials in place
   (`select(null)` restores defaults), so variant switching is instant.
   The `.fscene` document format carries variants as a
   `materialsVariants` component (variant names plus per-primitive
-  material mappings), so pre-converted `.fsceneb` assets keep their
-  variants; no container change was needed and existing files are
-  unaffected. `SceneModel` exposes selection declaratively as a
+  material mappings, the authored default, and the active selection), so
+  pre-converted `.fsceneb` assets keep their variants and an editor save
+  made while a variant is selected keeps the authored defaults; no
+  container change was needed and existing files are unaffected. Bindings
+  resolve primitives by index at selection time, so meshes rebuilt by
+  scene hot reload stay bound, and re-registered render items keep
+  subclass state (LOD tags) through the new mesh re-registration hook. `SceneModel` exposes selection declaratively as a
   `variant` property. The example app gained a Configurator example, a
   product configurator that live-downloads the Khronos
   MaterialsVariantsShoe and switches its colorways.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,31 @@
 ## 0.20.0
 
+* New declarative scene API. Scenes can now be described in `build()`
+  with widgets that own and reconcile retained scene-graph nodes:
+  `SceneView.declarative` (a view-owned `Scene` configured through
+  constructor props), `SceneNode` (transform, components, children),
+  `SceneMesh` (geometry plus material), and `SceneModel` (async `.glb`
+  loading with `placeholder`/`error` scene subtrees, sourced from the
+  asset bundle or app-supplied bytes via `SceneModelSource`). Rebuilds
+  apply only changed properties to the retained nodes; structure changes
+  reconcile through the element tree (keys, `GlobalKey` reparenting, and
+  hot reload of scene structure all work). Bridges connect the two styles
+  in both directions, `SceneNodeHost` mounts an app-owned node inside a
+  declarative tree, `SceneSubtree` mounts declarative children under any
+  node of an app-owned scene (both `SceneView` constructors take
+  `children`), and `SceneNodeController` hands imperative code the
+  widget-managed node. The imperative API is unchanged and remains fully
+  supported.
+
+* `KHR_materials_variants` support in the runtime importer. Models
+  declaring material variants get a `MaterialsVariantsComponent` on their
+  root with the declared names; `select(name)` swaps the mapped
+  primitives' materials in place (`select(null)` restores defaults), so
+  variant switching is instant. `SceneModel` exposes it declaratively as
+  a `variant` property. The example app gained a Configurator example, a
+  product configurator that live-downloads the Khronos
+  MaterialsVariantsShoe and switches its colorways.
+
 * Animation blending no longer flattens rigs with mirrored bones. Recovering
   the bind pose from the composed matrix put a mirrored axis's negative
   scale on X, so weighted blends faded the bone through zero scale and the

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -29,12 +29,17 @@
   component are rebound per instance), with the template evicted when
   the last user unmounts.
 
-* `KHR_materials_variants` support in the runtime importer. Models
-  declaring material variants get a `MaterialsVariantsComponent` on their
-  root with the declared names; `select(name)` swaps the mapped
-  primitives' materials in place (`select(null)` restores defaults), so
-  variant switching is instant. `SceneModel` exposes it declaratively as
-  a `variant` property. The example app gained a Configurator example, a
+* `KHR_materials_variants` support in both import paths. Models
+  declaring material variants get a `MaterialsVariantsComponent` (found
+  via `MaterialsVariantsComponent.of(root)`) with the declared names;
+  `select(name)` swaps the mapped primitives' materials in place
+  (`select(null)` restores defaults), so variant switching is instant.
+  The `.fscene` document format carries variants as a
+  `materialsVariants` component (variant names plus per-primitive
+  material mappings), so pre-converted `.fsceneb` assets keep their
+  variants; no container change was needed and existing files are
+  unaffected. `SceneModel` exposes selection declaratively as a
+  `variant` property. The example app gained a Configurator example, a
   product configurator that live-downloads the Khronos
   MaterialsVariantsShoe and switches its colorways.
 

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -17,6 +17,18 @@
   widget-managed node. The imperative API is unchanged and remains fully
   supported.
 
+* Declarative animation control and shared model templates. `SceneModel`
+  gained `animations`, a list of `SceneAnimationSpec`s declaring which
+  imported animations play by name with per-spec `playing`/`loop`/
+  `weight`/`speed`; rebuilding applies the differences to the underlying
+  clips as plain property writes, so blend weights compose with ordinary
+  Flutter animations. Models are also now cached and shared: widgets
+  whose sources have equal cache keys load and import once, each
+  mounting its own clone of the shared template (geometry, textures, and
+  materials stay shared on the GPU; primitives, skins, and the variants
+  component are rebound per instance), with the template evicted when
+  the last user unmounts.
+
 * `KHR_materials_variants` support in the runtime importer. Models
   declaring material variants get a `MaterialsVariantsComponent` on their
   root with the declared names; `select(name)` swaps the mapped

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -221,6 +221,7 @@ export 'src/widgets/declarative.dart'
     show
         AssetModelSource,
         MemoryModelSource,
+        SceneAnimationSpec,
         SceneMesh,
         SceneModel,
         SceneModelSource,

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -108,6 +108,8 @@ export 'src/components/instanced_mesh_component.dart'
     show InstancedMeshComponent;
 export 'src/components/lod_component.dart' show LodComponent;
 export 'src/components/mesh_component.dart' show MeshComponent;
+export 'src/components/materials_variants_component.dart'
+    show MaterialsVariantsComponent;
 export 'src/components/point_light_component.dart' show PointLightComponent;
 export 'src/components/semantics_component.dart' show SemanticsComponent;
 export 'src/components/splat_component.dart' show SplatComponent;
@@ -215,6 +217,17 @@ export 'src/skybox.dart'
     show EnvironmentSkySource, ShaderSkySource, SkySource, Skybox, SunSky;
 export 'src/sun_light.dart' show SunLight;
 export 'src/surface.dart' show Surface;
+export 'src/widgets/declarative.dart'
+    show
+        AssetModelSource,
+        MemoryModelSource,
+        SceneMesh,
+        SceneModel,
+        SceneModelSource,
+        SceneNode,
+        SceneNodeController,
+        SceneNodeHost,
+        SceneSubtree;
 export 'src/widgets/render_texture_view.dart' show RenderTextureView;
 export 'src/widgets/scene_view.dart'
     show

--- a/packages/flutter_scene/lib/src/animation/animation_player.dart
+++ b/packages/flutter_scene/lib/src/animation/animation_player.dart
@@ -25,16 +25,27 @@ class AnimationPlayer {
   AnimationClip createAnimationClip(Animation animation, Node bindTarget) {
     final clip = AnimationClip(animation, bindTarget);
 
-    // Record all of the unique default transforms that this AnimationClip
-    // will mutate.
+    // Record the default transforms this clip will mutate. Nodes already
+    // bound by another clip keep their recorded bind pose; re-capturing here
+    // would snapshot the current (possibly mid-playback, animated) transform
+    // as the rest pose and corrupt the blend baseline for every clip.
     for (final binding in clip._bindings) {
-      _targetTransforms[binding.node] = AnimationTransforms(
-        bindPose: _bindPoseOf(binding.node),
+      _targetTransforms.putIfAbsent(
+        binding.node,
+        () => AnimationTransforms(bindPose: _bindPoseOf(binding.node)),
       );
     }
 
     _clips[animation.name] = clip;
     return clip;
+  }
+
+  /// Unregisters [clip] so it no longer contributes to the blend.
+  ///
+  /// Bind poses recorded for its nodes are kept (other clips may share
+  /// them). No-op when [clip] is not registered.
+  void removeClip(AnimationClip clip) {
+    _clips.removeWhere((_, registered) => identical(registered, clip));
   }
 
   /// Returns the registered clip whose [Animation.name] equals [name],

--- a/packages/flutter_scene/lib/src/components/component.dart
+++ b/packages/flutter_scene/lib/src/components/component.dart
@@ -73,6 +73,18 @@ abstract class Component {
   /// Called when this component is removed from a node.
   void onDetach() {}
 
+  /// Returns a copy of this component for [cloneOwner], the [Node.clone]
+  /// counterpart of the owning node, or null to not carry the component to
+  /// clones (the default).
+  ///
+  /// Follows the clone's sharing rule for meshes, heavyweight payloads stay
+  /// shared while per-node identity is fresh, so an override typically wraps
+  /// the same payload in a new component instance (the light components
+  /// share their light object). Components whose state references other
+  /// nodes cannot self-clone through this hook and need caller-driven
+  /// rebinding instead (see `MaterialsVariantsComponent`).
+  Component? cloneFor(Node cloneOwner) => null;
+
   @internal
   void attachTo(Node node) {
     _node = node;

--- a/packages/flutter_scene/lib/src/components/directional_light_component.dart
+++ b/packages/flutter_scene/lib/src/components/directional_light_component.dart
@@ -2,6 +2,7 @@ import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_scene/src/node.dart';
 
 /// An engine [Component] that places a [DirectionalLight] in the scene.
 ///
@@ -51,4 +52,9 @@ class DirectionalLightComponent extends Component {
   /// the shadow-cascade fit both normalize it).
   Vector3 get worldDirection =>
       node.globalTransform.getRotation() * light.direction;
+
+  /// Clones carry the light, sharing the light object like other clone
+  /// payloads (geometry, materials).
+  @override
+  Component? cloneFor(Node cloneOwner) => DirectionalLightComponent(light);
 }

--- a/packages/flutter_scene/lib/src/components/lod_component.dart
+++ b/packages/flutter_scene/lib/src/components/lod_component.dart
@@ -76,10 +76,10 @@ class LodComponent extends MeshComponent {
   set lodBias(double value) => _selection.lodBias = value;
 
   @override
-  void onMount() {
-    super.onMount();
-    // Tag the item the base class just registered so the encoder selects a
-    // level per view instead of drawing the highest-detail fallback.
+  void onRenderItemsRegistered() {
+    // Tag the items the base class just registered so the encoder selects a
+    // level per view instead of drawing the highest-detail fallback. Runs on
+    // every re-registration, so the tags survive material refreshes.
     for (final item in renderItems) {
       item.lod = _selection;
     }

--- a/packages/flutter_scene/lib/src/components/materials_variants_component.dart
+++ b/packages/flutter_scene/lib/src/components/materials_variants_component.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/mesh.dart';
+
+/// One primitive's material choices under `KHR_materials_variants`.
+///
+/// Holds the primitive's default material and its per-variant alternates so
+/// [MaterialsVariantsComponent.select] can swap them in place.
+@internal
+class MaterialsVariantBinding {
+  MaterialsVariantBinding({
+    required this.primitive,
+    required this.defaultMaterial,
+    required this.materialsByVariant,
+  });
+
+  final MeshPrimitive primitive;
+  final Material defaultMaterial;
+
+  /// Variant index (into [MaterialsVariantsComponent.variants]) to the
+  /// material that variant assigns. A variant with no entry keeps
+  /// [defaultMaterial].
+  final Map<int, Material> materialsByVariant;
+}
+
+/// Switches an imported model between its named material variants
+/// (`KHR_materials_variants`).
+///
+/// The importer attaches this to the root of a model whose source declares
+/// variants. Read [variants] for the declared names and call [select] to
+/// swap every affected primitive's material in place; `select(null)` restores
+/// the source's default materials. Selection is cheap (material reassignment,
+/// no reload), so it is suitable for interactive switching, for example a
+/// product configurator.
+///
+/// ```dart
+/// final variants = model.getComponent<MaterialsVariantsComponent>();
+/// variants?.select('beach');
+/// ```
+/// {@category Materials}
+class MaterialsVariantsComponent extends Component {
+  // TODO(materials-variants): the offline document importer and the .fscene
+  // format do not carry variants yet (runtime importer only), and Node.clone
+  // does not clone components, so a cloned model loses variant switching.
+
+  /// Used by the importer; not for application construction.
+  @internal
+  MaterialsVariantsComponent.internal(
+    List<String> variants,
+    List<MaterialsVariantBinding> bindings,
+  ) : variants = List.unmodifiable(variants),
+      _bindings = bindings;
+
+  /// The variant names declared by the source, in declaration order.
+  final List<String> variants;
+
+  final List<MaterialsVariantBinding> _bindings;
+
+  String? _selected;
+
+  /// The currently selected variant name, or null when the defaults are
+  /// active.
+  String? get selected => _selected;
+
+  /// Applies the named variant to every mapped primitive.
+  ///
+  /// Pass null to restore the default materials. Throws [ArgumentError] when
+  /// [name] is not one of [variants]. Primitives the variant does not map
+  /// keep their default material.
+  void select(String? name) {
+    if (name == null) {
+      _selected = null;
+      for (final binding in _bindings) {
+        binding.primitive.material = binding.defaultMaterial;
+      }
+      return;
+    }
+    final index = variants.indexOf(name);
+    if (index < 0) {
+      throw ArgumentError.value(
+        name,
+        'name',
+        'Unknown variant; declared variants are $variants',
+      );
+    }
+    _selected = name;
+    for (final binding in _bindings) {
+      binding.primitive.material =
+          binding.materialsByVariant[index] ?? binding.defaultMaterial;
+    }
+  }
+}

--- a/packages/flutter_scene/lib/src/components/materials_variants_component.dart
+++ b/packages/flutter_scene/lib/src/components/materials_variants_component.dart
@@ -8,27 +8,39 @@ import 'package:flutter_scene/src/node.dart';
 
 /// One primitive's material choices under `KHR_materials_variants`.
 ///
-/// Holds the primitive's default material and its per-variant alternates so
-/// [MaterialsVariantsComponent.select] can swap them in place. [node] is the
-/// node whose mesh owns [primitive], so the swap can refresh its registered
-/// render items.
+/// Identifies the primitive as [node] plus [primitiveIndex] and resolves it
+/// at selection time, so a mesh whose primitives are rebuilt (a scene hot
+/// reload replacing the mesh component) stays bound instead of orphaning
+/// direct primitive references.
 @internal
 class MaterialsVariantBinding {
   MaterialsVariantBinding({
     required this.node,
-    required this.primitive,
+    required this.primitiveIndex,
     required this.defaultMaterial,
     required this.materialsByVariant,
   });
 
   final Node node;
-  final MeshPrimitive primitive;
+  final int primitiveIndex;
   final Material defaultMaterial;
 
   /// Variant index (into [MaterialsVariantsComponent.variants]) to the
   /// material that variant assigns. A variant with no entry keeps
   /// [defaultMaterial].
   final Map<int, Material> materialsByVariant;
+
+  /// The primitive this binding currently targets, or null when the mesh no
+  /// longer has one at [primitiveIndex].
+  MeshPrimitive? resolvePrimitive() {
+    final primitives = node.mesh?.primitives;
+    if (primitives == null ||
+        primitiveIndex < 0 ||
+        primitiveIndex >= primitives.length) {
+      return null;
+    }
+    return primitives[primitiveIndex];
+  }
 }
 
 /// Switches an imported model between its named material variants
@@ -42,15 +54,16 @@ class MaterialsVariantBinding {
 /// product configurator.
 ///
 /// ```dart
-/// final variants = model.getComponent<MaterialsVariantsComponent>();
+/// final variants = MaterialsVariantsComponent.of(model);
 /// variants?.select('beach');
 /// ```
 /// {@category Materials}
 class MaterialsVariantsComponent extends Component {
   // Carried by both import paths: the runtime importer attaches it directly,
   // and the .fscene document serializes it as a materialsVariants component.
-  // Clones get variant switching back through [rebindClone] (Node.clone
-  // itself does not carry components).
+  // Clones get variant switching back through [rebindClone]; the component
+  // cannot use [Component.cloneFor] because its bindings reference other
+  // nodes, which only the caller holding both roots can remap.
 
   /// Used by the importer; not for application construction.
   @internal
@@ -60,23 +73,30 @@ class MaterialsVariantsComponent extends Component {
   ) : variants = List.unmodifiable(variants),
       _bindings = bindings;
 
-  /// Finds the variants component for a loaded model.
+  /// Finds the first variants component for a loaded model.
   ///
-  /// The runtime importer attaches the component to the model's root; the
-  /// `.fscene` realizer attaches it to the document root node it was
-  /// serialized on, which sits below the synthesized scene root. This
-  /// searches [root] and then its subtree (breadth-first), so callers work
-  /// with either import path.
+  /// The runtime importer attaches one component to the model's root; the
+  /// `.fscene` realizer attaches one per document root (below the
+  /// synthesized scene root). This searches [root] and then its subtree
+  /// breadth-first, so callers work with either import path. A multi-root
+  /// document can carry several components; use [allOf] to reach every one.
   static MaterialsVariantsComponent? of(Node root) {
-    final direct = root.getComponent<MaterialsVariantsComponent>();
-    if (direct != null) return direct;
+    final all = allOf(root);
+    return all.isEmpty ? null : all.first;
+  }
+
+  /// Every variants component on [root] and its subtree, in breadth-first
+  /// order. Select on each to switch a multi-root model completely.
+  static List<MaterialsVariantsComponent> allOf(Node root) {
+    final found = <MaterialsVariantsComponent>[
+      ...root.getComponents<MaterialsVariantsComponent>(),
+    ];
     final queue = <Node>[...root.children];
     for (var i = 0; i < queue.length; i++) {
-      final component = queue[i].getComponent<MaterialsVariantsComponent>();
-      if (component != null) return component;
+      found.addAll(queue[i].getComponents<MaterialsVariantsComponent>());
       queue.addAll(queue[i].children);
     }
-    return null;
+    return found;
   }
 
   /// The variant names declared by the source, in declaration order.
@@ -98,76 +118,76 @@ class MaterialsVariantsComponent extends Component {
   ///
   /// Pass null to restore the default materials. Throws [ArgumentError] when
   /// [name] is not one of [variants]. Primitives the variant does not map
-  /// keep their default material.
+  /// keep their default material. Re-selecting the current variant is free.
   void select(String? name) {
-    if (name == null) {
-      _selected = null;
-      for (final binding in _bindings) {
-        binding.primitive.material = binding.defaultMaterial;
-      }
-      _refreshRenderItems();
-      return;
-    }
-    final index = variants.indexOf(name);
-    if (index < 0) {
+    if (name != null && !variants.contains(name)) {
       throw ArgumentError.value(
         name,
         'name',
         'Unknown variant; declared variants are $variants',
       );
     }
+    if (name == _selected) return;
     _selected = name;
+    _apply();
+  }
+
+  /// Re-applies the current selection to the bindings, for callers that
+  /// changed the binding list or the bound meshes after selection.
+  @internal
+  void reapply() => _apply();
+
+  void _apply() {
+    final index = _selected == null ? -1 : variants.indexOf(_selected!);
     for (final binding in _bindings) {
-      binding.primitive.material =
+      final primitive = binding.resolvePrimitive();
+      if (primitive == null) continue;
+      primitive.material =
           binding.materialsByVariant[index] ?? binding.defaultMaterial;
     }
     _refreshRenderItems();
   }
 
   /// Rebuilds this component for a [Node.clone] of the tree it was built
-  /// against, rebinding every binding to the clone's corresponding node and
-  /// primitive, and attaches the result to [cloneRoot].
+  /// against, rebinding every binding to the clone's corresponding node, and
+  /// attaches the result to [cloneRoot].
   ///
-  /// [Node.clone] does not carry components, so cloned models would lose
-  /// variant switching without this. Bindings whose node or primitive cannot
-  /// be resolved in the clone are dropped. Returns null (attaching nothing)
-  /// when [templateRoot] has no variants component.
+  /// Bindings whose node cannot be resolved in the clone are dropped.
+  /// Returns null (attaching nothing) when [templateRoot] has no variants
+  /// component. A template with several components (multi-root documents)
+  /// has each rebound onto [cloneRoot].
   @internal
   static MaterialsVariantsComponent? rebindClone(
     Node templateRoot,
     Node cloneRoot,
   ) {
-    final source = MaterialsVariantsComponent.of(templateRoot);
-    if (source == null) return null;
-    final bindings = <MaterialsVariantBinding>[];
-    for (final binding in source._bindings) {
-      final path = Node.getIndexPath(templateRoot, binding.node);
-      final cloneNode = path == null
-          ? null
-          : cloneRoot.getChildByIndexPath(path);
-      final templateMesh = binding.node.mesh;
-      final cloneMesh = cloneNode?.mesh;
-      if (cloneNode == null || templateMesh == null || cloneMesh == null) {
-        continue;
+    MaterialsVariantsComponent? first;
+    for (final source in allOf(templateRoot)) {
+      final bindings = <MaterialsVariantBinding>[];
+      for (final binding in source._bindings) {
+        final path = Node.getIndexPath(templateRoot, binding.node);
+        final cloneNode = path == null
+            ? null
+            : cloneRoot.getChildByIndexPath(path);
+        if (cloneNode == null) continue;
+        // Mesh.clone preserves primitive order, so the index carries over.
+        bindings.add(
+          MaterialsVariantBinding(
+            node: cloneNode,
+            primitiveIndex: binding.primitiveIndex,
+            defaultMaterial: binding.defaultMaterial,
+            materialsByVariant: binding.materialsByVariant,
+          ),
+        );
       }
-      // Mesh.clone preserves primitive order, so positions correspond.
-      final index = templateMesh.primitives.indexOf(binding.primitive);
-      if (index < 0 || index >= cloneMesh.primitives.length) continue;
-      bindings.add(
-        MaterialsVariantBinding(
-          node: cloneNode,
-          primitive: cloneMesh.primitives[index],
-          defaultMaterial: binding.defaultMaterial,
-          materialsByVariant: binding.materialsByVariant,
-        ),
+      final clone = MaterialsVariantsComponent.internal(
+        source.variants,
+        bindings,
       );
+      cloneRoot.addComponent(clone);
+      first ??= clone;
     }
-    final clone = MaterialsVariantsComponent.internal(
-      source.variants,
-      bindings,
-    );
-    cloneRoot.addComponent(clone);
-    return clone;
+    return first;
   }
 
   // Render items capture materials at registration, so mounted meshes must

--- a/packages/flutter_scene/lib/src/components/materials_variants_component.dart
+++ b/packages/flutter_scene/lib/src/components/materials_variants_component.dart
@@ -1,21 +1,27 @@
 import 'package:flutter/foundation.dart';
 
 import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/components/mesh_component.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/mesh.dart';
+import 'package:flutter_scene/src/node.dart';
 
 /// One primitive's material choices under `KHR_materials_variants`.
 ///
 /// Holds the primitive's default material and its per-variant alternates so
-/// [MaterialsVariantsComponent.select] can swap them in place.
+/// [MaterialsVariantsComponent.select] can swap them in place. [node] is the
+/// node whose mesh owns [primitive], so the swap can refresh its registered
+/// render items.
 @internal
 class MaterialsVariantBinding {
   MaterialsVariantBinding({
+    required this.node,
     required this.primitive,
     required this.defaultMaterial,
     required this.materialsByVariant,
   });
 
+  final Node node;
   final MeshPrimitive primitive;
   final Material defaultMaterial;
 
@@ -75,6 +81,7 @@ class MaterialsVariantsComponent extends Component {
       for (final binding in _bindings) {
         binding.primitive.material = binding.defaultMaterial;
       }
+      _refreshRenderItems();
       return;
     }
     final index = variants.indexOf(name);
@@ -89,6 +96,19 @@ class MaterialsVariantsComponent extends Component {
     for (final binding in _bindings) {
       binding.primitive.material =
           binding.materialsByVariant[index] ?? binding.defaultMaterial;
+    }
+    _refreshRenderItems();
+  }
+
+  // Render items capture materials at registration, so mounted meshes must
+  // re-register for a swap to take effect on screen.
+  void _refreshRenderItems() {
+    final seen = <Node>{};
+    for (final binding in _bindings) {
+      if (!seen.add(binding.node)) continue;
+      for (final meshComponent in binding.node.getComponents<MeshComponent>()) {
+        meshComponent.refreshMaterials();
+      }
     }
   }
 }

--- a/packages/flutter_scene/lib/src/components/materials_variants_component.dart
+++ b/packages/flutter_scene/lib/src/components/materials_variants_component.dart
@@ -48,8 +48,9 @@ class MaterialsVariantBinding {
 /// {@category Materials}
 class MaterialsVariantsComponent extends Component {
   // TODO(materials-variants): the offline document importer and the .fscene
-  // format do not carry variants yet (runtime importer only), and Node.clone
-  // does not clone components, so a cloned model loses variant switching.
+  // format do not carry variants yet (runtime importer only). Clones get
+  // variant switching back through [rebindClone] (Node.clone itself does not
+  // carry components).
 
   /// Used by the importer; not for application construction.
   @internal
@@ -98,6 +99,52 @@ class MaterialsVariantsComponent extends Component {
           binding.materialsByVariant[index] ?? binding.defaultMaterial;
     }
     _refreshRenderItems();
+  }
+
+  /// Rebuilds this component for a [Node.clone] of the tree it was built
+  /// against, rebinding every binding to the clone's corresponding node and
+  /// primitive, and attaches the result to [cloneRoot].
+  ///
+  /// [Node.clone] does not carry components, so cloned models would lose
+  /// variant switching without this. Bindings whose node or primitive cannot
+  /// be resolved in the clone are dropped. Returns null (attaching nothing)
+  /// when [templateRoot] has no variants component.
+  @internal
+  static MaterialsVariantsComponent? rebindClone(
+    Node templateRoot,
+    Node cloneRoot,
+  ) {
+    final source = templateRoot.getComponent<MaterialsVariantsComponent>();
+    if (source == null) return null;
+    final bindings = <MaterialsVariantBinding>[];
+    for (final binding in source._bindings) {
+      final path = Node.getIndexPath(templateRoot, binding.node);
+      final cloneNode = path == null
+          ? null
+          : cloneRoot.getChildByIndexPath(path);
+      final templateMesh = binding.node.mesh;
+      final cloneMesh = cloneNode?.mesh;
+      if (cloneNode == null || templateMesh == null || cloneMesh == null) {
+        continue;
+      }
+      // Mesh.clone preserves primitive order, so positions correspond.
+      final index = templateMesh.primitives.indexOf(binding.primitive);
+      if (index < 0 || index >= cloneMesh.primitives.length) continue;
+      bindings.add(
+        MaterialsVariantBinding(
+          node: cloneNode,
+          primitive: cloneMesh.primitives[index],
+          defaultMaterial: binding.defaultMaterial,
+          materialsByVariant: binding.materialsByVariant,
+        ),
+      );
+    }
+    final clone = MaterialsVariantsComponent.internal(
+      source.variants,
+      bindings,
+    );
+    cloneRoot.addComponent(clone);
+    return clone;
   }
 
   // Render items capture materials at registration, so mounted meshes must

--- a/packages/flutter_scene/lib/src/components/materials_variants_component.dart
+++ b/packages/flutter_scene/lib/src/components/materials_variants_component.dart
@@ -47,10 +47,10 @@ class MaterialsVariantBinding {
 /// ```
 /// {@category Materials}
 class MaterialsVariantsComponent extends Component {
-  // TODO(materials-variants): the offline document importer and the .fscene
-  // format do not carry variants yet (runtime importer only). Clones get
-  // variant switching back through [rebindClone] (Node.clone itself does not
-  // carry components).
+  // Carried by both import paths: the runtime importer attaches it directly,
+  // and the .fscene document serializes it as a materialsVariants component.
+  // Clones get variant switching back through [rebindClone] (Node.clone
+  // itself does not carry components).
 
   /// Used by the importer; not for application construction.
   @internal
@@ -60,10 +60,33 @@ class MaterialsVariantsComponent extends Component {
   ) : variants = List.unmodifiable(variants),
       _bindings = bindings;
 
+  /// Finds the variants component for a loaded model.
+  ///
+  /// The runtime importer attaches the component to the model's root; the
+  /// `.fscene` realizer attaches it to the document root node it was
+  /// serialized on, which sits below the synthesized scene root. This
+  /// searches [root] and then its subtree (breadth-first), so callers work
+  /// with either import path.
+  static MaterialsVariantsComponent? of(Node root) {
+    final direct = root.getComponent<MaterialsVariantsComponent>();
+    if (direct != null) return direct;
+    final queue = <Node>[...root.children];
+    for (var i = 0; i < queue.length; i++) {
+      final component = queue[i].getComponent<MaterialsVariantsComponent>();
+      if (component != null) return component;
+      queue.addAll(queue[i].children);
+    }
+    return null;
+  }
+
   /// The variant names declared by the source, in declaration order.
   final List<String> variants;
 
   final List<MaterialsVariantBinding> _bindings;
+
+  /// The per-primitive bindings, for the fscene codec.
+  @internal
+  List<MaterialsVariantBinding> get internalBindings => _bindings;
 
   String? _selected;
 
@@ -114,7 +137,7 @@ class MaterialsVariantsComponent extends Component {
     Node templateRoot,
     Node cloneRoot,
   ) {
-    final source = templateRoot.getComponent<MaterialsVariantsComponent>();
+    final source = MaterialsVariantsComponent.of(templateRoot);
     if (source == null) return null;
     final bindings = <MaterialsVariantBinding>[];
     for (final binding in source._bindings) {

--- a/packages/flutter_scene/lib/src/components/mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/mesh_component.dart
@@ -60,7 +60,17 @@ class MeshComponent extends Component {
       _renderItems.add(item);
       renderScene.add(item);
     }
+    onRenderItemsRegistered();
   }
+
+  /// Called after this component registers its render items, on mount and on
+  /// every re-registration ([mesh] assignment, [refreshMaterials]).
+  ///
+  /// Subclasses that decorate the registered items (the LOD component tags
+  /// them with its selection) must do so here rather than in [onMount], or
+  /// the decoration is lost when the items are rebuilt.
+  @protected
+  void onRenderItemsRegistered() {}
 
   /// Re-registers the render items so a changed [MeshPrimitive.material]
   /// takes effect.

--- a/packages/flutter_scene/lib/src/components/mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/mesh_component.dart
@@ -62,6 +62,20 @@ class MeshComponent extends Component {
     }
   }
 
+  /// Re-registers the render items so a changed [MeshPrimitive.material]
+  /// takes effect.
+  ///
+  /// Render items capture the primitive's material when registered, so
+  /// mutating `primitive.material` on a mounted mesh is invisible until the
+  /// items are rebuilt. Re-registering also re-buckets items whose new
+  /// material changes translucency. No-op while unmounted (mounting
+  /// registers fresh items).
+  @internal
+  void refreshMaterials() {
+    _unregisterRenderItems();
+    _registerRenderItems();
+  }
+
   void _unregisterRenderItems() {
     // Guard on attachment, not mount state: [Component.unmount] clears
     // the mounted flag before invoking [onUnmount], so checking

--- a/packages/flutter_scene/lib/src/components/point_light_component.dart
+++ b/packages/flutter_scene/lib/src/components/point_light_component.dart
@@ -2,6 +2,7 @@ import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_scene/src/node.dart';
 
 /// An engine [Component] that places a [PointLight] in the scene.
 ///
@@ -37,4 +38,9 @@ class PointLightComponent extends Component {
   /// The light's world-space position: the owning node's world-space
   /// translation.
   Vector3 get worldPosition => node.globalTransform.getTranslation();
+
+  /// Clones carry the light, sharing the light object like other clone
+  /// payloads (geometry, materials).
+  @override
+  Component? cloneFor(Node cloneOwner) => PointLightComponent(light);
 }

--- a/packages/flutter_scene/lib/src/components/spot_light_component.dart
+++ b/packages/flutter_scene/lib/src/components/spot_light_component.dart
@@ -2,6 +2,7 @@ import 'package:vector_math/vector_math.dart';
 
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/light.dart';
+import 'package:flutter_scene/src/node.dart';
 
 /// An engine [Component] that places a [SpotLight] in the scene.
 ///
@@ -45,4 +46,9 @@ class SpotLightComponent extends Component {
   /// length (the shader normalizes it).
   Vector3 get worldDirection =>
       node.globalTransform.getRotation() * light.direction;
+
+  /// Clones carry the light, sharing the light object like other clone
+  /// payloads (geometry, materials).
+  @override
+  Component? cloneFor(Node cloneOwner) => SpotLightComponent(light);
 }

--- a/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
@@ -899,22 +899,28 @@ class CameraCodec extends ComponentCodec {
 ///
 /// ```text
 /// variants: [String, ...]                    variant names, in order
+/// selected: String                           active variant, absent = default
 /// bindings: [{node: NodeRef,                 the node whose mesh is bound
 ///             primitive: int,                index into the mesh's primitives
+///             default: ResourceRef,          the default material
 ///             materials: {"<variantIndex>": ResourceRef, ...}}, ...]
 /// ```
 ///
-/// The binding's default material is not serialized; the mesh primitive's
-/// own material is the default, so whatever material the mesh carries at
-/// serialize time realizes as the default. Bindings resolve after the whole
+/// The default material is serialized explicitly so a document saved while a
+/// variant is selected keeps its authored defaults (the mesh's serialized
+/// material is the selected one in that case); documents without a `default`
+/// entry fall back to the mesh primitive's realized material. The selection
+/// itself round-trips through `selected`. Bindings resolve after the whole
 /// tree realizes (they reference other nodes' mesh components), through
 /// [RealizeContext.afterRealize].
 class MaterialsVariantsCodec extends ComponentCodec {
   @override
   String get type => 'materialsVariants';
 
-  // The nested bindings list is not schema-described (like the mesh codec's
-  // multi-primitive form); editing it stays inspector-opaque for now.
+  // TODO(materials-variants-schema): the nested bindings list is not
+  // schema-described (like the mesh codec's multi-primitive form), so the
+  // editor inspector cannot edit it; describe it once the schema system
+  // grows nested-list support.
   @override
   List<ComponentPropertyDef> get propertySchema => const [];
 
@@ -938,6 +944,8 @@ class MaterialsVariantsCodec extends ComponentCodec {
       for (final value in _stringList(spec.properties['variants'])) value,
     ];
     final rawBindings = spec.properties['bindings'];
+    final selectedProp = spec.properties['selected'];
+    final selected = selectedProp is StringValue ? selectedProp.value : null;
     final bindings = <MaterialsVariantBinding>[];
     final component = MaterialsVariantsComponent.internal(variants, bindings);
     context.afterRealize.add(() {
@@ -948,45 +956,59 @@ class MaterialsVariantsCodec extends ComponentCodec {
         );
         return;
       }
-      if (rawBindings is! ListValue) return;
-      for (final entry in rawBindings.values) {
-        if (entry is! MapValue) continue;
-        final nodeRef = entry.values['node'];
-        final primitiveIndex = entry.values['primitive'];
-        final materials = entry.values['materials'];
-        if (nodeRef is! NodeRefValue ||
-            primitiveIndex is! IntValue ||
-            materials is! MapValue) {
-          continue;
-        }
-        final node = resolveNode(nodeRef.id);
-        final mesh = node?.mesh;
-        if (node == null ||
-            mesh == null ||
-            primitiveIndex.value < 0 ||
-            primitiveIndex.value >= mesh.primitives.length) {
-          debugPrint(
-            'fscene: materialsVariants binding dropped (missing node or '
-            'primitive ${primitiveIndex.value})',
+      if (rawBindings is ListValue) {
+        for (final entry in rawBindings.values) {
+          if (entry is! MapValue) continue;
+          final nodeRef = entry.values['node'];
+          final primitiveIndex = entry.values['primitive'];
+          final materials = entry.values['materials'];
+          final defaultRef = entry.values['default'];
+          if (nodeRef is! NodeRefValue ||
+              primitiveIndex is! IntValue ||
+              materials is! MapValue) {
+            continue;
+          }
+          final node = resolveNode(nodeRef.id);
+          final mesh = node?.mesh;
+          if (node == null ||
+              mesh == null ||
+              primitiveIndex.value < 0 ||
+              primitiveIndex.value >= mesh.primitives.length) {
+            debugPrint(
+              'fscene: materialsVariants binding dropped (missing node or '
+              'primitive ${primitiveIndex.value})',
+            );
+            continue;
+          }
+          // The serialized default keeps authored defaults stable across
+          // saves and reloads made while a variant was selected; older
+          // documents without one fall back to the realized mesh material.
+          final defaultMaterial = defaultRef is ResourceRefValue
+              ? realizer.material(defaultRef.id)
+              : mesh.primitives[primitiveIndex.value].material;
+          final materialsByVariant = <int, Material>{};
+          for (final mapping in materials.values.entries) {
+            final variantIndex = int.tryParse(mapping.key);
+            final ref = mapping.value;
+            if (variantIndex == null || ref is! ResourceRefValue) continue;
+            materialsByVariant[variantIndex] = realizer.material(ref.id);
+          }
+          bindings.add(
+            MaterialsVariantBinding(
+              node: node,
+              primitiveIndex: primitiveIndex.value,
+              defaultMaterial: defaultMaterial,
+              materialsByVariant: materialsByVariant,
+            ),
           );
-          continue;
         }
-        final primitive = mesh.primitives[primitiveIndex.value];
-        final materialsByVariant = <int, Material>{};
-        for (final mapping in materials.values.entries) {
-          final variantIndex = int.tryParse(mapping.key);
-          final ref = mapping.value;
-          if (variantIndex == null || ref is! ResourceRefValue) continue;
-          materialsByVariant[variantIndex] = realizer.material(ref.id);
-        }
-        bindings.add(
-          MaterialsVariantBinding(
-            node: node,
-            primitive: primitive,
-            defaultMaterial: primitive.material,
-            materialsByVariant: materialsByVariant,
-          ),
-        );
+      }
+      if (selected != null && variants.contains(selected)) {
+        component.select(selected);
+      } else {
+        // Bindings may target primitives that currently carry a stale
+        // material (a reload while selected); re-apply the defaults.
+        component.reapply();
       }
     });
     return component;
@@ -998,9 +1020,7 @@ class MaterialsVariantsCodec extends ComponentCodec {
     final bindings = <PropertyValue>[];
     for (final binding in component.internalBindings) {
       final nodeId = nodeFsceneId(binding.node);
-      final mesh = binding.node.mesh;
-      final primitiveIndex = mesh?.primitives.indexOf(binding.primitive) ?? -1;
-      if (nodeId == null || primitiveIndex < 0) {
+      if (nodeId == null || binding.resolvePrimitive() == null) {
         debugPrint(
           'fscene: materialsVariants binding not serialized; its node was '
           'not realized from this document',
@@ -1016,29 +1036,35 @@ class MaterialsVariantsCodec extends ComponentCodec {
         if (materialId == null) continue;
         materials['${entry.key}'] = ResourceRefValue(materialId);
       }
+      final defaultId = _resourceSerializer._serializeResource(
+        binding.defaultMaterial,
+        context,
+      );
       bindings.add(
         MapValue({
           'node': NodeRefValue(nodeId),
-          'primitive': IntValue(primitiveIndex),
+          'primitive': IntValue(binding.primitiveIndex),
+          if (defaultId != null) 'default': ResourceRefValue(defaultId),
           'materials': MapValue(materials),
         }),
       );
     }
+    final selected = component.selected;
     return ComponentSpec(
       type,
       properties: {
         'variants': ListValue([
           for (final name in component.variants) StringValue(name),
         ]),
+        if (selected != null) 'selected': StringValue(selected),
         'bindings': ListValue(bindings),
       },
     );
   }
 
-  static Iterable<String> _stringList(PropertyValue? value) sync* {
-    if (value is! ListValue) return;
-    for (final entry in value.values) {
-      if (entry is StringValue) yield entry.value;
-    }
-  }
+  static List<String> _stringList(PropertyValue? value) => [
+    if (value is ListValue)
+      for (final entry in value.values)
+        if (entry is StringValue) entry.value,
+  ];
 }

--- a/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/builtin_codecs.dart
@@ -8,6 +8,7 @@ import 'package:flutter_scene/src/fscene/realize/fmat_overrides.dart';
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/geometry/mesh_geometry.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/material/physically_based_material.dart';
 import 'package:flutter_scene/src/material/preprocessed_material.dart';
 import 'package:flutter_scene/src/material/unlit_material.dart';
@@ -15,7 +16,9 @@ import 'package:flutter_scene/src/components/camera_component.dart';
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/components/directional_light_component.dart';
 import 'package:flutter_scene/src/components/environment_volume_component.dart';
+import 'package:flutter_scene/src/components/materials_variants_component.dart';
 import 'package:flutter_scene/src/components/mesh_component.dart';
+import 'package:flutter_scene/src/fscene/realize/node_identity.dart';
 import 'package:flutter_scene/src/components/point_light_component.dart';
 import 'package:flutter_scene/src/components/spot_light_component.dart';
 import 'package:flutter_scene/src/environment_settings.dart';
@@ -42,6 +45,7 @@ void registerBuiltinComponentCodecs(FsceneComponentRegistry registry) {
     // (which subclasses the mesh component) before the mesh codec sees it.
     ..register(ParticleEmitterCodec())
     ..register(MeshCodec())
+    ..register(MaterialsVariantsCodec())
     ..register(DirectionalLightCodec())
     ..register(PointLightCodec())
     ..register(SpotLightCodec())
@@ -886,5 +890,155 @@ class CameraCodec extends ComponentCodec {
         far: readDouble(p, 'far', numberDefault('far')),
       ),
     );
+  }
+}
+
+/// Codec for [MaterialsVariantsComponent] (`KHR_materials_variants`).
+///
+/// Spec shape:
+///
+/// ```text
+/// variants: [String, ...]                    variant names, in order
+/// bindings: [{node: NodeRef,                 the node whose mesh is bound
+///             primitive: int,                index into the mesh's primitives
+///             materials: {"<variantIndex>": ResourceRef, ...}}, ...]
+/// ```
+///
+/// The binding's default material is not serialized; the mesh primitive's
+/// own material is the default, so whatever material the mesh carries at
+/// serialize time realizes as the default. Bindings resolve after the whole
+/// tree realizes (they reference other nodes' mesh components), through
+/// [RealizeContext.afterRealize].
+class MaterialsVariantsCodec extends ComponentCodec {
+  @override
+  String get type => 'materialsVariants';
+
+  // The nested bindings list is not schema-described (like the mesh codec's
+  // multi-primitive form); editing it stays inspector-opaque for now.
+  @override
+  List<ComponentPropertyDef> get propertySchema => const [];
+
+  // Shares the mesh codec's resource-recovery path (origin tags, hand-built
+  // re-packing) for the variant materials.
+  static final MeshCodec _resourceSerializer = MeshCodec();
+
+  @override
+  bool claims(Component component) => component is MaterialsVariantsComponent;
+
+  @override
+  Component? realize(ComponentSpec spec, RealizeContext context) {
+    final realizer = context.resources;
+    if (realizer == null) {
+      debugPrint(
+        'fscene: materialsVariants component skipped (no resource realizer)',
+      );
+      return null;
+    }
+    final variants = <String>[
+      for (final value in _stringList(spec.properties['variants'])) value,
+    ];
+    final rawBindings = spec.properties['bindings'];
+    final bindings = <MaterialsVariantBinding>[];
+    final component = MaterialsVariantsComponent.internal(variants, bindings);
+    context.afterRealize.add(() {
+      final resolveNode = context.resolveNode;
+      if (resolveNode == null) {
+        debugPrint(
+          'fscene: materialsVariants bindings unresolved (no node resolver)',
+        );
+        return;
+      }
+      if (rawBindings is! ListValue) return;
+      for (final entry in rawBindings.values) {
+        if (entry is! MapValue) continue;
+        final nodeRef = entry.values['node'];
+        final primitiveIndex = entry.values['primitive'];
+        final materials = entry.values['materials'];
+        if (nodeRef is! NodeRefValue ||
+            primitiveIndex is! IntValue ||
+            materials is! MapValue) {
+          continue;
+        }
+        final node = resolveNode(nodeRef.id);
+        final mesh = node?.mesh;
+        if (node == null ||
+            mesh == null ||
+            primitiveIndex.value < 0 ||
+            primitiveIndex.value >= mesh.primitives.length) {
+          debugPrint(
+            'fscene: materialsVariants binding dropped (missing node or '
+            'primitive ${primitiveIndex.value})',
+          );
+          continue;
+        }
+        final primitive = mesh.primitives[primitiveIndex.value];
+        final materialsByVariant = <int, Material>{};
+        for (final mapping in materials.values.entries) {
+          final variantIndex = int.tryParse(mapping.key);
+          final ref = mapping.value;
+          if (variantIndex == null || ref is! ResourceRefValue) continue;
+          materialsByVariant[variantIndex] = realizer.material(ref.id);
+        }
+        bindings.add(
+          MaterialsVariantBinding(
+            node: node,
+            primitive: primitive,
+            defaultMaterial: primitive.material,
+            materialsByVariant: materialsByVariant,
+          ),
+        );
+      }
+    });
+    return component;
+  }
+
+  @override
+  ComponentSpec? serialize(Component component, SerializeContext context) {
+    if (component is! MaterialsVariantsComponent) return null;
+    final bindings = <PropertyValue>[];
+    for (final binding in component.internalBindings) {
+      final nodeId = nodeFsceneId(binding.node);
+      final mesh = binding.node.mesh;
+      final primitiveIndex = mesh?.primitives.indexOf(binding.primitive) ?? -1;
+      if (nodeId == null || primitiveIndex < 0) {
+        debugPrint(
+          'fscene: materialsVariants binding not serialized; its node was '
+          'not realized from this document',
+        );
+        continue;
+      }
+      final materials = <String, PropertyValue>{};
+      for (final entry in binding.materialsByVariant.entries) {
+        final materialId = _resourceSerializer._serializeResource(
+          entry.value,
+          context,
+        );
+        if (materialId == null) continue;
+        materials['${entry.key}'] = ResourceRefValue(materialId);
+      }
+      bindings.add(
+        MapValue({
+          'node': NodeRefValue(nodeId),
+          'primitive': IntValue(primitiveIndex),
+          'materials': MapValue(materials),
+        }),
+      );
+    }
+    return ComponentSpec(
+      type,
+      properties: {
+        'variants': ListValue([
+          for (final name in component.variants) StringValue(name),
+        ]),
+        'bindings': ListValue(bindings),
+      },
+    );
+  }
+
+  static Iterable<String> _stringList(PropertyValue? value) sync* {
+    if (value is! ListValue) return;
+    for (final entry in value.values) {
+      if (entry is StringValue) yield entry.value;
+    }
   }
 }

--- a/packages/flutter_scene/lib/src/fscene/realize/component_codec.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/component_codec.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/fscene/realize/component_schema.dart';
 import 'package:flutter_scene/src/fscene/realize/resource_realizer.dart';
 import 'package:flutter_scene/src/fscene/scene_document.dart';
 import 'package:flutter_scene/src/fscene/specs.dart';
+import 'package:flutter_scene/src/node.dart';
 
 /// Context handed to a [ComponentCodec] when realizing a [ComponentSpec] into
 /// a live [Component]. Carries the source [document] and a [resources]
@@ -23,6 +24,25 @@ class RealizeContext {
   /// Realizes referenced geometry/material resources, or null when resource
   /// realization is unavailable (a codec needing it should return null).
   final ResourceRealizer? resources;
+
+  /// Resolves a document node id to its realized [Node]. Set by the realizer
+  /// once its node map exists; null in contexts without one.
+  Node? Function(LocalId id)? resolveNode;
+
+  /// Callbacks the realizer runs after every node and component has been
+  /// realized. A codec whose spec references other nodes' components (for
+  /// example material variants binding into mesh primitives) registers its
+  /// resolution here rather than resolving during its own realize call,
+  /// when those components may not exist yet.
+  final List<void Function()> afterRealize = [];
+
+  /// Runs and clears [afterRealize]. The realizer calls this once per pass.
+  void runAfterRealize() {
+    for (final callback in afterRealize) {
+      callback();
+    }
+    afterRealize.clear();
+  }
 }
 
 /// Context handed to a [ComponentCodec] when serializing a live [Component]

--- a/packages/flutter_scene/lib/src/fscene/realize/realize.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/realize.dart
@@ -107,6 +107,7 @@ Node _realizeWith(
 
   // First pass: a bare node per spec (no children, no components yet).
   final nodes = <LocalId, Node>{};
+  context.resolveNode = (id) => nodes[id];
   for (final spec in document.nodes.values) {
     final node = tagNodeId(
       Node(name: spec.name)
@@ -155,6 +156,10 @@ Node _realizeWith(
       node.addComponent(component);
     }
   }
+
+  // Cross-node component resolution (for example material-variant bindings
+  // into mesh primitives) runs once every component exists.
+  context.runAfterRealize();
 
   final root = Node(
     name: 'root',

--- a/packages/flutter_scene/lib/src/fscene/reload/reload.dart
+++ b/packages/flutter_scene/lib/src/fscene/reload/reload.dart
@@ -57,6 +57,7 @@ Future<SceneDiff> reloadScene(
   }
 
   collect(liveRoot);
+  context.resolveNode = (id) => live[id];
 
   final newParents = _parents(newDocument);
   Node parentFor(LocalId id) => live[newParents[id]] ?? liveRoot;
@@ -150,6 +151,9 @@ Future<SceneDiff> reloadScene(
     ].whereType<Animation>().toList();
     liveRoot.reloadParsedAnimations(animations);
   }
+
+  // Cross-node component resolution for components realized in this pass.
+  context.runAfterRealize();
 
   return diff;
 }

--- a/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
+++ b/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
@@ -790,12 +790,20 @@ void _emitMaterialsVariants(
               '${entry.key}': ResourceRefValue(materialIds[entry.value]),
         };
         if (materials.isNotEmpty) {
+          final defaultIndex = primitive.material;
           bindingsByNode
               .putIfAbsent(i, () => [])
               .add(
                 MapValue({
                   'node': NodeRefValue(nodeIds[i]),
                   'primitive': IntValue(primIndex),
+                  // The authored default, kept explicit so an editor save
+                  // made while a variant is selected does not bake the
+                  // selection in as the default.
+                  if (defaultIndex != null &&
+                      defaultIndex >= 0 &&
+                      defaultIndex < materialIds.length)
+                    'default': ResourceRefValue(materialIds[defaultIndex]),
                   'materials': MapValue(materials),
                 }),
               );

--- a/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
+++ b/packages/flutter_scene/lib/src/importer/src/fscene_emitter/fscene_emitter.dart
@@ -196,6 +196,23 @@ SceneDocument buildSceneDocument(
     }
   }
 
+  // KHR_materials_variants: attach a materialsVariants component to each
+  // document root whose subtree has variant-mapped primitives. Bindings
+  // reference nodes and their mesh primitive index (triangle primitives
+  // only, matching the emitted mesh); the mapped materials are already in
+  // the resource pool ([materialIds] covers every source material).
+  if (doc.materialsVariants.isNotEmpty &&
+      sceneIndex >= 0 &&
+      sceneIndex < doc.scenes.length) {
+    _emitMaterialsVariants(
+      document,
+      doc,
+      sceneRoots: doc.scenes[sceneIndex].nodes,
+      nodeIds: nodeIds,
+      materialIds: materialIds,
+    );
+  }
+
   // Animations (one keyframe timeline/value payload per channel).
   for (final animation in doc.animations) {
     _buildAnimation(document, animation, doc, bufferData, nodeIds);
@@ -742,4 +759,74 @@ int _seedFrom(Uint8List data) {
     hash = (hash * 0x01000193) & 0xffffffff;
   }
   return hash == 0 ? 1 : hash;
+}
+
+/// Emits `KHR_materials_variants` as `materialsVariants` components, one per
+/// scene root whose subtree contains variant-mapped primitives, with each
+/// component's bindings scoped to that subtree.
+void _emitMaterialsVariants(
+  SceneDocument document,
+  GltfDocument doc, {
+  required List<int> sceneRoots,
+  required List<LocalId> nodeIds,
+  required List<LocalId> materialIds,
+}) {
+  // Per glTF node, the binding specs for its variant-mapped primitives. The
+  // primitive index counts emitted (triangle) primitives so it matches the
+  // realized mesh's primitive order.
+  final bindingsByNode = <int, List<PropertyValue>>{};
+  for (var i = 0; i < doc.nodes.length; i++) {
+    final meshIndex = doc.nodes[i].mesh;
+    if (meshIndex == null || meshIndex < 0 || meshIndex >= doc.meshes.length) {
+      continue;
+    }
+    var primIndex = 0;
+    for (final primitive in doc.meshes[meshIndex].primitives) {
+      if (primitive.mode != 4) continue;
+      if (primitive.variantMappings.isNotEmpty) {
+        final materials = <String, PropertyValue>{
+          for (final entry in primitive.variantMappings.entries)
+            if (entry.value >= 0 && entry.value < materialIds.length)
+              '${entry.key}': ResourceRefValue(materialIds[entry.value]),
+        };
+        if (materials.isNotEmpty) {
+          bindingsByNode
+              .putIfAbsent(i, () => [])
+              .add(
+                MapValue({
+                  'node': NodeRefValue(nodeIds[i]),
+                  'primitive': IntValue(primIndex),
+                  'materials': MapValue(materials),
+                }),
+              );
+        }
+      }
+      primIndex++;
+    }
+  }
+  if (bindingsByNode.isEmpty) return;
+
+  document.featuresUsed.add('materialsVariants');
+  final variantNames = ListValue([
+    for (final name in doc.materialsVariants) StringValue(name),
+  ]);
+  for (final root in sceneRoots) {
+    if (root < 0 || root >= nodeIds.length) continue;
+    // Collect the root's subtree (including itself) in the glTF index space.
+    final subtree = <int>[root];
+    final bindings = <PropertyValue>[];
+    for (var i = 0; i < subtree.length; i++) {
+      bindings.addAll(bindingsByNode[subtree[i]] ?? const []);
+      for (final child in doc.nodes[subtree[i]].children) {
+        if (child >= 0 && child < doc.nodes.length) subtree.add(child);
+      }
+    }
+    if (bindings.isEmpty) continue;
+    document.nodes[nodeIds[root]]!.components.add(
+      ComponentSpec(
+        'materialsVariants',
+        properties: {'variants': variantNames, 'bindings': ListValue(bindings)},
+      ),
+    );
+  }
 }

--- a/packages/flutter_scene/lib/src/importer/src/gltf/parser.dart
+++ b/packages/flutter_scene/lib/src/importer/src/gltf/parser.dart
@@ -6,6 +6,7 @@ GltfDocument parseGltfJson(Map<String, Object?> json) {
   // KHR_lights_punctual declares its lights at the document's extensions.
   final docExtensions = json['extensions'] as Map?;
   final punctual = docExtensions?['KHR_lights_punctual'] as Map?;
+  final variants = docExtensions?['KHR_materials_variants'] as Map?;
   return GltfDocument(
     scene: json['scene'] as int?,
     scenes: _list(json['scenes'], _parseScene),
@@ -21,6 +22,10 @@ GltfDocument parseGltfJson(Map<String, Object?> json) {
     skins: _list(json['skins'], _parseSkin),
     animations: _list(json['animations'], _parseAnimation),
     lights: _list(punctual?['lights'], _parsePunctualLight),
+    materialsVariants: [
+      for (final v in (variants?['variants'] as List?) ?? const [])
+        ((v as Map)['name'] as String?) ?? '',
+    ],
   );
 }
 
@@ -106,11 +111,26 @@ GltfMesh _parseMesh(Map<String, Object?> j) {
         final attrs =
             (pj['attributes'] as Map?)?.cast<String, int>() ??
             const <String, int>{};
+        // KHR_materials_variants: flatten each mapping's variant list into
+        // variant index -> material index. Later mappings do not overwrite
+        // earlier ones (the spec forbids a variant appearing twice).
+        final variantMappings = <int, int>{};
+        final variantsExt =
+            (pj['extensions'] as Map?)?['KHR_materials_variants'] as Map?;
+        for (final m in (variantsExt?['mappings'] as List?) ?? const []) {
+          final mapping = m as Map;
+          final material = mapping['material'] as int?;
+          if (material == null) continue;
+          for (final v in (mapping['variants'] as List?) ?? const []) {
+            variantMappings.putIfAbsent(v as int, () => material);
+          }
+        }
         return GltfMeshPrimitive(
           attributes: attrs,
           indices: pj['indices'] as int?,
           material: pj['material'] as int?,
           mode: (pj['mode'] as int?) ?? 4,
+          variantMappings: variantMappings,
         );
       })
       .toList(growable: false);

--- a/packages/flutter_scene/lib/src/importer/src/gltf/types.dart
+++ b/packages/flutter_scene/lib/src/importer/src/gltf/types.dart
@@ -20,6 +20,7 @@ class GltfDocument {
     this.skins = const [],
     this.animations = const [],
     this.lights = const [],
+    this.materialsVariants = const [],
   });
 
   final int? scene;
@@ -39,6 +40,11 @@ class GltfDocument {
   /// Punctual lights declared by the `KHR_lights_punctual` extension, indexed
   /// by [GltfNode.light]. Empty when the extension is absent.
   final List<GltfPunctualLight> lights;
+
+  /// Variant names declared by the `KHR_materials_variants` extension, in
+  /// declaration order. Empty when the extension is absent. Primitive
+  /// mappings ([GltfMeshPrimitive.variantMappings]) index into this list.
+  final List<String> materialsVariants;
 }
 
 /// A `KHR_lights_punctual` light definition. Fields match the extension spec.
@@ -131,6 +137,7 @@ class GltfMeshPrimitive {
     this.indices,
     this.material,
     this.mode = 4,
+    this.variantMappings = const {},
   });
 
   /// Maps glTF attribute names ('POSITION', 'NORMAL', 'TEXCOORD_0',
@@ -141,6 +148,11 @@ class GltfMeshPrimitive {
 
   /// Primitive topology. 4 = TRIANGLES (the only mode flutter_scene supports).
   final int mode;
+
+  /// `KHR_materials_variants` mappings, variant index (into
+  /// [GltfDocument.materialsVariants]) to material index. Empty when the
+  /// primitive declares no mappings; [material] stays the default.
+  final Map<int, int> variantMappings;
 }
 
 /// Component types from glTF spec section 5.1.1.

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -536,6 +536,11 @@ base class Node implements SceneGraph {
     return _animationPlayer!.createAnimationClip(animation, this);
   }
 
+  /// Unregisters [clip] from this node's animation player so it no longer
+  /// contributes to the blend. No-op when [clip] is not registered here.
+  void removeAnimationClip(AnimationClip clip) =>
+      _animationPlayer?.removeClip(clip);
+
   /// Load a glTF binary (GLB) model directly from raw bytes.
   ///
   /// No offline conversion is required, useful for runtime use cases such
@@ -830,6 +835,14 @@ base class Node implements SceneGraph {
     // clone renders with reversed cull winding: see-through, inverted geometry).
     result.excludeFromWindingParity = excludeFromWindingParity;
     result._animations.addAll(_animations);
+    // Components opt into cloning through [Component.cloneFor]; mesh
+    // components are excluded because the mesh is already cloned through the
+    // constructor above.
+    for (final component in _components) {
+      if (component is MeshComponent) continue;
+      final copy = component.cloneFor(result);
+      if (copy != null) result.addComponent(copy);
+    }
     if (recursive) {
       for (var child in children) {
         result.add(child._cloneAndCollectSkins(recursive, clonedSkins));

--- a/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
@@ -265,7 +265,7 @@ void _populateNode({
         variantBindings.add(
           MaterialsVariantBinding(
             node: engineNode,
-            primitive: primitive,
+            primitiveIndex: primitives.length,
             defaultMaterial: material,
             materialsByVariant: {
               for (final entry in p.variantMappings.entries)

--- a/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
@@ -264,6 +264,7 @@ void _populateNode({
         // default material index reuses the default instance.
         variantBindings.add(
           MaterialsVariantBinding(
+            node: engineNode,
             primitive: primitive,
             defaultMaterial: material,
             materialsByVariant: {

--- a/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
+++ b/packages/flutter_scene/lib/src/runtime_importer/runtime_importer.dart
@@ -7,6 +7,7 @@ import 'package:flutter_scene/src/importer/gltf.dart';
 import '../animation.dart';
 import '../components/component.dart';
 import '../components/directional_light_component.dart';
+import '../components/materials_variants_component.dart';
 import '../components/point_light_component.dart';
 import '../components/spot_light_component.dart';
 import '../light.dart';
@@ -123,6 +124,10 @@ Future<Node> _buildScene(
   // can refer to them by index regardless of the order we visit them in.
   final List<Node> engineNodes = List.generate(doc.nodes.length, (_) => Node());
 
+  // Collects each primitive's per-variant materials (KHR_materials_variants)
+  // so the component attached to the root can swap them later.
+  final List<MaterialsVariantBinding> variantBindings = [];
+
   for (int i = 0; i < doc.nodes.length; i++) {
     _populateNode(
       index: i,
@@ -132,6 +137,7 @@ Future<Node> _buildScene(
       packed: packed,
       engineNodes: engineNodes,
       textures: textures,
+      variantBindings: variantBindings,
     );
   }
 
@@ -163,6 +169,14 @@ Future<Node> _buildScene(
     name: 'root',
     localTransform: Matrix4.identity()..setEntry(2, 2, -1.0),
   )..excludeFromWindingParity = true;
+  if (doc.materialsVariants.isNotEmpty) {
+    root.addComponent(
+      MaterialsVariantsComponent.internal(
+        doc.materialsVariants,
+        variantBindings,
+      ),
+    );
+  }
   if (sceneIndex != null && sceneIndex < doc.scenes.length) {
     for (final rootNodeIdx in doc.scenes[sceneIndex].nodes) {
       if (rootNodeIdx >= 0 && rootNodeIdx < engineNodes.length) {
@@ -204,6 +218,7 @@ void _populateNode({
   required List<List<PackedPrimitive?>> packed,
   required List<Node> engineNodes,
   required List<Texture2D> textures,
+  required List<MaterialsVariantBinding> variantBindings,
 }) {
   engineNode.name = resolveGltfNodeName(gltfNode.name, index);
   final matrix = gltfNode.matrix;
@@ -242,7 +257,26 @@ void _populateNode({
       final material = p.material != null
           ? buildMaterial(doc.materials[p.material!], textures)
           : UnlitMaterial();
-      primitives.add(MeshPrimitive(geometry, material));
+      final primitive = MeshPrimitive(geometry, material);
+      if (p.variantMappings.isNotEmpty) {
+        // Build each variant's material now (textures are already decoded)
+        // so selection is a plain reassignment. A mapping that names the
+        // default material index reuses the default instance.
+        variantBindings.add(
+          MaterialsVariantBinding(
+            primitive: primitive,
+            defaultMaterial: material,
+            materialsByVariant: {
+              for (final entry in p.variantMappings.entries)
+                if (entry.value >= 0 && entry.value < doc.materials.length)
+                  entry.key: entry.value == p.material
+                      ? material
+                      : buildMaterial(doc.materials[entry.value], textures),
+            },
+          ),
+        );
+      }
+      primitives.add(primitive);
     }
     if (primitives.isNotEmpty) {
       engineNode.mesh = Mesh.primitives(primitives: primitives);

--- a/packages/flutter_scene/lib/src/scene.dart
+++ b/packages/flutter_scene/lib/src/scene.dart
@@ -1238,6 +1238,10 @@ base class Scene implements SceneGraph {
             (staticShadowSignature * 31 +
                 identityHashCode(item.geometry) +
                 identityHashCode(item.instanceTransforms) +
+                // Material identity matters to the depth pass (alpha-masked
+                // casters render through the masked depth shader), so a
+                // swapped material must invalidate cached static tiles.
+                identityHashCode(item.material) +
                 t[12].hashCode * 3 +
                 t[13].hashCode * 7 +
                 t[14].hashCode * 13);

--- a/packages/flutter_scene/lib/src/widgets/declarative.dart
+++ b/packages/flutter_scene/lib/src/widgets/declarative.dart
@@ -1,4 +1,11 @@
-import 'package:flutter/foundation.dart' show Uint8List, debugPrint;
+import 'package:flutter/foundation.dart'
+    show
+        Uint8List,
+        debugPrint,
+        immutable,
+        internal,
+        listEquals,
+        visibleForTesting;
 import 'package:flutter/rendering.dart'
     show
         BoxConstraints,
@@ -23,9 +30,11 @@ import 'package:flutter/widgets.dart'
         StatelessWidget,
         Widget,
         WidgetBuilder;
+import 'package:collection/collection.dart' show IterableExtension;
 import 'package:vector_math/vector_math.dart' show Matrix4, Quaternion, Vector3;
 
-import 'package:flutter_scene/src/animation.dart' show DecomposedTransform;
+import 'package:flutter_scene/src/animation.dart'
+    show AnimationClip, DecomposedTransform;
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/components/materials_variants_component.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
@@ -701,6 +710,173 @@ class MemoryModelSource extends SceneModelSource {
   Future<Uint8List> load() async => bytes;
 }
 
+/// Declares the playback state of one of a [SceneModel]'s imported
+/// animations.
+///
+/// An immutable value: rebuild with different values and the widget applies
+/// the differences to the underlying [AnimationClip] as plain property
+/// writes, so [weight] and [speed] can be driven by ordinary Flutter
+/// animations (a `TweenAnimationBuilder` cross-fading two clips' weights,
+/// for example). Clips for the same [name] persist across rebuilds; a spec
+/// that disappears from [SceneModel.animations] stops its clip.
+///
+/// A one-shot spec ([loop] false) whose [playing] flips from false to true
+/// restarts from the beginning; a looping spec resumes.
+/// {@category Widgets}
+@immutable
+class SceneAnimationSpec {
+  const SceneAnimationSpec(
+    this.name, {
+    this.playing = true,
+    this.loop = true,
+    this.weight = 1.0,
+    this.speed = 1.0,
+  });
+
+  /// The imported animation's name.
+  final String name;
+
+  /// Whether the clip advances. Pausing keeps the current playback time.
+  final bool playing;
+
+  /// Whether the clip wraps at the end instead of pausing.
+  final bool loop;
+
+  /// Blend weight in `[0, 1]`; overlapping clips are weight-blended and
+  /// normalized by the engine when the sum exceeds one.
+  final double weight;
+
+  /// Playback rate multiplier (negative plays in reverse).
+  final double speed;
+
+  @override
+  bool operator ==(Object other) =>
+      other is SceneAnimationSpec &&
+      other.name == name &&
+      other.playing == playing &&
+      other.loop == loop &&
+      other.weight == weight &&
+      other.speed == speed;
+
+  @override
+  int get hashCode => Object.hash(name, playing, loop, weight, speed);
+}
+
+/// Applies [SceneAnimationSpec]s to a model root's animation clips: creates
+/// clips lazily by name, diffs spec fields onto them, and stops clips whose
+/// specs disappear. Kept separate from the widget so it is testable without
+/// a GPU import.
+@internal
+class SceneAnimationBinder {
+  final Map<String, AnimationClip> _clips = {};
+  final Set<String> _warnedUnknown = {};
+  List<SceneAnimationSpec> _applied = const [];
+  Node? _modelRoot;
+
+  /// The clips created so far, keyed by animation name.
+  Map<String, AnimationClip> get clips => Map.unmodifiable(_clips);
+
+  /// Targets [modelRoot] (or null to unbind), clearing all clip state.
+  void bind(Node? modelRoot) {
+    _modelRoot = modelRoot;
+    _clips.clear();
+    _warnedUnknown.clear();
+    _applied = const [];
+  }
+
+  /// Diffs [specs] against the previously applied set.
+  void apply(List<SceneAnimationSpec> specs) {
+    final root = _modelRoot;
+    if (root == null) return;
+    final wanted = {for (final spec in specs) spec.name};
+    for (final entry in _clips.entries) {
+      if (!wanted.contains(entry.key)) {
+        entry.value.stop();
+      }
+    }
+    _clips.removeWhere((name, _) => !wanted.contains(name));
+    for (final spec in specs) {
+      var clip = _clips[spec.name];
+      if (clip == null) {
+        final animation = root.findAnimationByName(spec.name);
+        if (animation == null) {
+          if (_warnedUnknown.add(spec.name)) {
+            debugPrint(
+              'SceneModel: unknown animation "${spec.name}" (available: '
+              '${root.parsedAnimations.map((a) => a.name).toList()}).',
+            );
+          }
+          continue;
+        }
+        clip = root.createAnimationClip(animation);
+        _clips[spec.name] = clip;
+      }
+      final previous = _applied.firstWhereOrNull((s) => s.name == spec.name);
+      clip.loop = spec.loop;
+      clip.weight = spec.weight;
+      clip.playbackTimeScale = spec.speed;
+      if (spec.playing) {
+        // A one-shot re-triggered after finishing (or after an explicit
+        // pause) restarts; a looping clip just resumes.
+        final restarted = previous != null && !previous.playing;
+        if (restarted && !spec.loop) {
+          clip.replay();
+        } else {
+          clip.play();
+        }
+      } else {
+        clip.pause();
+      }
+    }
+    _applied = List.of(specs);
+  }
+}
+
+/// A refcounted template per [SceneModelSource.cacheKey]: bytes are loaded
+/// and imported once, and each [SceneModel] instance mounts a [Node.clone]
+/// of the shared template (geometry, textures, and materials stay shared;
+/// primitives, skins, and the variants component are per instance). The
+/// entry is evicted when the last user releases it.
+class _ModelTemplateCache {
+  static final Map<String, _ModelTemplateEntry> _entries = {};
+
+  static Future<Node> acquire(SceneModelSource source) {
+    final entry = _entries.putIfAbsent(
+      source.cacheKey,
+      () => _ModelTemplateEntry(_import(source)),
+    );
+    entry.refCount++;
+    return entry.template;
+  }
+
+  static Future<Node> _import(SceneModelSource source) async {
+    try {
+      final bytes = await source.load();
+      final import = SceneModel.debugImportOverride ?? Node.fromGlbBytes;
+      return await import(bytes);
+    } catch (_) {
+      // Evict so a later mount retries instead of caching the failure.
+      _entries.remove(source.cacheKey);
+      rethrow;
+    }
+  }
+
+  static void release(String cacheKey) {
+    final entry = _entries[cacheKey];
+    if (entry == null) return;
+    entry.refCount--;
+    if (entry.refCount <= 0) {
+      _entries.remove(cacheKey);
+    }
+  }
+}
+
+class _ModelTemplateEntry {
+  _ModelTemplateEntry(this.template);
+  final Future<Node> template;
+  int refCount = 0;
+}
+
 /// A declarative imported model: loads a `.glb` and mounts it as a node.
 ///
 /// The widget owns a wrapper [Node] carrying the transform props; the
@@ -714,22 +890,25 @@ class MemoryModelSource extends SceneModelSource {
 /// can change on rebuild for interactive switching (a product configurator).
 /// Null keeps the model's default materials.
 ///
+/// [animations] declares which imported animations play and how (see
+/// [SceneAnimationSpec]); rebuilding with changed specs applies the
+/// differences to the underlying clips.
+///
+/// Models are cached and shared: widgets whose sources have equal cache keys
+/// load and import once, and each mounts its own clone of the shared
+/// template (geometry, textures, and materials stay shared on the GPU). The
+/// template is evicted when the last widget using it unmounts.
+///
 /// ```dart
 /// SceneModel(
 ///   'models/shoe.glb',
 ///   variant: selectedColorway,
+///   animations: [SceneAnimationSpec('Spin', speed: 0.5)],
 ///   position: Vector3(0, 1, 0),
 /// )
 /// ```
 /// {@category Widgets}
 class SceneModel extends StatefulWidget {
-  // TODO(model-cache): each SceneModel instance imports (and uploads) its own
-  // copy of the model; share decoded templates across equal-keyed sources
-  // once component-aware Node cloning exists.
-  // TODO(model-animation): add a declarative prop for playing a named
-  // imported animation; until then use [onLoaded] and the imperative
-  // animation API.
-
   /// Loads the model from the asset bundle at [assetPath].
   ///
   /// Not const because the source is derived; use [SceneModel.from] with a
@@ -738,6 +917,7 @@ class SceneModel extends StatefulWidget {
     String assetPath, {
     super.key,
     this.variant,
+    this.animations = const [],
     this.placeholder,
     this.error,
     this.onLoaded,
@@ -762,6 +942,7 @@ class SceneModel extends StatefulWidget {
     this.source, {
     super.key,
     this.variant,
+    this.animations = const [],
     this.placeholder,
     this.error,
     this.onLoaded,
@@ -780,8 +961,21 @@ class SceneModel extends StatefulWidget {
          'Provide either transform or position/rotation/scale, not both.',
        );
 
+  /// Replaces the model import for tests, so widget tests can exercise the
+  /// full load/cache/clone path with hand-built node trees and no GPU.
+  @visibleForTesting
+  static Future<Node> Function(Uint8List bytes)? debugImportOverride;
+
+  /// Clears the shared model template cache (tests only).
+  @visibleForTesting
+  static void debugClearModelTemplateCache() =>
+      _ModelTemplateCache._entries.clear();
+
   /// Where the model bytes come from. Diffed by [SceneModelSource.cacheKey].
   final SceneModelSource source;
+
+  /// The animations to play, declared by name. See [SceneAnimationSpec].
+  final List<SceneAnimationSpec> animations;
 
   /// The `KHR_materials_variants` variant to select, or null for the
   /// model's default materials. Unknown names log a warning and keep the
@@ -835,6 +1029,8 @@ class _SceneModelState extends State<SceneModel>
   Node? _modelRoot;
   Object? _loadError;
   int _loadGeneration = 0;
+  String? _acquiredCacheKey;
+  final SceneAnimationBinder _animations = SceneAnimationBinder();
 
   @override
   String? get _name => widget.name;
@@ -869,22 +1065,41 @@ class _SceneModelState extends State<SceneModel>
 
   Future<void> _load() async {
     final generation = ++_loadGeneration;
+    final cacheKey = widget.source.cacheKey;
+    _acquiredCacheKey = cacheKey;
     try {
-      final bytes = await widget.source.load();
-      if (!mounted || generation != _loadGeneration) return;
-      final modelRoot = await Node.fromGlbBytes(bytes);
-      if (!mounted || generation != _loadGeneration) return;
+      final template = await _ModelTemplateCache.acquire(widget.source);
+      if (!mounted || generation != _loadGeneration) {
+        _ModelTemplateCache.release(cacheKey);
+        return;
+      }
+      // Each widget mounts its own clone of the shared template; heavy GPU
+      // resources stay shared, primitives/skins/variants are per instance.
+      final modelRoot = template.clone();
+      MaterialsVariantsComponent.rebindClone(template, modelRoot);
       _node.add(modelRoot);
       setState(() {
         _modelRoot = modelRoot;
         _loadError = null;
       });
       _applyVariant();
+      _animations.bind(modelRoot);
+      _animations.apply(widget.animations);
       widget.onLoaded?.call(modelRoot);
     } catch (e) {
-      if (!mounted || generation != _loadGeneration) return;
+      if (!mounted || generation != _loadGeneration) {
+        return;
+      }
       setState(() => _loadError = e);
     }
+  }
+
+  void _releaseTemplate() {
+    final acquired = _acquiredCacheKey;
+    if (acquired != null && _modelRoot != null) {
+      _ModelTemplateCache.release(acquired);
+    }
+    _acquiredCacheKey = null;
   }
 
   void _resetModel() {
@@ -893,8 +1108,16 @@ class _SceneModelState extends State<SceneModel>
     if (modelRoot != null) {
       _node.remove(modelRoot);
     }
+    _releaseTemplate();
+    _animations.bind(null);
     _modelRoot = null;
     _loadError = null;
+  }
+
+  @override
+  void dispose() {
+    _resetModel();
+    super.dispose();
   }
 
   void _applyVariant() {
@@ -919,8 +1142,13 @@ class _SceneModelState extends State<SceneModel>
     if (widget.source.cacheKey != oldWidget.source.cacheKey) {
       setState(_resetModel);
       _load();
-    } else if (widget.variant != oldWidget.variant) {
+      return;
+    }
+    if (widget.variant != oldWidget.variant) {
       _applyVariant();
+    }
+    if (!listEquals(widget.animations, oldWidget.animations)) {
+      _animations.apply(widget.animations);
     }
   }
 

--- a/packages/flutter_scene/lib/src/widgets/declarative.dart
+++ b/packages/flutter_scene/lib/src/widgets/declarative.dart
@@ -1,3 +1,5 @@
+import 'dart:async' show Completer;
+
 import 'package:flutter/foundation.dart'
     show
         Uint8List,
@@ -30,7 +32,6 @@ import 'package:flutter/widgets.dart'
         StatelessWidget,
         Widget,
         WidgetBuilder;
-import 'package:collection/collection.dart' show IterableExtension;
 import 'package:vector_math/vector_math.dart' show Matrix4, Quaternion, Vector3;
 
 import 'package:flutter_scene/src/animation.dart'
@@ -38,18 +39,19 @@ import 'package:flutter_scene/src/animation.dart'
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/components/materials_variants_component.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
+import 'package:flutter_scene/src/hot_reload/hot_reload_coordinator.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/mesh.dart';
 import 'package:flutter_scene/src/node.dart';
 import 'package:flutter_scene/src/widgets/scene_view.dart';
 
-/// The declarative scene layer: widgets that own and reconcile [Node]s in a
+/// The declarative scene layer, widgets that own and reconcile [Node]s in a
 /// retained [Scene]. Widgets are immutable descriptions; each widget's state
 /// holds the engine object and applies property diffs on rebuild, so an
 /// unchanged rebuild writes nothing and structural changes are proportional
 /// to what changed.
 ///
-/// Ownership rule: a scene widget owns the [Node] it creates. Imperative code
+/// The ownership rule is that a scene widget owns the [Node] it creates. Imperative code
 /// may read those nodes (raycasts, queries) but must not restructure them or
 /// write properties the widget also sets; such writes are overwritten by the
 /// next build. The bridges between the two worlds are [SceneNodeHost]
@@ -180,193 +182,11 @@ class SceneSubtree extends StatelessWidget {
   }
 }
 
-// Value equality for the mutable vector_math types (they compare by identity).
-// Scene widgets treat transform props as values; mutating one after passing
-// it to a widget is undefined behavior, matching Flutter's rule for
-// collection props.
-bool _vector3Equals(Vector3? a, Vector3? b) {
-  if (identical(a, b)) return true;
-  if (a == null || b == null) return false;
-  return a.x == b.x && a.y == b.y && a.z == b.z;
-}
-
-bool _quaternionEquals(Quaternion? a, Quaternion? b) {
-  if (identical(a, b)) return true;
-  if (a == null || b == null) return false;
-  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
-}
-
-bool _matrix4Equals(Matrix4? a, Matrix4? b) {
-  if (identical(a, b)) return true;
-  if (a == null || b == null) return false;
-  for (var i = 0; i < 16; i++) {
-    if (a.storage[i] != b.storage[i]) return false;
-  }
-  return true;
-}
-
-/// The shared engine-node lifecycle behind [SceneNode], [SceneMesh], and
-/// [SceneModel]: creates the node, keeps it attached under the parent
-/// resolved from context, applies transform/component/controller diffs, and
-/// detaches on removal.
-mixin _NodeLifecycle<T extends StatefulWidget> on State<T> {
-  final Node _node = Node();
-  Node? _attachedTo;
-  List<Component> _appliedComponents = const [];
-  SceneNodeController? _controller;
-
-  // Prop accessors implemented by each widget's state.
-  String? get _name;
-  Matrix4? get _transform;
-  Vector3? get _position;
-  Quaternion? get _rotation;
-  Vector3? get _scale;
-  bool get _visible;
-  List<Component> get _components;
-  SceneNodeController? get _widgetController;
-  List<Widget> get _children;
-
-  @override
-  void initState() {
-    super.initState();
-    _applyName();
-    _applyTransform();
-    _node.visible = _visible;
-    _syncComponents();
-    _syncController();
-  }
-
-  void didUpdateProps(covariant T oldWidget) {
-    _applyNameIfChanged(oldWidget);
-    _applyTransformIfChanged(oldWidget);
-    if (_visible != _node.visible) {
-      _node.visible = _visible;
-    }
-    _syncComponents();
-    _syncController();
-  }
-
-  // Per-widget hooks so subclasses read their own old-widget fields.
-  void _applyNameIfChanged(T oldWidget);
-  void _applyTransformIfChanged(T oldWidget);
-
-  void _applyName() {
-    _node.name = _name ?? '';
-  }
-
-  void _applyTransform() {
-    final transform = _transform;
-    if (transform != null) {
-      // Clone so later in-place mutation of the caller's matrix cannot skew
-      // the node behind the diff's back.
-      _node.localTransform = transform.clone();
-      return;
-    }
-    _node.setLocalTransformTrs(
-      DecomposedTransform(
-        translation: _position?.clone() ?? Vector3.zero(),
-        rotation: _rotation?.clone() ?? Quaternion.identity(),
-        scale: _scale?.clone() ?? Vector3(1.0, 1.0, 1.0),
-      ),
-    );
-  }
-
-  /// Identity-diffs the declared component list against what is attached:
-  /// removed instances detach, added instances attach. Order changes alone
-  /// are ignored (attach order is not semantic).
-  void _syncComponents() {
-    final declared = _components;
-    for (final component in _appliedComponents) {
-      if (!declared.any((c) => identical(c, component))) {
-        _node.removeComponent(component);
-      }
-    }
-    for (final component in declared) {
-      if (!_appliedComponents.any((c) => identical(c, component))) {
-        _node.addComponent(component);
-      }
-    }
-    _appliedComponents = List.of(declared);
-  }
-
-  void _syncController() {
-    final controller = _widgetController;
-    if (identical(controller, _controller)) return;
-    if (identical(_controller?._state, this)) {
-      _controller?._state = null;
-    }
-    _controller = controller;
-    controller?._state = this;
-  }
-
-  /// Attaches the node under the parent resolved from context, moving it if
-  /// the parent changed. Called from build, where inherited dependencies are
-  /// registered, so scope changes rebuild us and re-sync.
-  void _syncParent(BuildContext context) {
-    final parent = _resolveParent(context);
-    if (identical(parent, _attachedTo)) return;
-    _detach();
-    parent.add(_node);
-    _attachedTo = parent;
-  }
-
-  void _detach() {
-    final attachedTo = _attachedTo;
-    if (attachedTo != null) {
-      attachedTo.remove(_node);
-      _attachedTo = null;
-    }
-  }
-
-  @override
-  void deactivate() {
-    // Leave the scene while off the element tree; build re-attaches on
-    // reinsertion (GlobalKey moves), dispose follows otherwise.
-    _detach();
-    super.deactivate();
-  }
-
-  @override
-  void dispose() {
-    if (identical(_controller?._state, this)) {
-      _controller?._state = null;
-    }
-    super.dispose();
-  }
-
-  Widget buildHost(BuildContext context) {
-    _syncParent(context);
-    return _SceneParentScope(
-      parent: _node,
-      child: _NodeChildHost(children: _children),
-    );
-  }
-}
-
-/// A declarative [Node]: a transform in the scene graph, described in
-/// `build()`.
-///
-/// The widget owns a retained engine [Node]; rebuilding with changed
-/// properties applies only the differences, and removing the widget detaches
-/// the node. Give it [children] to describe a subtree, [components] for
-/// engine-side behavior, and a [controller] for imperative access.
-///
-/// Provide the transform either decomposed ([position], [rotation], [scale])
-/// or as a full [transform] matrix, not both. Transform props are treated as
-/// immutable values; do not mutate a vector after passing it (pass a new one
-/// instead). For motion every frame, prefer a [Component] or a
-/// [SceneNodeController] over rebuilding, so no widgets rebuild per frame.
-///
-/// ```dart
-/// SceneNode(
-///   position: Vector3(0, 1, 0),
-///   components: [SpinComponent()],
-///   children: [SceneMesh(geometry: geometry, material: material)],
-/// )
-/// ```
-/// {@category Widgets}
-class SceneNode extends StatefulWidget {
-  const SceneNode({
+/// The shared props of the node-managing scene widgets ([SceneNode],
+/// [SceneMesh], [SceneModel]), so the lifecycle mixin diffs them in one
+/// place and a new prop cannot be forgotten in one widget's diff.
+abstract class _SceneNodeWidgetBase extends StatefulWidget {
+  const _SceneNodeWidgetBase({
     super.key,
     this.name,
     this.position,
@@ -410,6 +230,189 @@ class SceneNode extends StatefulWidget {
 
   /// Scene widgets describing this node's children.
   final List<Widget> children;
+}
+
+/// The shared engine-node lifecycle behind [SceneNode], [SceneMesh], and
+/// [SceneModel]: creates the node, keeps it attached under the parent
+/// resolved from context, applies transform/component/controller diffs, and
+/// detaches on removal.
+///
+/// Transform props are diffed with the vector_math value equality the types
+/// define; mutating one after passing it to a widget is undefined behavior,
+/// matching Flutter's rule for collection props.
+mixin _NodeLifecycle<T extends _SceneNodeWidgetBase> on State<T> {
+  final Node _node = Node();
+  Node? _attachedTo;
+  List<Component> _declaredComponents = const [];
+  List<Component> _appliedComponents = const [];
+  SceneNodeController? _controller;
+
+  /// The hosted child widgets; [SceneModel]'s state adds its
+  /// placeholder/error subtrees.
+  List<Widget> get _children => widget.children;
+
+  @override
+  void initState() {
+    super.initState();
+    _node.name = widget.name ?? '';
+    _applyTransform();
+    _node.visible = widget.visible;
+    _syncComponents();
+    _syncController();
+  }
+
+  void didUpdateProps(_SceneNodeWidgetBase oldWidget) {
+    if (widget.name != oldWidget.name) {
+      _node.name = widget.name ?? '';
+    }
+    if (widget.transform != oldWidget.transform ||
+        widget.position != oldWidget.position ||
+        widget.rotation != oldWidget.rotation ||
+        widget.scale != oldWidget.scale) {
+      _applyTransform();
+    }
+    if (widget.visible != _node.visible) {
+      _node.visible = widget.visible;
+    }
+    _syncComponents();
+    _syncController();
+  }
+
+  void _applyTransform() {
+    final transform = widget.transform;
+    if (transform != null) {
+      // Clone so later in-place mutation of the caller's matrix cannot skew
+      // the node behind the diff's back.
+      _node.localTransform = transform.clone();
+      return;
+    }
+    _node.setLocalTransformTrs(
+      DecomposedTransform(
+        translation: widget.position?.clone() ?? Vector3.zero(),
+        rotation: widget.rotation?.clone() ?? Quaternion.identity(),
+        scale: widget.scale?.clone() ?? Vector3(1.0, 1.0, 1.0),
+      ),
+    );
+  }
+
+  /// Identity-diffs the declared component list against what is attached:
+  /// removed instances detach, added instances attach. Order changes alone
+  /// are ignored (attach order is not semantic). An unchanged list instance
+  /// (the common rebuild) skips the scan entirely.
+  void _syncComponents() {
+    final declared = widget.components;
+    if (identical(declared, _declaredComponents)) return;
+    _declaredComponents = declared;
+    for (final component in _appliedComponents) {
+      if (!declared.any((c) => identical(c, component))) {
+        _node.removeComponent(component);
+      }
+    }
+    for (final component in declared) {
+      if (!_appliedComponents.any((c) => identical(c, component))) {
+        _node.addComponent(component);
+      }
+    }
+    _appliedComponents = List.of(declared);
+  }
+
+  void _syncController() {
+    final controller = widget.controller;
+    if (identical(controller, _controller)) return;
+    if (identical(_controller?._state, this)) {
+      _controller?._state = null;
+    }
+    _controller = controller;
+    controller?._state = this;
+  }
+
+  /// Attaches the node under the parent resolved from context, moving it if
+  /// the parent changed. Called from build, where inherited dependencies are
+  /// registered, so scope changes rebuild us and re-sync.
+  void _syncParent(BuildContext context) {
+    final parent = _resolveParent(context);
+    if (identical(parent, _attachedTo)) return;
+    _detach();
+    parent.add(_node);
+    _attachedTo = parent;
+  }
+
+  void _detach() {
+    final attachedTo = _attachedTo;
+    if (attachedTo != null) {
+      attachedTo.remove(_node);
+      _attachedTo = null;
+    }
+  }
+
+  @override
+  void deactivate() {
+    // Leave the scene while off the element tree; build re-attaches on
+    // reinsertion (GlobalKey moves), dispose follows otherwise.
+    _detach();
+    super.deactivate();
+  }
+
+  @override
+  void dispose() {
+    // Detach the declared components so their onDetach cleanup runs and the
+    // instances are reusable (a stable component instance declared by a
+    // conditional subtree must attach again on the next mount).
+    for (final component in _appliedComponents) {
+      _node.removeComponent(component);
+    }
+    _appliedComponents = const [];
+    _declaredComponents = const [];
+    if (identical(_controller?._state, this)) {
+      _controller?._state = null;
+    }
+    super.dispose();
+  }
+
+  Widget buildHost(BuildContext context) {
+    _syncParent(context);
+    return _SceneParentScope(
+      parent: _node,
+      child: _NodeChildHost(children: _children),
+    );
+  }
+}
+
+/// A declarative [Node]: a transform in the scene graph, described in
+/// `build()`.
+///
+/// The widget owns a retained engine [Node]; rebuilding with changed
+/// properties applies only the differences, and removing the widget detaches
+/// the node. Give it [children] to describe a subtree, [components] for
+/// engine-side behavior, and a [controller] for imperative access.
+///
+/// Provide the transform either decomposed ([position], [rotation], [scale])
+/// or as a full [transform] matrix, not both. Transform props are treated as
+/// immutable values; do not mutate a vector after passing it (pass a new one
+/// instead). For motion every frame, prefer a [Component] or a
+/// [SceneNodeController] over rebuilding, so no widgets rebuild per frame.
+///
+/// ```dart
+/// SceneNode(
+///   position: Vector3(0, 1, 0),
+///   components: [SpinComponent()],
+///   children: [SceneMesh(geometry: geometry, material: material)],
+/// )
+/// ```
+/// {@category Widgets}
+class SceneNode extends _SceneNodeWidgetBase {
+  const SceneNode({
+    super.key,
+    super.name,
+    super.position,
+    super.rotation,
+    super.scale,
+    super.transform,
+    super.visible,
+    super.components,
+    super.controller,
+    super.children,
+  });
 
   @override
   State<SceneNode> createState() => _SceneNodeState();
@@ -417,44 +420,9 @@ class SceneNode extends StatefulWidget {
 
 class _SceneNodeState extends State<SceneNode> with _NodeLifecycle<SceneNode> {
   @override
-  String? get _name => widget.name;
-  @override
-  Matrix4? get _transform => widget.transform;
-  @override
-  Vector3? get _position => widget.position;
-  @override
-  Quaternion? get _rotation => widget.rotation;
-  @override
-  Vector3? get _scale => widget.scale;
-  @override
-  bool get _visible => widget.visible;
-  @override
-  List<Component> get _components => widget.components;
-  @override
-  SceneNodeController? get _widgetController => widget.controller;
-  @override
-  List<Widget> get _children => widget.children;
-
-  @override
   void didUpdateWidget(SceneNode oldWidget) {
     super.didUpdateWidget(oldWidget);
     didUpdateProps(oldWidget);
-  }
-
-  @override
-  void _applyNameIfChanged(SceneNode oldWidget) {
-    if (widget.name != oldWidget.name) _applyName();
-  }
-
-  @override
-  void _applyTransformIfChanged(SceneNode oldWidget) {
-    if (_matrix4Equals(widget.transform, oldWidget.transform) &&
-        _vector3Equals(widget.position, oldWidget.position) &&
-        _quaternionEquals(widget.rotation, oldWidget.rotation) &&
-        _vector3Equals(widget.scale, oldWidget.scale)) {
-      return;
-    }
-    _applyTransform();
   }
 
   @override
@@ -477,25 +445,21 @@ class _SceneNodeState extends State<SceneNode> with _NodeLifecycle<SceneNode> {
 /// )
 /// ```
 /// {@category Widgets}
-class SceneMesh extends StatefulWidget {
+class SceneMesh extends _SceneNodeWidgetBase {
   const SceneMesh({
     super.key,
     required this.geometry,
     required this.material,
-    this.name,
-    this.position,
-    this.rotation,
-    this.scale,
-    this.transform,
-    this.visible = true,
-    this.components = const [],
-    this.controller,
-    this.children = const [],
-  }) : assert(
-         transform == null ||
-             (position == null && rotation == null && scale == null),
-         'Provide either transform or position/rotation/scale, not both.',
-       );
+    super.name,
+    super.position,
+    super.rotation,
+    super.scale,
+    super.transform,
+    super.visible,
+    super.components,
+    super.controller,
+    super.children,
+  });
 
   /// The vertex data to draw.
   final Geometry geometry;
@@ -503,57 +467,11 @@ class SceneMesh extends StatefulWidget {
   /// The material shading [geometry].
   final Material material;
 
-  /// See [SceneNode.name].
-  final String? name;
-
-  /// See [SceneNode.position].
-  final Vector3? position;
-
-  /// See [SceneNode.rotation].
-  final Quaternion? rotation;
-
-  /// See [SceneNode.scale].
-  final Vector3? scale;
-
-  /// See [SceneNode.transform].
-  final Matrix4? transform;
-
-  /// See [SceneNode.visible].
-  final bool visible;
-
-  /// See [SceneNode.components].
-  final List<Component> components;
-
-  /// See [SceneNode.controller].
-  final SceneNodeController? controller;
-
-  /// See [SceneNode.children].
-  final List<Widget> children;
-
   @override
   State<SceneMesh> createState() => _SceneMeshState();
 }
 
 class _SceneMeshState extends State<SceneMesh> with _NodeLifecycle<SceneMesh> {
-  @override
-  String? get _name => widget.name;
-  @override
-  Matrix4? get _transform => widget.transform;
-  @override
-  Vector3? get _position => widget.position;
-  @override
-  Quaternion? get _rotation => widget.rotation;
-  @override
-  Vector3? get _scale => widget.scale;
-  @override
-  bool get _visible => widget.visible;
-  @override
-  List<Component> get _components => widget.components;
-  @override
-  SceneNodeController? get _widgetController => widget.controller;
-  @override
-  List<Widget> get _children => widget.children;
-
   @override
   void initState() {
     super.initState();
@@ -568,22 +486,6 @@ class _SceneMeshState extends State<SceneMesh> with _NodeLifecycle<SceneMesh> {
         !identical(widget.material, oldWidget.material)) {
       _node.mesh = Mesh(widget.geometry, widget.material);
     }
-  }
-
-  @override
-  void _applyNameIfChanged(SceneMesh oldWidget) {
-    if (widget.name != oldWidget.name) _applyName();
-  }
-
-  @override
-  void _applyTransformIfChanged(SceneMesh oldWidget) {
-    if (_matrix4Equals(widget.transform, oldWidget.transform) &&
-        _vector3Equals(widget.position, oldWidget.position) &&
-        _quaternionEquals(widget.rotation, oldWidget.rotation) &&
-        _vector3Equals(widget.scale, oldWidget.scale)) {
-      return;
-    }
-    _applyTransform();
   }
 
   @override
@@ -668,6 +570,13 @@ abstract class SceneModelSource {
 
   /// Loads the model's `.glb` bytes.
   Future<Uint8List> load();
+
+  /// Loads and imports the model, producing the shared template node tree.
+  ///
+  /// The default imports [load]'s bytes as a `.glb`. Override to import
+  /// through another pipeline (or, in tests, to produce a hand-built tree
+  /// with no GPU).
+  Future<Node> createNode() async => Node.fromGlbBytes(await load());
 }
 
 /// Loads a `.glb` model from the asset bundle.
@@ -692,7 +601,9 @@ class AssetModelSource extends SceneModelSource {
 /// network download, a local cache, generated content).
 ///
 /// [key] must uniquely identify the bytes; the widget reloads when the key
-/// changes, not when the buffer instance does.
+/// changes, not when the buffer instance does. The buffer stays referenced
+/// while the widget is mounted, since an unmount/remount cycle re-imports
+/// from it after the shared template is evicted.
 /// {@category Widgets}
 class MemoryModelSource extends SceneModelSource {
   const MemoryModelSource(this.bytes, {required this.key});
@@ -770,7 +681,7 @@ class SceneAnimationSpec {
 class SceneAnimationBinder {
   final Map<String, AnimationClip> _clips = {};
   final Set<String> _warnedUnknown = {};
-  List<SceneAnimationSpec> _applied = const [];
+  Map<String, SceneAnimationSpec> _applied = const {};
   Node? _modelRoot;
 
   /// The clips created so far, keyed by animation name.
@@ -781,7 +692,7 @@ class SceneAnimationBinder {
     _modelRoot = modelRoot;
     _clips.clear();
     _warnedUnknown.clear();
-    _applied = const [];
+    _applied = const {};
   }
 
   /// Diffs [specs] against the previously applied set.
@@ -791,7 +702,11 @@ class SceneAnimationBinder {
     final wanted = {for (final spec in specs) spec.name};
     for (final entry in _clips.entries) {
       if (!wanted.contains(entry.key)) {
+        // Stopping is not enough: the player blends every registered clip
+        // regardless of playing, so a lingering clip would keep posing the
+        // model at its first frame and dilute the remaining weights.
         entry.value.stop();
+        root.removeAnimationClip(entry.value);
       }
     }
     _clips.removeWhere((name, _) => !wanted.contains(name));
@@ -811,7 +726,7 @@ class SceneAnimationBinder {
         clip = root.createAnimationClip(animation);
         _clips[spec.name] = clip;
       }
-      final previous = _applied.firstWhereOrNull((s) => s.name == spec.name);
+      final previous = _applied[spec.name];
       clip.loop = spec.loop;
       clip.weight = spec.weight;
       clip.playbackTimeScale = spec.speed;
@@ -828,7 +743,7 @@ class SceneAnimationBinder {
         clip.pause();
       }
     }
-    _applied = List.of(specs);
+    _applied = {for (final spec in specs) spec.name: spec};
   }
 }
 
@@ -851,9 +766,7 @@ class _ModelTemplateCache {
 
   static Future<Node> _import(SceneModelSource source) async {
     try {
-      final bytes = await source.load();
-      final import = SceneModel.debugImportOverride ?? Node.fromGlbBytes;
-      return await import(bytes);
+      return await source.createNode();
     } catch (_) {
       // Evict so a later mount retries instead of caching the failure.
       _entries.remove(source.cacheKey);
@@ -861,6 +774,14 @@ class _ModelTemplateCache {
     }
   }
 
+  /// Drops the entry for [cacheKey] so the next acquire re-imports. Live
+  /// holders keep their clones; their later releases become no-ops.
+  static void evict(String cacheKey) => _entries.remove(cacheKey);
+
+  // TODO(model-cache-keepalive): eviction is immediate at refcount zero, so
+  // an unmount/remount cycle (a list scrolling a model off and back)
+  // re-imports from scratch; add a small keep-alive or unify with the
+  // SceneRegistry template cache.
   static void release(String cacheKey) {
     final entry = _entries[cacheKey];
     if (entry == null) return;
@@ -908,7 +829,7 @@ class _ModelTemplateEntry {
 /// )
 /// ```
 /// {@category Widgets}
-class SceneModel extends StatefulWidget {
+class SceneModel extends _SceneNodeWidgetBase {
   /// Loads the model from the asset bundle at [assetPath].
   ///
   /// Not const because the source is derived; use [SceneModel.from] with a
@@ -921,21 +842,16 @@ class SceneModel extends StatefulWidget {
     this.placeholder,
     this.error,
     this.onLoaded,
-    this.name,
-    this.position,
-    this.rotation,
-    this.scale,
-    this.transform,
-    this.visible = true,
-    this.components = const [],
-    this.controller,
-    this.children = const [],
-  }) : source = AssetModelSource(assetPath),
-       assert(
-         transform == null ||
-             (position == null && rotation == null && scale == null),
-         'Provide either transform or position/rotation/scale, not both.',
-       );
+    super.name,
+    super.position,
+    super.rotation,
+    super.scale,
+    super.transform,
+    super.visible,
+    super.components,
+    super.controller,
+    super.children,
+  }) : source = AssetModelSource(assetPath);
 
   /// Loads the model from an explicit [SceneModelSource].
   const SceneModel.from(
@@ -946,25 +862,16 @@ class SceneModel extends StatefulWidget {
     this.placeholder,
     this.error,
     this.onLoaded,
-    this.name,
-    this.position,
-    this.rotation,
-    this.scale,
-    this.transform,
-    this.visible = true,
-    this.components = const [],
-    this.controller,
-    this.children = const [],
-  }) : assert(
-         transform == null ||
-             (position == null && rotation == null && scale == null),
-         'Provide either transform or position/rotation/scale, not both.',
-       );
-
-  /// Replaces the model import for tests, so widget tests can exercise the
-  /// full load/cache/clone path with hand-built node trees and no GPU.
-  @visibleForTesting
-  static Future<Node> Function(Uint8List bytes)? debugImportOverride;
+    super.name,
+    super.position,
+    super.rotation,
+    super.scale,
+    super.transform,
+    super.visible,
+    super.components,
+    super.controller,
+    super.children,
+  });
 
   /// Clears the shared model template cache (tests only).
   @visibleForTesting
@@ -992,34 +899,6 @@ class SceneModel extends StatefulWidget {
   /// imported content imperatively (play animations, look up nodes).
   final void Function(Node modelRoot)? onLoaded;
 
-  /// See [SceneNode.name].
-  final String? name;
-
-  /// See [SceneNode.position].
-  final Vector3? position;
-
-  /// See [SceneNode.rotation].
-  final Quaternion? rotation;
-
-  /// See [SceneNode.scale].
-  final Vector3? scale;
-
-  /// See [SceneNode.transform].
-  final Matrix4? transform;
-
-  /// See [SceneNode.visible].
-  final bool visible;
-
-  /// See [SceneNode.components].
-  final List<Component> components;
-
-  /// See [SceneNode.controller]. The controller's node is the wrapper the
-  /// imported content hangs under.
-  final SceneNodeController? controller;
-
-  /// See [SceneNode.children].
-  final List<Widget> children;
-
   @override
   State<SceneModel> createState() => _SceneModelState();
 }
@@ -1029,25 +908,16 @@ class _SceneModelState extends State<SceneModel>
   Node? _modelRoot;
   Object? _loadError;
   int _loadGeneration = 0;
-  String? _acquiredCacheKey;
+  String? _heldTemplateKey;
+  bool _warnedUnknownVariant = false;
   final SceneAnimationBinder _animations = SceneAnimationBinder();
 
-  @override
-  String? get _name => widget.name;
-  @override
-  Matrix4? get _transform => widget.transform;
-  @override
-  Vector3? get _position => widget.position;
-  @override
-  Quaternion? get _rotation => widget.rotation;
-  @override
-  Vector3? get _scale => widget.scale;
-  @override
-  bool get _visible => widget.visible;
-  @override
-  List<Component> get _components => widget.components;
-  @override
-  SceneNodeController? get _widgetController => widget.controller;
+  // Ties this widget's load into the enclosing SceneView's reveal gate (the
+  // loading/warmUp machinery), so a gated view stays on its loading widget
+  // until declarative models are mounted. Registered once, on first build.
+  Completer<void>? _loadGate;
+  bool _gateChecked = false;
+
   @override
   List<Widget> get _children => [
     ...widget.children,
@@ -1065,19 +935,21 @@ class _SceneModelState extends State<SceneModel>
 
   Future<void> _load() async {
     final generation = ++_loadGeneration;
-    final cacheKey = widget.source.cacheKey;
-    _acquiredCacheKey = cacheKey;
+    final source = widget.source;
     try {
-      final template = await _ModelTemplateCache.acquire(widget.source);
+      final template = await _ModelTemplateCache.acquire(source);
       if (!mounted || generation != _loadGeneration) {
-        _ModelTemplateCache.release(cacheKey);
+        _ModelTemplateCache.release(source.cacheKey);
         return;
       }
       // Each widget mounts its own clone of the shared template; heavy GPU
-      // resources stay shared, primitives/skins/variants are per instance.
+      // resources stay shared, primitives/skins are per instance, and
+      // components come along through Component.cloneFor plus the variants
+      // rebind.
       final modelRoot = template.clone();
       MaterialsVariantsComponent.rebindClone(template, modelRoot);
       _node.add(modelRoot);
+      _heldTemplateKey = source.cacheKey;
       setState(() {
         _modelRoot = modelRoot;
         _loadError = null;
@@ -1085,21 +957,66 @@ class _SceneModelState extends State<SceneModel>
       _applyVariant();
       _animations.bind(modelRoot);
       _animations.apply(widget.animations);
+      _registerHotReload(source, modelRoot);
       widget.onLoaded?.call(modelRoot);
     } catch (e) {
       if (!mounted || generation != _loadGeneration) {
         return;
       }
       setState(() => _loadError = e);
+    } finally {
+      _settleLoadGate();
+    }
+  }
+
+  // Asset-sourced models participate in asset hot reload: when the .glb's
+  // bytes change, the shared template is evicted and this instance reloads
+  // in place. Debug only (the coordinator no-ops otherwise). The closure
+  // holds this state weakly so a dead widget cannot pin itself (the
+  // registration itself is dropped once the model root is collected).
+  void _registerHotReload(SceneModelSource source, Node modelRoot) {
+    if (source is! AssetModelSource) return;
+    final weakState = WeakReference<_SceneModelState>(this);
+    HotReloadCoordinator.instance.registerScene(
+      modelRoot,
+      assetKey: source.assetPath,
+      onReload: () async {
+        _ModelTemplateCache.evict(source.cacheKey);
+        final state = weakState.target;
+        if (state == null || !state.mounted) return;
+        state.setState(state._resetModel);
+        await state._load();
+      },
+    );
+  }
+
+  void _registerLoadGate(BuildContext context) {
+    if (_gateChecked) return;
+    _gateChecked = true;
+    final group = SceneScope.maybeOf(context)?.internalChildLoads;
+    if (group == null) return;
+    // Already-settled loads (a warm cache) register a completed future, so
+    // the gate never waits on them.
+    _loadGate = Completer<void>();
+    if (_modelRoot != null || _loadError != null) {
+      _loadGate!.complete();
+    }
+    group.add(_loadGate!.future);
+  }
+
+  void _settleLoadGate() {
+    final gate = _loadGate;
+    if (gate != null && !gate.isCompleted) {
+      gate.complete();
     }
   }
 
   void _releaseTemplate() {
-    final acquired = _acquiredCacheKey;
-    if (acquired != null && _modelRoot != null) {
-      _ModelTemplateCache.release(acquired);
+    final held = _heldTemplateKey;
+    if (held != null) {
+      _ModelTemplateCache.release(held);
+      _heldTemplateKey = null;
     }
-    _acquiredCacheKey = null;
   }
 
   void _resetModel() {
@@ -1117,25 +1034,28 @@ class _SceneModelState extends State<SceneModel>
   @override
   void dispose() {
     _resetModel();
+    _settleLoadGate();
     super.dispose();
   }
 
   void _applyVariant() {
     final modelRoot = _modelRoot;
-    final component = modelRoot == null
-        ? null
-        : MaterialsVariantsComponent.of(modelRoot);
-    if (component == null) return;
+    if (modelRoot == null) return;
     final variant = widget.variant;
-    if (variant != null && !component.variants.contains(variant)) {
-      debugPrint(
-        'SceneModel: unknown material variant "$variant" '
-        '(available: ${component.variants}); keeping defaults.',
-      );
-      component.select(null);
-      return;
+    for (final component in MaterialsVariantsComponent.allOf(modelRoot)) {
+      if (variant != null && !component.variants.contains(variant)) {
+        if (!_warnedUnknownVariant) {
+          _warnedUnknownVariant = true;
+          debugPrint(
+            'SceneModel: unknown material variant "$variant" '
+            '(available: ${component.variants}); keeping defaults.',
+          );
+        }
+        component.select(null);
+        continue;
+      }
+      component.select(variant);
     }
-    component.select(variant);
   }
 
   @override
@@ -1148,6 +1068,7 @@ class _SceneModelState extends State<SceneModel>
       return;
     }
     if (widget.variant != oldWidget.variant) {
+      _warnedUnknownVariant = false;
       _applyVariant();
     }
     if (!listEquals(widget.animations, oldWidget.animations)) {
@@ -1156,21 +1077,8 @@ class _SceneModelState extends State<SceneModel>
   }
 
   @override
-  void _applyNameIfChanged(SceneModel oldWidget) {
-    if (widget.name != oldWidget.name) _applyName();
+  Widget build(BuildContext context) {
+    _registerLoadGate(context);
+    return buildHost(context);
   }
-
-  @override
-  void _applyTransformIfChanged(SceneModel oldWidget) {
-    if (_matrix4Equals(widget.transform, oldWidget.transform) &&
-        _vector3Equals(widget.position, oldWidget.position) &&
-        _quaternionEquals(widget.rotation, oldWidget.rotation) &&
-        _vector3Equals(widget.scale, oldWidget.scale)) {
-      return;
-    }
-    _applyTransform();
-  }
-
-  @override
-  Widget build(BuildContext context) => buildHost(context);
 }

--- a/packages/flutter_scene/lib/src/widgets/declarative.dart
+++ b/packages/flutter_scene/lib/src/widgets/declarative.dart
@@ -1,0 +1,945 @@
+import 'package:flutter/foundation.dart' show Uint8List, debugPrint;
+import 'package:flutter/rendering.dart'
+    show
+        BoxConstraints,
+        BoxHitTestResult,
+        ContainerBoxParentData,
+        ContainerRenderObjectMixin,
+        Offset,
+        PaintingContext,
+        RenderBox,
+        RenderObject;
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter/widgets.dart'
+    show
+        BuildContext,
+        Builder,
+        FlutterError,
+        InheritedWidget,
+        MultiChildRenderObjectWidget,
+        SizedBox,
+        State,
+        StatefulWidget,
+        StatelessWidget,
+        Widget,
+        WidgetBuilder;
+import 'package:vector_math/vector_math.dart' show Matrix4, Quaternion, Vector3;
+
+import 'package:flutter_scene/src/animation.dart' show DecomposedTransform;
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/components/materials_variants_component.dart';
+import 'package:flutter_scene/src/geometry/geometry.dart';
+import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/mesh.dart';
+import 'package:flutter_scene/src/node.dart';
+import 'package:flutter_scene/src/widgets/scene_view.dart';
+
+/// The declarative scene layer: widgets that own and reconcile [Node]s in a
+/// retained [Scene]. Widgets are immutable descriptions; each widget's state
+/// holds the engine object and applies property diffs on rebuild, so an
+/// unchanged rebuild writes nothing and structural changes are proportional
+/// to what changed.
+///
+/// Ownership rule: a scene widget owns the [Node] it creates. Imperative code
+/// may read those nodes (raycasts, queries) but must not restructure them or
+/// write properties the widget also sets; such writes are overwritten by the
+/// next build. The bridges between the two worlds are [SceneNodeHost]
+/// (imperative subtree mounted inside a declarative tree) and
+/// [SceneNodeController] (imperative handle to a widget-owned node).
+
+/// Grants imperative access to the [Node] managed by a scene widget.
+///
+/// Attach one to a [SceneNode], [SceneMesh], or [SceneModel] and read [node]
+/// to raycast against it, follow it with a camera, or drive per-frame motion.
+/// Null while the widget is unmounted. For [SceneModel] the node is the
+/// wrapper the imported content mounts under once loaded.
+///
+/// Writes are subject to the ownership rule: do not set properties the
+/// owning widget also declares (they are overwritten on its next build).
+/// A controller may be attached to at most one widget at a time.
+/// {@category Widgets}
+class SceneNodeController {
+  _NodeLifecycle? _state;
+
+  /// The managed node, or null while the owning widget is unmounted.
+  Node? get node => _state?._node;
+}
+
+/// Provides the parent [Node] that descendant scene widgets attach to.
+class _SceneParentScope extends InheritedWidget {
+  const _SceneParentScope({required this.parent, required super.child});
+
+  final Node parent;
+
+  @override
+  bool updateShouldNotify(_SceneParentScope oldWidget) =>
+      !identical(parent, oldWidget.parent);
+}
+
+/// Resolves the node new scene widgets should attach under: the nearest
+/// [_SceneParentScope], else the enclosing [SceneView]'s scene root.
+Node _resolveParent(BuildContext context) {
+  final scope = context.dependOnInheritedWidgetOfExactType<_SceneParentScope>();
+  if (scope != null) return scope.parent;
+  final sceneScope = SceneScope.maybeOf(context);
+  if (sceneScope != null) return sceneScope.scene.root;
+  throw FlutterError(
+    'Scene widgets must be placed below a SceneView (or a SceneSubtree with an '
+    'explicit parent). No SceneScope or scene parent was found above this '
+    'widget.',
+  );
+}
+
+/// Hosts scene-widget children in the element tree while occupying no layout
+/// space and painting nothing. Scene widgets describe engine [Node]s, not
+/// pixels; this host exists so their elements live in the tree and reconcile.
+class _NodeChildHost extends MultiChildRenderObjectWidget {
+  const _NodeChildHost({super.children});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderNodeChildHost();
+}
+
+class _NodeHostParentData extends ContainerBoxParentData<RenderBox> {}
+
+class _RenderNodeChildHost extends RenderBox
+    with ContainerRenderObjectMixin<RenderBox, _NodeHostParentData> {
+  @override
+  void setupParentData(RenderObject child) {
+    if (child.parentData is! _NodeHostParentData) {
+      child.parentData = _NodeHostParentData();
+    }
+  }
+
+  @override
+  void performLayout() {
+    var child = firstChild;
+    while (child != null) {
+      child.layout(const BoxConstraints.tightFor(width: 0, height: 0));
+      child = (child.parentData! as _NodeHostParentData).nextSibling;
+    }
+    size = constraints.smallest;
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {}
+
+  @override
+  bool hitTestSelf(Offset position) => false;
+
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) =>
+      false;
+}
+
+/// Mounts declarative scene widgets under an app-owned [Node].
+///
+/// This is the bridge from an imperative scene to declarative subtrees: place
+/// it anywhere below a [SceneView] and its [children] attach under [parent]
+/// (or the scene root when [parent] is null). The same scene widgets work
+/// unchanged under either root mode.
+///
+/// ```dart
+/// SceneView(
+///   scene,
+///   children: [
+///     SceneSubtree(
+///       parent: markerAnchor,
+///       children: [SceneMesh(geometry: g, material: m)],
+///     ),
+///   ],
+/// )
+/// ```
+/// {@category Widgets}
+class SceneSubtree extends StatelessWidget {
+  const SceneSubtree({super.key, this.parent, this.children = const []});
+
+  /// The node the [children] attach under. When null, the enclosing scene's
+  /// root.
+  final Node? parent;
+
+  /// Scene widgets describing the subtree.
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return _SceneParentScope(
+      parent: parent ?? _resolveParent(context),
+      child: _NodeChildHost(children: children),
+    );
+  }
+}
+
+// Value equality for the mutable vector_math types (they compare by identity).
+// Scene widgets treat transform props as values; mutating one after passing
+// it to a widget is undefined behavior, matching Flutter's rule for
+// collection props.
+bool _vector3Equals(Vector3? a, Vector3? b) {
+  if (identical(a, b)) return true;
+  if (a == null || b == null) return false;
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+bool _quaternionEquals(Quaternion? a, Quaternion? b) {
+  if (identical(a, b)) return true;
+  if (a == null || b == null) return false;
+  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+bool _matrix4Equals(Matrix4? a, Matrix4? b) {
+  if (identical(a, b)) return true;
+  if (a == null || b == null) return false;
+  for (var i = 0; i < 16; i++) {
+    if (a.storage[i] != b.storage[i]) return false;
+  }
+  return true;
+}
+
+/// The shared engine-node lifecycle behind [SceneNode], [SceneMesh], and
+/// [SceneModel]: creates the node, keeps it attached under the parent
+/// resolved from context, applies transform/component/controller diffs, and
+/// detaches on removal.
+mixin _NodeLifecycle<T extends StatefulWidget> on State<T> {
+  final Node _node = Node();
+  Node? _attachedTo;
+  List<Component> _appliedComponents = const [];
+  SceneNodeController? _controller;
+
+  // Prop accessors implemented by each widget's state.
+  String? get _name;
+  Matrix4? get _transform;
+  Vector3? get _position;
+  Quaternion? get _rotation;
+  Vector3? get _scale;
+  bool get _visible;
+  List<Component> get _components;
+  SceneNodeController? get _widgetController;
+  List<Widget> get _children;
+
+  @override
+  void initState() {
+    super.initState();
+    _applyName();
+    _applyTransform();
+    _node.visible = _visible;
+    _syncComponents();
+    _syncController();
+  }
+
+  void didUpdateProps(covariant T oldWidget) {
+    _applyNameIfChanged(oldWidget);
+    _applyTransformIfChanged(oldWidget);
+    if (_visible != _node.visible) {
+      _node.visible = _visible;
+    }
+    _syncComponents();
+    _syncController();
+  }
+
+  // Per-widget hooks so subclasses read their own old-widget fields.
+  void _applyNameIfChanged(T oldWidget);
+  void _applyTransformIfChanged(T oldWidget);
+
+  void _applyName() {
+    _node.name = _name ?? '';
+  }
+
+  void _applyTransform() {
+    final transform = _transform;
+    if (transform != null) {
+      // Clone so later in-place mutation of the caller's matrix cannot skew
+      // the node behind the diff's back.
+      _node.localTransform = transform.clone();
+      return;
+    }
+    _node.setLocalTransformTrs(
+      DecomposedTransform(
+        translation: _position?.clone() ?? Vector3.zero(),
+        rotation: _rotation?.clone() ?? Quaternion.identity(),
+        scale: _scale?.clone() ?? Vector3(1.0, 1.0, 1.0),
+      ),
+    );
+  }
+
+  /// Identity-diffs the declared component list against what is attached:
+  /// removed instances detach, added instances attach. Order changes alone
+  /// are ignored (attach order is not semantic).
+  void _syncComponents() {
+    final declared = _components;
+    for (final component in _appliedComponents) {
+      if (!declared.any((c) => identical(c, component))) {
+        _node.removeComponent(component);
+      }
+    }
+    for (final component in declared) {
+      if (!_appliedComponents.any((c) => identical(c, component))) {
+        _node.addComponent(component);
+      }
+    }
+    _appliedComponents = List.of(declared);
+  }
+
+  void _syncController() {
+    final controller = _widgetController;
+    if (identical(controller, _controller)) return;
+    if (identical(_controller?._state, this)) {
+      _controller?._state = null;
+    }
+    _controller = controller;
+    controller?._state = this;
+  }
+
+  /// Attaches the node under the parent resolved from context, moving it if
+  /// the parent changed. Called from build, where inherited dependencies are
+  /// registered, so scope changes rebuild us and re-sync.
+  void _syncParent(BuildContext context) {
+    final parent = _resolveParent(context);
+    if (identical(parent, _attachedTo)) return;
+    _detach();
+    parent.add(_node);
+    _attachedTo = parent;
+  }
+
+  void _detach() {
+    final attachedTo = _attachedTo;
+    if (attachedTo != null) {
+      attachedTo.remove(_node);
+      _attachedTo = null;
+    }
+  }
+
+  @override
+  void deactivate() {
+    // Leave the scene while off the element tree; build re-attaches on
+    // reinsertion (GlobalKey moves), dispose follows otherwise.
+    _detach();
+    super.deactivate();
+  }
+
+  @override
+  void dispose() {
+    if (identical(_controller?._state, this)) {
+      _controller?._state = null;
+    }
+    super.dispose();
+  }
+
+  Widget buildHost(BuildContext context) {
+    _syncParent(context);
+    return _SceneParentScope(
+      parent: _node,
+      child: _NodeChildHost(children: _children),
+    );
+  }
+}
+
+/// A declarative [Node]: a transform in the scene graph, described in
+/// `build()`.
+///
+/// The widget owns a retained engine [Node]; rebuilding with changed
+/// properties applies only the differences, and removing the widget detaches
+/// the node. Give it [children] to describe a subtree, [components] for
+/// engine-side behavior, and a [controller] for imperative access.
+///
+/// Provide the transform either decomposed ([position], [rotation], [scale])
+/// or as a full [transform] matrix, not both. Transform props are treated as
+/// immutable values; do not mutate a vector after passing it (pass a new one
+/// instead). For motion every frame, prefer a [Component] or a
+/// [SceneNodeController] over rebuilding, so no widgets rebuild per frame.
+///
+/// ```dart
+/// SceneNode(
+///   position: Vector3(0, 1, 0),
+///   components: [SpinComponent()],
+///   children: [SceneMesh(geometry: geometry, material: material)],
+/// )
+/// ```
+/// {@category Widgets}
+class SceneNode extends StatefulWidget {
+  const SceneNode({
+    super.key,
+    this.name,
+    this.position,
+    this.rotation,
+    this.scale,
+    this.transform,
+    this.visible = true,
+    this.components = const [],
+    this.controller,
+    this.children = const [],
+  }) : assert(
+         transform == null ||
+             (position == null && rotation == null && scale == null),
+         'Provide either transform or position/rotation/scale, not both.',
+       );
+
+  /// The node's name, for lookups and debugging. Defaults to ''.
+  final String? name;
+
+  /// Local translation. Identity when null.
+  final Vector3? position;
+
+  /// Local rotation. Identity when null.
+  final Quaternion? rotation;
+
+  /// Local scale. One when null.
+  final Vector3? scale;
+
+  /// Full local transform. Mutually exclusive with the decomposed props.
+  final Matrix4? transform;
+
+  /// Whether the node (and its subtree) renders.
+  final bool visible;
+
+  /// Engine-side behavior attached to the node. Diffed by identity: keep a
+  /// component instance stable across rebuilds to keep its state.
+  final List<Component> components;
+
+  /// Imperative handle to the managed node.
+  final SceneNodeController? controller;
+
+  /// Scene widgets describing this node's children.
+  final List<Widget> children;
+
+  @override
+  State<SceneNode> createState() => _SceneNodeState();
+}
+
+class _SceneNodeState extends State<SceneNode> with _NodeLifecycle<SceneNode> {
+  @override
+  String? get _name => widget.name;
+  @override
+  Matrix4? get _transform => widget.transform;
+  @override
+  Vector3? get _position => widget.position;
+  @override
+  Quaternion? get _rotation => widget.rotation;
+  @override
+  Vector3? get _scale => widget.scale;
+  @override
+  bool get _visible => widget.visible;
+  @override
+  List<Component> get _components => widget.components;
+  @override
+  SceneNodeController? get _widgetController => widget.controller;
+  @override
+  List<Widget> get _children => widget.children;
+
+  @override
+  void didUpdateWidget(SceneNode oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    didUpdateProps(oldWidget);
+  }
+
+  @override
+  void _applyNameIfChanged(SceneNode oldWidget) {
+    if (widget.name != oldWidget.name) _applyName();
+  }
+
+  @override
+  void _applyTransformIfChanged(SceneNode oldWidget) {
+    if (_matrix4Equals(widget.transform, oldWidget.transform) &&
+        _vector3Equals(widget.position, oldWidget.position) &&
+        _quaternionEquals(widget.rotation, oldWidget.rotation) &&
+        _vector3Equals(widget.scale, oldWidget.scale)) {
+      return;
+    }
+    _applyTransform();
+  }
+
+  @override
+  Widget build(BuildContext context) => buildHost(context);
+}
+
+/// A declarative mesh node: [SceneNode] plus a [Geometry] and [Material].
+///
+/// The [geometry] and [material] are engine objects diffed by identity, so
+/// the mesh is only reassigned when a different instance is passed. Create
+/// them once (for example in `initState` or a field) rather than per build;
+/// constructing new GPU resources every rebuild is the main performance
+/// hazard of the declarative layer.
+///
+/// ```dart
+/// SceneMesh(
+///   geometry: CuboidGeometry(Vector3(1, 1, 1)),
+///   material: PhysicallyBasedMaterial(),
+///   position: Vector3(0, 1, 0),
+/// )
+/// ```
+/// {@category Widgets}
+class SceneMesh extends StatefulWidget {
+  const SceneMesh({
+    super.key,
+    required this.geometry,
+    required this.material,
+    this.name,
+    this.position,
+    this.rotation,
+    this.scale,
+    this.transform,
+    this.visible = true,
+    this.components = const [],
+    this.controller,
+    this.children = const [],
+  }) : assert(
+         transform == null ||
+             (position == null && rotation == null && scale == null),
+         'Provide either transform or position/rotation/scale, not both.',
+       );
+
+  /// The vertex data to draw.
+  final Geometry geometry;
+
+  /// The material shading [geometry].
+  final Material material;
+
+  /// See [SceneNode.name].
+  final String? name;
+
+  /// See [SceneNode.position].
+  final Vector3? position;
+
+  /// See [SceneNode.rotation].
+  final Quaternion? rotation;
+
+  /// See [SceneNode.scale].
+  final Vector3? scale;
+
+  /// See [SceneNode.transform].
+  final Matrix4? transform;
+
+  /// See [SceneNode.visible].
+  final bool visible;
+
+  /// See [SceneNode.components].
+  final List<Component> components;
+
+  /// See [SceneNode.controller].
+  final SceneNodeController? controller;
+
+  /// See [SceneNode.children].
+  final List<Widget> children;
+
+  @override
+  State<SceneMesh> createState() => _SceneMeshState();
+}
+
+class _SceneMeshState extends State<SceneMesh> with _NodeLifecycle<SceneMesh> {
+  @override
+  String? get _name => widget.name;
+  @override
+  Matrix4? get _transform => widget.transform;
+  @override
+  Vector3? get _position => widget.position;
+  @override
+  Quaternion? get _rotation => widget.rotation;
+  @override
+  Vector3? get _scale => widget.scale;
+  @override
+  bool get _visible => widget.visible;
+  @override
+  List<Component> get _components => widget.components;
+  @override
+  SceneNodeController? get _widgetController => widget.controller;
+  @override
+  List<Widget> get _children => widget.children;
+
+  @override
+  void initState() {
+    super.initState();
+    _node.mesh = Mesh(widget.geometry, widget.material);
+  }
+
+  @override
+  void didUpdateWidget(SceneMesh oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    didUpdateProps(oldWidget);
+    if (!identical(widget.geometry, oldWidget.geometry) ||
+        !identical(widget.material, oldWidget.material)) {
+      _node.mesh = Mesh(widget.geometry, widget.material);
+    }
+  }
+
+  @override
+  void _applyNameIfChanged(SceneMesh oldWidget) {
+    if (widget.name != oldWidget.name) _applyName();
+  }
+
+  @override
+  void _applyTransformIfChanged(SceneMesh oldWidget) {
+    if (_matrix4Equals(widget.transform, oldWidget.transform) &&
+        _vector3Equals(widget.position, oldWidget.position) &&
+        _quaternionEquals(widget.rotation, oldWidget.rotation) &&
+        _vector3Equals(widget.scale, oldWidget.scale)) {
+      return;
+    }
+    _applyTransform();
+  }
+
+  @override
+  Widget build(BuildContext context) => buildHost(context);
+}
+
+/// Mounts an app-owned [Node] subtree inside a declarative tree.
+///
+/// The inverse bridge to [SceneSubtree]: the declarative tree decides where
+/// [node] hangs (wrap in a [SceneNode] to position it), while the application
+/// owns everything inside it, imported models, procedurally generated
+/// content, nodes shared with other systems. The widget attaches [node] on
+/// mount and detaches it on removal; it never modifies or disposes the
+/// node's contents.
+///
+/// The node must not be attached anywhere else while hosted.
+/// {@category Widgets}
+class SceneNodeHost extends StatefulWidget {
+  const SceneNodeHost({super.key, required this.node});
+
+  /// The app-owned subtree to mount.
+  final Node node;
+
+  @override
+  State<SceneNodeHost> createState() => _SceneNodeHostState();
+}
+
+class _SceneNodeHostState extends State<SceneNodeHost> {
+  Node? _attachedTo;
+
+  void _syncParent(BuildContext context) {
+    final parent = _resolveParent(context);
+    if (identical(parent, _attachedTo)) return;
+    _detach(widget.node);
+    parent.add(widget.node);
+    _attachedTo = parent;
+  }
+
+  void _detach(Node node) {
+    final attachedTo = _attachedTo;
+    if (attachedTo != null) {
+      attachedTo.remove(node);
+      _attachedTo = null;
+    }
+  }
+
+  @override
+  void didUpdateWidget(SceneNodeHost oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(widget.node, oldWidget.node)) {
+      _detach(oldWidget.node);
+    }
+  }
+
+  @override
+  void deactivate() {
+    _detach(widget.node);
+    super.deactivate();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _syncParent(context);
+    return const SizedBox.shrink();
+  }
+}
+
+/// Describes where a [SceneModel] loads its model bytes from.
+///
+/// Mirrors the `ImageProvider` pattern: the widget diffs sources by
+/// [cacheKey], so rebuilding with an equal-keyed source does not reload.
+/// Built-in sources are [AssetModelSource] and [MemoryModelSource]; apps
+/// with custom transports (network, local cache) subclass this or download
+/// bytes themselves and wrap them in a [MemoryModelSource].
+/// {@category Widgets}
+abstract class SceneModelSource {
+  const SceneModelSource();
+
+  /// Identifies the model. A rebuild whose source has the same key keeps the
+  /// loaded model; a different key discards it and loads the new source.
+  String get cacheKey;
+
+  /// Loads the model's `.glb` bytes.
+  Future<Uint8List> load();
+}
+
+/// Loads a `.glb` model from the asset bundle.
+/// {@category Widgets}
+class AssetModelSource extends SceneModelSource {
+  const AssetModelSource(this.assetPath);
+
+  /// The bundle path of the `.glb` asset.
+  final String assetPath;
+
+  @override
+  String get cacheKey => 'asset:$assetPath';
+
+  @override
+  Future<Uint8List> load() async {
+    final data = await rootBundle.load(assetPath);
+    return data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
+  }
+}
+
+/// Wraps already-loaded `.glb` bytes, for models fetched by the app (a
+/// network download, a local cache, generated content).
+///
+/// [key] must uniquely identify the bytes; the widget reloads when the key
+/// changes, not when the buffer instance does.
+/// {@category Widgets}
+class MemoryModelSource extends SceneModelSource {
+  const MemoryModelSource(this.bytes, {required this.key});
+
+  /// The `.glb` file contents.
+  final Uint8List bytes;
+
+  /// Uniquely identifies [bytes] for diffing.
+  final String key;
+
+  @override
+  String get cacheKey => 'memory:$key';
+
+  @override
+  Future<Uint8List> load() async => bytes;
+}
+
+/// A declarative imported model: loads a `.glb` and mounts it as a node.
+///
+/// The widget owns a wrapper [Node] carrying the transform props; the
+/// imported content attaches under it when loading completes. While loading,
+/// [placeholder] (a scene-widget builder, not 2D UI) is mounted in its
+/// place; on failure, [error] is mounted instead. For a single reveal of a
+/// whole scene, prefer gating the enclosing [SceneView] with its `loading`
+/// arguments over per-model placeholders.
+///
+/// [variant] selects a named `KHR_materials_variants` material variant, and
+/// can change on rebuild for interactive switching (a product configurator).
+/// Null keeps the model's default materials.
+///
+/// ```dart
+/// SceneModel(
+///   'models/shoe.glb',
+///   variant: selectedColorway,
+///   position: Vector3(0, 1, 0),
+/// )
+/// ```
+/// {@category Widgets}
+class SceneModel extends StatefulWidget {
+  // TODO(model-cache): each SceneModel instance imports (and uploads) its own
+  // copy of the model; share decoded templates across equal-keyed sources
+  // once component-aware Node cloning exists.
+  // TODO(model-animation): add a declarative prop for playing a named
+  // imported animation; until then use [onLoaded] and the imperative
+  // animation API.
+
+  /// Loads the model from the asset bundle at [assetPath].
+  ///
+  /// Not const because the source is derived; use [SceneModel.from] with a
+  /// const [AssetModelSource] when const construction matters.
+  SceneModel(
+    String assetPath, {
+    super.key,
+    this.variant,
+    this.placeholder,
+    this.error,
+    this.onLoaded,
+    this.name,
+    this.position,
+    this.rotation,
+    this.scale,
+    this.transform,
+    this.visible = true,
+    this.components = const [],
+    this.controller,
+    this.children = const [],
+  }) : source = AssetModelSource(assetPath),
+       assert(
+         transform == null ||
+             (position == null && rotation == null && scale == null),
+         'Provide either transform or position/rotation/scale, not both.',
+       );
+
+  /// Loads the model from an explicit [SceneModelSource].
+  const SceneModel.from(
+    this.source, {
+    super.key,
+    this.variant,
+    this.placeholder,
+    this.error,
+    this.onLoaded,
+    this.name,
+    this.position,
+    this.rotation,
+    this.scale,
+    this.transform,
+    this.visible = true,
+    this.components = const [],
+    this.controller,
+    this.children = const [],
+  }) : assert(
+         transform == null ||
+             (position == null && rotation == null && scale == null),
+         'Provide either transform or position/rotation/scale, not both.',
+       );
+
+  /// Where the model bytes come from. Diffed by [SceneModelSource.cacheKey].
+  final SceneModelSource source;
+
+  /// The `KHR_materials_variants` variant to select, or null for the
+  /// model's default materials. Unknown names log a warning and keep the
+  /// defaults.
+  final String? variant;
+
+  /// Builds scene widgets mounted while the model loads.
+  final WidgetBuilder? placeholder;
+
+  /// Builds scene widgets mounted when loading fails.
+  final Widget Function(BuildContext context, Object error)? error;
+
+  /// Called with the imported model root after it mounts. Use it to reach
+  /// imported content imperatively (play animations, look up nodes).
+  final void Function(Node modelRoot)? onLoaded;
+
+  /// See [SceneNode.name].
+  final String? name;
+
+  /// See [SceneNode.position].
+  final Vector3? position;
+
+  /// See [SceneNode.rotation].
+  final Quaternion? rotation;
+
+  /// See [SceneNode.scale].
+  final Vector3? scale;
+
+  /// See [SceneNode.transform].
+  final Matrix4? transform;
+
+  /// See [SceneNode.visible].
+  final bool visible;
+
+  /// See [SceneNode.components].
+  final List<Component> components;
+
+  /// See [SceneNode.controller]. The controller's node is the wrapper the
+  /// imported content hangs under.
+  final SceneNodeController? controller;
+
+  /// See [SceneNode.children].
+  final List<Widget> children;
+
+  @override
+  State<SceneModel> createState() => _SceneModelState();
+}
+
+class _SceneModelState extends State<SceneModel>
+    with _NodeLifecycle<SceneModel> {
+  Node? _modelRoot;
+  Object? _loadError;
+  int _loadGeneration = 0;
+
+  @override
+  String? get _name => widget.name;
+  @override
+  Matrix4? get _transform => widget.transform;
+  @override
+  Vector3? get _position => widget.position;
+  @override
+  Quaternion? get _rotation => widget.rotation;
+  @override
+  Vector3? get _scale => widget.scale;
+  @override
+  bool get _visible => widget.visible;
+  @override
+  List<Component> get _components => widget.components;
+  @override
+  SceneNodeController? get _widgetController => widget.controller;
+  @override
+  List<Widget> get _children => [
+    ...widget.children,
+    if (_modelRoot == null && _loadError == null && widget.placeholder != null)
+      Builder(builder: widget.placeholder!),
+    if (_loadError != null && widget.error != null)
+      Builder(builder: (context) => widget.error!(context, _loadError!)),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final generation = ++_loadGeneration;
+    try {
+      final bytes = await widget.source.load();
+      if (!mounted || generation != _loadGeneration) return;
+      final modelRoot = await Node.fromGlbBytes(bytes);
+      if (!mounted || generation != _loadGeneration) return;
+      _node.add(modelRoot);
+      setState(() {
+        _modelRoot = modelRoot;
+        _loadError = null;
+      });
+      _applyVariant();
+      widget.onLoaded?.call(modelRoot);
+    } catch (e) {
+      if (!mounted || generation != _loadGeneration) return;
+      setState(() => _loadError = e);
+    }
+  }
+
+  void _resetModel() {
+    _loadGeneration++;
+    final modelRoot = _modelRoot;
+    if (modelRoot != null) {
+      _node.remove(modelRoot);
+    }
+    _modelRoot = null;
+    _loadError = null;
+  }
+
+  void _applyVariant() {
+    final component = _modelRoot?.getComponent<MaterialsVariantsComponent>();
+    if (component == null) return;
+    final variant = widget.variant;
+    if (variant != null && !component.variants.contains(variant)) {
+      debugPrint(
+        'SceneModel: unknown material variant "$variant" '
+        '(available: ${component.variants}); keeping defaults.',
+      );
+      component.select(null);
+      return;
+    }
+    component.select(variant);
+  }
+
+  @override
+  void didUpdateWidget(SceneModel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    didUpdateProps(oldWidget);
+    if (widget.source.cacheKey != oldWidget.source.cacheKey) {
+      setState(_resetModel);
+      _load();
+    } else if (widget.variant != oldWidget.variant) {
+      _applyVariant();
+    }
+  }
+
+  @override
+  void _applyNameIfChanged(SceneModel oldWidget) {
+    if (widget.name != oldWidget.name) _applyName();
+  }
+
+  @override
+  void _applyTransformIfChanged(SceneModel oldWidget) {
+    if (_matrix4Equals(widget.transform, oldWidget.transform) &&
+        _vector3Equals(widget.position, oldWidget.position) &&
+        _quaternionEquals(widget.rotation, oldWidget.rotation) &&
+        _vector3Equals(widget.scale, oldWidget.scale)) {
+      return;
+    }
+    _applyTransform();
+  }
+
+  @override
+  Widget build(BuildContext context) => buildHost(context);
+}

--- a/packages/flutter_scene/lib/src/widgets/declarative.dart
+++ b/packages/flutter_scene/lib/src/widgets/declarative.dart
@@ -1121,7 +1121,10 @@ class _SceneModelState extends State<SceneModel>
   }
 
   void _applyVariant() {
-    final component = _modelRoot?.getComponent<MaterialsVariantsComponent>();
+    final modelRoot = _modelRoot;
+    final component = modelRoot == null
+        ? null
+        : MaterialsVariantsComponent.of(modelRoot);
     if (component == null) return;
     final variant = widget.variant;
     if (variant != null && !component.variants.contains(variant)) {

--- a/packages/flutter_scene/lib/src/widgets/scene_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view.dart
@@ -289,6 +289,10 @@ class _SceneViewState extends State<SceneView>
 
   Scene get _scene => widget.scene ?? _ownedScene!;
 
+  // Loads declared by declarative children (SceneModel), so a gated view's
+  // reveal waits for them. Handed to descendants through SceneScope.
+  final ResourceGroup _childLoads = ResourceGroup();
+
   final _Repaint _repaint = _Repaint();
   final ValueNotifier<Duration> _elapsed = ValueNotifier<Duration>(
     Duration.zero,
@@ -324,9 +328,7 @@ class _SceneViewState extends State<SceneView>
   void initState() {
     super.initState();
     if (widget.scene == null) {
-      _ownedScene = Scene();
-      _ownedDefaultEnvironment = _ownedScene!.environment;
-      _applySceneProps(null);
+      _ensureOwnedScene();
     }
     _sceneSemantics = SceneSemanticsCoordinator(_scene);
     SemanticsBinding.instance.addSemanticsEnabledListener(_onSemanticsChanged);
@@ -340,6 +342,15 @@ class _SceneViewState extends State<SceneView>
     if (_gated) {
       _startRevealWatch();
     }
+  }
+
+  // Creates the owned scene for the declarative form and applies every scene
+  // prop, the single creation path for initState and constructor-form
+  // switches.
+  void _ensureOwnedScene() {
+    _ownedScene = Scene();
+    _ownedDefaultEnvironment = _ownedScene!.environment;
+    _applySceneProps(null);
   }
 
   // Applies the declarative constructor's scene-level props to the owned
@@ -378,13 +389,20 @@ class _SceneViewState extends State<SceneView>
       _ticker = widget.autoTick ? (createTicker(_onTick)..start()) : null;
     }
     final oldScene = oldWidget.scene ?? _ownedScene;
-    if (widget.scene == null && _ownedScene == null) {
-      // Switched from an app-owned scene to the declarative form.
-      _ownedScene = Scene();
-      _ownedDefaultEnvironment = _ownedScene!.environment;
-    }
     if (widget.scene == null) {
-      _applySceneProps(oldWidget.scene == null ? oldWidget : null);
+      if (oldWidget.scene != null || _ownedScene == null) {
+        // Switched from an app-owned scene to the declarative form. A stale
+        // owned scene from an earlier declarative phase is discarded so
+        // leftover imperative state cannot resurface.
+        _ensureOwnedScene();
+      } else {
+        _applySceneProps(oldWidget);
+      }
+    } else if (_ownedScene != null) {
+      // Switched from the declarative form to an app-owned scene; drop the
+      // owned scene so a later switch back starts fresh.
+      _ownedScene = null;
+      _ownedDefaultEnvironment = null;
     }
     if (!identical(_scene, oldScene)) {
       oldScene?.renderScene.semanticsComponentsChanged.removeListener(
@@ -396,13 +414,15 @@ class _SceneViewState extends State<SceneView>
       _sceneSemantics = SceneSemanticsCoordinator(_scene);
       _autoPointer = null;
     }
-    // A new set of resources to wait for (or newly gated): hold the scene again
-    // until they load.
+    // A new set of resources to wait for, a newly gated view, or a different
+    // scene: hold the scene again until its loads and warm-up complete.
     final gatedBefore =
         oldWidget.loading != null ||
         oldWidget.loadingBuilder != null ||
         oldWidget.warmUp;
-    if (widget.loading != oldWidget.loading || _gated != gatedBefore) {
+    if (widget.loading != oldWidget.loading ||
+        _gated != gatedBefore ||
+        !identical(_scene, oldScene)) {
       _revealed = !_gated;
       if (_gated) {
         _startRevealWatch();
@@ -422,6 +442,13 @@ class _SceneViewState extends State<SceneView>
     await Scene.initializeStaticResources();
     if (!mounted || generation != _revealGeneration) return;
     await widget.loading?.ready;
+    if (!mounted || generation != _revealGeneration) return;
+    // Wait a frame so declarative children have built and registered their
+    // loads, then wait for those loads, so gated views (and warm-up) cover
+    // SceneModel content too.
+    await SchedulerBinding.instance.endOfFrame;
+    if (!mounted || generation != _revealGeneration) return;
+    await _childLoads.ready;
     if (!mounted || generation != _revealGeneration) return;
     // Compile the pipelines the first frame needs while the loading widget is
     // still up, so the reveal frame does not stall.
@@ -592,11 +619,19 @@ class _SceneViewState extends State<SceneView>
         fit: StackFit.passthrough,
         children: [
           view,
-          SceneSubtree(children: widget.children),
+          // The explicit parent pins children to THIS view's scene; resolving
+          // through context could find an outer declarative tree's parent
+          // scope when views nest.
+          SceneSubtree(parent: _scene.root, children: widget.children),
         ],
       );
     }
-    return SceneScope(scene: _scene, elapsed: _elapsed, child: view);
+    return SceneScope(
+      scene: _scene,
+      elapsed: _elapsed,
+      internalChildLoads: _childLoads,
+      child: view,
+    );
   }
 
   Widget _buildView(BuildContext context) {
@@ -913,15 +948,15 @@ class _RenderSceneCustomPaint extends RenderCustomPaint {
 /// of a [SceneView].
 ///
 /// Resolve the scene from a descendant's [BuildContext] with [SceneScope.of].
-/// Today [SceneView] is the only producer and there are no built-in consumers;
-/// this plumbing exists so a future declarative node API can attach widgets to
-/// the right scene subtree without restructuring the view.
+/// Declarative scene widgets resolve their default attachment point through
+/// it, and other descendants may read the scene for queries.
 /// {@category Widgets}
 class SceneScope extends InheritedWidget {
   const SceneScope({
     super.key,
     required this.scene,
     required this.elapsed,
+    this.internalChildLoads,
     required super.child,
   });
 
@@ -934,6 +969,11 @@ class SceneScope extends InheritedWidget {
   /// about per-frame time can listen without forcing every dependent to rebuild
   /// each frame.
   final ValueListenable<Duration> elapsed;
+
+  /// The enclosing view's tracker for declarative child loads, so a gated
+  /// view's reveal waits for them. Engine plumbing, not application surface.
+  @internal
+  final ResourceGroup? internalChildLoads;
 
   /// The nearest [SceneScope], or null if there is none.
   static SceneScope? maybeOf(BuildContext context) =>

--- a/packages/flutter_scene/lib/src/widgets/scene_view.dart
+++ b/packages/flutter_scene/lib/src/widgets/scene_view.dart
@@ -7,6 +7,9 @@ import 'package:flutter/widgets.dart';
 
 import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/hot_reload/hot_reload_coordinator.dart';
+import 'package:flutter_scene/src/material/environment.dart';
+import 'package:flutter_scene/src/tone_mapping.dart';
+import 'package:flutter_scene/src/widgets/declarative.dart';
 import 'package:flutter_scene/src/render_view.dart';
 import 'package:flutter_scene/src/components/widget_component.dart';
 import 'package:flutter/gestures.dart';
@@ -72,12 +75,13 @@ typedef SceneLoadingBuilder =
 ///
 /// The active [scene] is exposed to descendants through [SceneScope], so widgets
 /// below can resolve the scene from their [BuildContext].
+///
+/// For a fully declarative scene, use [SceneView.declarative]: the view owns
+/// an internal [Scene] and declarative scene widgets ([SceneNode],
+/// [SceneMesh], [SceneModel]) describe its contents in [children]. Both
+/// constructors accept [children], so declarative subtrees also compose over
+/// an app-owned scene.
 /// {@category Widgets}
-//
-// TODO(declarative): a future declarative API will add a `SceneView.builder`
-// (or `child:`) form where SceneView owns an internal Scene that declarative
-// node widgets populate via SceneScope. The Scene stays the substrate either
-// way; reserve that constructor shape rather than reworking this one.
 class SceneView extends StatefulWidget {
   /// Renders [scene], driving a repaint each frame.
   ///
@@ -86,7 +90,7 @@ class SceneView extends StatefulWidget {
   /// camera (`Scene.camera`), falling back to a default camera when the scene
   /// has none, so `SceneView(scene)` always renders something.
   const SceneView(
-    this.scene, {
+    Scene this.scene, {
     super.key,
     this.camera,
     this.cameraBuilder,
@@ -99,7 +103,12 @@ class SceneView extends StatefulWidget {
     this.revealMinDuration = Duration.zero,
     this.warmUp = false,
     this.debugWidgetInput = false,
-  }) : assert(
+    this.children = const [],
+  }) : environment = null,
+       environmentIntensity = 1.0,
+       exposure = 1.0,
+       toneMapping = null,
+       assert(
          (camera != null ? 1 : 0) +
                  (cameraBuilder != null ? 1 : 0) +
                  (viewsBuilder != null ? 1 : 0) <=
@@ -107,8 +116,72 @@ class SceneView extends StatefulWidget {
          'Provide at most one of camera, cameraBuilder, or viewsBuilder.',
        );
 
-  /// The scene to render. Owned and mutated by the application.
-  final Scene scene;
+  /// Renders a view-owned [Scene] described declaratively by [children].
+  ///
+  /// The view constructs and owns an internal [Scene]; scene widgets in
+  /// [children] populate it, and the scene-level props ([environment],
+  /// [exposure], [toneMapping], ...) configure it. Omitted props mean the
+  /// scene defaults; removing a prop on a later build restores its default.
+  ///
+  /// ```dart
+  /// SceneView.declarative(
+  ///   children: [
+  ///     SceneMesh(geometry: geometry, material: material),
+  ///   ],
+  /// )
+  /// ```
+  const SceneView.declarative({
+    super.key,
+    this.environment,
+    this.environmentIntensity = 1.0,
+    this.exposure = 1.0,
+    ToneMappingMode this.toneMapping = ToneMappingMode.pbrNeutral,
+    this.camera,
+    this.cameraBuilder,
+    this.viewsBuilder,
+    this.autoTick = true,
+    this.pixelRatio,
+    this.onTick,
+    this.loading,
+    this.loadingBuilder,
+    this.revealMinDuration = Duration.zero,
+    this.warmUp = false,
+    this.debugWidgetInput = false,
+    this.children = const [],
+  }) : scene = null,
+       assert(
+         (camera != null ? 1 : 0) +
+                 (cameraBuilder != null ? 1 : 0) +
+                 (viewsBuilder != null ? 1 : 0) <=
+             1,
+         'Provide at most one of camera, cameraBuilder, or viewsBuilder.',
+       );
+
+  /// The scene to render, owned and mutated by the application. Null when
+  /// the view owns its scene ([SceneView.declarative]).
+  final Scene? scene;
+
+  /// Declarative scene widgets mounted at the scene root (via [SceneScope]).
+  ///
+  /// With [SceneView.declarative] this is the whole scene description; with
+  /// an app-owned [scene] it composes declarative subtrees over the
+  /// imperative graph. The widgets stay mounted (and keep loading) while the
+  /// view is gated behind [loading] or [warmUp].
+  final List<Widget> children;
+
+  /// The owned scene's environment map ([SceneView.declarative] only).
+  /// Identity-diffed; null means the scene's default studio environment.
+  final EnvironmentMap? environment;
+
+  /// The owned scene's environment intensity ([SceneView.declarative] only).
+  final double environmentIntensity;
+
+  /// The owned scene's exposure ([SceneView.declarative] only).
+  final double exposure;
+
+  /// The owned scene's tone mapping ([SceneView.declarative] only). Null on
+  /// the app-owned-scene constructor, which never writes scene properties.
+  final ToneMappingMode? toneMapping;
 
   /// A fixed camera. Mutually exclusive with [cameraBuilder] and
   /// [viewsBuilder].
@@ -208,6 +281,14 @@ class _Repaint extends ChangeNotifier {
 
 class _SceneViewState extends State<SceneView>
     with SingleTickerProviderStateMixin {
+  // The internal scene for SceneView.declarative, created once per state.
+  // The default environment is captured so clearing the environment prop
+  // restores it (the declarative contract: omitted prop means default).
+  Scene? _ownedScene;
+  EnvironmentMap? _ownedDefaultEnvironment;
+
+  Scene get _scene => widget.scene ?? _ownedScene!;
+
   final _Repaint _repaint = _Repaint();
   final ValueNotifier<Duration> _elapsed = ValueNotifier<Duration>(
     Duration.zero,
@@ -242,9 +323,14 @@ class _SceneViewState extends State<SceneView>
   @override
   void initState() {
     super.initState();
-    _sceneSemantics = SceneSemanticsCoordinator(widget.scene);
+    if (widget.scene == null) {
+      _ownedScene = Scene();
+      _ownedDefaultEnvironment = _ownedScene!.environment;
+      _applySceneProps(null);
+    }
+    _sceneSemantics = SceneSemanticsCoordinator(_scene);
     SemanticsBinding.instance.addSemanticsEnabledListener(_onSemanticsChanged);
-    widget.scene.renderScene.semanticsComponentsChanged.addListener(
+    _scene.renderScene.semanticsComponentsChanged.addListener(
       _onSemanticsChanged,
     );
     if (widget.autoTick) {
@@ -253,6 +339,29 @@ class _SceneViewState extends State<SceneView>
     _revealed = !_gated;
     if (_gated) {
       _startRevealWatch();
+    }
+  }
+
+  // Applies the declarative constructor's scene-level props to the owned
+  // scene, writing only what changed. Pass null to apply everything (initial
+  // apply, or right after the owned scene is created).
+  void _applySceneProps(SceneView? oldWidget) {
+    final scene = _ownedScene!;
+    if (oldWidget == null ||
+        !identical(widget.environment, oldWidget.environment)) {
+      scene.environment = widget.environment ?? _ownedDefaultEnvironment;
+    }
+    if (oldWidget == null ||
+        widget.environmentIntensity != oldWidget.environmentIntensity) {
+      scene.environmentIntensity = widget.environmentIntensity;
+    }
+    if (oldWidget == null || widget.exposure != oldWidget.exposure) {
+      scene.exposure = widget.exposure;
+    }
+    final toneMapping = widget.toneMapping;
+    if (toneMapping != null &&
+        (oldWidget == null || toneMapping != oldWidget.toneMapping)) {
+      scene.toneMapping = toneMapping;
     }
   }
 
@@ -268,14 +377,24 @@ class _SceneViewState extends State<SceneView>
       _ticker?.dispose();
       _ticker = widget.autoTick ? (createTicker(_onTick)..start()) : null;
     }
-    if (!identical(widget.scene, oldWidget.scene)) {
-      oldWidget.scene.renderScene.semanticsComponentsChanged.removeListener(
+    final oldScene = oldWidget.scene ?? _ownedScene;
+    if (widget.scene == null && _ownedScene == null) {
+      // Switched from an app-owned scene to the declarative form.
+      _ownedScene = Scene();
+      _ownedDefaultEnvironment = _ownedScene!.environment;
+    }
+    if (widget.scene == null) {
+      _applySceneProps(oldWidget.scene == null ? oldWidget : null);
+    }
+    if (!identical(_scene, oldScene)) {
+      oldScene?.renderScene.semanticsComponentsChanged.removeListener(
         _onSemanticsChanged,
       );
-      widget.scene.renderScene.semanticsComponentsChanged.addListener(
+      _scene.renderScene.semanticsComponentsChanged.addListener(
         _onSemanticsChanged,
       );
-      _sceneSemantics = SceneSemanticsCoordinator(widget.scene);
+      _sceneSemantics = SceneSemanticsCoordinator(_scene);
+      _autoPointer = null;
     }
     // A new set of resources to wait for (or newly gated): hold the scene again
     // until they load.
@@ -307,7 +426,7 @@ class _SceneViewState extends State<SceneView>
     // Compile the pipelines the first frame needs while the loading widget is
     // still up, so the reveal frame does not stall.
     if (widget.warmUp) {
-      await widget.scene.warmUp(_warmUpViews());
+      await _scene.warmUp(_warmUpViews());
       if (!mounted || generation != _revealGeneration) return;
     }
     final remaining =
@@ -346,7 +465,7 @@ class _SceneViewState extends State<SceneView>
     _elapsed.value,
     camera: widget.camera,
     cameraBuilder: widget.cameraBuilder,
-    sceneCamera: widget.scene.camera,
+    sceneCamera: _scene.camera,
   );
 
   List<RenderView> _viewsForFrame() => widget.viewsBuilder!(_elapsed.value);
@@ -358,11 +477,11 @@ class _SceneViewState extends State<SceneView>
   Size _viewSize = Size.zero;
   Offset? _debugPosition;
 
-  ScenePointer get _pointer => _autoPointer ??= ScenePointer(widget.scene);
+  ScenePointer get _pointer => _autoPointer ??= ScenePointer(_scene);
 
   bool get _autoInputAvailable =>
       widget.viewsBuilder == null &&
-      widget.scene.renderScene.widgetComponents.isNotEmpty;
+      _scene.renderScene.widgetComponents.isNotEmpty;
 
   void _autoPoint(Offset position) {
     final camera = _lastBuiltCamera;
@@ -446,7 +565,7 @@ class _SceneViewState extends State<SceneView>
     SemanticsBinding.instance.removeSemanticsEnabledListener(
       _onSemanticsChanged,
     );
-    widget.scene.renderScene.semanticsComponentsChanged.removeListener(
+    _scene.renderScene.semanticsComponentsChanged.removeListener(
       _onSemanticsChanged,
     );
     _ticker?.dispose();
@@ -458,94 +577,101 @@ class _SceneViewState extends State<SceneView>
   @override
   Widget build(BuildContext context) {
     _sceneSemantics.ambientTextDirection = Directionality.maybeOf(context);
-    return SceneScope(
-      scene: widget.scene,
-      elapsed: _elapsed,
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          _viewSize = constraints.biggest;
-          if (!_revealed) {
-            return _buildLoading(context);
-          }
-          return Listener(
-            // Translucent: forwarded events still reach the app's own
-            // gesture handlers; the scene never wins a gesture arena.
-            behavior: HitTestBehavior.translucent,
-            onPointerDown: _onPointerDown,
-            onPointerMove: _onPointerMove,
-            onPointerUp: _onPointerUp,
-            onPointerCancel: _onPointerCancel,
-            onPointerSignal: _onPointerSignal,
-            onPointerPanZoomStart: _onPointerPanZoomStart,
-            onPointerPanZoomUpdate: _onPointerPanZoomUpdate,
-            child: Stack(
-              fit: StackFit.passthrough,
-              children: [
-                _SceneCustomPaint(
-                  semantics: _sceneSemantics,
-                  painter: _ScenePainter(
-                    scene: widget.scene,
-                    cameraForFrame: widget.viewsBuilder == null
-                        ? _cameraForFrame
-                        : null,
-                    viewsForFrame: widget.viewsBuilder == null
-                        ? null
-                        : _viewsForFrame,
-                    pixelRatio: widget.pixelRatio,
-                    semantics: _sceneSemantics,
-                    repaint: _repaint,
-                  ),
-                  // Invisible hosts for the scene's WidgetComponents: each hosted
-                  // subtree stays fully live (state, tickers, animations) while
-                  // occupying no layout space and never painting to the screen; its
-                  // visual output streams into the component's texture. The Overlay
-                  // keeps dialogs, dropdowns, and tooltips inside the capture.
-                  // Riding as the paint widget's child puts each subtree's
-                  // semantics under the scene's semantics boundary, beside the
-                  // nodes synthesized for SemanticsComponents.
-                  child: SizedBox.expand(
-                    child: ValueListenableBuilder<int>(
-                      valueListenable:
-                          widget.scene.renderScene.widgetComponentsChanged,
-                      builder: (context, _, _) => Stack(
-                        children: [
-                          for (final component
-                              in widget.scene.renderScene.widgetComponents
-                                  .whereType<WidgetComponent>())
-                            WidgetTexture(
-                              key: ObjectKey(component),
-                              controller: component.controller,
-                              width: component.size.width,
-                              height: component.size.height,
-                              pixelRatio: component.pixelRatio,
-                              update: component.updatePolicy,
-                              // ExcludeSemantics gates the subtree's semantics
-                              // by the coordinator's per-frame decision (see
-                              // WidgetTextureController.semanticsHidden); the
-                              // subtree stays structurally present either way.
-                              child: ValueListenableBuilder<bool>(
-                                valueListenable:
-                                    component.controller.semanticsHidden,
-                                builder: (context, hidden, child) =>
-                                    ExcludeSemantics(
-                                      excluding: hidden,
-                                      child: child,
-                                    ),
-                                child: _WidgetComponentHost(
-                                  component: component,
-                                ),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-                if (widget.debugWidgetInput) _buildDebugOverlay(),
-              ],
+    Widget view = LayoutBuilder(
+      builder: (context, constraints) {
+        _viewSize = constraints.biggest;
+        return _buildView(context);
+      },
+    );
+    if (widget.children.isNotEmpty) {
+      // The declarative children mount outside the reveal gate so their
+      // content populates (and loads) while a loading widget is up. The host
+      // occupies no space and paints nothing.
+      view = Stack(
+        alignment: Alignment.topLeft,
+        fit: StackFit.passthrough,
+        children: [
+          view,
+          SceneSubtree(children: widget.children),
+        ],
+      );
+    }
+    return SceneScope(scene: _scene, elapsed: _elapsed, child: view);
+  }
+
+  Widget _buildView(BuildContext context) {
+    if (!_revealed) {
+      return _buildLoading(context);
+    }
+    return Listener(
+      // Translucent: forwarded events still reach the app's own
+      // gesture handlers; the scene never wins a gesture arena.
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: _onPointerDown,
+      onPointerMove: _onPointerMove,
+      onPointerUp: _onPointerUp,
+      onPointerCancel: _onPointerCancel,
+      onPointerSignal: _onPointerSignal,
+      onPointerPanZoomStart: _onPointerPanZoomStart,
+      onPointerPanZoomUpdate: _onPointerPanZoomUpdate,
+      child: Stack(
+        fit: StackFit.passthrough,
+        children: [
+          _SceneCustomPaint(
+            semantics: _sceneSemantics,
+            painter: _ScenePainter(
+              scene: _scene,
+              cameraForFrame: widget.viewsBuilder == null
+                  ? _cameraForFrame
+                  : null,
+              viewsForFrame: widget.viewsBuilder == null
+                  ? null
+                  : _viewsForFrame,
+              pixelRatio: widget.pixelRatio,
+              semantics: _sceneSemantics,
+              repaint: _repaint,
             ),
-          );
-        },
+            // Invisible hosts for the scene's WidgetComponents: each hosted
+            // subtree stays fully live (state, tickers, animations) while
+            // occupying no layout space and never painting to the screen; its
+            // visual output streams into the component's texture. The Overlay
+            // keeps dialogs, dropdowns, and tooltips inside the capture.
+            // Riding as the paint widget's child puts each subtree's
+            // semantics under the scene's semantics boundary, beside the
+            // nodes synthesized for SemanticsComponents.
+            child: SizedBox.expand(
+              child: ValueListenableBuilder<int>(
+                valueListenable: _scene.renderScene.widgetComponentsChanged,
+                builder: (context, _, _) => Stack(
+                  children: [
+                    for (final component
+                        in _scene.renderScene.widgetComponents
+                            .whereType<WidgetComponent>())
+                      WidgetTexture(
+                        key: ObjectKey(component),
+                        controller: component.controller,
+                        width: component.size.width,
+                        height: component.size.height,
+                        pixelRatio: component.pixelRatio,
+                        update: component.updatePolicy,
+                        // ExcludeSemantics gates the subtree's semantics
+                        // by the coordinator's per-frame decision (see
+                        // WidgetTextureController.semanticsHidden); the
+                        // subtree stays structurally present either way.
+                        child: ValueListenableBuilder<bool>(
+                          valueListenable: component.controller.semanticsHidden,
+                          builder: (context, hidden, child) =>
+                              ExcludeSemantics(excluding: hidden, child: child),
+                          child: _WidgetComponentHost(component: component),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          if (widget.debugWidgetInput) _buildDebugOverlay(),
+        ],
       ),
     );
   }

--- a/packages/flutter_scene/test/declarative_widgets_test.dart
+++ b/packages/flutter_scene/test/declarative_widgets_test.dart
@@ -1,0 +1,310 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+/// Reconciliation tests for the declarative scene widgets, run against a bare
+/// [Node] parent through [SceneSubtree] so no GPU (and no [Scene]) is needed.
+
+class _FakeMaterial implements Material {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeGeometry implements Geometry {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _CountingComponent extends Component {
+  int attaches = 0;
+  int detaches = 0;
+
+  @override
+  void onAttach() => attaches++;
+
+  @override
+  void onDetach() => detaches++;
+}
+
+void main() {
+  late Node root;
+
+  setUp(() {
+    root = Node(name: 'test-root');
+  });
+
+  Widget host(List<Widget> children) =>
+      SceneSubtree(parent: root, children: children);
+
+  group('SceneNode structure', () {
+    testWidgets('mounts under the parent and detaches on unmount', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host([SceneNode(name: 'a')]));
+      expect(root.children, hasLength(1));
+      expect(root.children.single.name, 'a');
+
+      await tester.pumpWidget(host([]));
+      expect(root.children, isEmpty);
+    });
+
+    testWidgets('nests children under the widget node', (tester) async {
+      await tester.pumpWidget(
+        host([
+          SceneNode(
+            name: 'parent',
+            children: [SceneNode(name: 'child')],
+          ),
+        ]),
+      );
+      final parent = root.children.single;
+      expect(parent.name, 'parent');
+      expect(parent.children.single.name, 'child');
+    });
+
+    testWidgets('non-scene widgets can sit between scene widgets', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host([Builder(builder: (context) => SceneNode(name: 'built'))]),
+      );
+      expect(root.children.single.name, 'built');
+    });
+
+    testWidgets('conditional removal detaches only the removed subtree', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host([SceneNode(name: 'a'), SceneNode(name: 'b')]),
+      );
+      expect(root.children.map((n) => n.name), ['a', 'b']);
+
+      await tester.pumpWidget(host([SceneNode(name: 'b')]));
+      // Without keys the first element pairs positionally and is renamed;
+      // the second unmounts.
+      expect(root.children, hasLength(1));
+      expect(root.children.single.name, 'b');
+    });
+
+    testWidgets('keys preserve engine-node identity across reorders', (
+      tester,
+    ) async {
+      final controllerA = SceneNodeController();
+      final controllerB = SceneNodeController();
+      Widget build(bool swapped) => host([
+        for (final entry in swapped ? ['b', 'a'] : ['a', 'b'])
+          SceneNode(
+            key: ValueKey(entry),
+            name: entry,
+            controller: entry == 'a' ? controllerA : controllerB,
+          ),
+      ]);
+
+      await tester.pumpWidget(build(false));
+      final nodeA = controllerA.node;
+      final nodeB = controllerB.node;
+      expect(nodeA, isNotNull);
+
+      await tester.pumpWidget(build(true));
+      expect(identical(controllerA.node, nodeA), isTrue);
+      expect(identical(controllerB.node, nodeB), isTrue);
+      expect(root.children, hasLength(2));
+    });
+
+    testWidgets('GlobalKey reparenting keeps the same engine node', (
+      tester,
+    ) async {
+      final key = GlobalKey();
+      final controller = SceneNodeController();
+      Widget build(bool underParent) => host([
+        SceneNode(
+          name: 'anchor',
+          children: [
+            if (underParent)
+              SceneNode(key: key, name: 'moved', controller: controller),
+          ],
+        ),
+        if (!underParent)
+          SceneNode(key: key, name: 'moved', controller: controller),
+      ]);
+
+      await tester.pumpWidget(build(true));
+      final moved = controller.node;
+      expect(moved, isNotNull);
+      expect(root.children.single.children.single, same(moved));
+
+      await tester.pumpWidget(build(false));
+      expect(identical(controller.node, moved), isTrue);
+      expect(root.children, hasLength(2));
+      expect(root.children[0].children, isEmpty);
+      expect(root.children.contains(moved), isTrue);
+    });
+  });
+
+  group('SceneNode props', () {
+    testWidgets('applies transform props and diffs on rebuild', (tester) async {
+      await tester.pumpWidget(
+        host([SceneNode(name: 'n', position: vm.Vector3(1, 2, 3))]),
+      );
+      final node = root.children.single;
+      expect(node.localTransform.getTranslation(), vm.Vector3(1, 2, 3));
+
+      await tester.pumpWidget(
+        host([SceneNode(name: 'n', position: vm.Vector3(4, 5, 6))]),
+      );
+      expect(identical(root.children.single, node), isTrue);
+      expect(node.localTransform.getTranslation(), vm.Vector3(4, 5, 6));
+    });
+
+    testWidgets('full transform matrix prop applies', (tester) async {
+      final transform = vm.Matrix4.identity()..setEntry(0, 3, 7.0);
+      await tester.pumpWidget(host([SceneNode(transform: transform)]));
+      expect(root.children.single.localTransform.entry(0, 3), 7.0);
+      // The widget clones; mutating the passed matrix must not leak through.
+      transform.setEntry(0, 3, 99.0);
+      expect(root.children.single.localTransform.entry(0, 3), 7.0);
+    });
+
+    testWidgets('visible prop applies and diffs', (tester) async {
+      await tester.pumpWidget(host([SceneNode(name: 'n', visible: false)]));
+      expect(root.children.single.visible, isFalse);
+      await tester.pumpWidget(host([SceneNode(name: 'n')]));
+      expect(root.children.single.visible, isTrue);
+    });
+
+    testWidgets('components identity-diff across rebuilds', (tester) async {
+      final keep = _CountingComponent();
+      final dropped = _CountingComponent();
+      await tester.pumpWidget(
+        host([
+          SceneNode(name: 'n', components: [keep, dropped]),
+        ]),
+      );
+      expect(keep.attaches, 1);
+      expect(dropped.attaches, 1);
+
+      final added = _CountingComponent();
+      await tester.pumpWidget(
+        host([
+          SceneNode(name: 'n', components: [keep, added]),
+        ]),
+      );
+      expect(keep.attaches, 1);
+      expect(keep.detaches, 0);
+      expect(dropped.detaches, 1);
+      expect(added.attaches, 1);
+
+      final node = root.children.single;
+      expect(node.getComponents<_CountingComponent>(), hasLength(2));
+    });
+
+    testWidgets('controller attaches, follows, and clears', (tester) async {
+      final controller = SceneNodeController();
+      expect(controller.node, isNull);
+
+      await tester.pumpWidget(host([SceneNode(controller: controller)]));
+      expect(controller.node, same(root.children.single));
+
+      await tester.pumpWidget(host([SceneNode()]));
+      expect(controller.node, isNull);
+
+      await tester.pumpWidget(host([]));
+      expect(controller.node, isNull);
+    });
+  });
+
+  group('SceneMesh', () {
+    testWidgets('sets the mesh and identity-diffs geometry/material', (
+      tester,
+    ) async {
+      final geometry = _FakeGeometry();
+      final materialA = _FakeMaterial();
+      await tester.pumpWidget(
+        host([SceneMesh(geometry: geometry, material: materialA)]),
+      );
+      final node = root.children.single;
+      final mesh = node.mesh;
+      expect(mesh, isNotNull);
+      expect(identical(mesh!.primitives.single.material, materialA), isTrue);
+
+      // Same instances: mesh object stays.
+      await tester.pumpWidget(
+        host([SceneMesh(geometry: geometry, material: materialA)]),
+      );
+      expect(identical(root.children.single.mesh, mesh), isTrue);
+
+      // New material instance: mesh rebuilt around it.
+      final materialB = _FakeMaterial();
+      await tester.pumpWidget(
+        host([SceneMesh(geometry: geometry, material: materialB)]),
+      );
+      expect(
+        identical(
+          root.children.single.mesh!.primitives.single.material,
+          materialB,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('SceneNodeHost', () {
+    testWidgets('mounts and unmounts an app-owned node without touching it', (
+      tester,
+    ) async {
+      final external = Node(name: 'external')..add(Node(name: 'inner'));
+      await tester.pumpWidget(host([SceneNodeHost(node: external)]));
+      expect(root.children.single, same(external));
+
+      await tester.pumpWidget(host([]));
+      expect(root.children, isEmpty);
+      // Contents untouched.
+      expect(external.children.single.name, 'inner');
+    });
+
+    testWidgets('swapping the hosted node swaps the attachment', (
+      tester,
+    ) async {
+      final first = Node(name: 'first');
+      final second = Node(name: 'second');
+      await tester.pumpWidget(host([SceneNodeHost(node: first)]));
+      expect(root.children.single, same(first));
+
+      await tester.pumpWidget(host([SceneNodeHost(node: second)]));
+      expect(root.children.single, same(second));
+      expect(first.parent, isNull);
+    });
+  });
+
+  group('SceneSubtree', () {
+    testWidgets('throws a useful error with no parent and no SceneScope', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const SceneSubtree(children: []));
+      expect(tester.takeException(), isFlutterError);
+    });
+
+    testWidgets('reparents children when the parent changes', (tester) async {
+      final other = Node(name: 'other-root');
+      final controller = SceneNodeController();
+      await tester.pumpWidget(
+        SceneSubtree(
+          parent: root,
+          children: [SceneNode(controller: controller)],
+        ),
+      );
+      final node = controller.node;
+      expect(root.children.single, same(node));
+
+      await tester.pumpWidget(
+        SceneSubtree(
+          parent: other,
+          children: [SceneNode(controller: controller)],
+        ),
+      );
+      expect(root.children, isEmpty);
+      expect(other.children.single, same(node));
+    });
+  });
+}

--- a/packages/flutter_scene/test/fscene/materials_variants_fscene_test.dart
+++ b/packages/flutter_scene/test/fscene/materials_variants_fscene_test.dart
@@ -1,0 +1,356 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_scene/scene.dart' hide Animation;
+// ignore: implementation_imports
+import 'package:flutter_scene/src/components/materials_variants_component.dart'
+    show MaterialsVariantBinding;
+// ignore: implementation_imports
+import 'package:flutter_scene/src/fscene/id.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/fscene/json/fscene_json.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/fscene/property_value.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/fscene/realize/builtin_codecs.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/fscene/realize/node_identity.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/fscene/realize/resource_origin.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/fscene/realize/resource_realizer.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/fscene/scene_document.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/fscene/specs.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/importer/in_memory_import.dart';
+import 'package:test/test.dart';
+
+/// KHR_materials_variants through the `.fscene` document pipeline: the glTF
+/// importer emits a `materialsVariants` component, it survives the JSON
+/// round-trip, and the codec realizes and serializes it (GPU-free via fake
+/// materials).
+
+class _FakeMaterial implements Material {
+  _FakeMaterial(this.label);
+  final String label;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeGeometry implements Geometry {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeRealizer implements ResourceRealizer {
+  _FakeRealizer(this.materials);
+  final Map<LocalId, Material> materials;
+
+  @override
+  Material material(LocalId id) => materials[id]!;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// Builds a minimal GLB: one triangle mesh with two materials and a
+/// two-variant `KHR_materials_variants` declaration mapping them.
+Uint8List _buildVariantsGlb() {
+  // Positions (3 vec3), normals (3 vec3), uvs (3 vec2), indices (3 uint16).
+  final buffer = BytesBuilder();
+  buffer.add(
+    Float32List.fromList([
+      0, 0, 0, 1, 0, 0, 0, 1, 0, // positions
+      0, 0, 1, 0, 0, 1, 0, 0, 1, // normals
+      0, 0, 1, 0, 0, 1, // uvs
+    ]).buffer.asUint8List(),
+  );
+  buffer.add(Uint16List.fromList([0, 1, 2]).buffer.asUint8List());
+  buffer.add(Uint8List(2)); // pad to 4-byte alignment
+  final bin = buffer.takeBytes();
+
+  final json = {
+    'asset': {'version': '2.0'},
+    'extensionsUsed': ['KHR_materials_variants'],
+    'extensions': {
+      'KHR_materials_variants': {
+        'variants': [
+          {'name': 'alpha'},
+          {'name': 'beta'},
+        ],
+      },
+    },
+    'scenes': [
+      {
+        'nodes': [0],
+      },
+    ],
+    'scene': 0,
+    'nodes': [
+      {'name': 'tri', 'mesh': 0},
+    ],
+    'materials': [
+      {'name': 'matA'},
+      {'name': 'matB'},
+    ],
+    'meshes': [
+      {
+        'primitives': [
+          {
+            'attributes': {'POSITION': 0, 'NORMAL': 1, 'TEXCOORD_0': 2},
+            'indices': 3,
+            'material': 0,
+            'extensions': {
+              'KHR_materials_variants': {
+                'mappings': [
+                  {
+                    'material': 0,
+                    'variants': [0],
+                  },
+                  {
+                    'material': 1,
+                    'variants': [1],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    ],
+    'buffers': [
+      {'byteLength': bin.length},
+    ],
+    'bufferViews': [
+      {'buffer': 0, 'byteOffset': 0, 'byteLength': 36},
+      {'buffer': 0, 'byteOffset': 36, 'byteLength': 36},
+      {'buffer': 0, 'byteOffset': 72, 'byteLength': 24},
+      {'buffer': 0, 'byteOffset': 96, 'byteLength': 6},
+    ],
+    'accessors': [
+      {
+        'bufferView': 0,
+        'componentType': 5126,
+        'count': 3,
+        'type': 'VEC3',
+        'min': [0, 0, 0],
+        'max': [1, 1, 0],
+      },
+      {'bufferView': 1, 'componentType': 5126, 'count': 3, 'type': 'VEC3'},
+      {'bufferView': 2, 'componentType': 5126, 'count': 3, 'type': 'VEC2'},
+      {'bufferView': 3, 'componentType': 5123, 'count': 3, 'type': 'SCALAR'},
+    ],
+  };
+
+  final jsonBytes = utf8.encode(jsonEncode(json));
+  final jsonPadded = jsonBytes.length % 4 == 0
+      ? jsonBytes.length
+      : jsonBytes.length + (4 - jsonBytes.length % 4);
+  final binPadded = bin.length % 4 == 0
+      ? bin.length
+      : bin.length + (4 - bin.length % 4);
+  final total = 12 + 8 + jsonPadded + 8 + binPadded;
+  final out = BytesBuilder();
+  void u32(int value) => out.add(
+    Uint8List(4)..buffer.asByteData().setUint32(0, value, Endian.little),
+  );
+  out.add(ascii.encode('glTF'));
+  u32(2);
+  u32(total);
+  u32(jsonPadded);
+  out.add(ascii.encode('JSON'));
+  out.add(jsonBytes);
+  for (var i = jsonBytes.length; i < jsonPadded; i++) {
+    out.add(const [0x20]); // JSON chunks pad with spaces
+  }
+  u32(binPadded);
+  out.add([0x42, 0x49, 0x4E, 0x00]); // 'BIN\0'
+  out.add(bin);
+  for (var i = bin.length; i < binPadded; i++) {
+    out.add(const [0]);
+  }
+  return out.takeBytes();
+}
+
+ComponentSpec? _variantsComponent(SceneDocument document) {
+  for (final rootId in document.roots) {
+    for (final component in document.nodes[rootId]!.components) {
+      if (component.type == 'materialsVariants') return component;
+    }
+  }
+  return null;
+}
+
+void main() {
+  group('emitter', () {
+    late SceneDocument document;
+
+    setUpAll(() {
+      document = importGlbToSceneDocument(_buildVariantsGlb());
+    });
+
+    test('attaches a materialsVariants component to the root', () {
+      final component = _variantsComponent(document);
+      expect(component, isNotNull);
+      final variants = component!.properties['variants'] as ListValue;
+      expect(
+        [for (final v in variants.values) (v as StringValue).value],
+        ['alpha', 'beta'],
+      );
+      expect(document.featuresUsed, contains('materialsVariants'));
+    });
+
+    test('bindings reference the mesh node, primitive, and materials', () {
+      final component = _variantsComponent(document)!;
+      final bindings = component.properties['bindings'] as ListValue;
+      expect(bindings.values, hasLength(1));
+      final binding = bindings.values.single as MapValue;
+      final nodeRef = binding.values['node'] as NodeRefValue;
+      final rootSpec = document.nodes[document.roots.single]!;
+      expect(nodeRef.id, rootSpec.id);
+      expect((binding.values['primitive'] as IntValue).value, 0);
+      final materials = binding.values['materials'] as MapValue;
+      expect(materials.values.keys.toSet(), {'0', '1'});
+      // Each mapped id must be a registered material resource.
+      for (final value in materials.values.values) {
+        final resource = document.resources[(value as ResourceRefValue).id];
+        expect(resource, isA<MaterialResource>());
+      }
+      // Variant 0 maps the same material the mesh uses as its default.
+      final meshComponent = rootSpec.components.firstWhere(
+        (c) => c.type == 'mesh',
+      );
+      expect(
+        (materials.values['0'] as ResourceRefValue).id,
+        (meshComponent.properties['material'] as ResourceRefValue).id,
+      );
+    });
+
+    test('the component survives the canonical JSON round-trip', () {
+      final text = writeFscene(document);
+      final reread = readFscene(text);
+      expect(writeFscene(reread), text);
+      final component = _variantsComponent(reread);
+      expect(component, isNotNull);
+      final variants = component!.properties['variants'] as ListValue;
+      expect(variants.values, hasLength(2));
+      expect(
+        (component.properties['bindings'] as ListValue).values,
+        hasLength(1),
+      );
+    });
+  });
+
+  group('codec', () {
+    test('realizes bindings after the tree exists and select swaps', () {
+      final document = SceneDocument();
+      final nodeId = document.newId();
+      final defaultId = document.newId();
+      final betaId = document.newId();
+
+      final defaultMaterial = _FakeMaterial('default');
+      final betaMaterial = _FakeMaterial('beta');
+      final primitive = MeshPrimitive(_FakeGeometry(), defaultMaterial);
+      final liveNode = tagNodeId(
+        Node(name: 'tri')..mesh = Mesh.primitives(primitives: [primitive]),
+        nodeId,
+      );
+
+      final context = RealizeContext(
+        document,
+        resources: _FakeRealizer({
+          defaultId: defaultMaterial,
+          betaId: betaMaterial,
+        }),
+      );
+      context.resolveNode = (id) => id == nodeId ? liveNode : null;
+
+      final spec = ComponentSpec(
+        'materialsVariants',
+        properties: {
+          'variants': ListValue([StringValue('alpha'), StringValue('beta')]),
+          'bindings': ListValue([
+            MapValue({
+              'node': NodeRefValue(nodeId),
+              'primitive': const IntValue(0),
+              'materials': MapValue({
+                '0': ResourceRefValue(defaultId),
+                '1': ResourceRefValue(betaId),
+              }),
+            }),
+          ]),
+        },
+      );
+
+      final component =
+          MaterialsVariantsCodec().realize(spec, context)
+              as MaterialsVariantsComponent;
+      // Bindings resolve only after the deferred pass runs.
+      component.select('beta');
+      expect(identical(primitive.material, defaultMaterial), isTrue);
+
+      context.runAfterRealize();
+      component.select('beta');
+      expect(identical(primitive.material, betaMaterial), isTrue);
+      component.select(null);
+      expect(identical(primitive.material, defaultMaterial), isTrue);
+    });
+
+    test('serializes variants, node ref, primitive index, and materials', () {
+      final source = SceneDocument();
+      final nodeId = source.newId();
+      final betaResource = source.addResource(
+        MaterialResource(source.newId(), type: 'physicallyBased', name: 'b'),
+      );
+
+      final defaultMaterial = _FakeMaterial('default');
+      final betaMaterial = tagResourceOrigin(
+        _FakeMaterial('beta'),
+        source,
+        betaResource.id,
+      );
+      final primitive = MeshPrimitive(_FakeGeometry(), defaultMaterial);
+      final liveNode = tagNodeId(
+        Node(name: 'tri')..mesh = Mesh.primitives(primitives: [primitive]),
+        nodeId,
+      );
+      final component = MaterialsVariantsComponent.internal(
+        ['alpha', 'beta'],
+        [
+          MaterialsVariantBinding(
+            node: liveNode,
+            primitive: primitive,
+            defaultMaterial: defaultMaterial,
+            materialsByVariant: {1: betaMaterial},
+          ),
+        ],
+      );
+
+      final dest = SceneDocument();
+      final spec = MaterialsVariantsCodec().serialize(
+        component,
+        SerializeContext(dest),
+      )!;
+      expect(spec.type, 'materialsVariants');
+      final variants = spec.properties['variants'] as ListValue;
+      expect(
+        [for (final v in variants.values) (v as StringValue).value],
+        ['alpha', 'beta'],
+      );
+      final binding =
+          (spec.properties['bindings'] as ListValue).values.single as MapValue;
+      expect((binding.values['node'] as NodeRefValue).id, nodeId);
+      expect((binding.values['primitive'] as IntValue).value, 0);
+      final materials = binding.values['materials'] as MapValue;
+      expect(materials.values.keys.toList(), ['1']);
+      // The variant material was copied into the destination document.
+      final copiedId = (materials.values['1'] as ResourceRefValue).id;
+      expect(dest.resources[copiedId], isA<MaterialResource>());
+    });
+  });
+}

--- a/packages/flutter_scene/test/fscene/materials_variants_fscene_test.dart
+++ b/packages/flutter_scene/test/fscene/materials_variants_fscene_test.dart
@@ -29,7 +29,7 @@ import 'package:flutter_scene/src/fscene/specs.dart';
 import 'package:flutter_scene/src/importer/in_memory_import.dart';
 import 'package:test/test.dart';
 
-/// KHR_materials_variants through the `.fscene` document pipeline: the glTF
+/// KHR_materials_variants through the `.fscene` document pipeline. The glTF
 /// importer emits a `materialsVariants` component, it survives the JSON
 /// round-trip, and the codec realizes and serializes it (GPU-free via fake
 /// materials).
@@ -221,13 +221,18 @@ void main() {
         final resource = document.resources[(value as ResourceRefValue).id];
         expect(resource, isA<MaterialResource>());
       }
-      // Variant 0 maps the same material the mesh uses as its default.
+      // Variant 0 maps the same material the mesh uses as its default, and
+      // the authored default is serialized explicitly so a save made while a
+      // variant is selected keeps it.
       final meshComponent = rootSpec.components.firstWhere(
         (c) => c.type == 'mesh',
       );
+      final meshMaterialId =
+          (meshComponent.properties['material'] as ResourceRefValue).id;
+      expect((materials.values['0'] as ResourceRefValue).id, meshMaterialId);
       expect(
-        (materials.values['0'] as ResourceRefValue).id,
-        (meshComponent.properties['material'] as ResourceRefValue).id,
+        (binding.values['default'] as ResourceRefValue).id,
+        meshMaterialId,
       );
     });
 
@@ -290,25 +295,84 @@ void main() {
       final component =
           MaterialsVariantsCodec().realize(spec, context)
               as MaterialsVariantsComponent;
-      // Bindings resolve only after the deferred pass runs.
+      // Bindings resolve only after the deferred pass runs; a selection made
+      // before that is re-applied by the pass.
       component.select('beta');
       expect(identical(primitive.material, defaultMaterial), isTrue);
 
       context.runAfterRealize();
-      component.select('beta');
       expect(identical(primitive.material, betaMaterial), isTrue);
       component.select(null);
       expect(identical(primitive.material, defaultMaterial), isTrue);
     });
 
-    test('serializes variants, node ref, primitive index, and materials', () {
+    test('a serialized selection re-applies after realize', () {
+      final document = SceneDocument();
+      final nodeId = document.newId();
+      final defaultId = document.newId();
+      final betaId = document.newId();
+
+      final defaultMaterial = _FakeMaterial('default');
+      final betaMaterial = _FakeMaterial('beta');
+      final primitive = MeshPrimitive(_FakeGeometry(), defaultMaterial);
+      final liveNode = tagNodeId(
+        Node(name: 'tri')..mesh = Mesh.primitives(primitives: [primitive]),
+        nodeId,
+      );
+
+      final context = RealizeContext(
+        document,
+        resources: _FakeRealizer({
+          defaultId: defaultMaterial,
+          betaId: betaMaterial,
+        }),
+      );
+      context.resolveNode = (id) => id == nodeId ? liveNode : null;
+
+      final spec = ComponentSpec(
+        'materialsVariants',
+        properties: {
+          'variants': ListValue([StringValue('alpha'), StringValue('beta')]),
+          'selected': StringValue('beta'),
+          'bindings': ListValue([
+            MapValue({
+              'node': NodeRefValue(nodeId),
+              'primitive': const IntValue(0),
+              'default': ResourceRefValue(defaultId),
+              'materials': MapValue({'1': ResourceRefValue(betaId)}),
+            }),
+          ]),
+        },
+      );
+
+      final component =
+          MaterialsVariantsCodec().realize(spec, context)
+              as MaterialsVariantsComponent;
+      context.runAfterRealize();
+      expect(component.selected, 'beta');
+      expect(identical(primitive.material, betaMaterial), isTrue);
+      // The serialized default wins over the primitive's current material,
+      // so deselecting restores the authored default.
+      component.select(null);
+      expect(identical(primitive.material, defaultMaterial), isTrue);
+    });
+
+    test('serializes variants, node ref, primitive index, default material, '
+        'and the active selection', () {
       final source = SceneDocument();
       final nodeId = source.newId();
+      final defaultResource = source.addResource(
+        MaterialResource(source.newId(), type: 'physicallyBased', name: 'd'),
+      );
       final betaResource = source.addResource(
         MaterialResource(source.newId(), type: 'physicallyBased', name: 'b'),
       );
 
-      final defaultMaterial = _FakeMaterial('default');
+      final defaultMaterial = tagResourceOrigin(
+        _FakeMaterial('default'),
+        source,
+        defaultResource.id,
+      );
       final betaMaterial = tagResourceOrigin(
         _FakeMaterial('beta'),
         source,
@@ -324,12 +388,12 @@ void main() {
         [
           MaterialsVariantBinding(
             node: liveNode,
-            primitive: primitive,
+            primitiveIndex: 0,
             defaultMaterial: defaultMaterial,
             materialsByVariant: {1: betaMaterial},
           ),
         ],
-      );
+      )..select('beta');
 
       final dest = SceneDocument();
       final spec = MaterialsVariantsCodec().serialize(
@@ -342,15 +406,21 @@ void main() {
         [for (final v in variants.values) (v as StringValue).value],
         ['alpha', 'beta'],
       );
+      expect((spec.properties['selected'] as StringValue).value, 'beta');
       final binding =
           (spec.properties['bindings'] as ListValue).values.single as MapValue;
       expect((binding.values['node'] as NodeRefValue).id, nodeId);
       expect((binding.values['primitive'] as IntValue).value, 0);
       final materials = binding.values['materials'] as MapValue;
       expect(materials.values.keys.toList(), ['1']);
-      // The variant material was copied into the destination document.
-      final copiedId = (materials.values['1'] as ResourceRefValue).id;
-      expect(dest.resources[copiedId], isA<MaterialResource>());
+      // The variant and default materials were copied into the destination
+      // document; even while 'beta' is selected, the serialized default is
+      // the authored one.
+      final copiedVariantId = (materials.values['1'] as ResourceRefValue).id;
+      expect(dest.resources[copiedVariantId], isA<MaterialResource>());
+      final copiedDefaultId =
+          (binding.values['default'] as ResourceRefValue).id;
+      expect((dest.resources[copiedDefaultId] as MaterialResource?)?.name, 'd');
     });
   });
 }

--- a/packages/flutter_scene/test/materials_variants_test.dart
+++ b/packages/flutter_scene/test/materials_variants_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter_scene/scene.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/components/materials_variants_component.dart'
+    show MaterialsVariantBinding;
+// ignore: implementation_imports
+import 'package:flutter_scene/src/importer/gltf.dart';
+import 'package:test/test.dart';
+
+/// KHR_materials_variants: parsing (pure data, no GPU) and the selection
+/// component's material swapping (fake materials, no GPU).
+
+class _FakeMaterial implements Material {
+  _FakeMaterial(this.label);
+  final String label;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeGeometry implements Geometry {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+Map<String, Object?> _documentJson() => {
+  'asset': {'version': '2.0'},
+  'extensionsUsed': ['KHR_materials_variants'],
+  'extensions': {
+    'KHR_materials_variants': {
+      'variants': [
+        {'name': 'midnight'},
+        {'name': 'beach'},
+        {'name': 'street'},
+      ],
+    },
+  },
+  'scenes': [
+    {
+      'nodes': [0],
+    },
+  ],
+  'nodes': [
+    {'mesh': 0},
+  ],
+  'materials': [
+    {'name': 'a'},
+    {'name': 'b'},
+    {'name': 'c'},
+  ],
+  'meshes': [
+    {
+      'primitives': [
+        {
+          'attributes': {'POSITION': 0},
+          'material': 0,
+          'extensions': {
+            'KHR_materials_variants': {
+              'mappings': [
+                {
+                  'material': 0,
+                  'variants': [0],
+                },
+                {
+                  'material': 1,
+                  'variants': [1],
+                },
+                {
+                  'material': 2,
+                  'variants': [2],
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+void main() {
+  group('parseGltfJson KHR_materials_variants', () {
+    test('parses document variant names in order', () {
+      final doc = parseGltfJson(_documentJson());
+      expect(doc.materialsVariants, ['midnight', 'beach', 'street']);
+    });
+
+    test('flattens primitive mappings to variant->material', () {
+      final doc = parseGltfJson(_documentJson());
+      final primitive = doc.meshes.first.primitives.first;
+      expect(primitive.variantMappings, {0: 0, 1: 1, 2: 2});
+    });
+
+    test('a mapping covering several variants maps each of them', () {
+      final json = _documentJson();
+      final meshes = json['meshes'] as List;
+      final primitive =
+          ((meshes.first as Map)['primitives'] as List).first as Map;
+      (primitive['extensions'] as Map)['KHR_materials_variants'] = {
+        'mappings': [
+          {
+            'material': 1,
+            'variants': [0, 2],
+          },
+        ],
+      };
+      final doc = parseGltfJson(json);
+      expect(doc.meshes.first.primitives.first.variantMappings, {0: 1, 2: 1});
+    });
+
+    test('document without the extension parses to empty variants', () {
+      final json = _documentJson()..remove('extensions');
+      final doc = parseGltfJson(json);
+      expect(doc.materialsVariants, isEmpty);
+    });
+  });
+
+  group('MaterialsVariantsComponent', () {
+    late _FakeMaterial defaultA;
+    late _FakeMaterial defaultB;
+    late _FakeMaterial beachA;
+    late MeshPrimitive primitiveA;
+    late MeshPrimitive primitiveB;
+    late MaterialsVariantsComponent component;
+
+    setUp(() {
+      defaultA = _FakeMaterial('defaultA');
+      defaultB = _FakeMaterial('defaultB');
+      beachA = _FakeMaterial('beachA');
+      primitiveA = MeshPrimitive(_FakeGeometry(), defaultA);
+      primitiveB = MeshPrimitive(_FakeGeometry(), defaultB);
+      component = MaterialsVariantsComponent.internal(
+        ['midnight', 'beach'],
+        [
+          MaterialsVariantBinding(
+            primitive: primitiveA,
+            defaultMaterial: defaultA,
+            materialsByVariant: {0: defaultA, 1: beachA},
+          ),
+          // primitiveB only maps variant 0; 'beach' leaves it on its default.
+          MaterialsVariantBinding(
+            primitive: primitiveB,
+            defaultMaterial: defaultB,
+            materialsByVariant: {0: defaultB},
+          ),
+        ],
+      );
+    });
+
+    test('exposes declared variant names and starts unselected', () {
+      expect(component.variants, ['midnight', 'beach']);
+      expect(component.selected, isNull);
+    });
+
+    test('select swaps mapped primitives and leaves unmapped on default', () {
+      component.select('beach');
+      expect(component.selected, 'beach');
+      expect(identical(primitiveA.material, beachA), isTrue);
+      expect(identical(primitiveB.material, defaultB), isTrue);
+    });
+
+    test('select(null) restores defaults', () {
+      component.select('beach');
+      component.select(null);
+      expect(component.selected, isNull);
+      expect(identical(primitiveA.material, defaultA), isTrue);
+      expect(identical(primitiveB.material, defaultB), isTrue);
+    });
+
+    test('select throws on an unknown name', () {
+      expect(() => component.select('nope'), throwsArgumentError);
+    });
+
+    test('variants list is unmodifiable', () {
+      expect(() => component.variants.add('x'), throwsUnsupportedError);
+    });
+  });
+
+  test('runtime import attaches the component for variant documents', () {
+    // Structural check only: the full import needs a GPU for textures, so
+    // this asserts the parsed document carries what _buildScene consumes.
+    final doc = parseGltfJson(_documentJson());
+    expect(doc.materialsVariants, isNotEmpty);
+    expect(doc.meshes.first.primitives.first.variantMappings, isNotEmpty);
+  });
+}

--- a/packages/flutter_scene/test/materials_variants_test.dart
+++ b/packages/flutter_scene/test/materials_variants_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_scene/src/importer/gltf.dart';
 import 'package:flutter_scene/src/render/render_scene.dart' show RenderScene;
 import 'package:test/test.dart';
 
-/// KHR_materials_variants: parsing (pure data, no GPU) and the selection
+/// KHR_materials_variants parsing (pure data, no GPU) and the selection
 /// component's material swapping (fake materials, no GPU).
 
 class _FakeMaterial implements Material {
@@ -139,14 +139,14 @@ void main() {
         [
           MaterialsVariantBinding(
             node: nodeA,
-            primitive: primitiveA,
+            primitiveIndex: 0,
             defaultMaterial: defaultA,
             materialsByVariant: {0: defaultA, 1: beachA},
           ),
-          // primitiveB only maps variant 0; 'beach' leaves it on its default.
+          // nodeB only maps variant 0; 'beach' leaves it on its default.
           MaterialsVariantBinding(
             node: nodeB,
-            primitive: primitiveB,
+            primitiveIndex: 0,
             defaultMaterial: defaultB,
             materialsByVariant: {0: defaultB},
           ),
@@ -178,6 +178,29 @@ void main() {
       expect(() => component.select('nope'), throwsArgumentError);
     });
 
+    test('re-selecting the active variant is a no-op', () {
+      component.select('beach');
+      // An external write is not clobbered by a repeat select, proving the
+      // early-out (a real select would reassign the mapped material).
+      final external = _FakeMaterial('external');
+      primitiveA.material = external;
+      component.select('beach');
+      expect(identical(primitiveA.material, external), isTrue);
+      component.select(null);
+      expect(identical(primitiveA.material, defaultA), isTrue);
+    });
+
+    test('bindings survive a mesh rebuild (index resolution)', () {
+      // A scene hot reload replaces the mesh component and its primitives;
+      // index-based resolution keeps the binding live instead of writing to
+      // the discarded primitive.
+      final rebuilt = MeshPrimitive(_FakeGeometry(), defaultA);
+      nodeA.mesh = Mesh.primitives(primitives: [rebuilt]);
+      component.select('beach');
+      expect(identical(rebuilt.material, beachA), isTrue);
+      expect(identical(primitiveA.material, defaultA), isTrue);
+    });
+
     test('variants list is unmodifiable', () {
       expect(() => component.variants.add('x'), throwsUnsupportedError);
     });
@@ -199,9 +222,61 @@ void main() {
     });
   });
 
+  group('allOf', () {
+    test('finds every component in the subtree, breadth-first', () {
+      final rootA = Node(name: 'a')
+        ..addComponent(MaterialsVariantsComponent.internal(const ['x'], []));
+      final rootB = Node(name: 'b')
+        ..addComponent(MaterialsVariantsComponent.internal(const ['x'], []));
+      final root = Node()
+        ..add(rootA)
+        ..add(rootB);
+      expect(MaterialsVariantsComponent.allOf(root), hasLength(2));
+      expect(
+        identical(
+          MaterialsVariantsComponent.of(root),
+          rootA.getComponent<MaterialsVariantsComponent>(),
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('LOD tags survive material refreshes', () {
+    test('refreshMaterials re-tags re-registered items', () {
+      final material = _FakeMaterial('m');
+      final lod = LodComponent([
+        LodLevel(geometry: _FakeGeometry(), material: material, screenSize: 0),
+      ]);
+      final node = Node()..addComponent(lod);
+      final renderScene = RenderScene();
+      node.debugMountInto(renderScene);
+      expect(renderScene.items.single.lod, isNotNull);
+
+      lod.refreshMaterials();
+      expect(renderScene.items.single.lod, isNotNull);
+    });
+  });
+
+  group('Node.clone components', () {
+    test('light components carry to clones, sharing the light payload', () {
+      final light = PointLight(intensity: 7.0);
+      final node = Node(name: 'lamp')..addComponent(PointLightComponent(light));
+      final clone = node.clone();
+      final cloned = clone.getComponent<PointLightComponent>();
+      expect(cloned, isNotNull);
+      expect(identical(cloned!.light, light), isTrue);
+      // A fresh component instance, so both nodes can be mounted at once.
+      expect(
+        identical(cloned, node.getComponent<PointLightComponent>()),
+        isFalse,
+      );
+    });
+  });
+
   test('runtime import attaches the component for variant documents', () {
-    // Structural check only: the full import needs a GPU for textures, so
-    // this asserts the parsed document carries what _buildScene consumes.
+    // Structural check only, the full import needs a GPU for textures; this
+    // asserts the parsed document carries what _buildScene consumes.
     final doc = parseGltfJson(_documentJson());
     expect(doc.materialsVariants, isNotEmpty);
     expect(doc.meshes.first.primitives.first.variantMappings, isNotEmpty);

--- a/packages/flutter_scene/test/materials_variants_test.dart
+++ b/packages/flutter_scene/test/materials_variants_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_scene/src/components/materials_variants_component.dart'
     show MaterialsVariantBinding;
 // ignore: implementation_imports
 import 'package:flutter_scene/src/importer/gltf.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/render/render_scene.dart' show RenderScene;
 import 'package:test/test.dart';
 
 /// KHR_materials_variants: parsing (pure data, no GPU) and the selection
@@ -120,6 +122,8 @@ void main() {
     late _FakeMaterial beachA;
     late MeshPrimitive primitiveA;
     late MeshPrimitive primitiveB;
+    late Node nodeA;
+    late Node nodeB;
     late MaterialsVariantsComponent component;
 
     setUp(() {
@@ -128,16 +132,20 @@ void main() {
       beachA = _FakeMaterial('beachA');
       primitiveA = MeshPrimitive(_FakeGeometry(), defaultA);
       primitiveB = MeshPrimitive(_FakeGeometry(), defaultB);
+      nodeA = Node()..mesh = Mesh.primitives(primitives: [primitiveA]);
+      nodeB = Node()..mesh = Mesh.primitives(primitives: [primitiveB]);
       component = MaterialsVariantsComponent.internal(
         ['midnight', 'beach'],
         [
           MaterialsVariantBinding(
+            node: nodeA,
             primitive: primitiveA,
             defaultMaterial: defaultA,
             materialsByVariant: {0: defaultA, 1: beachA},
           ),
           // primitiveB only maps variant 0; 'beach' leaves it on its default.
           MaterialsVariantBinding(
+            node: nodeB,
             primitive: primitiveB,
             defaultMaterial: defaultB,
             materialsByVariant: {0: defaultB},
@@ -172,6 +180,22 @@ void main() {
 
     test('variants list is unmodifiable', () {
       expect(() => component.variants.add('x'), throwsUnsupportedError);
+    });
+
+    test('select refreshes a mounted mesh\'s render items', () {
+      // Render items capture the material at registration; a variant swap on
+      // a live scene must re-register so the new material actually draws.
+      final renderScene = RenderScene();
+      nodeA.debugMountInto(renderScene);
+      expect(renderScene.items, hasLength(1));
+      expect(identical(renderScene.items.single.material, defaultA), isTrue);
+
+      component.select('beach');
+      expect(renderScene.items, hasLength(1));
+      expect(identical(renderScene.items.single.material, beachA), isTrue);
+
+      component.select(null);
+      expect(identical(renderScene.items.single.material, defaultA), isTrue);
     });
   });
 

--- a/packages/flutter_scene/test/scene_model_test.dart
+++ b/packages/flutter_scene/test/scene_model_test.dart
@@ -1,0 +1,408 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart' hide Animation;
+import 'package:flutter_scene/scene.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/components/materials_variants_component.dart'
+    show MaterialsVariantBinding;
+// ignore: implementation_imports
+import 'package:flutter_scene/src/widgets/declarative.dart'
+    show SceneAnimationBinder;
+import 'package:flutter_test/flutter_test.dart';
+
+/// SceneModel widget tests: the import is replaced with a GPU-free
+/// hand-built node tree via [SceneModel.debugImportOverride], so the full
+/// load / template-cache / clone / variant / animation path runs headless.
+
+class _FakeMaterial implements Material {
+  _FakeMaterial(this.label);
+  final String label;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeGeometry implements Geometry {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// A source whose load completes on demand, to hold the widget in its
+/// loading phase.
+class _GatedSource extends SceneModelSource {
+  _GatedSource(this.key);
+  final String key;
+  final Completer<Uint8List> gate = Completer<Uint8List>();
+
+  @override
+  String get cacheKey => 'gated:$key';
+
+  @override
+  Future<Uint8List> load() => gate.future;
+}
+
+class _FailingSource extends SceneModelSource {
+  _FailingSource(this.key);
+  final String key;
+
+  @override
+  String get cacheKey => 'failing:$key';
+
+  @override
+  Future<Uint8List> load() async => throw StateError('no bytes for $key');
+}
+
+/// Builds a template like the runtime importer would: a root carrying a
+/// variants component and a parsed animation, over a child with a mesh.
+Node _buildTemplate({List<String> variants = const ['a', 'b']}) {
+  final defaultMaterial = _FakeMaterial('default');
+  final variantMaterial = _FakeMaterial('variant-b');
+  final primitive = MeshPrimitive(_FakeGeometry(), defaultMaterial);
+  final child = Node(name: 'shoe')
+    ..mesh = Mesh.primitives(primitives: [primitive]);
+  final root = Node(name: 'root')..add(child);
+  if (variants.isNotEmpty) {
+    root.addComponent(
+      MaterialsVariantsComponent.internal(variants, [
+        MaterialsVariantBinding(
+          node: child,
+          primitive: primitive,
+          defaultMaterial: defaultMaterial,
+          materialsByVariant: {1: variantMaterial},
+        ),
+      ]),
+    );
+  }
+  root.addParsedAnimation(Animation(name: 'Spin'));
+  root.addParsedAnimation(Animation(name: 'Wave'));
+  return root;
+}
+
+void main() {
+  late Node sceneRoot;
+  late int importCalls;
+
+  setUp(() {
+    sceneRoot = Node(name: 'scene-root');
+    importCalls = 0;
+    SceneModel.debugImportOverride = (bytes) async {
+      importCalls++;
+      return _buildTemplate();
+    };
+    SceneModel.debugClearModelTemplateCache();
+  });
+
+  tearDown(() {
+    SceneModel.debugImportOverride = null;
+    SceneModel.debugClearModelTemplateCache();
+  });
+
+  Widget host(List<Widget> children) =>
+      SceneSubtree(parent: sceneRoot, children: children);
+
+  MemoryModelSource source(String key) =>
+      MemoryModelSource(Uint8List(0), key: key);
+
+  group('loading phases', () {
+    testWidgets('placeholder mounts while loading, model replaces it', (
+      tester,
+    ) async {
+      final gated = _GatedSource('m');
+      await tester.pumpWidget(
+        host([
+          SceneModel.from(
+            gated,
+            placeholder: (context) => SceneNode(name: 'placeholder'),
+          ),
+        ]),
+      );
+      final wrapper = sceneRoot.children.single;
+      expect(wrapper.getChildByName('placeholder'), isNotNull);
+      expect(wrapper.getChildByName('shoe'), isNull);
+
+      gated.gate.complete(Uint8List(0));
+      await tester.pump();
+      await tester.pump();
+      expect(wrapper.getChildByName('placeholder'), isNull);
+      expect(wrapper.getChildByName('shoe'), isNotNull);
+    });
+
+    testWidgets('error builder mounts on failure', (tester) async {
+      await tester.pumpWidget(
+        host([
+          SceneModel.from(
+            _FailingSource('x'),
+            error: (context, error) => SceneNode(name: 'error-node'),
+          ),
+        ]),
+      );
+      await tester.pump();
+      await tester.pump();
+      final wrapper = sceneRoot.children.single;
+      expect(wrapper.getChildByName('error-node'), isNotNull);
+    });
+  });
+
+  group('template cache', () {
+    testWidgets('equal-keyed sources import once and get distinct clones', (
+      tester,
+    ) async {
+      final roots = <Node>[];
+      await tester.pumpWidget(
+        host([
+          SceneModel.from(source('m'), onLoaded: roots.add),
+          SceneModel.from(source('m'), onLoaded: roots.add),
+        ]),
+      );
+      await tester.pump();
+      await tester.pump();
+      expect(importCalls, 1);
+      expect(roots, hasLength(2));
+      expect(identical(roots[0], roots[1]), isFalse);
+      // Clones share geometry but own their primitives.
+      final meshes = [
+        for (final root in roots) root.getChildByName('shoe')!.mesh!,
+      ];
+      expect(
+        identical(
+          meshes[0].primitives.single.geometry,
+          meshes[1].primitives.single.geometry,
+        ),
+        isTrue,
+      );
+      expect(
+        identical(meshes[0].primitives.single, meshes[1].primitives.single),
+        isFalse,
+      );
+    });
+
+    testWidgets('the template is evicted when the last user unmounts', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host([SceneModel.from(source('m')), SceneModel.from(source('m'))]),
+      );
+      await tester.pump();
+      await tester.pump();
+      expect(importCalls, 1);
+
+      // Dropping one keeps the template alive for the other.
+      await tester.pumpWidget(host([SceneModel.from(source('m'))]));
+      await tester.pumpWidget(
+        host([SceneModel.from(source('m')), SceneModel.from(source('m'))]),
+      );
+      await tester.pump();
+      await tester.pump();
+      expect(importCalls, 1);
+
+      // Dropping all evicts; the next mount imports again.
+      await tester.pumpWidget(host([]));
+      await tester.pumpWidget(host([SceneModel.from(source('m'))]));
+      await tester.pump();
+      await tester.pump();
+      expect(importCalls, 2);
+    });
+
+    testWidgets('a failed import is not cached; a retry imports again', (
+      tester,
+    ) async {
+      SceneModel.debugImportOverride = (bytes) async {
+        importCalls++;
+        if (importCalls == 1) throw StateError('flaky');
+        return _buildTemplate();
+      };
+      await tester.pumpWidget(host([SceneModel.from(source('m'))]));
+      await tester.pump();
+      await tester.pump();
+      expect(importCalls, 1);
+
+      // A different key forces a reload; same key would too after eviction,
+      // but exercise the recovery path through a fresh source.
+      await tester.pumpWidget(host([]));
+      final roots = <Node>[];
+      await tester.pumpWidget(
+        host([SceneModel.from(source('m'), onLoaded: roots.add)]),
+      );
+      await tester.pump();
+      await tester.pump();
+      expect(importCalls, 2);
+      expect(roots, hasLength(1));
+    });
+  });
+
+  group('variants on clones', () {
+    testWidgets('variant selection applies to the instance, not the shared '
+        'template', (tester) async {
+      final roots = <Node>[];
+      await tester.pumpWidget(
+        host([
+          SceneModel.from(source('m'), variant: 'b', onLoaded: roots.add),
+          SceneModel.from(source('m'), onLoaded: roots.add),
+        ]),
+      );
+      await tester.pump();
+      await tester.pump();
+      String materialOf(Node root) =>
+          (root.getChildByName('shoe')!.mesh!.primitives.single.material
+                  as _FakeMaterial)
+              .label;
+      expect(materialOf(roots[0]), 'variant-b');
+      expect(materialOf(roots[1]), 'default');
+    });
+
+    testWidgets('variant changes on rebuild swap the clone in place', (
+      tester,
+    ) async {
+      final roots = <Node>[];
+      await tester.pumpWidget(
+        host([SceneModel.from(source('m'), onLoaded: roots.add)]),
+      );
+      await tester.pump();
+      await tester.pump();
+      final primitive = roots.single
+          .getChildByName('shoe')!
+          .mesh!
+          .primitives
+          .single;
+      expect((primitive.material as _FakeMaterial).label, 'default');
+
+      await tester.pumpWidget(
+        host([SceneModel.from(source('m'), variant: 'b')]),
+      );
+      expect((primitive.material as _FakeMaterial).label, 'variant-b');
+    });
+  });
+
+  group('animations', () {
+    testWidgets('specs flow to clips on load and on rebuild', (tester) async {
+      final binderProbe = <Node>[];
+      await tester.pumpWidget(
+        host([
+          SceneModel.from(
+            source('m'),
+            animations: const [
+              SceneAnimationSpec('Spin', weight: 0.5, speed: 2.0),
+            ],
+            onLoaded: binderProbe.add,
+          ),
+        ]),
+      );
+      await tester.pump();
+      await tester.pump();
+      // The clip is observable through a second binder on the same root: the
+      // player is per node and clips are name-keyed, so creating again
+      // returns fresh clips; instead assert through spec-driven state below.
+      final root = binderProbe.single;
+      final binder = SceneAnimationBinder()..bind(root);
+      binder.apply(const [SceneAnimationSpec('Spin')]);
+      expect(binder.clips.containsKey('Spin'), isTrue);
+    });
+  });
+
+  group('SceneAnimationBinder', () {
+    late Node root;
+    late SceneAnimationBinder binder;
+
+    setUp(() {
+      root = _buildTemplate();
+      binder = SceneAnimationBinder()..bind(root);
+    });
+
+    test('creates clips lazily and applies spec fields', () {
+      binder.apply(const [
+        SceneAnimationSpec('Spin', weight: 0.25, speed: 1.5, loop: false),
+      ]);
+      final clip = binder.clips['Spin']!;
+      expect(clip.playing, isTrue);
+      expect(clip.loop, isFalse);
+      expect(clip.weight, 0.25);
+      expect(clip.playbackTimeScale, 1.5);
+    });
+
+    test('field changes apply to the existing clip', () {
+      binder.apply(const [SceneAnimationSpec('Spin')]);
+      final clip = binder.clips['Spin']!;
+      binder.apply(const [SceneAnimationSpec('Spin', weight: 0.1, speed: -1)]);
+      expect(identical(binder.clips['Spin'], clip), isTrue);
+      expect(clip.weight, 0.1);
+      expect(clip.playbackTimeScale, -1);
+    });
+
+    test('playing false pauses without resetting; true resumes', () {
+      binder.apply(const [SceneAnimationSpec('Spin')]);
+      final clip = binder.clips['Spin']!;
+      binder.apply(const [SceneAnimationSpec('Spin', playing: false)]);
+      expect(clip.playing, isFalse);
+      binder.apply(const [SceneAnimationSpec('Spin')]);
+      expect(clip.playing, isTrue);
+    });
+
+    test('a removed spec stops its clip', () {
+      binder.apply(const [
+        SceneAnimationSpec('Spin'),
+        SceneAnimationSpec('Wave'),
+      ]);
+      final wave = binder.clips['Wave']!;
+      binder.apply(const [SceneAnimationSpec('Spin')]);
+      expect(wave.playing, isFalse);
+      expect(binder.clips.containsKey('Wave'), isFalse);
+      expect(binder.clips.containsKey('Spin'), isTrue);
+    });
+
+    test('unknown names warn without throwing and known ones still apply', () {
+      binder.apply(const [
+        SceneAnimationSpec('Nope'),
+        SceneAnimationSpec('Spin'),
+      ]);
+      expect(binder.clips.containsKey('Nope'), isFalse);
+      expect(binder.clips.containsKey('Spin'), isTrue);
+    });
+
+    test('specs are value-equal', () {
+      expect(
+        const SceneAnimationSpec('A', weight: 0.5),
+        const SceneAnimationSpec('A', weight: 0.5),
+      );
+      expect(
+        const SceneAnimationSpec('A'),
+        isNot(const SceneAnimationSpec('B')),
+      );
+    });
+  });
+
+  group('MaterialsVariantsComponent.rebindClone', () {
+    test('rebinds to the clone and leaves the template untouched', () {
+      final template = _buildTemplate();
+      final clone = template.clone();
+      final component = MaterialsVariantsComponent.rebindClone(
+        template,
+        clone,
+      )!;
+      component.select('b');
+
+      final templatePrimitive = template
+          .getChildByName('shoe')!
+          .mesh!
+          .primitives
+          .single;
+      final clonePrimitive = clone
+          .getChildByName('shoe')!
+          .mesh!
+          .primitives
+          .single;
+      expect((clonePrimitive.material as _FakeMaterial).label, 'variant-b');
+      expect((templatePrimitive.material as _FakeMaterial).label, 'default');
+
+      component.select(null);
+      expect((clonePrimitive.material as _FakeMaterial).label, 'default');
+    });
+
+    test('returns null for templates without variants', () {
+      final template = _buildTemplate(variants: const []);
+      final clone = template.clone();
+      expect(MaterialsVariantsComponent.rebindClone(template, clone), isNull);
+      expect(clone.getComponent<MaterialsVariantsComponent>(), isNull);
+    });
+  });
+}

--- a/packages/flutter_scene/test/scene_model_test.dart
+++ b/packages/flutter_scene/test/scene_model_test.dart
@@ -11,9 +11,9 @@ import 'package:flutter_scene/src/widgets/declarative.dart'
     show SceneAnimationBinder;
 import 'package:flutter_test/flutter_test.dart';
 
-/// SceneModel widget tests: the import is replaced with a GPU-free
-/// hand-built node tree via [SceneModel.debugImportOverride], so the full
-/// load / template-cache / clone / variant / animation path runs headless.
+/// SceneModel widget tests. Sources override [SceneModelSource.createNode]
+/// to produce GPU-free hand-built node trees, so the full
+/// load/template-cache/clone/variant/animation path runs headless.
 
 class _FakeMaterial implements Material {
   _FakeMaterial(this.label);
@@ -28,18 +28,42 @@ class _FakeGeometry implements Geometry {
   dynamic noSuchMethod(Invocation invocation) => null;
 }
 
-/// A source whose load completes on demand, to hold the widget in its
-/// loading phase.
-class _GatedSource extends SceneModelSource {
-  _GatedSource(this.key);
+/// Counts template imports across all fake sources, mirroring the shared
+/// template cache's behavior.
+int importCalls = 0;
+
+/// A source that imports a hand-built template, keyed like an app source.
+class _FakeSource extends SceneModelSource {
+  _FakeSource(this.key, {Node Function()? buildTemplate})
+    : _buildTemplate = buildTemplate ?? _buildDefaultTemplate;
+
   final String key;
-  final Completer<Uint8List> gate = Completer<Uint8List>();
+  final Node Function() _buildTemplate;
 
   @override
-  String get cacheKey => 'gated:$key';
+  String get cacheKey => 'fake:$key';
 
   @override
-  Future<Uint8List> load() => gate.future;
+  Future<Uint8List> load() async => Uint8List(0);
+
+  @override
+  Future<Node> createNode() async {
+    importCalls++;
+    return _buildTemplate();
+  }
+}
+
+/// A source whose import completes on demand, to hold the widget in its
+/// loading phase.
+class _GatedSource extends _FakeSource {
+  _GatedSource(super.key);
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<Node> createNode() async {
+    await gate.future;
+    return super.createNode();
+  }
 }
 
 class _FailingSource extends SceneModelSource {
@@ -53,21 +77,39 @@ class _FailingSource extends SceneModelSource {
   Future<Uint8List> load() async => throw StateError('no bytes for $key');
 }
 
-/// Builds a template like the runtime importer would: a root carrying a
-/// variants component and a parsed animation, over a child with a mesh.
-Node _buildTemplate({List<String> variants = const ['a', 'b']}) {
+/// A source that fails on the first import and succeeds after, for the
+/// failed-imports-are-not-cached path.
+class _FlakySource extends _FakeSource {
+  _FlakySource(super.key);
+
+  @override
+  Future<Node> createNode() async {
+    importCalls++;
+    if (importCalls == 1) throw StateError('flaky');
+    return _buildDefaultTemplate();
+  }
+}
+
+/// Builds a template like the runtime importer would. A root carrying a
+/// variants component, parsed animations, and a punctual light, over a child
+/// with a mesh.
+Node _buildDefaultTemplate({List<String> variants = const ['a', 'b']}) {
   final defaultMaterial = _FakeMaterial('default');
   final variantMaterial = _FakeMaterial('variant-b');
   final primitive = MeshPrimitive(_FakeGeometry(), defaultMaterial);
   final child = Node(name: 'shoe')
     ..mesh = Mesh.primitives(primitives: [primitive]);
-  final root = Node(name: 'root')..add(child);
+  final light = Node(name: 'lamp')
+    ..addComponent(PointLightComponent(PointLight(intensity: 3.0, range: 5.0)));
+  final root = Node(name: 'root')
+    ..add(child)
+    ..add(light);
   if (variants.isNotEmpty) {
     root.addComponent(
       MaterialsVariantsComponent.internal(variants, [
         MaterialsVariantBinding(
           node: child,
-          primitive: primitive,
+          primitiveIndex: 0,
           defaultMaterial: defaultMaterial,
           materialsByVariant: {1: variantMaterial},
         ),
@@ -81,28 +123,17 @@ Node _buildTemplate({List<String> variants = const ['a', 'b']}) {
 
 void main() {
   late Node sceneRoot;
-  late int importCalls;
 
   setUp(() {
     sceneRoot = Node(name: 'scene-root');
     importCalls = 0;
-    SceneModel.debugImportOverride = (bytes) async {
-      importCalls++;
-      return _buildTemplate();
-    };
     SceneModel.debugClearModelTemplateCache();
   });
 
-  tearDown(() {
-    SceneModel.debugImportOverride = null;
-    SceneModel.debugClearModelTemplateCache();
-  });
+  tearDown(SceneModel.debugClearModelTemplateCache);
 
   Widget host(List<Widget> children) =>
       SceneSubtree(parent: sceneRoot, children: children);
-
-  MemoryModelSource source(String key) =>
-      MemoryModelSource(Uint8List(0), key: key);
 
   group('loading phases', () {
     testWidgets('placeholder mounts while loading, model replaces it', (
@@ -121,7 +152,7 @@ void main() {
       expect(wrapper.getChildByName('placeholder'), isNotNull);
       expect(wrapper.getChildByName('shoe'), isNull);
 
-      gated.gate.complete(Uint8List(0));
+      gated.gate.complete();
       await tester.pump();
       await tester.pump();
       expect(wrapper.getChildByName('placeholder'), isNull);
@@ -151,8 +182,8 @@ void main() {
       final roots = <Node>[];
       await tester.pumpWidget(
         host([
-          SceneModel.from(source('m'), onLoaded: roots.add),
-          SceneModel.from(source('m'), onLoaded: roots.add),
+          SceneModel.from(_FakeSource('m'), onLoaded: roots.add),
+          SceneModel.from(_FakeSource('m'), onLoaded: roots.add),
         ]),
       );
       await tester.pump();
@@ -177,20 +208,39 @@ void main() {
       );
     });
 
+    testWidgets('clones carry importer-attached components', (tester) async {
+      final roots = <Node>[];
+      await tester.pumpWidget(
+        host([SceneModel.from(_FakeSource('m'), onLoaded: roots.add)]),
+      );
+      await tester.pump();
+      await tester.pump();
+      final lamp = roots.single.getChildByName('lamp')!;
+      final component = lamp.getComponent<PointLightComponent>();
+      expect(component, isNotNull);
+      expect(component!.light.intensity, 3.0);
+    });
+
     testWidgets('the template is evicted when the last user unmounts', (
       tester,
     ) async {
       await tester.pumpWidget(
-        host([SceneModel.from(source('m')), SceneModel.from(source('m'))]),
+        host([
+          SceneModel.from(_FakeSource('m')),
+          SceneModel.from(_FakeSource('m')),
+        ]),
       );
       await tester.pump();
       await tester.pump();
       expect(importCalls, 1);
 
       // Dropping one keeps the template alive for the other.
-      await tester.pumpWidget(host([SceneModel.from(source('m'))]));
+      await tester.pumpWidget(host([SceneModel.from(_FakeSource('m'))]));
       await tester.pumpWidget(
-        host([SceneModel.from(source('m')), SceneModel.from(source('m'))]),
+        host([
+          SceneModel.from(_FakeSource('m')),
+          SceneModel.from(_FakeSource('m')),
+        ]),
       );
       await tester.pump();
       await tester.pump();
@@ -198,7 +248,7 @@ void main() {
 
       // Dropping all evicts; the next mount imports again.
       await tester.pumpWidget(host([]));
-      await tester.pumpWidget(host([SceneModel.from(source('m'))]));
+      await tester.pumpWidget(host([SceneModel.from(_FakeSource('m'))]));
       await tester.pump();
       await tester.pump();
       expect(importCalls, 2);
@@ -207,22 +257,15 @@ void main() {
     testWidgets('a failed import is not cached; a retry imports again', (
       tester,
     ) async {
-      SceneModel.debugImportOverride = (bytes) async {
-        importCalls++;
-        if (importCalls == 1) throw StateError('flaky');
-        return _buildTemplate();
-      };
-      await tester.pumpWidget(host([SceneModel.from(source('m'))]));
+      await tester.pumpWidget(host([SceneModel.from(_FlakySource('m'))]));
       await tester.pump();
       await tester.pump();
       expect(importCalls, 1);
 
-      // A different key forces a reload; same key would too after eviction,
-      // but exercise the recovery path through a fresh source.
       await tester.pumpWidget(host([]));
       final roots = <Node>[];
       await tester.pumpWidget(
-        host([SceneModel.from(source('m'), onLoaded: roots.add)]),
+        host([SceneModel.from(_FlakySource('m'), onLoaded: roots.add)]),
       );
       await tester.pump();
       await tester.pump();
@@ -237,8 +280,8 @@ void main() {
       final roots = <Node>[];
       await tester.pumpWidget(
         host([
-          SceneModel.from(source('m'), variant: 'b', onLoaded: roots.add),
-          SceneModel.from(source('m'), onLoaded: roots.add),
+          SceneModel.from(_FakeSource('m'), variant: 'b', onLoaded: roots.add),
+          SceneModel.from(_FakeSource('m'), onLoaded: roots.add),
         ]),
       );
       await tester.pump();
@@ -256,7 +299,7 @@ void main() {
     ) async {
       final roots = <Node>[];
       await tester.pumpWidget(
-        host([SceneModel.from(source('m'), onLoaded: roots.add)]),
+        host([SceneModel.from(_FakeSource('m'), onLoaded: roots.add)]),
       );
       await tester.pump();
       await tester.pump();
@@ -268,35 +311,59 @@ void main() {
       expect((primitive.material as _FakeMaterial).label, 'default');
 
       await tester.pumpWidget(
-        host([SceneModel.from(source('m'), variant: 'b')]),
+        host([SceneModel.from(_FakeSource('m'), variant: 'b')]),
       );
       expect((primitive.material as _FakeMaterial).label, 'variant-b');
     });
   });
 
   group('animations', () {
-    testWidgets('specs flow to clips on load and on rebuild', (tester) async {
-      final binderProbe = <Node>[];
+    testWidgets('specs flow to clips on load', (tester) async {
+      final roots = <Node>[];
       await tester.pumpWidget(
         host([
           SceneModel.from(
-            source('m'),
+            _FakeSource('m'),
             animations: const [
               SceneAnimationSpec('Spin', weight: 0.5, speed: 2.0),
             ],
-            onLoaded: binderProbe.add,
+            onLoaded: roots.add,
           ),
         ]),
       );
       await tester.pump();
       await tester.pump();
-      // The clip is observable through a second binder on the same root: the
-      // player is per node and clips are name-keyed, so creating again
-      // returns fresh clips; instead assert through spec-driven state below.
-      final root = binderProbe.single;
-      final binder = SceneAnimationBinder()..bind(root);
+      final binder = SceneAnimationBinder()..bind(roots.single);
       binder.apply(const [SceneAnimationSpec('Spin')]);
       expect(binder.clips.containsKey('Spin'), isTrue);
+    });
+  });
+
+  group('component lifecycle', () {
+    testWidgets('a stable component survives unmount and remount', (
+      tester,
+    ) async {
+      final spin = _CountingComponent();
+      Widget build(bool show) => host([
+        if (show) SceneNode(name: 'n', components: [spin]),
+      ]);
+
+      await tester.pumpWidget(build(true));
+      expect(spin.attaches, 1);
+      expect(spin.isAttached, isTrue);
+
+      // Unmounting detaches the component (running onDetach cleanup)...
+      await tester.pumpWidget(build(false));
+      expect(spin.detaches, 1);
+      expect(spin.isAttached, isFalse);
+
+      // ...so the same instance can attach again on the next mount.
+      await tester.pumpWidget(build(true));
+      expect(spin.attaches, 2);
+      expect(
+        sceneRoot.children.single.getComponent<_CountingComponent>(),
+        spin,
+      );
     });
   });
 
@@ -305,7 +372,7 @@ void main() {
     late SceneAnimationBinder binder;
 
     setUp(() {
-      root = _buildTemplate();
+      root = _buildDefaultTemplate();
       binder = SceneAnimationBinder()..bind(root);
     });
 
@@ -338,7 +405,7 @@ void main() {
       expect(clip.playing, isTrue);
     });
 
-    test('a removed spec stops its clip', () {
+    test('a removed spec stops its clip and unregisters it', () {
       binder.apply(const [
         SceneAnimationSpec('Spin'),
         SceneAnimationSpec('Wave'),
@@ -348,6 +415,13 @@ void main() {
       expect(wave.playing, isFalse);
       expect(binder.clips.containsKey('Wave'), isFalse);
       expect(binder.clips.containsKey('Spin'), isTrue);
+      // Re-adding creates a fresh registration rather than resurrecting the
+      // stopped clip.
+      binder.apply(const [
+        SceneAnimationSpec('Spin'),
+        SceneAnimationSpec('Wave'),
+      ]);
+      expect(identical(binder.clips['Wave'], wave), isFalse);
     });
 
     test('unknown names warn without throwing and known ones still apply', () {
@@ -373,7 +447,7 @@ void main() {
 
   group('MaterialsVariantsComponent.rebindClone', () {
     test('rebinds to the clone and leaves the template untouched', () {
-      final template = _buildTemplate();
+      final template = _buildDefaultTemplate();
       final clone = template.clone();
       final component = MaterialsVariantsComponent.rebindClone(
         template,
@@ -399,10 +473,21 @@ void main() {
     });
 
     test('returns null for templates without variants', () {
-      final template = _buildTemplate(variants: const []);
+      final template = _buildDefaultTemplate(variants: const []);
       final clone = template.clone();
       expect(MaterialsVariantsComponent.rebindClone(template, clone), isNull);
       expect(clone.getComponent<MaterialsVariantsComponent>(), isNull);
     });
   });
+}
+
+class _CountingComponent extends Component {
+  int attaches = 0;
+  int detaches = 0;
+
+  @override
+  void onAttach() => attaches++;
+
+  @override
+  void onDetach() => detaches++;
 }


### PR DESCRIPTION
Scenes can now be described in `build()` with widgets that own and reconcile retained scene-graph nodes, as an optional alternative to the imperative Scene/Node API (which is unchanged). Rebuilds apply only changed properties, structure reconciles through the element tree, and hot reload of scene structure works in place.

`SceneView.declarative` renders a view-owned `Scene` configured through constructor props. `SceneNode` declares a transform, components, and children; `SceneMesh` adds identity-diffed geometry and material; `SceneModel` loads a `.glb` asynchronously with placeholder/error subtrees, named-variant selection, and declarative animation playback via `SceneAnimationSpec` (playing/loop/weight/speed diffed onto clips as plain property writes). Equal-keyed models load once and share a refcounted template; each widget mounts its own clone, keeping GPU resources shared. `SceneSubtree`, `SceneNodeHost`, and `SceneNodeController` bridge the declarative and imperative styles in both directions.

`KHR_materials_variants` is supported by both import paths. Imported models carry a `MaterialsVariantsComponent` whose `select(name)` swaps mapped materials in place, and the `.fscene` format serializes variants as a component with no container change, so pre-converted assets keep them. Fixing live swaps surfaced a render-item gap (materials were captured at registration), now re-registered on selection with a regression test.

The new Configurator example live-downloads the Khronos MaterialsVariantsShoe (© Shopify, CC BY 4.0) into a showroom scene with colorway-reactive lighting, and the Animation example now blends dash.glb's clips declaratively. The declarative layer, model caching, animations, and format round-trip are covered by GPU-free tests via an injectable importer seam.
