### PR TITLE
Keep the Argos upload step alive when no build URL is printed

### DIFF
--- a/.github/workflows/smoke_render_jobs.yml
+++ b/.github/workflows/smoke_render_jobs.yml
@@ -97,7 +97,10 @@ jobs:
           fi
           out=$(npx --yes @argos-ci/cli upload build/smoke --build-name "${{ inputs.argos_prefix }}linux" "${reference_args[@]}" 2>&1) || true
           echo "$out"
-          url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1)
+          # The grep misses when the upload failed and printed no URL (fork
+          # PRs have no ARGOS_TOKEN); that miss must not fail the step, which
+          # runs with pipefail on windows.
+          url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1) || true
           echo "build_url=$url" >> "$GITHUB_OUTPUT"
       - name: Notify Discord on failure
         if: failure() && github.event_name != 'pull_request'
@@ -211,7 +214,10 @@ jobs:
           fi
           out=$(npx --yes @argos-ci/cli upload build/smoke --build-name "${{ inputs.argos_prefix }}android_${{ matrix.backend }}" "${reference_args[@]}" 2>&1) || true
           echo "$out"
-          url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1)
+          # The grep misses when the upload failed and printed no URL (fork
+          # PRs have no ARGOS_TOKEN); that miss must not fail the step, which
+          # runs with pipefail on windows.
+          url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1) || true
           echo "build_url=$url" >> "$GITHUB_OUTPUT"
       - name: Notify Discord on failure
         if: failure() && github.event_name != 'pull_request'
@@ -277,7 +283,10 @@ jobs:
           fi
           out=$(npx --yes @argos-ci/cli upload build/smoke --build-name "${{ inputs.argos_prefix }}web" "${reference_args[@]}" 2>&1) || true
           echo "$out"
-          url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1)
+          # The grep misses when the upload failed and printed no URL (fork
+          # PRs have no ARGOS_TOKEN); that miss must not fail the step, which
+          # runs with pipefail on windows.
+          url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1) || true
           echo "build_url=$url" >> "$GITHUB_OUTPUT"
       - name: Notify Discord on failure
         if: failure() && github.event_name != 'pull_request'
@@ -346,7 +355,10 @@ jobs:
           fi
           out=$(npx --yes @argos-ci/cli upload build/smoke --build-name "${{ inputs.argos_prefix }}windows" "${reference_args[@]}" 2>&1) || true
           echo "$out"
-          url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1)
+          # The grep misses when the upload failed and printed no URL (fork
+          # PRs have no ARGOS_TOKEN); that miss must not fail the step, which
+          # runs with pipefail on windows.
+          url=$(printf '%s' "$out" | grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' | head -1) || true
           echo "build_url=$url" >> "$GITHUB_OUTPUT"
       - name: Notify Discord on failure
         if: failure() && github.event_name != 'pull_request'


### PR DESCRIPTION
Fork PRs run without ARGOS_TOKEN, so the Argos upload fails and prints no build URL. The url extraction grep then exits 1, which fails the step on windows, the only job whose script runs with pipefail (its explicit `shell: bash` gets `-e -o pipefail` while the default linux shell is `-e` only). Seen on #259, where windows was the sole red check while all renders passed. Rescue the url assignment in all four upload steps so a failed upload stays non-fatal everywhere.