### PR TITLE
Handle quaternion double cover in slerp

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Declarative animation control via `SceneModel.animations` (`SceneAnimationSpec`), plus cached model templates so equal sources load once and share GPU resources.
 * `KHR_materials_variants` support in both import paths via `MaterialsVariantsComponent`, declaratively via `SceneModel.variant`, with a new Configurator example.
 * Fixed animation blending collapsing rigs with mirrored bones.
+* Fixed slerp taking the long arc when interpolating between quaternions in opposite hemispheres.
 * Automatic exposure (eye adaptation) via `Scene.autoExposure`, metered entirely on the GPU.
 * Imported materials keep their source names via the new `Material.name`.
 * Fixed cloned skinned meshes all drawing with the last-updated skeleton.

--- a/packages/flutter_scene/lib/src/math_extensions.dart
+++ b/packages/flutter_scene/lib/src/math_extensions.dart
@@ -45,17 +45,23 @@ extension QuaternionSlerp on Quaternion {
   /// numerically more stable.
   Quaternion slerp(Quaternion to, double weight) {
     double cosine = dot(to);
-    if (cosine.abs() < 1.0 - 1e-3 /* epsilon */ ) {
+    Quaternion target = to;
+    // q and -q are the same rotation; pick the nearer one to take the short arc.
+    if (cosine < 0.0) {
+      target = to.scaled(-1.0);
+      cosine = -cosine;
+    }
+    if (cosine < 1.0 - 1e-3 /* epsilon */ ) {
       // Spherical interpolation.
       double sine = sqrt(1.0 - cosine * cosine);
       double angle = atan2(sine, cosine);
       double sineInverse = 1.0 / sine;
       double c0 = sin((1.0 - weight) * angle) * sineInverse;
       double c1 = sin(weight * angle) * sineInverse;
-      return scaled(c0) + to.scaled(c1);
+      return scaled(c0) + target.scaled(c1);
     } else {
       // Linear interpolation.
-      return (scaled(1.0 - weight) + to.scaled(weight)).normalized();
+      return (scaled(1.0 - weight) + target.scaled(weight)).normalized();
     }
   }
 }

--- a/packages/flutter_scene/test/math_extensions_test.dart
+++ b/packages/flutter_scene/test/math_extensions_test.dart
@@ -1,0 +1,77 @@
+// QuaternionSlerp tests. Guards the double-cover fix: q and -q are the
+// same rotation, so slerp must negate the target on a negative dot product
+// and take the short arc, without collapsing near-antipodal inputs to zero.
+
+import 'dart:math';
+
+import 'package:flutter_scene/src/math_extensions.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+const double _degrees = pi / 180.0;
+
+/// Rotation of [deg] degrees about +Z.
+Quaternion _rotZ(double deg) =>
+    Quaternion.axisAngle(Vector3(0, 0, 1), deg * _degrees);
+
+/// Magnitude in degrees of the +X axis rotation applied by [q], measured
+/// in the XY plane. Lets a Z-rotation be checked as a single scalar; the
+/// sign follows vector_math's rotation convention, so compare magnitudes.
+double _probeAngle(Quaternion q) {
+  final v = q.rotated(Vector3(1, 0, 0));
+  return atan2(v.y, v.x).abs() / _degrees;
+}
+
+/// True when [a] and [b] describe the same rotation, allowing the sign
+/// ambiguity of the double cover.
+bool _sameRotation(Quaternion a, Quaternion b) => a.dot(b).abs() > 1 - 1e-6;
+
+void main() {
+  group('QuaternionSlerp.slerp', () {
+    test('sign-flipped inputs take the short arc', () {
+      final a = _rotZ(10);
+      // Same rotation as _rotZ(31), but the exporter-style negated form so
+      // dot(a, b) < 0. The midpoint must land at 20.5 degrees (short arc),
+      // not ~200 degrees the long way round.
+      final b = _rotZ(31).scaled(-1.0);
+      expect(a.dot(b), lessThan(0));
+
+      final mid = a.slerp(b, 0.5);
+      expect(_probeAngle(mid), closeTo(20.5, 1e-3));
+    });
+
+    test('matches the non-flipped arc it is equivalent to', () {
+      final a = _rotZ(10);
+      final b = _rotZ(31);
+      final flipped = a.slerp(b.scaled(-1.0), 0.5);
+      final plain = a.slerp(b, 0.5);
+      expect(_sameRotation(flipped, plain), isTrue);
+      expect(_probeAngle(flipped), closeTo(_probeAngle(plain), 1e-3));
+    });
+
+    test('weight 0 and 1 return the endpoint rotations', () {
+      final a = _rotZ(10);
+      final b = _rotZ(31).scaled(-1.0);
+      expect(_sameRotation(a.slerp(b, 0.0), a), isTrue);
+      // At weight 1 the result is the same rotation as b even though it may
+      // come back as the negated (short-arc) form.
+      expect(_sameRotation(a.slerp(b, 1.0), b), isTrue);
+    });
+
+    test('exactly antipodal inputs stay normalized', () {
+      final a = _rotZ(37);
+      final antipode = a.scaled(-1.0); // dot == -1, the zero-sum trap
+      final result = a.slerp(antipode, 0.5);
+      expect(result.length, closeTo(1.0, 1e-6));
+      expect(result.x.isNaN, isFalse);
+      expect(_sameRotation(result, a), isTrue);
+    });
+
+    test('non-flipped short arc is unchanged', () {
+      final a = _rotZ(10);
+      final b = _rotZ(31);
+      expect(_probeAngle(a.slerp(b, 0.5)), closeTo(20.5, 1e-3));
+      expect(_sameRotation(a.slerp(b, 1.0), b), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
`QuaternionSlerp.slerp` doesn't account for quaternion double cover. When `dot(to)` is negative the two inputs sit in opposite hemispheres, and `atan2(sine, cosine)` then returns an angle over 90 degrees, so the interpolation sweeps the long way round.

This shows up in skeletal animation. glTF exporters are free to emit either `q` or `-q` for a keyframe, and `animation_builder.dart` passes accessor values through unchanged, so sign-flipped pairs reach the resolver as-is. A pair 21 degrees apart then interpolates as a 339 degree rotation over a single frame, which reads as a limb snapping backwards through the body.

`dash.glb` mostly avoids this. `Idle` and `Run` contain no sign flips at all, and the only ones in `Jump`/`JumpStart` are on `ToesPivot` and `KneeIK` at 1-2 degrees, where the artifact isn't visible. With a character pack from KayKit for example, I see 128 of 173 clips affected, mostly on `upperleg` during walk and run cycles.

The `.abs()` has to go too, since it was hiding the sign this needs to test. Widening the epsilon isn't an alternative: near-antipodal inputs would then take the lerp branch and sum to roughly the zero quaternion before normalising.

Same approach as three.js `Quaternion.slerp`, which negates one of the inputs when the dot product is negative.