### PR TITLE
Expose the particle system as public API

### DIFF
--- a/examples/flutter_app/lib/example_explosion.dart
+++ b/examples/flutter_app/lib/example_explosion.dart
@@ -1,20 +1,7 @@
-// Stylized explosion demo. The particle configuration types live under
-// lib/src/particles (not yet part of the public barrel); a dev app may
-// import them directly.
-// ignore_for_file: implementation_imports
-
 import 'dart:math';
 
 import 'package:flutter/material.dart' hide Material;
 import 'package:flutter_scene/scene.dart';
-import 'package:flutter_scene/src/components/mesh_particle_emitter_component.dart';
-import 'package:flutter_scene/src/components/particle_emitter_component.dart';
-import 'package:flutter_scene/src/components/trail_component.dart';
-import 'package:flutter_scene/src/particles/distribution.dart';
-import 'package:flutter_scene/src/particles/emitter_shape.dart' as shape;
-import 'package:flutter_scene/src/particles/particle_module.dart';
-import 'package:flutter_scene/src/particles/particle_system.dart';
-import 'package:flutter_scene/src/particles/spawner.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_overlay.dart';
@@ -294,7 +281,7 @@ class ExampleExplosionState extends State<ExampleExplosion> {
   ParticleSystem _fireball(TextureSource atlas) {
     final system = ParticleSystem(
       maxParticles: 24,
-      shape: const shape.SphereShape(radius: 0.12),
+      shape: const SphereEmitterShape(radius: 0.12),
       spawner: Spawner(bursts: const [ParticleBurst(time: 0.02, count: 13)]),
       looping: false,
       duration: 2.0,
@@ -346,7 +333,7 @@ class ExampleExplosionState extends State<ExampleExplosion> {
   ParticleSystem _sparks(TextureSource dot) {
     final system = ParticleSystem(
       maxParticles: 96,
-      shape: const shape.SphereShape(radius: 0.05),
+      shape: const SphereEmitterShape(radius: 0.05),
       spawner: Spawner(bursts: const [ParticleBurst(time: 0.0, count: 70)]),
       looping: false,
       duration: 2.0,
@@ -389,7 +376,7 @@ class ExampleExplosionState extends State<ExampleExplosion> {
   ParticleSystem _smoke(TextureSource atlas) {
     final system = ParticleSystem(
       maxParticles: 24,
-      shape: const shape.ConeShape(angle: 0.5, radius: 0.4),
+      shape: const ConeEmitterShape(angle: 0.5, radius: 0.4),
       spawner: Spawner(bursts: const [ParticleBurst(time: 0.22, count: 10)]),
       looping: false,
       duration: 2.0,
@@ -445,7 +432,7 @@ class ExampleExplosionState extends State<ExampleExplosion> {
   ParticleSystem _debris() {
     final system = ParticleSystem(
       maxParticles: 40,
-      shape: const shape.ConeShape(angle: 0.55, radius: 0.15),
+      shape: const ConeEmitterShape(angle: 0.55, radius: 0.15),
       spawner: Spawner(bursts: const [ParticleBurst(time: 0.0, count: 26)]),
       looping: false,
       duration: 2.0,

--- a/examples/flutter_app/lib/example_particles.dart
+++ b/examples/flutter_app/lib/example_particles.dart
@@ -1,5 +1,5 @@
-// Particle emitter demo. The configuration types live under lib/src/particles
-// (not yet part of the public barrel); a dev app may import them directly.
+// Particle emitter demo. Reaches two internal helpers (the icosphere builder
+// and the noise field) directly.
 // ignore_for_file: implementation_imports
 
 import 'dart:async';
@@ -9,17 +9,9 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart';
-import 'package:flutter_scene/src/components/mesh_particle_emitter_component.dart';
-import 'package:flutter_scene/src/components/particle_emitter_component.dart';
-import 'package:flutter_scene/src/components/trail_component.dart';
 import 'package:flutter_scene/src/geometry/primitives.dart'
     show buildIcosphereArrays;
 import 'package:flutter_scene/src/noise/fast_noise_lite.dart';
-import 'package:flutter_scene/src/particles/distribution.dart';
-import 'package:flutter_scene/src/particles/emitter_shape.dart' as shape;
-import 'package:flutter_scene/src/particles/particle_module.dart';
-import 'package:flutter_scene/src/particles/particle_system.dart';
-import 'package:flutter_scene/src/particles/spawner.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_overlay.dart';
@@ -2145,7 +2137,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
   Node _flameCore(TextureSource atlas) {
     _coreSystem = ParticleSystem(
       maxParticles: 64,
-      shape: const shape.ConeShape(angle: 0.10, radius: 0.14),
+      shape: const ConeEmitterShape(angle: 0.10, radius: 0.14),
       spawner: Spawner(rate: _coreRate),
       // Lifetime sets the flipbook pace (64 frames once over life), so keep
       // it above a second or the flames strobe.
@@ -2219,7 +2211,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
   Node _flameTongues(TextureSource atlas) {
     _tongueSystem = ParticleSystem(
       maxParticles: 64,
-      shape: const shape.ConeShape(angle: 0.25, radius: 0.22),
+      shape: const ConeEmitterShape(angle: 0.25, radius: 0.22),
       spawner: Spawner(rate: _tongueRate),
       lifetime: const UniformFloat(0.55, 0.85),
       startSpeed: const UniformFloat(0.3, 0.55),
@@ -2278,7 +2270,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
   Node _glow(TextureSource dot) {
     _glowSystem = ParticleSystem(
       maxParticles: 16,
-      shape: const shape.SphereShape(radius: 0.15),
+      shape: const SphereEmitterShape(radius: 0.15),
       spawner: Spawner(rate: _glowRate),
       lifetime: const UniformFloat(0.6, 1.0),
       startSpeed: const UniformFloat(0.05, 0.15),
@@ -2310,7 +2302,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
   Node _smoke(TextureSource atlas) {
     _smokeSystem = ParticleSystem(
       maxParticles: 64,
-      shape: const shape.ConeShape(angle: 0.18, radius: 0.16),
+      shape: const ConeEmitterShape(angle: 0.18, radius: 0.16),
       spawner: Spawner(rate: _smokeRate),
       lifetime: const UniformFloat(3.0, 4.5),
       startSpeed: const UniformFloat(0.3, 0.55),
@@ -2375,7 +2367,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
   Node _groundFog(TextureSource atlas) {
     _fogSystem = ParticleSystem(
       maxParticles: 32,
-      shape: const shape.ConeShape(angle: 0.02, radius: 6.5),
+      shape: const ConeEmitterShape(angle: 0.02, radius: 6.5),
       spawner: Spawner(rate: _fogRate),
       lifetime: const UniformFloat(7.0, 11.0),
       startSpeed: const UniformFloat(0.02, 0.06),
@@ -2428,7 +2420,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
   Node _embers(TextureSource dot) {
     _emberSystem = ParticleSystem(
       maxParticles: 96,
-      shape: const shape.ConeShape(angle: 0.5, radius: 0.28),
+      shape: const ConeEmitterShape(angle: 0.5, radius: 0.28),
       spawner: Spawner(
         rate: _emberRate,
         bursts: const [ParticleBurst(time: 0.8, count: 9, interval: 2.3)],
@@ -2515,7 +2507,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
     _leafFallSystem = ParticleSystem(
       maxParticles: 90,
       // A wide, shallow slab up in the canopy; leaves start heading down.
-      shape: shape.BoxShape(
+      shape: BoxEmitterShape(
         halfExtents: vm.Vector3(8.0, 0.6, 8.0),
         direction: vm.Vector3(0, -1, 0),
       ),
@@ -2585,7 +2577,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
   Node _dustMotes(TextureSource dot) {
     _moteSystem = ParticleSystem(
       maxParticles: 160,
-      shape: const shape.SphereShape(radius: 2.6),
+      shape: const SphereEmitterShape(radius: 2.6),
       spawner: Spawner(rate: _moteRate),
       lifetime: const UniformFloat(3.5, 6.5),
       startSpeed: const UniformFloat(0.01, 0.05),

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -16,6 +16,8 @@
 * `BasicSimulation` (queries and triggers, pure Dart) replaces `BasicPhysicsWorld`/`BasicCollider`/`BasicKinematicBody`.
 * Colliders without a sibling `RigidBody` now attach as static geometry instead of throwing.
 * Spatial audio through an optional pluggable-backend contract. `AudioEngine` (implemented by `flutter_scene_soloud` and `flutter_scene_fmod`), with `AudioListener`, `AudioSource`/`ClipAudioSource`, `AudioBus`, and distance attenuation. Import `package:flutter_scene/audio.dart`; it is not in the core barrel.
+* CPU particle systems are now public. `ParticleEmitterComponent` (camera-facing billboards), `MeshParticleEmitterComponent` (instanced 3D debris), and `TrailComponent` (ribbon trails), all driven by a `ParticleSystem` built from emitter shapes, spawners, over-life distributions, and a module stack (acceleration, drag, size/color-over-life, rotation, flipbook, curl-noise turbulence), with new Particles and Explosion examples.
+* Sprites and billboard particles depth-test against opaque geometry again, so closer objects occlude them.
 
 ## 0.19.0
 

--- a/packages/flutter_scene/dartdoc_options.yaml
+++ b/packages/flutter_scene/dartdoc_options.yaml
@@ -5,6 +5,7 @@ dartdoc:
     - "Materials"
     - "Lighting and environment"
     - "Rendering"
+    - "Particles"
     - "Animation"
     - "Physics"
     - "Audio"

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -116,6 +116,46 @@ export 'src/components/splat_component.dart' show SplatComponent;
 export 'src/components/spot_light_component.dart' show SpotLightComponent;
 export 'src/render/lod.dart' show LodLevel;
 export 'src/components/widget_component.dart' show WidgetComponent, WidgetInput;
+export 'src/components/particle_emitter_component.dart'
+    show ParticleEmitterComponent;
+export 'src/components/mesh_particle_emitter_component.dart'
+    show MeshParticleEmitterComponent, MeshParticleFacing;
+export 'src/components/trail_component.dart' show TrailComponent;
+export 'src/particles/particle_system.dart' show ParticleSystem;
+export 'src/particles/particle_storage.dart' show ParticleStorage;
+export 'src/particles/particle_module.dart'
+    show
+        AccelerationModule,
+        ColorOverLifeModule,
+        FlipbookModule,
+        LinearDragModule,
+        ParticleModule,
+        RotationModule,
+        SizeOverLifeModule,
+        TurbulenceModule;
+export 'src/particles/emitter_shape.dart'
+    show
+        BoxEmitterShape,
+        ConeEmitterShape,
+        EmitterShape,
+        PointEmitterShape,
+        SphereEmitterShape;
+export 'src/particles/distribution.dart'
+    show
+        ColorDistribution,
+        ColorGradient,
+        ColorStop,
+        ConstantColor,
+        ConstantFloat,
+        CurveFloat,
+        FloatDistribution,
+        GradientColor,
+        ParticleCurve,
+        ParticleKeyframe,
+        UniformColor,
+        UniformCurveFloat,
+        UniformFloat;
+export 'src/particles/spawner.dart' show ParticleBurst, Spawner;
 export 'src/geometry/splat_geometry.dart' show SplatCropMode;
 export 'src/splats/gaussian_splats.dart' show GaussianSplats;
 export 'src/splats/splat_codec.dart' show SplatFormat;

--- a/packages/flutter_scene/lib/src/components/mesh_particle_emitter_component.dart
+++ b/packages/flutter_scene/lib/src/components/mesh_particle_emitter_component.dart
@@ -11,10 +11,8 @@ import 'package:flutter_scene/src/node.dart';
 import 'package:flutter_scene/src/particles/particle_storage.dart';
 import 'package:flutter_scene/src/particles/particle_system.dart';
 
-// TODO(particles): export alongside the sprite emitter once the particle
-// authoring API is promoted to the public barrel.
-
 /// How a mesh particle orients itself.
+/// {@category Particles}
 enum MeshParticleFacing {
   /// Tumbles around the particle's random unit axis by its rotation (which
   /// `RotationModule` integrates from the angular velocity). The default,
@@ -44,6 +42,7 @@ enum MeshParticleFacing {
 /// Per-particle color is not applied to mesh instances.
 /// TODO(particles): per-instance color needs an instanced color attribute on
 /// the mesh instancing path; route ColorOverLife through it once that lands.
+/// {@category Particles}
 class MeshParticleEmitterComponent extends Component {
   /// Creates an emitter that draws [system]'s particles as instances of
   /// [geometries] (each particle picks one), all sharing [material].

--- a/packages/flutter_scene/lib/src/components/particle_emitter_component.dart
+++ b/packages/flutter_scene/lib/src/components/particle_emitter_component.dart
@@ -6,10 +6,6 @@ import 'package:flutter_scene/src/particles/particle_system.dart';
 
 import 'package:vector_math/vector_math.dart';
 
-// TODO(particles): export this (and the configuration types under
-// lib/src/particles/) from lib/scene.dart with a `{@category Particles}` doc
-// category once the authoring API settles across the later rendering phases.
-
 /// An engine component that simulates a [ParticleSystem] on the CPU and draws
 /// its live particles as one instanced batch of camera-facing billboards.
 ///
@@ -22,6 +18,7 @@ import 'package:vector_math/vector_math.dart';
 /// Configure the effect through the [system] (shape, spawner, modules, start
 /// distributions, gravity) and the [material] (texture, tint, blend mode). Set
 /// [facing]/[velocityStretch] for spark-like streaks.
+/// {@category Particles}
 class ParticleEmitterComponent extends MeshComponent {
   /// Creates an emitter that drives [system]. When [material] is omitted a
   /// default [SpriteMaterial] (untextured, alpha-blended) is used; configure

--- a/packages/flutter_scene/lib/src/components/trail_component.dart
+++ b/packages/flutter_scene/lib/src/components/trail_component.dart
@@ -17,10 +17,8 @@ import 'package:flutter_scene/src/mesh.dart';
 import 'package:flutter_scene/src/particles/distribution.dart';
 import 'package:flutter_scene/src/render/frame_transients.dart';
 
-// TODO(particles): export alongside the particle emitters once the
-// authoring API is promoted to the public barrel. Per-particle trails (a
-// ribbon per particle of a ParticleSystem) are the natural follow-up and
-// need per-ribbon particle ids.
+// TODO(particles): per-particle trails (a ribbon per particle of a
+// ParticleSystem) are a natural follow-up and need per-ribbon particle ids.
 
 /// An engine component that trails a camera-facing ribbon behind its owning
 /// node as the node moves, for missiles, sword slashes, tracers, and debris.
@@ -42,6 +40,7 @@ import 'package:flutter_scene/src/render/frame_transients.dart';
 /// culling. A custom [Material] must also disable culling, since a
 /// camera-facing strip's winding flips wherever the path doubles back on
 /// itself.
+/// {@category Particles}
 class TrailComponent extends MeshComponent {
   /// Creates a trail. [maxPoints] bounds the recorded path (oldest points
   /// expire first); [material] defaults to a translucent unlit material

--- a/packages/flutter_scene/lib/src/fscene/realize/particle_emitter_codec.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/particle_emitter_codec.dart
@@ -317,10 +317,10 @@ EmitterShape _shapeFromProperties(Map<String, PropertyValue> p) {
   final radius = _num(p, 'shapeRadius', _kShapeRadius);
   final angle = _num(p, 'shapeAngle', _kShapeAngle);
   return switch (_str(p, 'shapeType', _kShapeType)) {
-    'point' => PointShape(),
-    'sphere' => SphereShape(radius: radius),
-    'box' => BoxShape(halfExtents: Vector3.all(radius)),
-    _ => ConeShape(angle: angle, radius: radius),
+    'point' => PointEmitterShape(),
+    'sphere' => SphereEmitterShape(radius: radius),
+    'box' => BoxEmitterShape(halfExtents: Vector3.all(radius)),
+    _ => ConeEmitterShape(angle: angle, radius: radius),
   };
 }
 
@@ -353,21 +353,21 @@ List<ParticleModule> _modulesFromProperties(Map<String, PropertyValue> p) {
 }
 
 String _shapeTypeName(EmitterShape shape) => switch (shape) {
-  PointShape() => 'point',
-  SphereShape() => 'sphere',
-  BoxShape() => 'box',
-  ConeShape() => 'cone',
+  PointEmitterShape() => 'point',
+  SphereEmitterShape() => 'sphere',
+  BoxEmitterShape() => 'box',
+  ConeEmitterShape() => 'cone',
   _ => 'cone',
 };
 
 double _shapeRadius(EmitterShape shape) => switch (shape) {
-  SphereShape(:final radius) => radius,
-  ConeShape(:final radius) => radius,
+  SphereEmitterShape(:final radius) => radius,
+  ConeEmitterShape(:final radius) => radius,
   _ => _kShapeRadius,
 };
 
 double _shapeAngle(EmitterShape shape) =>
-    shape is ConeShape ? shape.angle : _kShapeAngle;
+    shape is ConeEmitterShape ? shape.angle : _kShapeAngle;
 
 T? _moduleOf<T extends ParticleModule>(List<ParticleModule> modules) {
   for (final module in modules) {

--- a/packages/flutter_scene/lib/src/particles/distribution.dart
+++ b/packages/flutter_scene/lib/src/particles/distribution.dart
@@ -4,6 +4,7 @@ import 'package:vector_math/vector_math.dart';
 
 /// One control point of a [ParticleCurve]: a [value] at normalized time [t]
 /// (in `[0, 1]`).
+/// {@category Particles}
 class ParticleKeyframe {
   /// Creates a keyframe placing [value] at normalized time [t].
   const ParticleKeyframe(this.t, this.value);
@@ -24,6 +25,7 @@ class ParticleKeyframe {
 /// vary over the emitter's run (emit rate) read one keyed on system age. The
 /// curve is piecewise-linear between keyframes and clamped to the first/last
 /// value outside their range.
+/// {@category Particles}
 class ParticleCurve {
   /// Builds a curve from [keyframes], baked into a [resolution]-entry table.
   ///
@@ -106,6 +108,7 @@ class ParticleCurve {
 
 /// One color stop of a [ColorGradient]: a linear RGBA [color] at normalized
 /// time [t].
+/// {@category Particles}
 class ColorStop {
   /// Creates a stop placing [color] (linear RGBA) at normalized time [t].
   const ColorStop(this.t, this.color);
@@ -122,6 +125,7 @@ class ColorStop {
 /// Like [ParticleCurve] but for linear RGBA colors. Used for color-over-life
 /// gradients. Linearly interpolates between stops and clamps to the first/last
 /// color outside their range.
+/// {@category Particles}
 class ColorGradient {
   /// Builds a gradient from [stops], baked into a [resolution]-entry table.
   ///
@@ -215,6 +219,7 @@ class ColorGradient {
 /// deterministic and repeatable). The variants cover the four common authoring
 /// modes: a constant, a random range, a curve over life, and a per-particle
 /// random blend between two curves.
+/// {@category Particles}
 sealed class FloatDistribution {
   const FloatDistribution();
 
@@ -224,6 +229,7 @@ sealed class FloatDistribution {
 }
 
 /// A [FloatDistribution] that is [value] for every particle.
+/// {@category Particles}
 class ConstantFloat extends FloatDistribution {
   /// Creates a constant distribution.
   const ConstantFloat(this.value);
@@ -237,6 +243,7 @@ class ConstantFloat extends FloatDistribution {
 
 /// A [FloatDistribution] that picks a value in `[min, max]` per particle from
 /// its stored random (constant over the particle's life).
+/// {@category Particles}
 class UniformFloat extends FloatDistribution {
   /// Creates a uniform-range distribution over `[min, max]`.
   const UniformFloat(this.min, this.max);
@@ -251,6 +258,7 @@ class UniformFloat extends FloatDistribution {
 
 /// A [FloatDistribution] that samples [curve] over the particle's normalized
 /// age and scales it by [scale].
+/// {@category Particles}
 class CurveFloat extends FloatDistribution {
   /// Creates a curve-over-life distribution.
   const CurveFloat(this.curve, {this.scale = 1.0});
@@ -269,6 +277,7 @@ class CurveFloat extends FloatDistribution {
 /// A [FloatDistribution] whose value follows, per particle, a blend between a
 /// [min] and [max] curve chosen by the particle's stored random. Each particle
 /// keeps its own curve inside the envelope for the whole life.
+/// {@category Particles}
 class UniformCurveFloat extends FloatDistribution {
   /// Creates a distribution that blends between [min] and [max] curves by the
   /// per-particle random.
@@ -287,6 +296,7 @@ class UniformCurveFloat extends FloatDistribution {
 
 /// A color value generator sampled per particle, the color analog of
 /// [FloatDistribution].
+/// {@category Particles}
 sealed class ColorDistribution {
   const ColorDistribution();
 
@@ -296,6 +306,7 @@ sealed class ColorDistribution {
 }
 
 /// A [ColorDistribution] that is [color] for every particle.
+/// {@category Particles}
 class ConstantColor extends ColorDistribution {
   /// Creates a constant color distribution.
   const ConstantColor(this.color);
@@ -312,6 +323,7 @@ class ConstantColor extends ColorDistribution {
 
 /// A [ColorDistribution] that samples [gradient] over the particle's normalized
 /// age (color over life).
+/// {@category Particles}
 class GradientColor extends ColorDistribution {
   /// Creates a color-over-life distribution.
   const GradientColor(this.gradient);
@@ -326,6 +338,7 @@ class GradientColor extends ColorDistribution {
 
 /// A [ColorDistribution] that picks a color between [a] and [b] per particle
 /// from its stored random (constant over the particle's life).
+/// {@category Particles}
 class UniformColor extends ColorDistribution {
   /// Creates a distribution that blends between [a] and [b] by the per-particle
   /// random.

--- a/packages/flutter_scene/lib/src/particles/emitter_shape.dart
+++ b/packages/flutter_scene/lib/src/particles/emitter_shape.dart
@@ -16,6 +16,7 @@ import 'package:flutter_scene/src/particles/vec3_distribution.dart';
 /// Shapes draw their randomness from [ParticleStorage.randomFor] with salts in
 /// the `20+` range, kept disjoint from the salts the system uses for its other
 /// spawn properties so values do not correlate.
+/// {@category Particles}
 abstract class EmitterShape {
   /// Creates an emitter shape.
   const EmitterShape();
@@ -31,9 +32,10 @@ const int _saltC = 22;
 const int _saltD = 23;
 
 /// Emits every particle from the local origin along a single [direction].
-class PointShape extends EmitterShape {
+/// {@category Particles}
+class PointEmitterShape extends EmitterShape {
   /// Creates a point emitter heading along [direction] (default +Y).
-  PointShape({Vector3? direction})
+  PointEmitterShape({Vector3? direction})
     : direction = (direction?.clone() ?? Vector3(0, 1, 0))..normalize();
 
   /// The unit emission direction shared by every particle.
@@ -58,9 +60,10 @@ class PointShape extends EmitterShape {
 /// the shell. [hemisphere] restricts both position and direction to the +Y
 /// half. A zero [radius] degenerates to a point emitting in uniformly random
 /// directions.
-class SphereShape extends EmitterShape {
+/// {@category Particles}
+class SphereEmitterShape extends EmitterShape {
   /// Creates a sphere emitter of the given [radius].
-  const SphereShape({
+  const SphereEmitterShape({
     this.radius = 1.0,
     this.surfaceOnly = false,
     this.hemisphere = false,
@@ -108,9 +111,10 @@ class SphereShape extends EmitterShape {
 ///
 /// The disc is sampled area-uniform and the directions are sampled uniform over
 /// the cone's solid angle, so neither the centre nor the axis is over-weighted.
-class ConeShape extends EmitterShape {
+/// {@category Particles}
+class ConeEmitterShape extends EmitterShape {
   /// Creates a cone emitter with base [radius] and cone half-[angle] (radians).
-  const ConeShape({this.angle = 0.5, this.radius = 0.0})
+  const ConeEmitterShape({this.angle = 0.5, this.radius = 0.0})
     : assert(angle >= 0),
       assert(radius >= 0);
 
@@ -142,10 +146,11 @@ class ConeShape extends EmitterShape {
 
 /// Emits particles uniformly inside an axis-aligned box, each headed along a
 /// shared [direction].
-class BoxShape extends EmitterShape {
+/// {@category Particles}
+class BoxEmitterShape extends EmitterShape {
   /// Creates a box emitter spanning `[-halfExtents, halfExtents]`, heading
   /// along [direction] (default +Y).
-  BoxShape({Vector3? halfExtents, Vector3? direction})
+  BoxEmitterShape({Vector3? halfExtents, Vector3? direction})
     : direction = (direction?.clone() ?? Vector3(0, 1, 0))..normalize(),
       _box = UniformBoxVec3(
         (halfExtents?.clone() ?? Vector3.all(0.5))..scale(-1.0),

--- a/packages/flutter_scene/lib/src/particles/particle_module.dart
+++ b/packages/flutter_scene/lib/src/particles/particle_module.dart
@@ -16,6 +16,7 @@ const int _saltFlipbookStart = 10;
 /// particles (to apply forces or evaluate over-life properties). Both default
 /// to no-ops so a module implements only the phase it needs. A module touches
 /// only the storage columns it documents.
+/// {@category Particles}
 abstract class ParticleModule {
   /// Creates a particle module.
   const ParticleModule();
@@ -30,6 +31,7 @@ abstract class ParticleModule {
 /// Adds a constant [acceleration] (world units per second squared) to every
 /// particle's velocity each step. Use it for wind or as an extra gravity on top
 /// of the system's own gravity.
+/// {@category Particles}
 class AccelerationModule extends ParticleModule {
   /// Creates a constant-acceleration force.
   AccelerationModule(Vector3 acceleration)
@@ -54,6 +56,7 @@ class AccelerationModule extends ParticleModule {
 
 /// Damps velocity toward zero with a linear drag [coefficient] (per second):
 /// each step scales velocity by `max(0, 1 - coefficient * dt)`.
+/// {@category Particles}
 class LinearDragModule extends ParticleModule {
   /// Creates a linear drag force with the given [coefficient].
   LinearDragModule(this.coefficient) : assert(coefficient >= 0);
@@ -77,6 +80,7 @@ class LinearDragModule extends ParticleModule {
 /// Scales each particle's rendered size by a [FloatDistribution] sampled over
 /// its normalized age, relative to the size set at spawn (`size = baseSize *
 /// scale(age / lifetime)`).
+/// {@category Particles}
 class SizeOverLifeModule extends ParticleModule {
   /// Creates a size-over-life force driven by [scale].
   const SizeOverLifeModule(this.scale);
@@ -98,6 +102,7 @@ class SizeOverLifeModule extends ParticleModule {
 
 /// Sets each particle's color from a [ColorDistribution] sampled over its
 /// normalized age (color over life).
+/// {@category Particles}
 class ColorOverLifeModule extends ParticleModule {
   /// Creates a color-over-life force driven by [color].
   ColorOverLifeModule(this.color);
@@ -132,6 +137,7 @@ class ColorOverLifeModule extends ParticleModule {
 /// particle by a stable random frame so simultaneous spawns do not animate in
 /// lockstep; leave it off for once-over-life erosion sequences, which must
 /// start at frame zero.
+/// {@category Particles}
 class FlipbookModule extends ParticleModule {
   /// Creates a flipbook animator over [frameCount] cells.
   const FlipbookModule({
@@ -183,6 +189,7 @@ class FlipbookModule extends ParticleModule {
 /// `curl * strength * dt` to its velocity. Larger [frequency] gives smaller,
 /// busier eddies; [scroll] drifts the whole field (an upward scroll makes
 /// rising flames lick).
+/// {@category Particles}
 class TurbulenceModule extends ParticleModule {
   /// Creates a curl-noise force.
   TurbulenceModule({
@@ -230,6 +237,7 @@ class TurbulenceModule extends ParticleModule {
 
 /// Integrates each particle's in-plane rotation from its angular velocity
 /// (`rotation += angularVelocity * dt`).
+/// {@category Particles}
 class RotationModule extends ParticleModule {
   /// Creates a rotation integrator.
   const RotationModule();

--- a/packages/flutter_scene/lib/src/particles/particle_storage.dart
+++ b/packages/flutter_scene/lib/src/particles/particle_storage.dart
@@ -16,6 +16,7 @@ import 'dart:typed_data';
 /// Color is stored as four floats per particle (matching the billboard
 /// instance buffer's `float32x4` color attribute and the over-life color
 /// math). A packed RGBA8 column is a later memory optimization.
+/// {@category Particles}
 class ParticleStorage {
   /// Allocates storage for up to [capacity] simultaneous particles.
   ParticleStorage(this.capacity)

--- a/packages/flutter_scene/lib/src/particles/particle_system.dart
+++ b/packages/flutter_scene/lib/src/particles/particle_system.dart
@@ -37,6 +37,7 @@ const double _minLifetime = 1e-4;
 /// (already-live particles still finish their lives). All randomness derives
 /// from [seed], so a given seed and step sequence reproduce exactly (the basis
 /// for byte-for-byte tests and editor scrubbing).
+/// {@category Particles}
 class ParticleSystem {
   /// Creates a particle system. The distributions, shape, spawner, gravity,
   /// looping behaviour, fixed-step size, and seed are all configurable; only

--- a/packages/flutter_scene/lib/src/particles/spawner.dart
+++ b/packages/flutter_scene/lib/src/particles/spawner.dart
@@ -6,6 +6,7 @@
 /// [time]) for [cycles] occurrences, or forever when [cycles] is null; a
 /// non-positive [interval] is a single shot. Burst times are absolute on the
 /// system clock.
+/// {@category Particles}
 class ParticleBurst {
   /// Creates a burst of [count] particles at [time], optionally repeating.
   const ParticleBurst({
@@ -38,6 +39,7 @@ class ParticleBurst {
 /// than one particle per step still emits on the right cadence rather than
 /// truncating to zero), and bursts fire when their scheduled time falls in the
 /// step's half-open time window.
+/// {@category Particles}
 class Spawner {
   /// Creates a spawner emitting [rate] particles per second plus [bursts].
   Spawner({this.rate = 0.0, List<ParticleBurst> bursts = const []})

--- a/packages/flutter_scene/test/fscene/particle_emitter_codec_test.dart
+++ b/packages/flutter_scene/test/fscene/particle_emitter_codec_test.dart
@@ -45,8 +45,8 @@ void main() {
       final s = particleSystemFromProperties(_authoredProperties());
       expect(s.storage.capacity, 256);
       expect(s.spawner.rate, 80.0);
-      expect(s.shape, isA<ConeShape>());
-      expect((s.shape as ConeShape).radius, closeTo(0.4, 1e-9));
+      expect(s.shape, isA<ConeEmitterShape>());
+      expect((s.shape as ConeEmitterShape).radius, closeTo(0.4, 1e-9));
       expect(s.lifetime, isA<UniformFloat>());
       expect(s.gravity.y, closeTo(-9.8, 1e-5)); // gravity stored as float32
       expect(s.looping, isFalse);
@@ -66,7 +66,7 @@ void main() {
 
     test('falls back to defaults for an empty spec', () {
       final s = particleSystemFromProperties({});
-      expect(s.shape, isA<ConeShape>());
+      expect(s.shape, isA<ConeEmitterShape>());
       expect(s.looping, isTrue);
       expect(s.storage.capacity, greaterThan(0));
     });
@@ -107,7 +107,7 @@ void main() {
       expect(rebuilt.looping, original.looping);
       expect(rebuilt.duration, original.duration);
       expect(rebuilt.gravity.y, closeTo(original.gravity.y, 1e-9));
-      expect((rebuilt.shape as ConeShape).radius, closeTo(0.4, 1e-9));
+      expect((rebuilt.shape as ConeEmitterShape).radius, closeTo(0.4, 1e-9));
 
       // Distributions survive (compare a sampled value).
       expect(

--- a/packages/flutter_scene/test/particles/emitter_shape_test.dart
+++ b/packages/flutter_scene/test/particles/emitter_shape_test.dart
@@ -24,9 +24,9 @@ Vector3 _vel(ParticleStorage s, int i) =>
 final List<double> _seeds = [for (var i = 0; i < 64; i++) (i + 0.5) / 64.0];
 
 void main() {
-  group('PointShape', () {
+  group('PointEmitterShape', () {
     test('spawns at the origin heading along the normalized direction', () {
-      final shape = PointShape(direction: Vector3(0, 2, 0));
+      final shape = PointEmitterShape(direction: Vector3(0, 2, 0));
       final s = _spawn([0.1]);
       shape.sample(s, 0);
       expect(_pos(s, 0).length, 0.0);
@@ -36,9 +36,9 @@ void main() {
     });
   });
 
-  group('SphereShape', () {
+  group('SphereEmitterShape', () {
     test('surface points sit on the shell, radially directed', () {
-      const shape = SphereShape(radius: 2.0, surfaceOnly: true);
+      const shape = SphereEmitterShape(radius: 2.0, surfaceOnly: true);
       final s = _spawn(_seeds);
       for (var i = 0; i < s.aliveCount; i++) {
         shape.sample(s, i);
@@ -51,7 +51,7 @@ void main() {
     });
 
     test('volume points stay inside the sphere', () {
-      const shape = SphereShape(radius: 3.0);
+      const shape = SphereEmitterShape(radius: 3.0);
       final s = _spawn(_seeds);
       for (var i = 0; i < s.aliveCount; i++) {
         shape.sample(s, i);
@@ -61,7 +61,7 @@ void main() {
     });
 
     test('hemisphere keeps positions and directions in the +Y half', () {
-      const shape = SphereShape(radius: 1.0, hemisphere: true);
+      const shape = SphereEmitterShape(radius: 1.0, hemisphere: true);
       final s = _spawn(_seeds);
       for (var i = 0; i < s.aliveCount; i++) {
         shape.sample(s, i);
@@ -71,9 +71,9 @@ void main() {
     });
   });
 
-  group('ConeShape', () {
+  group('ConeEmitterShape', () {
     test('base sits in the XZ plane within the radius', () {
-      const shape = ConeShape(angle: 0.4, radius: 1.5);
+      const shape = ConeEmitterShape(angle: 0.4, radius: 1.5);
       final s = _spawn(_seeds);
       for (var i = 0; i < s.aliveCount; i++) {
         shape.sample(s, i);
@@ -87,7 +87,7 @@ void main() {
 
     test('directions are unit length within the cone half-angle', () {
       const angle = 0.4;
-      const shape = ConeShape(angle: angle, radius: 0.0);
+      const shape = ConeEmitterShape(angle: angle, radius: 0.0);
       final s = _spawn(_seeds);
       for (var i = 0; i < s.aliveCount; i++) {
         shape.sample(s, i);
@@ -98,9 +98,9 @@ void main() {
     });
   });
 
-  group('BoxShape', () {
+  group('BoxEmitterShape', () {
     test('positions fill the box and share the direction', () {
-      final shape = BoxShape(
+      final shape = BoxEmitterShape(
         halfExtents: Vector3(1, 2, 3),
         direction: Vector3(0, 0, 4),
       );

--- a/packages/flutter_scene/test/particles/particle_system_test.dart
+++ b/packages/flutter_scene/test/particles/particle_system_test.dart
@@ -40,7 +40,7 @@ void main() {
   group('stepping', () {
     test('drains the accumulator in whole fixed steps', () {
       final system = ParticleSystem(
-        shape: PointShape(),
+        shape: PointEmitterShape(),
         spawner: Spawner(),
         fixedStep: _fixed,
       );
@@ -50,7 +50,7 @@ void main() {
 
     test('clamps an over-long frame to maxFrameTime', () {
       final system = ParticleSystem(
-        shape: PointShape(),
+        shape: PointEmitterShape(),
         spawner: Spawner(),
         fixedStep: _fixed,
         maxFrameTime: 0.25,
@@ -61,7 +61,7 @@ void main() {
 
     test('leftover time carries into the next step', () {
       final system = ParticleSystem(
-        shape: PointShape(),
+        shape: PointEmitterShape(),
         spawner: Spawner(),
         fixedStep: _fixed,
       );
@@ -75,7 +75,7 @@ void main() {
   group('emission and motion', () {
     test('spawns a unit 3D rotation axis per particle', () {
       final system = ParticleSystem(
-        shape: PointShape(),
+        shape: PointEmitterShape(),
         spawner: Spawner(rate: 300.0),
         seed: 4,
       );
@@ -94,7 +94,7 @@ void main() {
 
     test('emits and integrates velocity over a step', () {
       final system = ParticleSystem(
-        shape: PointShape(direction: Vector3(0, 1, 0)),
+        shape: PointEmitterShape(direction: Vector3(0, 1, 0)),
         spawner: Spawner(bursts: const [ParticleBurst(time: 0.0, count: 1)]),
         startSpeed: const ConstantFloat(2.0),
         fixedStep: _fixed,
@@ -109,7 +109,7 @@ void main() {
 
     test('gravity accelerates velocity downward', () {
       final system = ParticleSystem(
-        shape: PointShape(),
+        shape: PointEmitterShape(),
         spawner: Spawner(bursts: const [ParticleBurst(time: 0.0, count: 1)]),
         startSpeed: const ConstantFloat(0.0),
         gravity: Vector3(0, -10, 0),
@@ -122,7 +122,7 @@ void main() {
 
     test('particles die once they outlive their lifetime', () {
       final system = ParticleSystem(
-        shape: PointShape(),
+        shape: PointEmitterShape(),
         spawner: Spawner(bursts: const [ParticleBurst(time: 0.0, count: 5)]),
         lifetime: const ConstantFloat(0.05), // ~3 steps
         fixedStep: _fixed,
@@ -137,7 +137,7 @@ void main() {
   group('looping', () {
     test('a non-looping system stops emitting past its duration', () {
       final system = ParticleSystem(
-        shape: PointShape(),
+        shape: PointEmitterShape(),
         spawner: Spawner(rate: 60.0),
         lifetime: const ConstantFloat(100.0),
         looping: false,
@@ -154,7 +154,7 @@ void main() {
   group('prewarm', () {
     test('populates the system at construction', () {
       final cold = ParticleSystem(
-        shape: PointShape(),
+        shape: PointEmitterShape(),
         spawner: Spawner(rate: 60.0),
         lifetime: const ConstantFloat(100.0),
         fixedStep: _fixed,
@@ -162,7 +162,7 @@ void main() {
       expect(cold.storage.aliveCount, 0);
 
       final warm = ParticleSystem(
-        shape: PointShape(),
+        shape: PointEmitterShape(),
         spawner: Spawner(rate: 60.0),
         lifetime: const ConstantFloat(100.0),
         fixedStep: _fixed,
@@ -175,7 +175,7 @@ void main() {
   group('determinism', () {
     ParticleSystem build() => ParticleSystem(
       maxParticles: 512,
-      shape: const SphereShape(radius: 1.0),
+      shape: const SphereEmitterShape(radius: 1.0),
       spawner: Spawner(
         rate: 200.0,
         bursts: const [ParticleBurst(time: 0.1, count: 50)],
@@ -219,7 +219,7 @@ void main() {
       final a = build();
       final b = ParticleSystem(
         maxParticles: 512,
-        shape: const SphereShape(radius: 1.0),
+        shape: const SphereEmitterShape(radius: 1.0),
         spawner: Spawner(rate: 200.0),
         startSpeed: const UniformFloat(1.0, 3.0),
         seed: 9999,


### PR DESCRIPTION
Promotes the CPU particle authoring surface to the public `scene.dart` barrel under a new Particles doc category, the billboard, mesh, and trail emitter components, `ParticleSystem`, the module stack, emitter shapes, distributions, and spawners. The emitter shapes are renamed to `*EmitterShape` so they no longer collide with the physics collider shapes. The Particles and Explosion examples move off the internal imports.