### PR TITLE
Draw cloned skinned meshes with their own skeletons

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -76,6 +76,14 @@
   material name, so materials can be looked up after loading. `.fscene`
   documents store it as an optional `name` on material resources.
 
+* Cloned skinned meshes no longer render as a single body. Clones share
+  their template's skinned geometry, and the shared geometry held the
+  per-frame joints texture, so every clone drew whichever skeleton
+  updated last (at that skeleton's position). Joint state now rides each
+  render item and is applied to the geometry per draw, so clones of a
+  skinned model animate and place independently in every pass (color,
+  shadows, depth prepass, and picking masks).
+
 ## 0.19.0
 
 * Steady-state frame allocations cut sharply. Every fullscreen pass (bloom,

--- a/packages/flutter_scene/lib/src/components/mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/mesh_component.dart
@@ -112,16 +112,13 @@ class MeshComponent extends Component {
     final worldTransform = node.globalTransform;
     final windingFlipped = node.windingFlipped;
 
-    // A skinned node uploads its joint matrices once per frame; both
-    // render passes then sample the same joints texture.
+    // A skinned node uploads its joint matrices once per frame. The texture
+    // rides on the render items, not the geometry, so nodes sharing one
+    // skinned geometry (clones) each draw with their own skeleton; the
+    // render passes apply it to the geometry per draw.
     final skin = node.skin;
-    if (skin != null) {
-      final jointsTexture = skin.getJointsTexture();
-      final jointsTextureWidth = skin.getTextureWidth();
-      for (final item in _renderItems) {
-        item.geometry.setJointsTexture(jointsTexture, jointsTextureWidth);
-      }
-    }
+    final jointsTexture = skin?.getJointsTexture();
+    final jointsTextureWidth = skin?.getTextureWidth() ?? 0;
 
     final renderScene = node.internalRenderScene;
     final frustumCulled = node.frustumCulled;
@@ -136,6 +133,8 @@ class MeshComponent extends Component {
       item.windingFlipped = windingFlipped;
       item.shadowStatic = node.shadowStatic;
       item.highlightColor = highlightColor;
+      item.jointsTexture = jointsTexture;
+      item.jointsTextureWidth = jointsTextureWidth;
 
       final wasBounded = item.worldBounds != null;
       final boundsChanged = item.refreshWorldBounds();

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -591,7 +591,9 @@ abstract class Geometry {
   /// by [Skin.getJointsTexture].
   ///
   /// The default implementation does nothing; [SkinnedGeometry] overrides
-  /// it to bind the texture in [bind].
+  /// it to bind the texture in [bind]. The render passes call this right
+  /// before each draw's bind, so a geometry shared between several skinned
+  /// nodes carries the correct skeleton for every draw.
   void setJointsTexture(gpu.Texture? texture, int width) {}
 
   /// Binds vertex/index buffers and per-frame uniforms onto [pass] in

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -247,6 +247,9 @@ class _DepthPrepassEncoder {
     // absent from the prepass and SSAO/SSR read the farther surface behind them.
     _renderPass.setCullMode(item.material.renderCullMode);
     final geometry = item.geometry;
+    // Skinned items draw through the full bind path below; apply this item's
+    // skeleton to the (possibly shared) geometry first.
+    item.applyJointsTexture(geometry);
     // An alpha-masked material samples its mask through the full-vertex
     // varyings, so it skips the position-only path too.
     final masked = item.material.depthAlphaMasked;

--- a/packages/flutter_scene/lib/src/render/object_filter.dart
+++ b/packages/flutter_scene/lib/src/render/object_filter.dart
@@ -141,6 +141,9 @@ class _ObjectMaskEncoder {
     }
     _renderPass.clearBindings();
     final geometry = item.geometry;
+    // Skinned items draw through the full bind path below; apply this item's
+    // skeleton to the (possibly shared) geometry first.
+    item.applyJointsTexture(geometry);
     // Unskinned geometry fills the mask through a position-only shader and
     // layout; skinned geometry falls back to its full vertex shader and bind.
     // A `vertex { }` material displaces geometry, so pick against its displaced

--- a/packages/flutter_scene/lib/src/render/render_scene.dart
+++ b/packages/flutter_scene/lib/src/render/render_scene.dart
@@ -9,6 +9,7 @@ import 'package:flutter_scene/src/components/point_light_component.dart';
 import 'package:flutter_scene/src/components/semantics_component.dart';
 import 'package:flutter_scene/src/components/spot_light_component.dart';
 import 'package:flutter_scene/src/geometry/geometry.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/render/bvh.dart';
 import 'package:flutter_scene/src/render/lod.dart';
@@ -66,6 +67,26 @@ class RenderItem {
   /// Static casters render into cached shadow tiles; dynamic casters render
   /// every frame (see the shadow cache).
   bool shadowStatic = false;
+
+  /// The owning node's joints texture and its edge length in texels, or
+  /// null/0 for an unskinned node. Refreshed each frame from the node's
+  /// [Skin]. Carried per item rather than on the geometry so nodes sharing
+  /// one skinned geometry (clones of a skinned model) each draw with their
+  /// own skeleton; every render pass applies it via [applyJointsTexture]
+  /// just before binding a draw.
+  gpu.Texture? jointsTexture;
+  int jointsTextureWidth = 0;
+
+  /// Applies this item's joints texture to [drawnGeometry] (which differs
+  /// from [geometry] when a level of detail was selected). No-op for
+  /// unskinned items. Render passes call this immediately before the
+  /// geometry's bind, so a geometry shared between skinned items holds the
+  /// right skeleton for each draw.
+  void applyJointsTexture(Geometry drawnGeometry) {
+    final texture = jointsTexture;
+    if (texture == null) return;
+    drawnGeometry.setJointsTexture(texture, jointsTextureWidth);
+  }
 
   /// World-space transform, refreshed each frame from the owning node.
   final Matrix4 worldTransform = Matrix4.identity();

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -107,6 +107,10 @@ class ShadowEncoder {
     }
     _renderPass.clearBindings();
     final geometry = item.geometry;
+    // Skinned casters bind their joints texture through the full-vertex
+    // path below; apply this item's skeleton to the (possibly shared)
+    // geometry first.
+    item.applyJointsTexture(geometry);
     // An alpha-masked caster draws through the masked depth shader (so only
     // its opaque texels cast) and needs the full-vertex varyings, so it skips
     // the position-only path. It also keeps the material's own culling, so the

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -53,6 +53,8 @@ base class _TranslucentRecord {
     this.windingFlipped,
     this.lightListOffset,
     this.lightListCount,
+    this.jointsTexture,
+    this.jointsTextureWidth,
   );
   final Matrix4 worldTransform;
   final Geometry geometry;
@@ -64,6 +66,10 @@ base class _TranslucentRecord {
   // The owning item's punctual-light slice, captured at submit time.
   final int lightListOffset;
   final int lightListCount;
+  // The owning item's joints texture, applied to the geometry right before
+  // this draw so skinned items sharing one geometry keep their own skeleton.
+  final gpu.Texture? jointsTexture;
+  final int jointsTextureWidth;
 }
 
 /// The viewport size of the scene color pass currently being encoded.
@@ -292,6 +298,8 @@ base class SceneEncoder {
             item.windingFlipped != (instanceTransform.determinant() < 0),
             item.lightListOffset,
             item.lightListCount,
+            item.jointsTexture,
+            item.jointsTextureWidth,
           ),
         );
       }
@@ -307,6 +315,8 @@ base class SceneEncoder {
           item.windingFlipped,
           item.lightListOffset,
           item.lightListCount,
+          item.jointsTexture,
+          item.jointsTextureWidth,
         ),
       );
     }
@@ -512,6 +522,7 @@ base class SceneEncoder {
       final item = record.item;
       record.material.lightListOffset = item.lightListOffset;
       record.material.lightListCount = item.lightListCount;
+      item.applyJointsTexture(record.geometry);
       final instances = item.instanceTransforms;
       if (instances != null) {
         _encodeInstanced(
@@ -567,6 +578,10 @@ base class SceneEncoder {
     for (final record in _translucentRecords) {
       record.material.lightListOffset = record.lightListOffset;
       record.material.lightListCount = record.lightListCount;
+      final joints = record.jointsTexture;
+      if (joints != null) {
+        record.geometry.setJointsTexture(joints, record.jointsTextureWidth);
+      }
       _encode(
         record.pipeline,
         record.worldTransform,

--- a/packages/flutter_scene/test/skinned_clone_joints_test.dart
+++ b/packages/flutter_scene/test/skinned_clone_joints_test.dart
@@ -1,0 +1,134 @@
+// Regression test for cloned skinned meshes rendering as a single body.
+// Clones share one skinned geometry, so per-frame joint state must ride
+// the render items and be applied to the geometry per draw; writing it
+// into the shared geometry during the pre-pass made every clone draw the
+// last-updated skeleton (at that skeleton's position, since skinned draws
+// use an identity model transform). GPU-gated like the other render
+// suites, since joints textures are real GPU textures.
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+// ignore: implementation_imports
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+// ignore: implementation_imports
+import 'package:flutter_scene/src/render/render_scene.dart';
+
+bool _gpuAvailable() {
+  try {
+    Scene();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Records every [setJointsTexture] call so the test can assert which
+/// skeleton each draw would bind.
+class _RecordingGeometry extends Geometry {
+  final List<(gpu.Texture?, int)> jointsCalls = [];
+
+  @override
+  void setJointsTexture(gpu.Texture? texture, int width) {
+    jointsCalls.add((texture, width));
+  }
+
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    TransientWriter transientsBuffer,
+    Matrix4 modelTransform,
+    Matrix4 cameraTransform,
+    Vector3 cameraPosition, {
+    gpu.Shader? shaderOverride,
+  }) => throw UnsupportedError('Stub geometry is not renderable');
+}
+
+class _StubMaterial extends Material {
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    TransientWriter transientsBuffer,
+    Lighting lighting,
+  ) => throw UnsupportedError('Stub material is not renderable');
+}
+
+/// A node with a mesh, a one-joint skin, and the joint as a child, so
+/// [Node.clone] re-binds each clone's skin to its own joint.
+Node _skinnedTemplate(Geometry geometry) {
+  final joint = Node(name: 'joint');
+  final template = Node(mesh: Mesh(geometry, _StubMaterial()));
+  template.add(joint);
+  template.skin = Skin()
+    ..joints.add(joint)
+    ..inverseBindMatrices.add(Matrix4.identity());
+  return template;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final gpuAvailable = _gpuAvailable();
+
+  RenderItem itemOf(RenderScene renderScene, Node node) =>
+      renderScene.items.singleWhere((item) => identical(item.sourceNode, node));
+
+  test('cloned skinned nodes carry their own joints textures', () {
+    final renderScene = RenderScene();
+    final root = Node()..debugMountInto(renderScene);
+
+    final geometry = _RecordingGeometry();
+    final template = _skinnedTemplate(geometry);
+    final a = template.clone();
+    final b = template.clone();
+    root.add(a);
+    root.add(b);
+    root.scenePrePass(0.0);
+
+    final itemA = itemOf(renderScene, a);
+    final itemB = itemOf(renderScene, b);
+
+    // The geometry (the heavy GPU resource) stays shared across clones...
+    expect(itemA.geometry, same(geometry));
+    expect(itemB.geometry, same(geometry));
+    // ...so per-skeleton state must not be written into it by the pre-pass.
+    expect(geometry.jointsCalls, isEmpty);
+
+    // Each clone's item carries its own skin's texture.
+    expect(itemA.jointsTexture, isNotNull);
+    expect(itemB.jointsTexture, isNotNull);
+    expect(itemA.jointsTexture, isNot(same(itemB.jointsTexture)));
+    expect(itemA.jointsTextureWidth, greaterThan(0));
+  }, skip: gpuAvailable ? false : 'no GPU context in this environment');
+
+  test('applyJointsTexture binds each item\'s own skeleton per draw', () {
+    final renderScene = RenderScene();
+    final root = Node()..debugMountInto(renderScene);
+
+    final geometry = _RecordingGeometry();
+    final template = _skinnedTemplate(geometry);
+    final a = template.clone();
+    final b = template.clone();
+    root.add(a);
+    root.add(b);
+    root.scenePrePass(0.0);
+
+    final itemA = itemOf(renderScene, a);
+    final itemB = itemOf(renderScene, b);
+
+    // The render passes call this immediately before each draw's bind.
+    itemA.applyJointsTexture(geometry);
+    itemB.applyJointsTexture(geometry);
+    expect(geometry.jointsCalls, [
+      (itemA.jointsTexture, itemA.jointsTextureWidth),
+      (itemB.jointsTexture, itemB.jointsTextureWidth),
+    ]);
+  }, skip: gpuAvailable ? false : 'no GPU context in this environment');
+
+  test('applyJointsTexture is a no-op for unskinned items', () {
+    final geometry = _RecordingGeometry();
+    final item = RenderItem(geometry: geometry, material: _StubMaterial());
+    item.applyJointsTexture(geometry);
+    expect(geometry.jointsCalls, isEmpty);
+  });
+}


### PR DESCRIPTION
Resolves #257.

Clones share the template's skinned geometry, and the shared geometry held the per-frame joints texture, so every clone drew whichever skeleton updated last, at that skeleton's position. Joint state now rides each render item and is applied to the geometry right before each draw's bind in every pass, so clones animate and place independently while the geometry stays shared.