### PR TITLE
Let a raw material own the vertex stage

### DIFF
--- a/MATERIALS.md
+++ b/MATERIALS.md
@@ -8,10 +8,11 @@ flutter_scene gives you two ways to write a custom material:
    name-addressed parameters with no std140 packing by hand, and the engine's
    physically based lighting for free if you want it. This is the path most
    materials should use.
-2. **`ShaderMaterial` (the low-level escape hatch).** You write a complete raw
-   GLSL fragment shader, declare your own uniform blocks and samplers, and bind
-   them by name from Dart, packing std140 yourself. Use this when you need full
-   control or a shader shape the `.fmat` format doesn't cover yet.
+2. **`ShaderMaterial` (the low-level escape hatch).** You write complete raw
+   GLSL, for the fragment stage and optionally the vertex stage too, declare
+   your own uniform blocks and samplers, and bind them by name from Dart,
+   packing std140 yourself. Use this when you need full control or a shader
+   shape the `.fmat` format doesn't cover yet.
 
 Both paths share the same engine contract (the vertex outputs your shader
 receives and the color it must output), documented below. If you've used
@@ -567,15 +568,10 @@ When you need a shader shape the `.fmat` format doesn't cover, write a complete
 raw fragment shader and drive it with `ShaderMaterial`. You declare your own
 uniform blocks and samplers and bind them by name, packing std140 yourself.
 
