### PR TITLE
Harden the Android smoke jobs against adb transport wedges

### DIFF
--- a/.github/workflows/smoke_render_jobs.yml
+++ b/.github/workflows/smoke_render_jobs.yml
@@ -171,20 +171,29 @@ jobs:
             adb logcat -c &&
             (adb logcat -v time > examples/smoke_render/build/android-diagnostics/logcat_${{ matrix.backend }}.txt 2>&1 & echo $! > /tmp/smoke-logcat.pid) &&
             cd examples/smoke_render &&
-            (flutter drive
+            (drive() { timeout 1200 flutter drive
             --flavor ${{ matrix.backend }}
             --driver=test_driver/integration_test.dart
             --target=integration_test/smoke_test.dart
             -d emulator-5554
             --dart-define=SMOKE_EXPECTED_ANDROID_IMPELLER_BACKEND=${{ matrix.expected_backend }}
             --enable-impeller
-            --enable-flutter-gpu;
+            --enable-flutter-gpu; };
+            drive;
             status=$?;
+            if [ "$status" -ne 0 ] && ! ls build/smoke/*.png >/dev/null 2>&1; then
+            echo "flutter drive failed (status $status) before rendering any frames; restarting adb and retrying once.";
+            adb kill-server || true;
+            adb start-server || true;
+            adb wait-for-device;
+            drive;
+            status=$?;
+            fi;
             (adb devices -l > build/android-diagnostics/adb_devices_after_${{ matrix.backend }}.txt 2>&1 || true);
             kill "$(cat /tmp/smoke-logcat.pid)" || true;
             exit "$status")
       - name: Upload Android diagnostics
-        if: ${{ failure() }}
+        if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: android-diagnostics-${{ inputs.argos_prefix }}android_${{ matrix.backend }}

--- a/apps/flutter_scene_editor_app/lib/main.dart
+++ b/apps/flutter_scene_editor_app/lib/main.dart
@@ -26,7 +26,7 @@ void main() {
     exit(1);
   }
   WidgetsFlutterBinding.ensureInitialized();
-  final controller = RegularWindowController(
+  final controller = WindowController(
     size: const Size(1280, 800),
     // The runner styles the window with a hidden title bar by this title
     // (see AppDelegate.swift); keep the two in sync.
@@ -34,13 +34,13 @@ void main() {
     delegate: _MainWindowDelegate(),
   );
   runWidget(
-    RegularWindow(controller: controller, child: const FlutterSceneEditorApp()),
+    Window(controller: controller, child: const FlutterSceneEditorApp()),
   );
 }
 
 /// Quits the app when the main editor window closes, taking any floating
 /// panel windows with it.
-class _MainWindowDelegate with RegularWindowControllerDelegate {
+class _MainWindowDelegate with WindowControllerDelegate {
   @override
   void onWindowDestroyed() {
     exit(0);

--- a/packages/flutter_scene_editor/lib/src/shell/docking_shell.dart
+++ b/packages/flutter_scene_editor/lib/src/shell/docking_shell.dart
@@ -49,7 +49,7 @@ class DockPanel {
 ///
 /// When the `windowing` feature flag is enabled, a tab's context menu offers
 /// "Move to New Window", which floats the panel into its own OS window
-/// (rendered as a [RegularWindow] sibling view via [ViewAnchor]). Closing the
+/// (rendered as a [Window] sibling view via [ViewAnchor]). Closing the
 /// window re-docks the panel. Without the flag the menu item is absent and
 /// floating panels persisted in the layout are re-docked.
 class DockingShell extends StatefulWidget {
@@ -81,7 +81,7 @@ class _DockingShellState extends State<DockingShell> {
 
   // One native window per floating panel, keyed by panel id and kept in sync
   // with the layout's floating list.
-  final Map<String, RegularWindowController> _floatControllers = {};
+  final Map<String, WindowController> _floatControllers = {};
 
   @override
   void initState() {
@@ -120,13 +120,13 @@ class _DockingShellState extends State<DockingShell> {
 
   /// Creates windows for newly floating panels and tears down windows whose
   /// panels re-docked. Stale windows are destroyed a frame later so their
-  /// [RegularWindow] view unmounts first.
+  /// [Window] view unmounts first.
   void _syncFloatWindows() {
     if (!isWindowingEnabled) return;
     for (final id in _layout.floating) {
       _floatControllers.putIfAbsent(
         id,
-        () => RegularWindowController(
+        () => WindowController(
           size: const Size(480, 640),
           title: _panelById(id)?.title ?? id,
           delegate: _FloatWindowDelegate(() => _redock(id)),
@@ -155,7 +155,7 @@ class _DockingShellState extends State<DockingShell> {
         views: [
           for (final id in _layout.floating)
             if (_floatControllers[id] != null)
-              RegularWindow(
+              Window(
                 controller: _floatControllers[id]!,
                 child: _FloatWindowScaffold(
                   theme: theme,
@@ -213,13 +213,13 @@ class _DockingShellState extends State<DockingShell> {
 
 /// Re-docks the panel instead of destroying the window outright when the user
 /// clicks the native close button; the shell then tears the window down.
-class _FloatWindowDelegate with RegularWindowControllerDelegate {
+class _FloatWindowDelegate with WindowControllerDelegate {
   _FloatWindowDelegate(this.onCloseRequested);
 
   final VoidCallback onCloseRequested;
 
   @override
-  void onWindowCloseRequested(RegularWindowController controller) {
+  void onWindowCloseRequested(WindowController controller) {
     onCloseRequested();
   }
 }


### PR DESCRIPTION
The emulator's adb link occasionally wedges after boot and flutter drive retries the VM service connection forever, burning the job to its 45 minute timeout with no diagnostics (about 8% of recent android_vulkan runs). Each drive is now capped at 20 minutes, retried once with an adb restart when it failed before rendering any frames (so genuine test failures never auto-retry), and the diagnostics artifact also uploads on cancellation.

Also adopts the Window/WindowController renames from today's Flutter master, which broke analysis repo-wide.