### PR TITLE
Add flutter_scene_net and the Multiplayer example

### DIFF
--- a/examples/flutter_app/lib/example_multiplayer.dart
+++ b/examples/flutter_app/lib/example_multiplayer.dart
@@ -1,0 +1,296 @@
+import 'dart:async';
+
+import 'package:dashwire/dashwire.dart';
+import 'package:dashwire_replication/dashwire_replication.dart' hide Authority;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'net/multiplayer_game.dart';
+
+/// Multiplayer arena. Host a game in-app (desktop/mobile) and join it from
+/// other instances by address, including web builds; movement is
+/// server-authoritative with interpolated remote poses.
+class ExampleMultiplayer extends StatefulWidget {
+  const ExampleMultiplayer({super.key});
+
+  @override
+  State<ExampleMultiplayer> createState() => _ExampleMultiplayerState();
+}
+
+class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
+  final Scene scene = Scene();
+  final Node arena = Node();
+  final TextEditingController _address = TextEditingController(
+    text: 'localhost:$gamePort',
+  );
+  final FocusNode _focus = FocusNode();
+  final Set<LogicalKeyboardKey> _pressed = {};
+
+  SceneHost? _host;
+  SceneReplication? _replication;
+  String? _status;
+  Timer? _hud;
+
+  @override
+  void initState() {
+    super.initState();
+    final ground = Node(
+      mesh: Mesh(
+        CuboidGeometry(
+          vm.Vector3(fieldHalfSize * 2 + 2, 0.4, fieldHalfSize * 2 + 2),
+        ),
+        PhysicallyBasedMaterial()
+          ..baseColorFactor = vm.Vector4(0.16, 0.19, 0.23, 1),
+      ),
+    )..localTransform = vm.Matrix4.translation(vm.Vector3(0, -0.2, 0));
+    scene.add(ground);
+    scene.add(arena);
+    // A 2 Hz HUD refresh; scene state itself never triggers rebuilds.
+    _hud = Timer.periodic(
+      const Duration(milliseconds: 500),
+      (_) => setState(() {}),
+    );
+  }
+
+  Node _playerNode(Replica replica) {
+    final player = replica as NetPlayer;
+    final color = HSVColor.fromAHSV(
+      1,
+      player.hue.value % 360,
+      0.65,
+      0.9,
+    ).toColor();
+    final isMe = player.owner == _replication?.localPeerId;
+    final body = Node(
+      mesh: Mesh(
+        SphereGeometry(radius: playerRadius),
+        PhysicallyBasedMaterial()
+          ..baseColorFactor = vm.Vector4(color.r, color.g, color.b, 1),
+      ),
+    );
+    // A nose marker makes facing visible; the local player gets a white one.
+    body.add(
+      Node(
+          mesh: Mesh(
+            CuboidGeometry(vm.Vector3(0.15, 0.15, 0.5)),
+            UnlitMaterial()
+              ..baseColorFactor = isMe
+                  ? vm.Vector4(1, 1, 1, 1)
+                  : vm.Vector4(0.1, 0.1, 0.1, 1),
+          ),
+        )
+        ..localTransform = vm.Matrix4.translation(
+          vm.Vector3(0, 0.2, playerRadius),
+        ),
+    );
+    return body;
+  }
+
+  Node _pelletNode(Replica replica) => Node(
+    mesh: Mesh(
+      SphereGeometry(radius: 0.18),
+      UnlitMaterial()..baseColorFactor = vm.Vector4(1, 0.85, 0.35, 1),
+    ),
+  );
+
+  Future<void> _start(Future<WireConnection> Function() connect) async {
+    setState(() => _status = 'connecting');
+    try {
+      final session = await connectSession(
+        await connect(),
+        schemaHash: multiplayerRegistry().schemaHash,
+      );
+      _replication = SceneReplication(
+        registry: multiplayerRegistry(),
+        session: session,
+        root: arena,
+        builders: {'net.player': _playerNode, 'net.pellet': _pelletNode},
+      );
+      session.done.whenComplete(() {
+        if (mounted && _replication != null) _leave();
+      });
+      setState(() => _status = null);
+    } catch (error) {
+      setState(() => _status = 'failed: $error');
+    }
+  }
+
+  Future<void> _hostGame() async {
+    final host = await SceneHost.start(
+      room: buildMultiplayerRoom(),
+      port: gamePort,
+    );
+    _host = host;
+    await _start(host.connectLocal);
+  }
+
+  Future<void> _joinGame() async {
+    final address = _address.text.trim();
+    await _start(() => connectWebSocket(Uri.parse('ws://$address')));
+  }
+
+  Future<void> _leave() async {
+    final replication = _replication;
+    final host = _host;
+    _replication = null;
+    _host = null;
+    await replication?.close();
+    await host?.stop();
+    if (mounted) setState(() => _status = null);
+  }
+
+  @override
+  void dispose() {
+    _hud?.cancel();
+    _focus.dispose();
+    _address.dispose();
+    _leave();
+    super.dispose();
+  }
+
+  void _onTick(Duration elapsed, double deltaSeconds) {
+    final replication = _replication;
+    if (replication == null) return;
+    double axis(
+      LogicalKeyboardKey minus,
+      LogicalKeyboardKey plus,
+      LogicalKeyboardKey minusAlt,
+      LogicalKeyboardKey plusAlt,
+    ) {
+      var value = 0.0;
+      if (_pressed.contains(minus) || _pressed.contains(minusAlt)) value -= 1;
+      if (_pressed.contains(plus) || _pressed.contains(plusAlt)) value += 1;
+      return value;
+    }
+
+    replication.owned<NetPlayer>()?.input.value = (
+      axis(
+        LogicalKeyboardKey.keyA,
+        LogicalKeyboardKey.keyD,
+        LogicalKeyboardKey.arrowLeft,
+        LogicalKeyboardKey.arrowRight,
+      ),
+      0.0,
+      axis(
+        LogicalKeyboardKey.keyW,
+        LogicalKeyboardKey.keyS,
+        LogicalKeyboardKey.arrowUp,
+        LogicalKeyboardKey.arrowDown,
+      ),
+    );
+    replication.flush();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final connected = _replication != null;
+    return Stack(
+      children: [
+        KeyboardListener(
+          focusNode: _focus,
+          autofocus: true,
+          onKeyEvent: (event) {
+            if (event is KeyDownEvent) _pressed.add(event.logicalKey);
+            if (event is KeyUpEvent) _pressed.remove(event.logicalKey);
+          },
+          child: SceneView(
+            scene,
+            onTick: _onTick,
+            cameraBuilder: (elapsed) => PerspectiveCamera(
+              position: vm.Vector3(0, 22, 18),
+              target: vm.Vector3(0, 0, 0),
+            ),
+          ),
+        ),
+        if (!connected)
+          Center(
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Text('Multiplayer arena'),
+                    const SizedBox(height: 12),
+                    if (SceneHost.isSupported)
+                      FilledButton(
+                        onPressed: _hostGame,
+                        child: const Text('Host on this device'),
+                      ),
+                    if (!SceneHost.isSupported)
+                      const Text('Hosting needs a desktop or mobile build.'),
+                    const SizedBox(height: 12),
+                    SizedBox(
+                      width: 260,
+                      child: TextField(
+                        controller: _address,
+                        decoration: const InputDecoration(
+                          labelText: 'host address',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    OutlinedButton(
+                      onPressed: _joinGame,
+                      child: const Text('Join'),
+                    ),
+                    if (_status != null) ...[
+                      const SizedBox(height: 8),
+                      Text(_status!, style: const TextStyle(fontSize: 12)),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          )
+        else
+          Positioned(
+            left: 12,
+            top: 12,
+            child: DefaultTextStyle(
+              style: const TextStyle(color: Colors.white, fontSize: 13),
+              child: Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: Colors.black.withValues(alpha: 0.55),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (_host != null)
+                      Text(
+                        _host!.addresses.isEmpty
+                            ? 'hosting on port ${_host!.port}'
+                            : 'hosting, join at '
+                                  '${_host!.addresses.first}:${_host!.port}',
+                      ),
+                    Text(
+                      'rtt ${_replication!.session.clock.rttMillis.toStringAsFixed(0)}ms'
+                      ', move with WASD/arrows',
+                    ),
+                    for (final player
+                        in _replication!.replicas.whereType<NetPlayer>())
+                      Text(
+                        '${player.name.value}: ${player.score.value}'
+                        '${player.owner == _replication!.localPeerId ? '  (you)' : ''}',
+                      ),
+                    const SizedBox(height: 6),
+                    OutlinedButton(
+                      onPressed: _leave,
+                      child: const Text('Leave'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -29,6 +29,7 @@ import 'example_fscene_stream.dart';
 import 'example_lod.dart';
 import 'example_logo.dart';
 import 'example_materialize.dart';
+import 'example_multiplayer.dart';
 import 'example_nav_route.dart';
 import 'example_physics.dart';
 import 'example_physics_box3d.dart';
@@ -165,6 +166,7 @@ class _MyAppState extends State<MyApp> {
       'Car': (context) => const ExampleCar(),
       'Animation': (context) => const ExampleAnimation(),
       'Flutter Logo': (context) => const ExampleLogo(),
+      'Multiplayer': (context) => const ExampleMultiplayer(),
       'Configurator': (context) => const ExampleConfigurator(),
       'Lights': (context) => const ExampleLights(),
       'Spot Shadow': (context) => const ExampleSpotShadow(),

--- a/examples/flutter_app/lib/net/multiplayer_game.dart
+++ b/examples/flutter_app/lib/net/multiplayer_game.dart
@@ -1,0 +1,126 @@
+/// Shared multiplayer schema and server simulation.
+///
+/// Pure Dart on purpose, the in-app host uses it directly, and the same file
+/// could drive a headless `dart run` server unchanged.
+library;
+
+import 'dart:math';
+
+import 'package:dashwire_replication/dashwire_replication.dart';
+
+/// Half-extent of the square play field on the XZ plane.
+const double fieldHalfSize = 11;
+const double moveSpeed = 8;
+const double playerRadius = 0.5;
+const double pelletPickupRadius = 1.0;
+const int pelletTotal = 24;
+const int gameTickRate = 30;
+const int gamePort = 8123;
+
+final class NetPlayer extends TransformReplica {
+  NetPlayer() {
+    hue = rep('hue', 0.0, codec: Codecs.quantized(1), mode: SendMode.spawnOnly);
+    name = rep('name', '', codec: Codecs.string, mode: SendMode.onChange);
+    score = rep('score', 0, codec: Codecs.varUint, mode: SendMode.onChange);
+    input = rep(
+      'input',
+      (0.0, 0.0, 0.0),
+      codec: Codecs.vec3(0.05),
+      write: Authority.owner,
+      validate: (peer, v) => v.$1.abs() <= 1.05 && v.$3.abs() <= 1.05,
+    );
+  }
+
+  @override
+  String get typeKey => 'net.player';
+
+  late final Rep<double> hue;
+  late final Rep<String> name;
+  late final Rep<int> score;
+
+  /// Owner-written movement intent on the XZ plane, clamped server-side.
+  late final Rep<Vec3> input;
+}
+
+final class NetPellet extends TransformReplica {
+  NetPellet();
+
+  @override
+  String get typeKey => 'net.pellet';
+}
+
+ReplicaRegistry multiplayerRegistry() => ReplicaRegistry()
+  ..register(NetPlayer.new)
+  ..register(NetPellet.new);
+
+/// Builds the authoritative game room, join/leave spawns players, the tick
+/// integrates owner input and awards pellet pickups.
+Room buildMultiplayerRoom({Random? random}) {
+  final rng = random ?? Random();
+  final players = <int, NetPlayer>{};
+  final pellets = <NetPellet>[];
+  late final Room room;
+
+  (double, double, double) scatter(double y) => (
+    (rng.nextDouble() * 2 - 1) * fieldHalfSize,
+    y,
+    (rng.nextDouble() * 2 - 1) * fieldHalfSize,
+  );
+
+  room = Room(
+    registry: multiplayerRegistry(),
+    tickRate: gameTickRate,
+    onJoin: (session) {
+      final player = NetPlayer()
+        ..hue.value = rng.nextDouble() * 360
+        ..name.value = 'player ${session.peerId}';
+      player.position.value = scatter(playerRadius);
+      room.host.spawn(player, owner: session.peerId);
+      players[session.peerId] = player;
+    },
+    onLeave: (session) {
+      final player = players.remove(session.peerId);
+      if (player?.id != null) room.host.despawn(player!.id!);
+    },
+    onTick: (tick) {
+      const dt = 1.0 / gameTickRate;
+      for (final player in players.values) {
+        var (dx, _, dz) = player.input.value;
+        final length = sqrt(dx * dx + dz * dz);
+        if (length > 1) {
+          dx /= length;
+          dz /= length;
+        }
+        final (x, y, z) = player.position.value;
+        player.position.value = (
+          (x + dx * moveSpeed * dt).clamp(-fieldHalfSize, fieldHalfSize),
+          y,
+          (z + dz * moveSpeed * dt).clamp(-fieldHalfSize, fieldHalfSize),
+        );
+        if (length > 0.01) {
+          // Face the travel direction (yaw about +Y).
+          final yaw = atan2(dx, dz);
+          player.rotation.value = (0, sin(yaw / 2), 0, cos(yaw / 2));
+        }
+        for (final pellet in pellets) {
+          final (px, _, pz) = pellet.position.value;
+          final (cx, _, cz) = player.position.value;
+          final ddx = px - cx;
+          final ddz = pz - cz;
+          if (ddx * ddx + ddz * ddz < pelletPickupRadius * pelletPickupRadius) {
+            player.score.value += 1;
+            pellet.position.value = scatter(0.25);
+          }
+        }
+      }
+    },
+  );
+
+  for (var i = 0; i < pelletTotal; i++) {
+    final pellet = NetPellet();
+    pellet.position.value = scatter(0.25);
+    room.host.spawn(pellet, importance: 0.3);
+    pellets.add(pellet);
+  }
+  return room;
+}

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -14,6 +14,10 @@ dependencies:
     sdk: flutter
   flutter_gpu_shaders: ^0.5.1
   flutter_scene: ^0.20.0
+  # Multiplayer example.
+  dashwire: ^0.1.0
+  dashwire_replication: ^0.1.0
+  flutter_scene_net: ^0.1.0
   # Native Rapier physics backend, used by the Physics example. Pulls
   # in a Rust build hook, so building this app now requires cargo.
   flutter_scene_rapier:

--- a/packages/flutter_scene_net/CHANGELOG.md
+++ b/packages/flutter_scene_net/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- `SceneReplication` binds replicas to scene nodes through per-type builders and detaches them on despawn.
+- `TransformReplica`-backed replicas get a `NetworkTransformComponent` that interpolates remote poses a fixed delay in the past.
+- `TransformReplicaVectors` adapts the record-typed pose to `vector_math` types.
+- `SceneHost` runs a dashwire room and WebSocket listener inside the app (with loopback self-join) on dart:io platforms; a throwing stub on web.

--- a/packages/flutter_scene_net/LICENSE
+++ b/packages/flutter_scene_net/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2023 Brandon DeRosier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/flutter_scene_net/README.md
+++ b/packages/flutter_scene_net/README.md
@@ -1,0 +1,22 @@
+# flutter_scene_net
+
+[dashwire](https://pub.dev/packages/dashwire) multiplayer for [flutter_scene](https://pub.dev/packages/flutter_scene). Binds replicated state to the scene graph so networked entities become nodes that render smoothly.
+
+- `SceneReplication` maps replicas to scene nodes through per-type builders, spawning and despawning nodes as the server dictates.
+- Replicas that extend `TransformReplica` get a `NetworkTransformComponent`, an interpolation buffer that renders remote poses a fixed delay in the past so motion stays smooth under jitter.
+- `SceneHost` runs a dashwire room and WebSocket listener inside the app, so a game can host from one device with a loopback self-join, no separate server process. Native only; a throwing stub on web.
+
+See the Multiplayer example in the [flutter_scene repository](https://github.com/bdero/flutter_scene/tree/master/examples/flutter_app) for a full host-and-join demo.
+
+## Usage
+
+```dart
+final replication = SceneReplication(
+  registry: registry,
+  session: session,
+  root: sceneRoot,
+  builders: {'pawn': (replica) => Node()},
+);
+```
+
+Server-authoritative state flows in over a dashwire `Session`; each replica type names a builder that produces its scene node.

--- a/packages/flutter_scene_net/example/README.md
+++ b/packages/flutter_scene_net/example/README.md
@@ -1,0 +1,36 @@
+# flutter_scene_net example
+
+A full host-and-join demo lives in the [flutter_scene repository](https://github.com/bdero/flutter_scene/tree/master/examples/flutter_app) as the "Multiplayer" example. The core wiring:
+
+```dart
+import 'package:dashwire/dashwire.dart';
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+
+// A replicated pawn whose pose drives a scene node.
+final class Pawn extends TransformReplica {
+  @override
+  String get typeKey => 'pawn';
+}
+
+Future<void> connectAndRender(WireConnection connection, Node sceneRoot) async {
+  final registry = ReplicaRegistry()..register(Pawn.new);
+
+  final session = await connectSession(
+    connection,
+    schemaHash: registry.schemaHash,
+  );
+
+  // Replicas spawned by the server become nodes under [sceneRoot]; those
+  // backed by TransformReplica interpolate their poses automatically.
+  SceneReplication(
+    registry: registry,
+    session: session,
+    root: sceneRoot,
+    builders: {'pawn': (replica) => Node()},
+  );
+}
+```
+
+To host from inside the app instead of connecting to a server, use `SceneHost`.

--- a/packages/flutter_scene_net/lib/flutter_scene_net.dart
+++ b/packages/flutter_scene_net/lib/flutter_scene_net.dart
@@ -1,0 +1,12 @@
+/// dashwire multiplayer for flutter_scene.
+///
+/// Replicas whose types extend [TransformReplica] become scene nodes through
+/// a [SceneReplication] binding; remote poses render slightly in the past
+/// through interpolation. [SceneHost] runs a room inside the app on
+/// dart:io platforms so a game can host without a separate server.
+library;
+
+export 'src/hosting/hosting.dart' show SceneHost;
+export 'src/network_transform.dart' show NetworkTransformComponent;
+export 'src/scene_replication.dart' show ReplicaNodeBuilder, SceneReplication;
+export 'src/transform_replica.dart' show TransformReplicaVectors;

--- a/packages/flutter_scene_net/lib/src/hosting/hosting.dart
+++ b/packages/flutter_scene_net/lib/src/hosting/hosting.dart
@@ -1,0 +1,9 @@
+/// In-app hosting, a room plus a WebSocket server inside the game process,
+/// so desktop and mobile builds can host without a separate server binary.
+/// Unavailable on the web ([SceneHost.isSupported] is false there); browsers
+/// cannot listen for connections.
+library;
+
+export 'hosting_stub.dart'
+    if (dart.library.io) 'hosting_io.dart'
+    show SceneHost;

--- a/packages/flutter_scene_net/lib/src/hosting/hosting_io.dart
+++ b/packages/flutter_scene_net/lib/src/hosting/hosting_io.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dashwire/dashwire.dart';
+import 'package:dashwire/server.dart';
+import 'package:dashwire_replication/dashwire_replication.dart';
+
+/// Runs a [Room] inside the app with a WebSocket listener, the listen-server
+/// topology. The hosting player joins over an in-process loopback via
+/// [connectLocal]; others connect to `ws://<address>:<port>`.
+final class SceneHost {
+  SceneHost._(this.room, this._server, this.addresses);
+
+  static bool get isSupported => true;
+
+  /// Binds a WebSocket server on [port] (0 picks one), wires it into
+  /// [room], and starts the room's tick pump.
+  static Future<SceneHost> start({required Room room, int port = 0}) async {
+    final server = await WebSocketWireServer.bind(
+      InternetAddress.anyIPv4,
+      port,
+    );
+    room
+      ..accept(server.connections)
+      ..start();
+    final addresses = <String>[];
+    try {
+      for (final interface in await NetworkInterface.list(
+        type: InternetAddressType.IPv4,
+      )) {
+        for (final address in interface.addresses) {
+          if (!address.isLoopback) addresses.add(address.address);
+        }
+      }
+    } on SocketException {
+      // Interface enumeration can be restricted (sandboxes); hosting still
+      // works, the UI just cannot display a LAN address.
+    }
+    return SceneHost._(room, server, addresses);
+  }
+
+  final Room room;
+  final WebSocketWireServer _server;
+
+  /// Non-loopback IPv4 addresses other devices can join through.
+  final List<String> addresses;
+
+  int get port => _server.port;
+
+  /// Connects the hosting player to its own room in-process.
+  Future<WireConnection> connectLocal() async {
+    final (clientEnd, serverEnd) = LoopbackConnection.pair();
+    unawaited(room.admit(serverEnd));
+    return clientEnd;
+  }
+
+  Future<void> stop() async {
+    await room.stop();
+    await _server.close();
+  }
+}

--- a/packages/flutter_scene_net/lib/src/hosting/hosting_stub.dart
+++ b/packages/flutter_scene_net/lib/src/hosting/hosting_stub.dart
@@ -1,0 +1,23 @@
+import 'package:dashwire/dashwire.dart';
+import 'package:dashwire_replication/dashwire_replication.dart';
+
+/// Web stub; hosting requires dart:io. See hosting_io.dart for the API.
+final class SceneHost {
+  SceneHost._();
+
+  static bool get isSupported => false;
+
+  static Future<SceneHost> start({required Room room, int port = 0}) =>
+      throw UnsupportedError('in-app hosting requires dart:io');
+
+  Room get room => throw UnsupportedError('in-app hosting requires dart:io');
+  int get port => throw UnsupportedError('in-app hosting requires dart:io');
+  List<String> get addresses =>
+      throw UnsupportedError('in-app hosting requires dart:io');
+
+  Future<WireConnection> connectLocal() =>
+      throw UnsupportedError('in-app hosting requires dart:io');
+
+  Future<void> stop() =>
+      throw UnsupportedError('in-app hosting requires dart:io');
+}

--- a/packages/flutter_scene_net/lib/src/network_transform.dart
+++ b/packages/flutter_scene_net/lib/src/network_transform.dart
@@ -1,0 +1,110 @@
+import 'dart:math';
+
+import 'package:dashwire/dashwire.dart';
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' hide Colors;
+
+import 'transform_replica.dart';
+
+/// Drives the owning node's transform from a [TransformReplica].
+///
+/// Replicated poses arrive at packet rate; rendering [delay] in the past
+/// through a small sample buffer turns them into smooth motion, the
+/// standard snapshot-interpolation tradeoff of latency for continuity.
+// TODO(prediction): owned replicas currently render on the same delayed
+// timeline as everything else; input-replay prediction needs the tick
+// infrastructure wired through here.
+final class NetworkTransformComponent extends Component {
+  NetworkTransformComponent(
+    this.replica, {
+    this.delay = const Duration(milliseconds: 100),
+  }) {
+    _push();
+    replica.position.onChanged((_, _) => _push());
+    replica.rotation.onChanged((_, _) => _push());
+  }
+
+  final TransformReplica replica;
+
+  /// How far in the past remote poses render.
+  final Duration delay;
+
+  final List<(int, Vector3, Quaternion)> _samples = [];
+
+  void _push() {
+    _samples.add((
+      defaultNowMicros(),
+      replica.positionVector,
+      replica.rotationQuaternion,
+    ));
+    if (_samples.length > 64) _samples.removeAt(0);
+  }
+
+  @override
+  void update(double deltaSeconds) {
+    final (position, rotation) = sampleAt(
+      defaultNowMicros() - delay.inMicroseconds,
+    );
+    node.localTransform = Matrix4.compose(position, rotation, _unitScale);
+  }
+
+  static final Vector3 _unitScale = Vector3(1, 1, 1);
+
+  /// The interpolated pose at monotonic time [micros].
+  (Vector3, Quaternion) sampleAt(int micros) {
+    final first = _samples.first;
+    if (_samples.length == 1 || micros <= first.$1) {
+      return (first.$2, first.$3);
+    }
+    for (var i = 0; i < _samples.length - 1; i++) {
+      final (t0, p0, q0) = _samples[i];
+      final (t1, p1, q1) = _samples[i + 1];
+      if (micros >= t0 && micros <= t1) {
+        final f = (micros - t0) / (t1 - t0);
+        return (_lerp(p0, p1, f), _slerp(q0, q1, f));
+      }
+    }
+    final last = _samples.last;
+    return (last.$2, last.$3);
+  }
+
+  static Vector3 _lerp(Vector3 a, Vector3 b, double f) => Vector3(
+    a.x + (b.x - a.x) * f,
+    a.y + (b.y - a.y) * f,
+    a.z + (b.z - a.z) * f,
+  );
+
+  static Quaternion _slerp(Quaternion a, Quaternion b, double f) {
+    var dot = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+    var bx = b.x, by = b.y, bz = b.z, bw = b.w;
+    // Take the short arc; q and -q are the same rotation.
+    if (dot < 0) {
+      dot = -dot;
+      bx = -bx;
+      by = -by;
+      bz = -bz;
+      bw = -bw;
+    }
+    // Nearly parallel, normalized lerp avoids the degenerate divide.
+    if (dot > 0.9995) {
+      final q = Quaternion(
+        a.x + (bx - a.x) * f,
+        a.y + (by - a.y) * f,
+        a.z + (bz - a.z) * f,
+        a.w + (bw - a.w) * f,
+      );
+      return q..normalize();
+    }
+    final theta = acos(dot);
+    final sinTheta = sin(theta);
+    final wa = sin((1 - f) * theta) / sinTheta;
+    final wb = sin(f * theta) / sinTheta;
+    return Quaternion(
+      a.x * wa + bx * wb,
+      a.y * wa + by * wb,
+      a.z * wa + bz * wb,
+      a.w * wa + bw * wb,
+    );
+  }
+}

--- a/packages/flutter_scene_net/lib/src/scene_replication.dart
+++ b/packages/flutter_scene_net/lib/src/scene_replication.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:dashwire/dashwire.dart';
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' hide Colors;
+
+import 'network_transform.dart';
+import 'transform_replica.dart';
+
+/// Builds the scene subtree representing [replica] at spawn time.
+typedef ReplicaNodeBuilder = Node Function(Replica replica);
+
+/// Binds a replication client to a scene graph.
+///
+/// Spawned replicas become nodes under [root] through per-type builders;
+/// [TransformReplica]s additionally get a [NetworkTransformComponent] so
+/// their poses render interpolated. Despawns detach the node.
+final class SceneReplication {
+  SceneReplication({
+    required ReplicaRegistry registry,
+    required this.session,
+    required this.root,
+    required Map<String, ReplicaNodeBuilder> builders,
+    this.interpolationDelay = const Duration(milliseconds: 100),
+    void Function(Replica replica, Node node)? onSpawn,
+    void Function(Replica replica, Node node)? onDespawn,
+  }) : _builders = builders,
+       _onSpawn = onSpawn,
+       _onDespawn = onDespawn {
+    client = ReplicationClient(
+      registry: registry,
+      session: session,
+      onSpawn: _spawned,
+      onDespawn: _despawned,
+    );
+  }
+
+  final Session session;
+
+  /// Parent for every replicated node.
+  final Node root;
+
+  final Map<String, ReplicaNodeBuilder> _builders;
+  final Duration interpolationDelay;
+  final void Function(Replica, Node)? _onSpawn;
+  final void Function(Replica, Node)? _onDespawn;
+  late final ReplicationClient client;
+  final Map<NetId, Node> _nodes = {};
+
+  int get localPeerId => client.localPeerId;
+
+  Iterable<Replica> get replicas => client.replicas.values;
+
+  Node? nodeFor(NetId id) => _nodes[id];
+
+  /// This client's owned replica of type [T], if spawned.
+  T? owned<T extends Replica>() => client.replicas.values
+      .whereType<T>()
+      .where((r) => r.owner == localPeerId)
+      .firstOrNull;
+
+  void _spawned(Replica replica) {
+    final builder = _builders[replica.typeKey];
+    if (builder == null) return;
+    final node = builder(replica);
+    if (replica is TransformReplica) {
+      node.localTransform = Matrix4.compose(
+        replica.positionVector,
+        replica.rotationQuaternion,
+        Vector3(1, 1, 1),
+      );
+      node.addComponent(
+        NetworkTransformComponent(replica, delay: interpolationDelay),
+      );
+    }
+    root.add(node);
+    _nodes[replica.id!] = node;
+    _onSpawn?.call(replica, node);
+  }
+
+  void _despawned(Replica replica) {
+    final node = _nodes.remove(replica.id);
+    if (node == null) return;
+    _onDespawn?.call(replica, node);
+    root.remove(node);
+  }
+
+  /// Sends pending owner-authority writes. Call once per frame or tick.
+  void flush() => client.flush();
+
+  /// Closes the session and detaches every replicated node.
+  Future<void> close() async {
+    await session.close();
+    for (final node in _nodes.values) {
+      root.remove(node);
+    }
+    _nodes.clear();
+  }
+}

--- a/packages/flutter_scene_net/lib/src/transform_replica.dart
+++ b/packages/flutter_scene_net/lib/src/transform_replica.dart
@@ -1,0 +1,28 @@
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:vector_math/vector_math.dart' hide Colors;
+
+/// vector_math adapters over [TransformReplica]'s record-typed pose.
+extension TransformReplicaVectors on TransformReplica {
+  Vector3 get positionVector =>
+      Vector3(position.value.$1, position.value.$2, position.value.$3);
+
+  Quaternion get rotationQuaternion => Quaternion(
+    rotation.value.$1,
+    rotation.value.$2,
+    rotation.value.$3,
+    rotation.value.$4,
+  );
+
+  /// Writes a pose into the replicated fields (authority side).
+  void setPose(Vector3 translation, [Quaternion? orientation]) {
+    position.value = (translation.x, translation.y, translation.z);
+    if (orientation != null) {
+      rotation.value = (
+        orientation.x,
+        orientation.y,
+        orientation.z,
+        orientation.w,
+      );
+    }
+  }
+}

--- a/packages/flutter_scene_net/pubspec.yaml
+++ b/packages/flutter_scene_net/pubspec.yaml
@@ -1,0 +1,35 @@
+name: flutter_scene_net
+description: dashwire multiplayer for flutter_scene. Replica-to-node binding, interpolated transform sync, and in-app hosting.
+repository: https://github.com/bdero/flutter_scene
+homepage: https://github.com/bdero/flutter_scene
+version: 0.1.0
+
+topics:
+  - multiplayer
+  - networking
+  - gamedev
+  - dashwire
+
+platforms:
+  macos:
+  ios:
+  android:
+  windows:
+  linux:
+  web:
+
+environment:
+  sdk: ^3.10.0
+  flutter: ">=3.29.0-1.0.pre.242"
+resolution: workspace
+dependencies:
+  dashwire: ^0.1.0
+  dashwire_replication: ^0.1.0
+  flutter:
+    sdk: flutter
+  flutter_scene: ^0.20.0
+  vector_math: ^2.1.4
+dev_dependencies:
+  flutter_lints: ^5.0.0
+  flutter_test:
+    sdk: flutter

--- a/packages/flutter_scene_net/test/flutter_scene_net_test.dart
+++ b/packages/flutter_scene_net/test/flutter_scene_net_test.dart
@@ -1,0 +1,127 @@
+import 'package:dashwire/dashwire.dart';
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final class _Pawn extends TransformReplica {
+  _Pawn();
+
+  @override
+  String get typeKey => 'pawn';
+}
+
+ReplicaRegistry _registry() => ReplicaRegistry()..register(_Pawn.new);
+
+Future<void> _pump([int rounds = 4]) async {
+  for (var i = 0; i < rounds; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 3));
+  }
+}
+
+void main() {
+  test('a room-replicated pose drives a scene node', () async {
+    final room = Room(registry: _registry());
+    final (clientEnd, serverEnd) = LoopbackConnection.pair();
+    final admitted = room.admit(serverEnd);
+    final session = await connectSession(
+      clientEnd,
+      schemaHash: _registry().schemaHash,
+      pingInterval: const Duration(seconds: 10),
+    );
+    await admitted;
+
+    final root = Node();
+    final replication = SceneReplication(
+      registry: _registry(),
+      session: session,
+      root: root,
+      builders: {'pawn': (replica) => Node()},
+      interpolationDelay: const Duration(milliseconds: 30),
+    );
+
+    final pawn = _Pawn();
+    pawn.position.value = (1.0, 2.0, 3.0);
+    final id = room.host.spawn(pawn);
+    room.advance(1 / 30);
+    await _pump();
+
+    final node = replication.nodeFor(id);
+    expect(node, isNotNull);
+    expect(root.children, contains(node));
+    // The spawn pose applies immediately.
+    expect(node!.localTransform.getTranslation().x, closeTo(1, 0.01));
+
+    pawn.position.value = (5.0, 2.0, 3.0);
+    room.advance(1 / 30);
+    await _pump();
+    // Past the interpolation delay the buffer has settled on the new pose.
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    final transform = node.getComponent<NetworkTransformComponent>()!;
+    transform.update(1 / 60);
+    final translation = node.localTransform.getTranslation();
+    expect(translation.x, closeTo(5, 0.01));
+    expect(translation.y, closeTo(2, 0.01));
+    expect(translation.z, closeTo(3, 0.01));
+
+    room.host.despawn(id);
+    room.advance(1 / 30);
+    await _pump();
+    expect(replication.nodeFor(id), isNull);
+    expect(root.children, isEmpty);
+
+    await replication.close();
+    await room.stop();
+  });
+
+  test('SceneHost serves loopback and WebSocket joiners', () async {
+    final room = Room(registry: _registry());
+    final host = await SceneHost.start(room: room);
+    room.host.spawn(_Pawn()..position.value = (7.0, 0.0, 0.0));
+
+    final localSession = await connectSession(
+      await host.connectLocal(),
+      schemaHash: _registry().schemaHash,
+    );
+    final remoteSession = await connectSession(
+      await connectWebSocket(Uri.parse('ws://127.0.0.1:${host.port}')),
+      schemaHash: _registry().schemaHash,
+    );
+    final local = ReplicationClient(
+      registry: _registry(),
+      session: localSession,
+    );
+    final remote = ReplicationClient(
+      registry: _registry(),
+      session: remoteSession,
+    );
+
+    final sw = Stopwatch()..start();
+    while ((local.replicas.isEmpty || remote.replicas.isEmpty) &&
+        sw.elapsedMilliseconds < 3000) {
+      await _pump(1);
+    }
+    expect(local.replicas.values.single, isA<_Pawn>());
+    expect(remote.replicas.values.single, isA<_Pawn>());
+
+    await localSession.close();
+    await remoteSession.close();
+    await host.stop();
+  });
+
+  test('interpolation samples between pushed poses', () async {
+    final pawn = _Pawn();
+    final component = NetworkTransformComponent(pawn);
+    final start = defaultNowMicros();
+    pawn.position.value = (0.0, 0.0, 0.0);
+    await Future<void>.delayed(const Duration(milliseconds: 40));
+    pawn.position.value = (10.0, 0.0, 0.0);
+    final end = defaultNowMicros();
+
+    final (mid, _) = component.sampleAt((start + end) ~/ 2);
+    expect(mid.x, greaterThan(0.5));
+    expect(mid.x, lessThan(9.5));
+    final (late_, _) = component.sampleAt(end + 1000);
+    expect(late_.x, 10);
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ workspace:
   - packages/flutter_scene_rapier
   - packages/flutter_scene_soloud
   - packages/flutter_scene_fmod
+  - packages/flutter_scene_net
   - packages/flutter_scene_box3d
   - packages/flutter_scene_editor_core
   - packages/flutter_scene_editor


### PR DESCRIPTION
Adds `flutter_scene_net`, the multiplayer integration that binds replicated state to the scene graph, plus a Multiplayer example in the example app.

`SceneReplication` maps replicas to scene nodes through per-type builders, spawning and despawning nodes as the server dictates. Replicas that extend `TransformReplica` get a `NetworkTransformComponent` that interpolates remote poses a fixed delay in the past for smooth motion under jitter. `SceneHost` runs a room and WebSocket listener inside the app so a game can host from one device with a loopback self-join.

The package depends on the newly published `dashwire` and `dashwire_replication`.