-`ShaderMaterial` covers the fragment stage. The vertex stage has two routes: a
-`.fmat` `vertex { }` block, which runs on every mesh type and pass for you, or a
-`Geometry` subclass that sets its own vertex shader and buffers, where the
-pipeline layout comes from the shader's own reflection. The second is how you
-get a fully custom attribute layout, but `Geometry.bind` and `Material.bind`
-take render-pass and buffer types that `package:flutter_scene/gpu.dart` does not
-export yet, so it currently means importing from `lib/src`. If you are writing a
-material that needs those, file an issue; the intent is to make that path
-supported rather than an internals reach-through.
+`ShaderMaterial` covers both stages. Pass only a `fragmentShader` and the
+engine's vertex shader runs, which is the common case. Pass a `vertexShader`
+too and the material owns the whole pipeline; see [Raw vertex
+shaders](#raw-vertex-shaders) for the contract yours has to meet.
 
 ```glsl
 // shaders/vertex_color.frag
@@ -623,6 +619,110 @@ The footguns are mixing `vec3` and `float`: a `float` after a `vec3` fills the
 `vec3`'s trailing pad, while a `vec3` after a `float` jumps to the next 16-byte
 boundary. **When in doubt, declare blocks with `vec4`s and group trailing scalars
 into `vec4`-aligned rows of four**, and the layout is unambiguous.
+
+---
+
+# Raw vertex shaders
+
+A `ShaderMaterial` can supply the vertex shader as well as the fragment one.
+The engine's standard vertex shader then does not run, so your shader owns
+everything it used to provide.
+
+```dart
+final material = ShaderMaterial(
+  vertexShader: library['RippleVertex']!,
+  fragmentShader: library['RippleFragment']!,
+);
+material.setUniformBlockFromFloats('TintInfo', [...]);            // fragment
+material.setUniformBlock('RippleInfo', bytes,
+    stage: ShaderStage.vertex);                                    // vertex
+```
+
+Uniform blocks and textures are set by name on either stage, chosen with
+`ShaderStage`. A block declared in both stages is two bindings, so set it twice.
+
+## The contract
+
+For an unskinned mesh, the engine binds these and your shader declares whatever
+it uses:
+
+```glsl
+uniform FrameInfo {
+  mat4 camera_transform;
+  vec3 camera_position;
+} frame_info;
+
+in vec3 position;
+in vec3 normal;
+in vec2 texture_coords;
+in vec4 color;
+
+// Instance-rate model matrix columns, bound in the slot after the vertex
+// streams. A non-instanced draw gets a single-element buffer.
+in vec4 model_transform_0;
+in vec4 model_transform_1;
+in vec4 model_transform_2;
+in vec4 model_transform_3;
+```
+
+Your shader writes `gl_Position` and the five outputs the fragment stage reads
+(`v_position`, `v_normal`, `v_viewvector`, `v_texture_coords`, `v_color`), plus
+any of your own varyings. A skinned mesh instead takes its model transform,
+`enable_skinning`, and `joint_texture_size` in `FrameInfo`, and adds the
+`joints` and `weights` attributes and a `joints_texture` sampler.
+
+## Mesh kinds and passes
+
+A vertex shader is registered per mesh kind, so one material can customize
+static meshes and leave others to the engine:
+
+```dart
+material.setVertexShader(skinnedShader, variant: MeshVariant.skinned);
+material.setVertexShader(depthShader, variant: MeshVariant.depth);
+```
+
+`MeshVariant.depth` is the position-only pass that draws shadow maps and the
+depth prepass. Supply it when your vertex stage moves geometry, or the shadow
+keeps the undisplaced shape. Any variant you leave unset falls back to the
+engine's shader.
+
+## Your own vertex layout
+
+By default your shader is fed the engine's standard layout, which is what the
+declarations above describe. To feed it something else (extra channels, a
+packed format, or fewer attributes), describe the layout and bind buffers to
+match:
+
+```dart
+geometry.setVertexLayout(
+  VertexLayoutDescriptor(buffers: [
+    VertexBufferDescriptor(
+      strideInBytes: 20,
+      attributes: [
+        VertexAttributeDescriptor(name: 'position', format: VertexFormat.float32x3),
+        VertexAttributeDescriptor(
+            name: 'uv2', format: VertexFormat.float32x2, offsetInBytes: 12),
+      ],
+    ),
+  ]),
+  bindsModelTransform: false,
+);
+```
+
+Attributes match the shader by name, so extra UV sets and per-vertex data are
+ordinary channels rather than special cases. Pass `bindsModelTransform: false`
+when your shader takes the model transform some other way than the instance-rate
+slot, so the encoder leaves that slot alone.
+
+For a single extra channel alongside the standard vertex, `setCustomAttribute`
+is simpler and needs no layout (it also works on skinned meshes):
+
+```dart
+geometry.setCustomAttribute('phase', phaseValues, components: 1);
+```
+
+See `examples/flutter_app/lib/example_raw_shader.dart` with
+`shaders/example_ripple.vert` and `.frag` for a worked pair.
 
 ---
 
@@ -682,10 +782,9 @@ attributes), and hot reload are implemented. Remaining and in-flight work:
   `MaterialParameters` API.
 - **Additive/multiply blending and per-material depth state** are not yet
   configurable.
-- **Custom vertex attributes on skinned meshes** are not supported (they use the
-  engine's default layout, not the described layout the attributes ride on), and
-  per-instance custom attributes are not exposed yet. See [The `vertex`
-  block](#the-vertex-block).
+- **Per-instance custom attributes** are not exposed yet; the instance-rate slot
+  carries the model transform. Per-vertex custom attributes work on both static
+  and skinned meshes.
 - **An inspector** that surfaces the parameter hints as UI does not exist (the
   metadata is emitted for future tooling).
 

--- a/MATERIALS.md
+++ b/MATERIALS.md
@@ -683,8 +683,16 @@ material.setVertexShader(depthShader, variant: MeshVariant.depth);
 
 `MeshVariant.depth` is the position-only pass that draws shadow maps and the
 depth prepass. Supply it when your vertex stage moves geometry, or the shadow
-keeps the undisplaced shape. Any variant you leave unset falls back to the
-engine's shader.
+keeps the undisplaced shape.
+
+Any variant you leave unset falls back to the engine's shader for that mesh
+kind, which is what makes customizing only static meshes a one-shader job. The
+catch is that the engine's shader writes only the engine varyings. If your
+fragment shader reads a varying your own vertex shader writes, the fallback
+pairs it with a vertex shader that never writes it, and pipeline creation fails
+on the backend. A debug build warns and names the missing variant when this is
+about to happen. So either supply every variant your scene draws, or keep the
+fragment shader to the engine varyings.
 
 ## Your own vertex layout
 

--- a/examples/flutter_app/lib/example_raw_shader.dart
+++ b/examples/flutter_app/lib/example_raw_shader.dart
@@ -1,0 +1,217 @@
+// Raw shader pair: a ShaderMaterial that owns both stages.
+//
+// The Toon example customizes only the fragment stage and lets the engine
+// drive vertices; the Custom vertices example customizes both through a
+// managed `.fmat`. This one hands ShaderMaterial a hand-written vertex shader
+// as well as a fragment shader, so the material owns the whole pipeline and
+// the engine's standard vertex shader never runs:
+//   1. Author both shaders (shaders/example_ripple.vert / .frag) against the
+//      engine contract documented in MATERIALS.md.
+//   2. Compile them through the `flutter_gpu_shaders` build hook.
+//   3. Hand both to ShaderMaterial and set each stage's uniforms by name.
+//
+// The vertex stage displaces the mesh along its normal with a travelling
+// ripple, which is not something the fragment stage could fake.
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' hide Material;
+import 'package:flutter_scene/gpu.dart' as gpu;
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+import 'example_overlay.dart';
+import 'example_panel.dart';
+import 'example_settings.dart';
+
+class ExampleRawShader extends StatefulWidget {
+  const ExampleRawShader({super.key});
+
+  @override
+  State<ExampleRawShader> createState() => _ExampleRawShaderState();
+}
+
+class _ExampleRawShaderState extends State<ExampleRawShader> {
+  final Scene scene = Scene();
+  bool loaded = false;
+
+  double amplitude = 0.5;
+  double wavelength = 1.4;
+  double speed = 2.4;
+
+  ShaderMaterial? _material;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final library = await gpu.loadShaderLibraryAsync(
+      'build/shaderbundles/example.shaderbundle',
+    );
+    final vertexShader = library?['RippleVertex'];
+    final fragmentShader = library?['RippleFragment'];
+    if (vertexShader == null || fragmentShader == null) {
+      throw StateError(
+        'Ripple shaders missing from example.shaderbundle. The build hook '
+        'should have produced them; rerun `flutter run` with a clean build.',
+      );
+    }
+    if (!mounted) return;
+
+    final material = ShaderMaterial(
+      vertexShader: vertexShader,
+      fragmentShader: fragmentShader,
+    );
+    // Fragment-stage parameters. The stage defaults to fragment, matching the
+    // fragment-only workflow.
+    material.setUniformBlockFromFloats('TintInfo', [
+      0.45, 0.85, 1.0, 1.0, // crest
+      0.04, 0.16, 0.42, 1.0, // trough
+    ]);
+    _material = material;
+    _setRippleUniforms(0);
+
+    scene.add(Node(mesh: Mesh(_grid(), material)));
+    setState(() => loaded = true);
+  }
+
+  // The ripple moves vertices, so the surface needs enough of them to bend
+  // smoothly.
+  MeshGeometry _grid() {
+    const n = 140;
+    const size = 24.0;
+    final count = (n + 1) * (n + 1);
+    final positions = Float32List(count * 3);
+    final normals = Float32List(count * 3);
+    var v = 0;
+    for (var r = 0; r <= n; r++) {
+      for (var c = 0; c <= n; c++) {
+        positions[v * 3] = (c / n - 0.5) * size;
+        positions[v * 3 + 2] = (r / n - 0.5) * size;
+        normals[v * 3 + 1] = 1.0;
+        v++;
+      }
+    }
+    final indices = <int>[];
+    for (var r = 0; r < n; r++) {
+      for (var c = 0; c < n; c++) {
+        final i0 = r * (n + 1) + c;
+        final i2 = i0 + (n + 1);
+        indices.addAll([i0, i0 + 1, i2, i0 + 1, i2 + 1, i2]);
+      }
+    }
+    return MeshGeometry.fromArrays(
+      positions: positions,
+      normals: normals,
+      indices: indices,
+    );
+  }
+
+  // Must match the `RippleInfo` block in example_ripple.vert, packed std140.
+  // Four floats fill one 16-byte row, so there is no padding to add.
+  void _setRippleUniforms(double time) {
+    _material?.setUniformBlock(
+      'RippleInfo',
+      ByteData.sublistView(
+        Float32List.fromList([time, amplitude, wavelength, speed]),
+      ),
+      stage: ShaderStage.vertex,
+    );
+  }
+
+  @override
+  void dispose() {
+    scene.removeAll();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!loaded) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: SceneView(
+            scene,
+            camera: PerspectiveCamera(
+              position: vm.Vector3(0, 6.0, 11.0),
+              target: vm.Vector3(0, 0, 0),
+            ),
+            onTick: (elapsed, deltaSeconds) {
+              _setRippleUniforms(elapsed.inMicroseconds / 1e6);
+              exampleSettings.applyTo(scene);
+            },
+          ),
+        ),
+        ExampleOverlay.bottomLeftPanel(
+          child: ExamplePanelCard(
+            icon: Icons.waves,
+            title: 'Ripple',
+            body: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _SliderRow(
+                  label: 'Amplitude',
+                  value: amplitude,
+                  min: 0,
+                  max: 1.5,
+                  onChanged: (val) => setState(() => amplitude = val),
+                ),
+                _SliderRow(
+                  label: 'Wavelength',
+                  value: wavelength,
+                  min: 0.3,
+                  max: 4.0,
+                  onChanged: (val) => setState(() => wavelength = val),
+                ),
+                _SliderRow(
+                  label: 'Speed',
+                  value: speed,
+                  min: 0,
+                  max: 6,
+                  onChanged: (val) => setState(() => speed = val),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SliderRow extends StatelessWidget {
+  const _SliderRow({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 96,
+          child: Text(label, style: const TextStyle(color: Colors.white)),
+        ),
+        Expanded(
+          child: Slider(value: value, min: min, max: max, onChanged: onChanged),
+        ),
+      ],
+    );
+  }
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -45,6 +45,7 @@ import 'example_ssr.dart';
 import 'example_widget_texture.dart';
 import 'example_split_screen.dart';
 import 'example_stress_tests.dart';
+import 'example_raw_shader.dart';
 import 'example_toon.dart';
 import 'example_toon_fmat.dart';
 import 'example_vertex_curve.dart';
@@ -178,6 +179,7 @@ class _MyAppState extends State<MyApp> {
       'Auto Exposure': (context) => const ExampleAutoExposure(),
       'Navigation Route': (context) => const ExampleNavRoute(),
       'Toon': (context) => const ExampleToon(),
+      'Raw shader': (context) => const ExampleRawShader(),
       'Toon (.fmat)': (context) => const ExampleToonFmat(),
       'Custom vertices (.fmat)': (context) => const ExampleVertexCurve(),
       'Materialize (.fmat)': (context) => const ExampleMaterialize(),

--- a/examples/flutter_app/shaders/example.shaderbundle.json
+++ b/examples/flutter_app/shaders/example.shaderbundle.json
@@ -6,5 +6,13 @@
     "WaveFragment": {
         "type": "fragment",
         "file": "shaders/example_wave.frag"
+    },
+    "RippleVertex": {
+        "type": "vertex",
+        "file": "shaders/example_ripple.vert"
+    },
+    "RippleFragment": {
+        "type": "fragment",
+        "file": "shaders/example_ripple.frag"
     }
 }

--- a/examples/flutter_app/shaders/example_ripple.frag
+++ b/examples/flutter_app/shaders/example_ripple.frag
@@ -1,0 +1,26 @@
+// Fragment half of the raw shader pair. Reads the varying the vertex stage
+// added and a tint bound to the fragment stage, and outputs linear color
+// premultiplied by alpha (the engine resolve pass applies exposure and tone
+// mapping).
+
+uniform TintInfo {
+  vec4 crest;
+  vec4 trough;
+}
+tint;
+
+in vec3 v_position;
+in vec3 v_normal;
+in vec3 v_viewvector;
+in vec2 v_texture_coords;
+in vec4 v_color;
+in float v_ripple;
+
+out vec4 frag_color;
+
+void main() {
+  vec3 normal = normalize(v_normal);
+  float facing = clamp(dot(normal, normalize(v_viewvector)), 0.0, 1.0);
+  vec3 base = mix(tint.trough.rgb, tint.crest.rgb, v_ripple);
+  frag_color = vec4(base * mix(0.35, 1.0, facing), 1.0);
+}

--- a/examples/flutter_app/shaders/example_ripple.vert
+++ b/examples/flutter_app/shaders/example_ripple.vert
@@ -1,0 +1,60 @@
+// Example raw vertex shader, driven by ShaderMaterial. Displaces the mesh
+// along its normal with a travelling ripple and hands the fragment stage the
+// displacement it applied.
+//
+// This is the whole engine contract for an unskinned mesh. FrameInfo and the
+// instance-rate model_transform columns are bound by the engine; RippleInfo is
+// bound from Dart with setUniformBlock(..., stage: ShaderStage.vertex).
+
+uniform FrameInfo {
+  mat4 camera_transform;
+  vec3 camera_position;
+}
+frame_info;
+
+uniform RippleInfo {
+  float time;
+  float amplitude;
+  float wavelength;
+  float speed;
+}
+ripple;
+
+in vec3 position;
+in vec3 normal;
+in vec2 texture_coords;
+in vec4 color;
+
+// Instance-rate model matrix columns, bound in the slot after the vertex
+// streams. A non-instanced draw gets a single-element buffer.
+in vec4 model_transform_0;
+in vec4 model_transform_1;
+in vec4 model_transform_2;
+in vec4 model_transform_3;
+
+out vec3 v_position;
+out vec3 v_normal;
+out vec3 v_viewvector;
+out vec2 v_texture_coords;
+out vec4 v_color;
+out float v_ripple;
+
+void main() {
+  mat4 model_transform = mat4(model_transform_0, model_transform_1,
+                              model_transform_2, model_transform_3);
+  vec4 world_position = model_transform * vec4(position, 1.0);
+
+  float phase = length(world_position.xz) / max(ripple.wavelength, 0.001);
+  float wave = sin(phase - ripple.time * ripple.speed);
+  vec3 world_normal = normalize(mat3(model_transform) * normal);
+  world_position.xyz += world_normal * wave * ripple.amplitude;
+
+  v_position = world_position.xyz;
+  v_normal = world_normal;
+  v_viewvector = frame_info.camera_position - world_position.xyz;
+  v_texture_coords = texture_coords;
+  v_color = color;
+  v_ripple = wave * 0.5 + 0.5;
+
+  gl_Position = frame_info.camera_transform * world_position;
+}

--- a/examples/smoke_render/hook/build.dart
+++ b/examples/smoke_render/hook/build.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_gpu_shaders/build.dart';
 import 'package:flutter_scene/build_hooks.dart';
 import 'package:hooks/hooks.dart';
 
@@ -7,6 +8,14 @@ void main(List<String> args) {
       buildInput: config,
       buildOutput: output,
       materials: ['assets/custom_material.fmat', 'assets/noise_parity.fmat'],
+    );
+    // The hand-written vertex/fragment pair the raw_shader_pair scene draws
+    // with. Compiled here so every backend's compiler sees it.
+    await buildShaderBundleJson(
+      buildInput: config,
+      buildOutput: output,
+      manifestFileName: 'shaders/smoke.shaderbundle.json',
+      glesLanguageVersion: 300,
     );
   });
 }

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -116,7 +116,14 @@ Future<void> loadSmokeMaterials() async {
     'build/shaderbundles/materials.fmat.json',
   );
   _materialsMetadata = (jsonDecode(sidecar) as Map).cast<String, Object?>();
+  _rawPairLibrary = await gpu.loadShaderLibraryAsync(
+    'build/shaderbundles/smoke.shaderbundle',
+  );
 }
+
+/// The hand-written shader pair pre-loaded by [loadSmokeMaterials], so the
+/// synchronous scene setup can build a [ShaderMaterial] from both stages.
+gpu.ShaderLibrary? _rawPairLibrary;
 
 /// Builds a `PreprocessedMaterial` for the named `.fmat`, resolving its
 /// generated vertex variants from the sidecar's variant map (as the DataAssets
@@ -502,6 +509,71 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
       camera: PerspectiveCamera(
         position: vm.Vector3(0.8, 2.0, -6.5),
         target: vm.Vector3(0, 1.5, 0),
+      ),
+    );
+  }),
+
+  // A hand-written vertex/fragment pair driven through ShaderMaterial, with no
+  // engine vertex shader involved. The vertex stage displaces the grid along
+  // its normal from a vertex-stage uniform block, so a backend that fails to
+  // compile the pair, mismatches the described layout, or drops the vertex
+  // uniform draws a flat or empty surface instead of a ripple.
+  SmokeScene('raw_shader_pair', () {
+    final material =
+        ShaderMaterial(
+          vertexShader: _rawPairLibrary!['RawPairVertex']!,
+          fragmentShader: _rawPairLibrary!['RawPairFragment']!,
+        )..setUniformBlockFromFloats('TintInfo', [
+          0.45, 0.85, 1.0, 1.0, // crest
+          0.04, 0.16, 0.42, 1.0, // trough
+        ]);
+    // Fixed time, so the frame is deterministic.
+    material.setUniformBlock(
+      'RippleInfo',
+      ByteData.sublistView(Float32List.fromList([1.2, 0.3, 0.22, 1.0])),
+      stage: ShaderStage.vertex,
+    );
+
+    const n = 48;
+    const size = 3.0;
+    final count = (n + 1) * (n + 1);
+    final positions = Float32List(count * 3);
+    final normals = Float32List(count * 3);
+    var v = 0;
+    for (var r = 0; r <= n; r++) {
+      for (var c = 0; c <= n; c++) {
+        positions[v * 3] = (c / n - 0.5) * size;
+        positions[v * 3 + 2] = (r / n - 0.5) * size;
+        normals[v * 3 + 1] = 1.0;
+        v++;
+      }
+    }
+    final indices = <int>[];
+    for (var r = 0; r < n; r++) {
+      for (var c = 0; c < n; c++) {
+        final i0 = r * (n + 1) + c;
+        final i2 = i0 + (n + 1);
+        indices.addAll([i0, i0 + 1, i2, i0 + 1, i2 + 1, i2]);
+      }
+    }
+    final scene = Scene()..environmentIntensity = 0.0;
+    scene.add(
+      Node(
+        mesh: Mesh(
+          MeshGeometry.fromArrays(
+            positions: positions,
+            normals: normals,
+            indices: indices,
+          ),
+          material,
+        ),
+      ),
+    );
+    return (
+      scene: scene,
+      camera: PerspectiveCamera(
+        position: vm.Vector3(0, 2.6, 3.4),
+        target: vm.Vector3.zero(),
       ),
     );
   }),

--- a/examples/smoke_render/pubspec.yaml
+++ b/examples/smoke_render/pubspec.yaml
@@ -31,6 +31,7 @@ flutter:
     # hook/build.dart.
     - build/shaderbundles/materials.shaderbundle
     - build/shaderbundles/materials.fmat.json
+    - build/shaderbundles/smoke.shaderbundle
     # Skinned animated test model (assets_src is a symlink into
     # examples/assets_src), for the skinned_animation scene.
     - assets_src/two_triangles.glb

--- a/examples/smoke_render/shaders/raw_pair.frag
+++ b/examples/smoke_render/shaders/raw_pair.frag
@@ -1,0 +1,26 @@
+// Fragment half of the raw shader pair. Reads the varying the vertex stage
+// added and a tint bound to the fragment stage, and outputs linear color
+// premultiplied by alpha (the engine resolve pass applies exposure and tone
+// mapping).
+
+uniform TintInfo {
+  vec4 crest;
+  vec4 trough;
+}
+tint;
+
+in vec3 v_position;
+in vec3 v_normal;
+in vec3 v_viewvector;
+in vec2 v_texture_coords;
+in vec4 v_color;
+in float v_ripple;
+
+out vec4 frag_color;
+
+void main() {
+  vec3 normal = normalize(v_normal);
+  float facing = clamp(dot(normal, normalize(v_viewvector)), 0.0, 1.0);
+  vec3 base = mix(tint.trough.rgb, tint.crest.rgb, v_ripple);
+  frag_color = vec4(base * mix(0.35, 1.0, facing), 1.0);
+}

--- a/examples/smoke_render/shaders/raw_pair.vert
+++ b/examples/smoke_render/shaders/raw_pair.vert
@@ -1,0 +1,60 @@
+// Example raw vertex shader, driven by ShaderMaterial. Displaces the mesh
+// along its normal with a travelling ripple and hands the fragment stage the
+// displacement it applied.
+//
+// This is the whole engine contract for an unskinned mesh. FrameInfo and the
+// instance-rate model_transform columns are bound by the engine; RippleInfo is
+// bound from Dart with setUniformBlock(..., stage: ShaderStage.vertex).
+
+uniform FrameInfo {
+  mat4 camera_transform;
+  vec3 camera_position;
+}
+frame_info;
+
+uniform RippleInfo {
+  float time;
+  float amplitude;
+  float wavelength;
+  float speed;
+}
+ripple;
+
+in vec3 position;
+in vec3 normal;
+in vec2 texture_coords;
+in vec4 color;
+
+// Instance-rate model matrix columns, bound in the slot after the vertex
+// streams. A non-instanced draw gets a single-element buffer.
+in vec4 model_transform_0;
+in vec4 model_transform_1;
+in vec4 model_transform_2;
+in vec4 model_transform_3;
+
+out vec3 v_position;
+out vec3 v_normal;
+out vec3 v_viewvector;
+out vec2 v_texture_coords;
+out vec4 v_color;
+out float v_ripple;
+
+void main() {
+  mat4 model_transform = mat4(model_transform_0, model_transform_1,
+                              model_transform_2, model_transform_3);
+  vec4 world_position = model_transform * vec4(position, 1.0);
+
+  float phase = length(world_position.xz) / max(ripple.wavelength, 0.001);
+  float wave = sin(phase - ripple.time * ripple.speed);
+  vec3 world_normal = normalize(mat3(model_transform) * normal);
+  world_position.xyz += world_normal * wave * ripple.amplitude;
+
+  v_position = world_position.xyz;
+  v_normal = world_normal;
+  v_viewvector = frame_info.camera_position - world_position.xyz;
+  v_texture_coords = texture_coords;
+  v_color = color;
+  v_ripple = wave * 0.5 + 0.5;
+
+  gl_Position = frame_info.camera_transform * world_position;
+}

--- a/examples/smoke_render/shaders/smoke.shaderbundle.json
+++ b/examples/smoke_render/shaders/smoke.shaderbundle.json
@@ -1,0 +1,10 @@
+{
+    "RawPairVertex": {
+        "type": "vertex",
+        "file": "shaders/raw_pair.vert"
+    },
+    "RawPairFragment": {
+        "type": "fragment",
+        "file": "shaders/raw_pair.frag"
+    }
+}

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -3,6 +3,7 @@
 * `ShaderMaterial` owns the vertex stage too. Pass a `vertexShader` (per `MeshVariant`, so skinned and shadow passes can differ) and set uniforms and textures on either stage with `ShaderStage`, so a hand-written shader pair needs no subclassing.
 * Geometry can declare its own pipeline vertex layout with `setVertexLayout`, and `VertexAttributeDescriptor`/`VertexBufferDescriptor`/`VertexLayoutDescriptor` are public.
 * Custom vertex attributes work on skinned meshes.
+* A `ShaderMaterial` that supplies a vertex shader for some mesh kinds but not others warns in debug builds, naming the missing variant, instead of failing opaquely at pipeline creation.
 * `IndexType`, `VertexFormat`, and `VertexStepMode` are exported, so 32-bit indices and caller-declared layouts no longer need `lib/src` imports.
 
 * Fixed instanced meshes losing their lighting, shadow, and fog bindings on GLES, which drew them (and any mesh sharing their pipeline) black.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.20.1
 
+* `ShaderMaterial` owns the vertex stage too. Pass a `vertexShader` (per `MeshVariant`, so skinned and shadow passes can differ) and set uniforms and textures on either stage with `ShaderStage`, so a hand-written shader pair needs no subclassing.
+* Geometry can declare its own pipeline vertex layout with `setVertexLayout`, and `VertexAttributeDescriptor`/`VertexBufferDescriptor`/`VertexLayoutDescriptor` are public.
+* Custom vertex attributes work on skinned meshes.
+* `IndexType`, `VertexFormat`, and `VertexStepMode` are exported, so 32-bit indices and caller-declared layouts no longer need `lib/src` imports.
+
 * Fixed instanced meshes losing their lighting, shadow, and fog bindings on GLES, which drew them (and any mesh sharing their pipeline) black.
 * Fixed uncompressed `.fsceneb` textures uploading without mipmaps, so a cooked scene is mipmapped whether or not `compressTextures` is set.
 * Fixed cooked `.fsceneb` and `.fstex` textures sampling without anisotropic filtering, which blurred them at grazing angles.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Geometry can declare its own pipeline vertex layout with `setVertexLayout`, and `VertexAttributeDescriptor`/`VertexBufferDescriptor`/`VertexLayoutDescriptor` are public.
 * Custom vertex attributes work on skinned meshes.
 * A `ShaderMaterial` that supplies a vertex shader for some mesh kinds but not others warns in debug builds, naming the missing variant, instead of failing opaquely at pipeline creation.
+* Debug builds check a custom material's uniform blocks against the shader's reflection, so a misspelled or optimized-out block name and a buffer too small for its std140 layout raise named exceptions instead of failing at bind time or reading past the end.
+* Debug builds check a caller-declared vertex layout against the buffers actually bound, so a slot count mismatch raises instead of feeding the pipeline undefined vertex data.
 * `IndexType`, `VertexFormat`, and `VertexStepMode` are exported, so 32-bit indices and caller-declared layouts no longer need `lib/src` imports.
 
 * Fixed instanced meshes losing their lighting, shadow, and fog bindings on GLES, which drew them (and any mesh sharing their pipeline) black.

--- a/packages/flutter_scene/lib/gpu.dart
+++ b/packages/flutter_scene/lib/gpu.dart
@@ -24,4 +24,8 @@ export 'src/gpu/gpu.dart'
         SamplerOptions,
         MinMagFilter,
         MipFilter,
-        SamplerAddressMode;
+        SamplerAddressMode,
+        // Value types a caller-declared vertex layout and index buffer need.
+        IndexType,
+        VertexFormat,
+        VertexStepMode;

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -27,6 +27,11 @@ export 'src/geometry/billboard_geometry.dart'
 export 'src/geometry/geometry.dart'
     show Geometry, SkinnedGeometry, UnskinnedGeometry;
 export 'src/geometry/line_segments_geometry.dart' show LineSegmentsGeometry;
+export 'src/geometry/vertex_layout.dart'
+    show
+        VertexAttributeDescriptor,
+        VertexBufferDescriptor,
+        VertexLayoutDescriptor;
 export 'src/geometry/mesh_data.dart'
     show
         LineSegmentData,
@@ -75,6 +80,7 @@ export 'src/material/physically_based_material.dart'
 export 'src/material/preprocessed_material.dart' show PreprocessedMaterial;
 export 'src/material/preprocessed_sky.dart' show PreprocessedSky;
 export 'src/material/shader_material.dart' show ShaderMaterial;
+export 'src/material/shader_stage.dart' show MeshVariant, ShaderStage;
 export 'src/material/sprite_material.dart' show SpriteBlendMode, SpriteMaterial;
 export 'src/material/unlit_material.dart' show UnlitMaterial;
 export 'src/fmat/material_registry.dart'

--- a/packages/flutter_scene/lib/src/geometry/billboard_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/billboard_geometry.dart
@@ -168,7 +168,7 @@ class BillboardGeometry extends Geometry {
   }
 
   @override
-  VertexLayoutDescriptor? get instancedVertexLayout => _kBillboardLayout;
+  VertexLayoutDescriptor? get defaultVertexLayout => _kBillboardLayout;
 
   // The billboard supplies its own slot-1 instance buffer (per-instance
   // attributes) and reads the model transform from the FrameInfo uniform, so

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -199,8 +199,9 @@ abstract class Geometry {
   /// is uploaded to its own buffer and bound after the geometry's built-in
   /// attributes in the color pass; the depth-style passes fetch only position,
   /// so an attribute-driven vertex displacement is not reflected in shadows.
-  /// Re-attaching the same [name] replaces it. Custom attributes require the
-  /// described-layout (unskinned) geometry path.
+  /// Re-attaching the same [name] replaces it. Attaching one to a skinned mesh
+  /// switches it to a described layout, since reflection cannot know which
+  /// slot the stream was bound to.
   /// {@category Geometry}
   void setCustomAttribute(
     String name,
@@ -630,11 +631,43 @@ abstract class Geometry {
   /// The explicit pipeline vertex layout this geometry's vertex shader
   /// expects, or null for the shader bundle's default interleaved layout.
   ///
-  /// A non-null layout signals the encoders that the shader consumes the
-  /// model transform from the instance-rate vertex buffer (slot 1) rather
-  /// than a per-draw uniform, so every draw must bind an instance buffer.
+  /// A caller-supplied layout ([setVertexLayout]) wins over the subclass's
+  /// [defaultVertexLayout].
   @internal
-  VertexLayoutDescriptor? get instancedVertexLayout => null;
+  VertexLayoutDescriptor? get instancedVertexLayout =>
+      _vertexLayout ?? defaultVertexLayout;
+
+  /// The layout this geometry kind uses when the caller supplies none.
+  /// Subclasses that describe their vertices override this.
+  @protected
+  VertexLayoutDescriptor? get defaultVertexLayout => null;
+
+  VertexLayoutDescriptor? _vertexLayout;
+  bool? _bindsModelTransformInstance;
+
+  /// Declares the pipeline vertex layout this geometry's buffers provide,
+  /// overriding the built-in one, or restores the built-in when [layout] is
+  /// null.
+  ///
+  /// Use this with [setVertexShader] to run a vertex stage over vertices the
+  /// engine has no opinion about (extra channels, a packed format, or fewer
+  /// attributes than the standard vertex carries). The buffers bound by
+  /// [setVertices] and [setCustomAttribute] must match the slots described
+  /// here, in order.
+  ///
+  /// A described layout normally means the shader reads the model transform
+  /// from an instance-rate buffer the encoder binds in the trailing slot. Pass
+  /// [bindsModelTransform] false when the shader gets the transform some other
+  /// way (a uniform, as skinned meshes do), so the encoder leaves that slot
+  /// alone.
+  /// {@category Geometry}
+  void setVertexLayout(
+    VertexLayoutDescriptor? layout, {
+    bool bindsModelTransform = true,
+  }) {
+    _vertexLayout = layout;
+    _bindsModelTransformInstance = layout == null ? null : bindsModelTransform;
+  }
 
   /// Whether the color encoder should bind the node's model transform as a
   /// one-element instance-rate buffer at the slot after this geometry's
@@ -647,7 +680,8 @@ abstract class Geometry {
   /// takes the model transform some other way (a uniform) overrides this to
   /// false so the encoder leaves its slot alone.
   @internal
-  bool get bindsModelTransformInstance => instancedVertexLayout != null;
+  bool get bindsModelTransformInstance =>
+      _bindsModelTransformInstance ?? (instancedVertexLayout != null);
 
   /// Whether this geometry should be drawn without back-face culling.
   ///
@@ -853,7 +887,7 @@ class UnskinnedGeometry extends Geometry {
   }
 
   @override
-  VertexLayoutDescriptor? get instancedVertexLayout {
+  VertexLayoutDescriptor? get defaultVertexLayout {
     final base = _isDeInterleaved
         ? kUnskinnedSoAColorLayout
         : kUnskinnedInstancedLayout;
@@ -926,6 +960,24 @@ class SkinnedGeometry extends Geometry {
 
   @override
   String get materialVertexVariant => 'skinned';
+
+  @override
+  VertexLayoutDescriptor? get defaultVertexLayout {
+    // Without custom attributes the pipeline layout comes from the shader's
+    // own reflection, which is how skinned meshes have always drawn. Custom
+    // attribute streams have to be described, though, since reflection cannot
+    // know which slot the caller bound them to.
+    if (!hasCustomAttributes) return null;
+    return VertexLayoutDescriptor(
+      buffers: [kSkinnedVertexBuffer, ...customAttributeBuffers],
+    );
+  }
+
+  // The model transform rides in the skinned FrameInfo block, not an
+  // instance-rate buffer, so describing the layout must not make the encoder
+  // bind one.
+  @override
+  bool get bindsModelTransformInstance => false;
 
   @override
   bool get _autoScanBoundsOnUpload => false;
@@ -1235,3 +1287,42 @@ void bindUnskinnedFrameInfo(
     transientsBuffer.emplace(ByteData.sublistView(scratch)),
   );
 }
+
+/// Slot 0 of a skinned mesh: the interleaved 80-byte vertex stream the
+/// `SkinnedVertex` shader reads. Offsets match the bytes
+/// [InterleavedLayoutAdapter.packSkinned] emits.
+@internal
+const VertexBufferDescriptor kSkinnedVertexBuffer = VertexBufferDescriptor(
+  strideInBytes: kSkinnedPerVertexSize,
+  attributes: [
+    VertexAttributeDescriptor(
+      name: 'position',
+      format: gpu.VertexFormat.float32x3,
+    ),
+    VertexAttributeDescriptor(
+      name: 'normal',
+      format: gpu.VertexFormat.float32x3,
+      offsetInBytes: 12,
+    ),
+    VertexAttributeDescriptor(
+      name: 'texture_coords',
+      format: gpu.VertexFormat.float32x2,
+      offsetInBytes: 24,
+    ),
+    VertexAttributeDescriptor(
+      name: 'color',
+      format: gpu.VertexFormat.float32x4,
+      offsetInBytes: 32,
+    ),
+    VertexAttributeDescriptor(
+      name: 'joints',
+      format: gpu.VertexFormat.float32x4,
+      offsetInBytes: 48,
+    ),
+    VertexAttributeDescriptor(
+      name: 'weights',
+      format: gpu.VertexFormat.float32x4,
+      offsetInBytes: 64,
+    ),
+  ],
+);

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -661,6 +661,28 @@ abstract class Geometry {
   /// way (a uniform, as skinned meshes do), so the encoder leaves that slot
   /// alone.
   /// {@category Geometry}
+  // A caller-declared layout describes one buffer per bound slot, so a count
+  // mismatch means the pipeline reads a slot nothing was bound to. That reads
+  // undefined vertex data rather than failing, so catch it in debug where the
+  // cause is still obvious. Debug-only; the built-in layouts always agree.
+  bool _checkDeclaredLayout() {
+    final layout = _vertexLayout;
+    if (layout == null) return true;
+    final expected = vertexStreamCount + (bindsModelTransformInstance ? 1 : 0);
+    if (layout.buffers.length != expected) {
+      throw StateError(
+        'Geometry: setVertexLayout described ${layout.buffers.length} vertex '
+        'buffer slots, but this draw binds $expected (${_vertexStreams.length} '
+        'vertex stream(s), ${_customAttributes.length} custom attribute(s)'
+        '${bindsModelTransformInstance ? ", plus the instance-rate model "
+                  "transform" : ""}). Describe one buffer per bound slot, in order, '
+        'or pass bindsModelTransform: false if the shader takes the model '
+        'transform another way.',
+      );
+    }
+    return true;
+  }
+
   void setVertexLayout(
     VertexLayoutDescriptor? layout, {
     bool bindsModelTransform = true,
@@ -704,6 +726,7 @@ abstract class Geometry {
   @internal
   void bindGeometryBuffers(gpu.RenderPass pass) {
     _requireVertices();
+    assert(_checkDeclaredLayout());
     var slot = 0;
     for (; slot < _vertexStreams.length; slot++) {
       bindVertexBufferCompat(

--- a/packages/flutter_scene/lib/src/geometry/line_segments_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/line_segments_geometry.dart
@@ -123,7 +123,7 @@ class LineSegmentsGeometry extends Geometry {
   }
 
   @override
-  VertexLayoutDescriptor? get instancedVertexLayout => _kLineSegmentsLayout;
+  VertexLayoutDescriptor? get defaultVertexLayout => _kLineSegmentsLayout;
 
   // The segments supply their own slot-1 instance buffer and read the model
   // transform from the FrameInfo uniform, so the color encoder must not bind

--- a/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/splat_geometry.dart
@@ -156,7 +156,7 @@ class SplatGeometry extends Geometry {
   );
 
   @override
-  VertexLayoutDescriptor? get instancedVertexLayout => _kSplatLayout;
+  VertexLayoutDescriptor? get defaultVertexLayout => _kSplatLayout;
 
   // The splat index arrives through the slot-1 instance buffer; the model
   // transform rides the FrameInfo uniform.

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/material.dart';
+import 'package:flutter_scene/src/material/shader_stage.dart';
 import 'package:flutter_scene/src/texture/texture2d.dart';
 import 'package:flutter_scene/src/render/frame_transients.dart';
 
@@ -87,6 +88,9 @@ class ShaderMaterial extends Material {
   /// names.
   ShaderMaterial({
     gpu.Shader? fragmentShader,
+    gpu.Shader? vertexShader,
+    gpu.Shader? skinnedVertexShader,
+    gpu.Shader? depthVertexShader,
     this.useEnvironment = false,
     this.cullingMode = gpu.CullMode.backFace,
     this.windingOrder = gpu.WindingOrder.counterClockwise,
@@ -95,6 +99,9 @@ class ShaderMaterial extends Material {
     if (fragmentShader != null) {
       setFragmentShader(fragmentShader);
     }
+    setVertexShader(vertexShader);
+    setVertexShader(skinnedVertexShader, variant: MeshVariant.skinned);
+    setVertexShader(depthVertexShader, variant: MeshVariant.depth);
   }
 
   /// Whether the engine should bind the active environment's IBL textures
@@ -120,42 +127,110 @@ class ShaderMaterial extends Material {
 
   final Map<String, ByteData> _uniformBlocks = {};
   final Map<String, _BoundTexture> _textures = {};
+  final Map<String, ByteData> _vertexUniformBlocks = {};
+  final Map<String, _BoundTexture> _vertexTextures = {};
+  final Map<MeshVariant, gpu.Shader> _vertexShaders = {};
+
+  Map<String, ByteData> _blocksFor(ShaderStage stage) =>
+      stage == ShaderStage.vertex ? _vertexUniformBlocks : _uniformBlocks;
+
+  Map<String, _BoundTexture> _texturesFor(ShaderStage stage) =>
+      stage == ShaderStage.vertex ? _vertexTextures : _textures;
+
+  /// Assigns the vertex shader this material draws [variant] meshes with, or
+  /// clears it when [shader] is null.
+  ///
+  /// With no vertex shader the engine's standard one runs, which is the
+  /// fragment-only workflow. Supplying one takes over the vertex stage for
+  /// that mesh kind, and the shader must then satisfy the engine contract
+  /// (see `MATERIALS.md`): it declares the `FrameInfo` block, the attributes
+  /// its geometry's layout provides, and the `v_*` outputs the fragment stage
+  /// reads.
+  ///
+  /// A mesh kind with no shader falls back to the engine's, so a material can
+  /// customize static meshes and leave skinned ones alone. Supply
+  /// [MeshVariant.depth] when the vertex stage moves geometry and the shadow
+  /// and depth passes should see the same displacement.
+  void setVertexShader(
+    gpu.Shader? shader, {
+    MeshVariant variant = MeshVariant.unskinned,
+  }) {
+    if (shader == null) {
+      _vertexShaders.remove(variant);
+      return;
+    }
+    _vertexShaders[variant] = shader;
+  }
+
+  /// The vertex shader assigned for [variant], or null when the engine's
+  /// standard one runs.
+  gpu.Shader? vertexShaderFor(MeshVariant variant) => _vertexShaders[variant];
+
+  @override
+  gpu.Shader? materialVertexShader(String variant) =>
+      _vertexShaders[MeshVariant.fromName(variant)];
 
   /// Assign the byte contents of a uniform block by name.
   ///
   /// [bytes] must already match the block's std140 layout. Replacing
   /// an existing assignment overrides the previous value. Pass `null`
-  /// to clear the binding.
-  void setUniformBlock(String name, ByteData? bytes) {
+  /// to clear the binding. [stage] picks which shader the block binds
+  /// against; a block declared in both stages must be set for both.
+  void setUniformBlock(
+    String name,
+    ByteData? bytes, {
+    ShaderStage stage = ShaderStage.fragment,
+  }) {
+    final blocks = _blocksFor(stage);
     if (bytes == null) {
-      _uniformBlocks.remove(name);
+      blocks.remove(name);
     } else {
-      _uniformBlocks[name] = bytes;
+      blocks[name] = bytes;
     }
   }
 
   /// Convenience wrapper around [setUniformBlock] that packs a list
   /// of float values. The caller is still responsible for std140
   /// padding; see the class doc.
-  void setUniformBlockFromFloats(String name, List<double> floats) {
-    setUniformBlock(name, ByteData.sublistView(Float32List.fromList(floats)));
+  void setUniformBlockFromFloats(
+    String name,
+    List<double> floats, {
+    ShaderStage stage = ShaderStage.fragment,
+  }) {
+    setUniformBlock(
+      name,
+      ByteData.sublistView(Float32List.fromList(floats)),
+      stage: stage,
+    );
   }
 
   /// Read back a previously-set uniform block, or `null` when none
   /// has been set.
-  ByteData? getUniformBlock(String name) => _uniformBlocks[name];
+  ByteData? getUniformBlock(
+    String name, {
+    ShaderStage stage = ShaderStage.fragment,
+  }) => _blocksFor(stage)[name];
 
-  /// All currently-bound uniform block names. Order is insertion order.
+  /// All currently-bound fragment uniform block names, in insertion order.
   Iterable<String> get uniformBlockNames => _uniformBlocks.keys;
+
+  /// All currently-bound vertex uniform block names, in insertion order.
+  Iterable<String> get vertexUniformBlockNames => _vertexUniformBlocks.keys;
 
   /// Assign a texture to a sampler uniform by name.
   ///
   /// [texture] accepts a raw [gpu.Texture] (the low-level custom-shader path),
   /// a [Texture2D], or a `RenderTexture` (sampled live; an explicit [sampler]
   /// overrides the source's own sampling). Pass `null` to clear the binding.
-  void setTexture(String name, Object? texture, {gpu.SamplerOptions? sampler}) {
+  void setTexture(
+    String name,
+    Object? texture, {
+    gpu.SamplerOptions? sampler,
+    ShaderStage stage = ShaderStage.fragment,
+  }) {
+    final textures = _texturesFor(stage);
     if (texture == null) {
-      _textures.remove(name);
+      textures.remove(name);
       return;
     }
     if (texture is! gpu.Texture && texture is! TextureSource) {
@@ -165,7 +240,7 @@ class ShaderMaterial extends Material {
         'Expected a gpu.Texture, a Texture2D, or a RenderTexture',
       );
     }
-    _textures[name] = _BoundTexture(texture, sampler);
+    textures[name] = _BoundTexture(texture, sampler);
   }
 
   /// Read back a previously-set texture binding, or `null` when none
@@ -173,8 +248,10 @@ class ShaderMaterial extends Material {
   ///
   /// A slot holding a `RenderTexture` resolves to its latest completed
   /// frame (null before the first render).
-  gpu.Texture? getTexture(String name) =>
-      _resolveShaderTexture(_textures[name]?.source);
+  gpu.Texture? getTexture(
+    String name, {
+    ShaderStage stage = ShaderStage.fragment,
+  }) => _resolveShaderTexture(_texturesFor(stage)[name]?.source);
 
   // ShaderMaterial accepts a raw gpu.Texture in addition to a TextureSource, so
   // it resolves locally rather than through the material.dart helpers.
@@ -183,8 +260,11 @@ class ShaderMaterial extends Material {
   static gpu.SamplerOptions? _shaderTextureSampler(Object? source) =>
       source is TextureSource ? source.sampledSampler : null;
 
-  /// All currently-bound sampler names. Order is insertion order.
+  /// All currently-bound fragment sampler names, in insertion order.
   Iterable<String> get textureNames => _textures.keys;
+
+  /// All currently-bound vertex sampler names, in insertion order.
+  Iterable<String> get vertexTextureNames => _vertexTextures.keys;
 
   @override
   bool isOpaque() => isOpaqueOverride;
@@ -221,6 +301,31 @@ class ShaderMaterial extends Material {
 
     if (useEnvironment) {
       _bindEnvironmentTextures(pass, lighting);
+    }
+  }
+
+  @override
+  void bindVertexStage(
+    gpu.RenderPass pass,
+    gpu.Shader vertexShader,
+    TransientWriter transientsBuffer,
+  ) {
+    for (final entry in _vertexUniformBlocks.entries) {
+      pass.bindUniform(
+        vertexShader.getUniformSlot(entry.key),
+        transientsBuffer.emplace(entry.value),
+      );
+    }
+    for (final entry in _vertexTextures.entries) {
+      final resolved = _resolveShaderTexture(entry.value.source);
+      pass.bindTexture(
+        vertexShader.getUniformSlot(entry.key),
+        Material.whitePlaceholder(resolved),
+        sampler:
+            entry.value.sampler ??
+            _shaderTextureSampler(entry.value.source) ??
+            gpu.SamplerOptions(),
+      );
     }
   }
 

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 
 import 'package:flutter_scene/src/light.dart';
@@ -166,9 +168,31 @@ class ShaderMaterial extends Material {
   /// standard one runs.
   gpu.Shader? vertexShaderFor(MeshVariant variant) => _vertexShaders[variant];
 
+  final Set<MeshVariant> _warnedMissingVariants = <MeshVariant>{};
+
   @override
-  gpu.Shader? materialVertexShader(String variant) =>
-      _vertexShaders[MeshVariant.fromName(variant)];
+  gpu.Shader? materialVertexShader(String variant) {
+    final kind = MeshVariant.fromName(variant);
+    final shader = _vertexShaders[kind];
+    // Falling back to the engine's shader is fine when the fragment shader
+    // only reads engine varyings, and fatal when it reads one this material's
+    // own vertex shader writes: the engine's does not write it, and pipeline
+    // creation fails with a backend interface error naming an anonymous
+    // location. Say which variant is missing while the author can still act
+    // on it. Debug-only, and once per variant.
+    assert(() {
+      if (shader == null && _vertexShaders.isNotEmpty) {
+        _warnMissingVertexVariant(kind);
+      }
+      return true;
+    }());
+    return shader;
+  }
+
+  void _warnMissingVertexVariant(MeshVariant kind) {
+    if (!_warnedMissingVariants.add(kind)) return;
+    debugPrint(missingVertexVariantMessage(_vertexShaders.keys, kind));
+  }
 
   /// Assign the byte contents of a uniform block by name.
   ///
@@ -355,3 +379,18 @@ class _BoundTexture {
   final Object source;
   final gpu.SamplerOptions? sampler;
 }
+
+/// The warning a [ShaderMaterial] prints when it is asked for a vertex shader
+/// for [missing] while supplying [supplied]. Library-visible for tests.
+@visibleForTesting
+String missingVertexVariantMessage(
+  Iterable<MeshVariant> supplied,
+  MeshVariant missing,
+) =>
+    'flutter_scene: a ShaderMaterial supplies a vertex shader for '
+    '${supplied.map((v) => v.name).join(', ')} but not for ${missing.name}, '
+    'so this draw pairs the engine\'s ${missing.name} vertex shader with '
+    'your fragment shader. That works only if the fragment shader reads '
+    'engine varyings alone; a custom varying the engine shader does not write '
+    'fails pipeline creation. Supply a ${missing.name} variant, or keep the '
+    'fragment shader to the engine varyings.';

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -189,6 +189,37 @@ class ShaderMaterial extends Material {
     return shader;
   }
 
+  // Validates a uniform block against the shader's reflection before binding
+  // it. Debug-only (the reflection lookup is a native call, and it must stay
+  // fresh across a shader hot reload rather than being memoized), and it turns
+  // two silent-or-fatal mistakes into named exceptions: a block the shader
+  // does not declare, and a buffer smaller than the block's std140 size.
+  bool _checkBlock(
+    gpu.UniformSlot slot,
+    String name,
+    ByteData bytes,
+    ShaderStage stage,
+  ) {
+    final size = slot.sizeInBytes;
+    if (size == null) {
+      throw StateError(
+        'ShaderMaterial: the ${stage.name} shader declares no uniform block '
+        'named "$name". Check the spelling (a block binds by its type name, '
+        'not its instance name), and note that a block nothing in the shader '
+        'reads is optimized out and reflects as absent.',
+      );
+    }
+    if (bytes.lengthInBytes < size) {
+      throw StateError(
+        'ShaderMaterial: uniform block "$name" on the ${stage.name} shader '
+        'needs $size bytes but was given ${bytes.lengthInBytes}. std140 pads '
+        'a vec3 to 16 bytes and strides array elements to 16, so a packed '
+        'Float32List is usually short; see the std140 table in MATERIALS.md.',
+      );
+    }
+    return true;
+  }
+
   void _warnMissingVertexVariant(MeshVariant kind) {
     if (!_warnedMissingVariants.add(kind)) return;
     debugPrint(missingVertexVariantMessage(_vertexShaders.keys, kind));
@@ -303,10 +334,9 @@ class ShaderMaterial extends Material {
     pass.setWindingOrder(windingOrder);
 
     for (final entry in _uniformBlocks.entries) {
-      pass.bindUniform(
-        fragmentShader.getUniformSlot(entry.key),
-        transientsBuffer.emplace(entry.value),
-      );
+      final slot = fragmentShader.getUniformSlot(entry.key);
+      assert(_checkBlock(slot, entry.key, entry.value, ShaderStage.fragment));
+      pass.bindUniform(slot, transientsBuffer.emplace(entry.value));
     }
 
     for (final entry in _textures.entries) {
@@ -335,10 +365,9 @@ class ShaderMaterial extends Material {
     TransientWriter transientsBuffer,
   ) {
     for (final entry in _vertexUniformBlocks.entries) {
-      pass.bindUniform(
-        vertexShader.getUniformSlot(entry.key),
-        transientsBuffer.emplace(entry.value),
-      );
+      final slot = vertexShader.getUniformSlot(entry.key);
+      assert(_checkBlock(slot, entry.key, entry.value, ShaderStage.vertex));
+      pass.bindUniform(slot, transientsBuffer.emplace(entry.value));
     }
     for (final entry in _vertexTextures.entries) {
       final resolved = _resolveShaderTexture(entry.value.source);

--- a/packages/flutter_scene/lib/src/material/shader_stage.dart
+++ b/packages/flutter_scene/lib/src/material/shader_stage.dart
@@ -1,0 +1,43 @@
+/// Which shader a material binds a uniform block or texture against.
+///
+/// A block declared in both stages is two bindings, not one, so setting it
+/// for the fragment stage alone leaves the vertex stage's copy unset.
+/// {@category Materials}
+enum ShaderStage {
+  /// The vertex shader, when the material supplies one.
+  vertex,
+
+  /// The fragment shader.
+  fragment,
+}
+
+/// The mesh kind a vertex shader runs on.
+///
+/// A geometry selects the variant it needs, and the engine's standard shader
+/// runs for any variant a material does not supply.
+/// {@category Materials}
+enum MeshVariant {
+  /// A static mesh, whose vertices arrive as-is.
+  unskinned('unskinned'),
+
+  /// A skinned mesh, whose vertices are posed by joints before the material's
+  /// shader sees them.
+  skinned('skinned'),
+
+  /// The position-only pass that draws shadow maps and the depth prepass.
+  /// Supply this when the vertex stage moves geometry, so its shadow moves
+  /// with it.
+  depth('depth');
+
+  const MeshVariant(this.name);
+
+  /// The wire name the geometry and the `.fmat` sidecar use.
+  final String name;
+
+  /// The variant [name] selects, or [unskinned] for an unknown name.
+  static MeshVariant fromName(String name) => switch (name) {
+    'skinned' => MeshVariant.skinned,
+    'depth' => MeshVariant.depth,
+    _ => MeshVariant.unskinned,
+  };
+}

--- a/packages/flutter_scene/test/shader_material_vertex_test.dart
+++ b/packages/flutter_scene/test/shader_material_vertex_test.dart
@@ -5,6 +5,9 @@
 import 'dart:typed_data';
 
 import 'package:flutter_scene/scene.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene/src/material/shader_material.dart'
+    show missingVertexVariantMessage;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -13,6 +16,17 @@ void main() {
     for (final variant in MeshVariant.values) {
       expect(material.vertexShaderFor(variant), isNull);
     }
+  });
+
+  test('the missing-variant warning names both sides', () {
+    final message = missingVertexVariantMessage([
+      MeshVariant.unskinned,
+    ], MeshVariant.skinned);
+    // The author needs to know which variant to add and why the engine's
+    // fallback may not link, so both variant names have to appear.
+    expect(message, contains('unskinned'));
+    expect(message, contains('skinned'));
+    expect(message, contains('varying'));
   });
 
   test('MeshVariant maps the names the geometry and sidecar use', () {

--- a/packages/flutter_scene/test/shader_material_vertex_test.dart
+++ b/packages/flutter_scene/test/shader_material_vertex_test.dart
@@ -1,0 +1,95 @@
+// Covers the raw path's vertex-stage surface: which variant a vertex shader is
+// registered for, and that the two stages keep separate uniform and texture
+// bindings. The GPU-side binding is covered by the raw_shader_pair smoke scene.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('no vertex shader means the engine drives the vertex stage', () {
+    final material = ShaderMaterial();
+    for (final variant in MeshVariant.values) {
+      expect(material.vertexShaderFor(variant), isNull);
+    }
+  });
+
+  test('MeshVariant maps the names the geometry and sidecar use', () {
+    expect(MeshVariant.fromName('unskinned'), MeshVariant.unskinned);
+    expect(MeshVariant.fromName('skinned'), MeshVariant.skinned);
+    expect(MeshVariant.fromName('depth'), MeshVariant.depth);
+    // An unknown variant falls back rather than throwing mid-draw.
+    expect(MeshVariant.fromName('something-else'), MeshVariant.unskinned);
+    expect(MeshVariant.unskinned.name, 'unskinned');
+  });
+
+  group('stage-addressed bindings', () {
+    test('a block set on one stage does not appear on the other', () {
+      final material = ShaderMaterial();
+      final bytes = ByteData.sublistView(Float32List.fromList([1, 2, 3, 4]));
+
+      material.setUniformBlock('RippleInfo', bytes, stage: ShaderStage.vertex);
+      expect(
+        material.getUniformBlock('RippleInfo', stage: ShaderStage.vertex),
+        same(bytes),
+      );
+      expect(material.getUniformBlock('RippleInfo'), isNull);
+      expect(material.vertexUniformBlockNames, contains('RippleInfo'));
+      expect(material.uniformBlockNames, isNot(contains('RippleInfo')));
+    });
+
+    test('the same block name can hold different bytes per stage', () {
+      final material = ShaderMaterial();
+      final vertexBytes = ByteData(16);
+      final fragmentBytes = ByteData(16);
+
+      material.setUniformBlock(
+        'Shared',
+        vertexBytes,
+        stage: ShaderStage.vertex,
+      );
+      material.setUniformBlock('Shared', fragmentBytes);
+      expect(
+        material.getUniformBlock('Shared', stage: ShaderStage.vertex),
+        same(vertexBytes),
+      );
+      expect(material.getUniformBlock('Shared'), same(fragmentBytes));
+    });
+
+    test('the fragment stage stays the default', () {
+      final material = ShaderMaterial();
+      material.setUniformBlockFromFloats('FragInfo', [1, 0, 0, 1]);
+      expect(material.uniformBlockNames, contains('FragInfo'));
+      expect(material.vertexUniformBlockNames, isEmpty);
+    });
+
+    test('clearing a binding only clears its own stage', () {
+      final material = ShaderMaterial();
+      material.setUniformBlock(
+        'Shared',
+        ByteData(16),
+        stage: ShaderStage.vertex,
+      );
+      material.setUniformBlock('Shared', ByteData(16));
+
+      material.setUniformBlock('Shared', null, stage: ShaderStage.vertex);
+      expect(material.vertexUniformBlockNames, isEmpty);
+      expect(material.uniformBlockNames, contains('Shared'));
+    });
+
+    test('textures are addressed per stage too', () {
+      final material = ShaderMaterial();
+      expect(material.vertexTextureNames, isEmpty);
+      expect(material.textureNames, isEmpty);
+      expect(
+        () => material.setTexture(
+          'displacement',
+          Object(),
+          stage: ShaderStage.vertex,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Resolves https://github.com/bdero/flutter_scene/issues/283.

`ShaderMaterial` now takes a vertex shader as well as a fragment one, registered per `MeshVariant` so skinned meshes and the shadow pass can differ, and its uniform and texture setters take a `ShaderStage`. Writing a complete shader pair no longer means subclassing `Geometry` or importing from `lib/src`.

Geometry gains a public `setVertexLayout` for vertices the engine has no opinion about, custom attributes now work on skinned meshes, and the value types those need are exported (`IndexType`, the vertex formats, and the layout descriptors), which also closes the 32-bit index gap.

The contract a custom vertex shader has to satisfy is in MATERIALS.md, with a worked pair in the example app and a `raw_shader_pair` smoke scene so every backend compiles and draws one.