### PR TITLE
Release the SceneModel template lease on import failure

### DIFF
--- a/packages/flutter_scene/lib/src/widgets/declarative.dart
+++ b/packages/flutter_scene/lib/src/widgets/declarative.dart
@@ -1046,6 +1046,13 @@ class _SceneModelState extends State<SceneModel>
       _registerHotReload(source, modelRoot);
       widget.onLoaded?.call(modelRoot);
     } catch (e) {
+      // A failed load never reaches the success path above, so nothing else
+      // will ever release this lease (_heldTemplateLease is only set there).
+      // Release unconditionally rather than relying on _import's own evict:
+      // that only removes the entry when it is still the one installed for
+      // the key, and this lease's refcount would otherwise stay incremented
+      // forever, keyed off nothing.
+      _ModelTemplateCache.release(lease);
       if (!mounted || generation != _loadGeneration) {
         return;
       }

--- a/packages/flutter_scene/lib/src/widgets/declarative.dart
+++ b/packages/flutter_scene/lib/src/widgets/declarative.dart
@@ -1046,13 +1046,15 @@ class _SceneModelState extends State<SceneModel>
       _registerHotReload(source, modelRoot);
       widget.onLoaded?.call(modelRoot);
     } catch (e) {
-      // A failed load never reaches the success path above, so nothing else
-      // will ever release this lease (_heldTemplateLease is only set there).
-      // Release unconditionally rather than relying on _import's own evict:
-      // that only removes the entry when it is still the one installed for
-      // the key, and this lease's refcount would otherwise stay incremented
-      // forever, keyed off nothing.
-      _ModelTemplateCache.release(lease);
+      // A throw before the handoff to _heldTemplateLease means nothing else
+      // will ever release this lease (_import's evict only removes the
+      // entry, never this refcount). A throw after the handoff (post-mount
+      // work like an onLoaded callback) lands here too, and there dispose
+      // releases the held lease, so releasing again would double-count a
+      // shared entry.
+      if (!identical(_heldTemplateLease, lease)) {
+        _ModelTemplateCache.release(lease);
+      }
       if (!mounted || generation != _loadGeneration) {
         return;
       }

--- a/packages/flutter_scene/test/scene_model_test.dart
+++ b/packages/flutter_scene/test/scene_model_test.dart
@@ -336,6 +336,53 @@ void main() {
         expect(importCalls, 2);
       },
     );
+
+    testWidgets(
+      'a throw after the lease handoff (an onLoaded callback) does not '
+      'double-release the shared template entry',
+      (tester) async {
+        const keyA = ValueKey('a');
+        const keyB = ValueKey('b');
+        const keyC = ValueKey('c');
+
+        // A's onLoaded throws after the lease was handed to the widget; B
+        // shares the entry. A's load lands in the catch branch holding a
+        // lease that dispose will also release.
+        await tester.pumpWidget(
+          host([
+            SceneModel.from(
+              _FakeSource('shared'),
+              key: keyA,
+              onLoaded: (_) => throw StateError('onLoaded'),
+            ),
+            SceneModel.from(_FakeSource('shared'), key: keyB),
+          ]),
+        );
+        await tester.pump();
+        await tester.pump();
+        expect(importCalls, 1);
+
+        // A unmounts and releases its held lease. A second release from the
+        // catch branch would have already decremented the shared refcount,
+        // so this one would hit zero and evict the entry B still uses.
+        await tester.pumpWidget(
+          host([SceneModel.from(_FakeSource('shared'), key: keyB)]),
+        );
+        await tester.pump();
+
+        // C mounts under the same key while B is live. If the entry was
+        // wrongly evicted, C re-imports; otherwise it reuses B's entry.
+        await tester.pumpWidget(
+          host([
+            SceneModel.from(_FakeSource('shared'), key: keyB),
+            SceneModel.from(_FakeSource('shared'), key: keyC),
+          ]),
+        );
+        await tester.pump();
+        await tester.pump();
+        expect(importCalls, 1);
+      },
+    );
   });
 
   group('variants on clones', () {


### PR DESCRIPTION
Follow-up from your review on #259 — the catch branch in `SceneModel`'s `_load` never released the lease it acquired, so a failed import left that entry's refcount stuck incremented.

You're right that it's harmless today, since `_import`'s own catch already evicts the entry regardless of refcount. But that's relying on the eviction-on-any-failure behavior as an implicit guarantee rather than having the lease accounting be correct on its own, so tightened it up: the catch branch now releases the lease unconditionally, same as the mismatched-generation branch in the try already does.

## Test plan
- `flutter analyze` clean.
- `flutter test` — full suite green (1024 passed). No new test added for this specific one since there's currently no path where it's observable from the outside (as you noted) — happy to add one if you'd rather have the invariant pinned down explicitly.