### PR TITLE
Move audio to an optional sub-barrel

### DIFF
--- a/examples/flutter_app/lib/example_audio.dart
+++ b/examples/flutter_app/lib/example_audio.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/audio.dart';
 import 'package:flutter_scene_soloud/flutter_scene_soloud.dart';
 import 'package:http/http.dart' as http;
 import 'package:vector_math/vector_math.dart' as vm;

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Physics is now an optional sub-barrel. Import `package:flutter_scene/physics.dart` (or `package:scene/physics.dart` for the pure contract); the core `package:flutter_scene/scene.dart` no longer carries physics types.
 * `BasicSimulation` (queries and triggers, pure Dart) replaces `BasicPhysicsWorld`/`BasicCollider`/`BasicKinematicBody`.
 * Colliders without a sibling `RigidBody` now attach as static geometry instead of throwing.
+* Spatial audio through an optional pluggable-backend contract. `AudioEngine` (implemented by `flutter_scene_soloud` and `flutter_scene_fmod`), with `AudioListener`, `AudioSource`/`ClipAudioSource`, `AudioBus`, and distance attenuation. Import `package:flutter_scene/audio.dart`; it is not in the core barrel.
 
 ## 0.19.0
 

--- a/packages/flutter_scene/lib/audio.dart
+++ b/packages/flutter_scene/lib/audio.dart
@@ -1,0 +1,19 @@
+/// Audio for flutter_scene, an optional pluggable-backend contract.
+///
+/// The spatial-audio scene-graph surface, [AudioEngine] (the contract a
+/// backend implements), [AudioListener], [AudioSource] / [ClipAudioSource],
+/// [AudioBus], [AudioClip], and the attenuation model. Attach a backend
+/// engine, `SoloudAudioEngine` from `package:flutter_scene_soloud` or
+/// `FmodAudioEngine` from `package:flutter_scene_fmod`. Import this only when
+/// a build needs audio; the core `package:flutter_scene/scene.dart` does not
+/// carry it.
+library;
+
+export 'src/audio/audio_attenuation.dart' show AudioAttenuation, AudioRolloff;
+export 'src/audio/audio_bus.dart' show AudioBus;
+export 'src/audio/audio_clip.dart' show AudioClip;
+export 'src/audio/audio_engine.dart' show AudioEngine;
+export 'src/audio/audio_listener.dart' show AudioListener;
+export 'src/audio/audio_source.dart' show AudioSource;
+export 'src/audio/audio_voice.dart' show AudioVoice;
+export 'src/audio/clip_audio_source.dart' show ClipAudioSource;

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -149,14 +149,8 @@ export 'src/texture/texture2d.dart'
     show Texture2D, TextureSource, TextureSampling, GpuTextureSource;
 export 'src/texture/texture_registry.dart' show loadTexture;
 export 'src/texture/mipmap.dart' show TextureContent;
-export 'src/audio/audio_attenuation.dart' show AudioAttenuation, AudioRolloff;
-export 'src/audio/audio_bus.dart' show AudioBus;
-export 'src/audio/audio_clip.dart' show AudioClip;
-export 'src/audio/audio_engine.dart' show AudioEngine;
-export 'src/audio/audio_listener.dart' show AudioListener;
-export 'src/audio/audio_source.dart' show AudioSource;
-export 'src/audio/audio_voice.dart' show AudioVoice;
-export 'src/audio/clip_audio_source.dart' show ClipAudioSource;
+// Audio is an optional contract, exported from
+// `package:flutter_scene/audio.dart`.
 // Physics is an optional contract, exported from
 // `package:flutter_scene/physics.dart`.
 export 'src/post_process/post_effect.dart' show PostEffect, PostInsertion;

--- a/packages/flutter_scene/test/audio_contract_test.dart
+++ b/packages/flutter_scene/test/audio_contract_test.dart
@@ -5,6 +5,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/audio.dart';
 import 'package:scene/scene.dart';
 import 'package:flutter_scene/src/fscene/realize/audio_codecs.dart';
 import 'package:flutter_scene/src/fscene/realize/component_codec.dart';

--- a/packages/flutter_scene_fmod/lib/src/fmod_audio.dart
+++ b/packages/flutter_scene_fmod/lib/src/fmod_audio.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter/widgets.dart';
-import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/audio.dart';
 import 'package:fmod/fmod.dart' as fmod;
 import 'package:vector_math/vector_math.dart';
 

--- a/packages/flutter_scene_soloud/lib/src/soloud_audio.dart
+++ b/packages/flutter_scene_soloud/lib/src/soloud_audio.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/audio.dart';
 import 'package:flutter_soloud/flutter_soloud.dart' as sl;
 import 'package:vector_math/vector_math.dart';
 


### PR DESCRIPTION
Audio is a pluggable-backend contract (SoLoud, FMOD), so it no longer sits in the core barrel. The `AudioEngine` contract and the spatial-audio components move to `package:flutter_scene/audio.dart`; `scene.dart` drops its audio types, and the backends, example, and tests import the sub-barrel. Also adds the missing 0.20.0 CHANGELOG entry for audio.