### PR TITLE
Let apps see and release the GPU memory the engine holds

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.20.1
 
+* GPU memory can be inspected and released. `takeMemoryReport()` reports what the engine's shared caches are pinning, `releaseTexture`/`releaseScene` give a claim back, and `clearTextureCache`/`clearSceneTemplateCache` drop everything.
+* `ResourceGroup.track` scopes a load to the group's lifetime, so `dispose()` releases the claims it took. Previously `dispose()` only released the progress notifier despite the name.
+* Fixed `ResourceGroup` throwing when it was disposed while a tracked load was still in flight, which is what tearing down a level mid-load does.
+
 * `ShaderMaterial` owns the vertex stage too. Pass a `vertexShader` (per `MeshVariant`, so skinned and shadow passes can differ) and set uniforms and textures on either stage with `ShaderStage`, so a hand-written shader pair needs no subclassing.
 * Geometry can declare its own pipeline vertex layout with `setVertexLayout`, and `VertexAttributeDescriptor`/`VertexBufferDescriptor`/`VertexLayoutDescriptor` are public.
 * Custom vertex attributes work on skinned meshes.

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -86,7 +86,13 @@ export 'src/material/unlit_material.dart' show UnlitMaterial;
 export 'src/fmat/material_registry.dart'
     show FmatMaterialRegistry, loadFmatMaterial, loadFmatSky;
 export 'src/importer/scene_registry.dart'
-    show SceneRegistry, SceneReloadCallback, loadScene, loadSceneSubtree;
+    show
+        SceneRegistry,
+        SceneReloadCallback,
+        clearSceneTemplateCache,
+        loadScene,
+        loadSceneSubtree,
+        releaseScene;
 
 export 'src/ambient_occlusion.dart'
     show AmbientOcclusionSettings, SpecularAmbientOcclusionMode;
@@ -193,7 +199,10 @@ export 'src/texture_atlas.dart'
     show TextureAtlas, generateSolidColorAtlasPixels;
 export 'src/texture/texture2d.dart'
     show Texture2D, TextureSource, TextureSampling, GpuTextureSource;
-export 'src/texture/texture_registry.dart' show loadTexture;
+export 'src/memory_report.dart'
+    show MemoryCategory, MemoryReport, takeMemoryReport;
+export 'src/texture/texture_registry.dart'
+    show clearTextureCache, loadTexture, releaseTexture;
 export 'src/texture/mipmap.dart' show TextureContent;
 // Audio is an optional contract, exported from
 // `package:flutter_scene/audio.dart`.

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show internal;
 import 'package:flutter/services.dart';
 
 import 'package:scene/scene.dart';
@@ -27,6 +28,11 @@ typedef SceneReloadCallback = void Function(Node root);
 /// call realizes its own node graph from it. An entry is dropped when the
 /// scene's assets hot reload, so the next load re-reads them.
 final Map<String, Future<_SceneTemplate>> _sceneTemplates = {};
+
+/// Outstanding [loadScene] claims per template key, so releasing one caller's
+/// claim cannot drop a template another caller is still loading instances
+/// from.
+final Map<String, int> _sceneTemplateHolders = {};
 
 /// Tracked dependency sets of streamed lazy subtrees, keyed by placeholder
 /// node, so repeated loads refresh the registration instead of duplicating it.
@@ -219,12 +225,14 @@ final class SceneRegistry {
     }
 
     final pending = _sceneTemplates[key] ??= loadTemplate();
+    _sceneTemplateHolders.update(key, (n) => n + 1, ifAbsent: () => 1);
     _SceneTemplate template;
     try {
       template = await pending;
     } catch (_) {
       // Don't cache a failed load; the next call retries.
       _sceneTemplates.remove(key);
+      _sceneTemplateHolders.remove(key);
       rethrow;
     }
 
@@ -460,3 +468,46 @@ Future<void> loadSceneSubtree(
     registry: registry,
   );
 }
+
+/// Releases one claim on the template [loadScene] built for [sourcePath],
+/// dropping it from the shared cache when no claims remain.
+///
+/// Returns whether the template was dropped. A template holds the scene's
+/// realized geometry, materials, and textures, shared by every instance loaded
+/// from it, so this is the lever for unloading a level.
+///
+/// Dropping the template releases the engine's reference, not the memory.
+/// Nodes already realized from it keep their own references and stay resident
+/// until they are removed from the scene and collected. See
+/// `Scene.memoryReport` for what is actually resident.
+/// {@category Assets and loading}
+Future<bool> releaseScene(
+  String sourcePath, {
+  String? package,
+  AssetBundle? bundle,
+}) async {
+  final registry = await SceneRegistry.load(bundle: bundle);
+  final key = registry.resolveKey(sourcePath, package: package);
+  final holders = _sceneTemplateHolders[key];
+  if (holders == null) return false;
+  if (holders > 1) {
+    _sceneTemplateHolders[key] = holders - 1;
+    return false;
+  }
+  _sceneTemplateHolders.remove(key);
+  return _sceneTemplates.remove(key) != null;
+}
+
+/// Drops every cached scene template, whatever their outstanding claims.
+///
+/// Prefer [releaseScene] where the caller knows what it loaded. Nodes already
+/// realized keep their own references and stay resident until collected.
+/// {@category Assets and loading}
+void clearSceneTemplateCache() {
+  _sceneTemplates.clear();
+  _sceneTemplateHolders.clear();
+}
+
+/// The number of scene templates the shared cache is holding.
+@internal
+int sceneTemplateCacheCount() => _sceneTemplates.length;

--- a/packages/flutter_scene/lib/src/memory_report.dart
+++ b/packages/flutter_scene/lib/src/memory_report.dart
@@ -1,0 +1,84 @@
+/// What flutter_scene is currently keeping resident on the GPU, and what is
+/// holding it.
+library;
+
+import 'package:flutter/foundation.dart';
+
+import 'importer/scene_registry.dart';
+import 'texture/texture_registry.dart';
+
+/// One category of resident GPU memory.
+/// {@category Assets and loading}
+@immutable
+class MemoryCategory {
+  const MemoryCategory({
+    required this.name,
+    required this.bytes,
+    required this.count,
+  });
+
+  /// What this category holds (`textures`, `scene templates`).
+  final String name;
+
+  /// Resident bytes, or null where the size is not knowable from Dart.
+  final int? bytes;
+
+  /// How many resources the category holds.
+  final int count;
+
+  @override
+  String toString() =>
+      '$name: $count${bytes == null ? '' : ' (${_mib(bytes!)} MiB)'}';
+}
+
+/// A snapshot of what flutter_scene is keeping resident.
+///
+/// Covers what the engine's shared caches pin, which is the memory an app has
+/// no other way to see or release. It does not cover resources the app holds
+/// itself (a [Texture2D] you constructed and kept), and it is a measure of
+/// what is *pinned*, not of what the GPU has actually reclaimed. Dropping the
+/// last reference to a resource makes it collectable, but the reclaim happens
+/// on the engine's schedule.
+/// {@category Assets and loading}
+@immutable
+class MemoryReport {
+  const MemoryReport(this.categories);
+
+  /// Every category, in a stable order.
+  final List<MemoryCategory> categories;
+
+  /// Total resident bytes across the categories that can report a size.
+  int get totalBytes =>
+      categories.fold(0, (sum, category) => sum + (category.bytes ?? 0));
+
+  @override
+  String toString() =>
+      'MemoryReport(${_mib(totalBytes)} MiB)\n'
+      '${categories.map((c) => '  $c').join('\n')}';
+}
+
+/// Takes a [MemoryReport] of what the engine's shared caches are holding.
+///
+/// Cheap enough to poll (it walks the cache maps and reads each texture's
+/// reflected size), so it is reasonable to surface in a debug overlay.
+/// {@category Assets and loading}
+MemoryReport takeMemoryReport() {
+  final textures = textureCacheFootprint();
+  return MemoryReport([
+    MemoryCategory(
+      name: 'textures',
+      bytes: textures.bytes,
+      count: textures.count,
+    ),
+    // A template's footprint is spread across the geometry, materials, and
+    // textures it realized, which are not individually measurable from here
+    // yet, so only the count is reported.
+    MemoryCategory(
+      name: 'scene templates',
+      bytes: null,
+      count: sceneTemplateCacheCount(),
+    ),
+  ]);
+}
+
+String _mib(int bytes) => (bytes / (1024 * 1024)).toStringAsFixed(2);

--- a/packages/flutter_scene/lib/src/resource_group.dart
+++ b/packages/flutter_scene/lib/src/resource_group.dart
@@ -40,6 +40,8 @@ class ResourceGroup {
   int _completed = 0;
   final List<Object> _failures = <Object>[];
   final List<Future<void>> _tracked = <Future<void>>[];
+  final List<Future<void> Function()> _releases = <Future<void> Function()>[];
+  bool _disposed = false;
   final ValueNotifier<double> _progress = ValueNotifier<double>(1.0);
 
   /// Tracks [load] and returns it unchanged, so the call reads inline:
@@ -101,9 +103,56 @@ class ResourceGroup {
   /// The errors from any tracked loads that failed, in completion order.
   List<Object> get failures => List<Object>.unmodifiable(_failures);
 
-  /// Releases the [progress] notifier. Call when the group is no longer used;
-  /// after disposal the group must not be added to or listened on.
-  void dispose() => _progress.dispose();
+  /// Releases this group's claim on everything loaded through [track], then
+  /// releases the [progress] notifier.
+  ///
+  /// Call when the scope this group represents ends, typically a level or a
+  /// screen. Each tracked load took a claim on the engine's shared cache, and
+  /// this gives them all back, so a resource nothing else claims leaves the
+  /// cache. After disposal the group must not be added to or listened on.
+  ///
+  /// This releases the engine's references, not the memory. A resource a live
+  /// scene still points at stays resident until that reference goes too, and
+  /// the GPU allocation is reclaimed after that on the engine's schedule
+  /// rather than at this call. Use [takeMemoryReport] to see what is actually
+  /// pinned.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    release();
+    _progress.dispose();
+  }
+
+  /// Releases this group's claims without disposing [progress], so the group
+  /// can be refilled and reused. [dispose] calls this for you.
+  void release() {
+    for (final release in _releases) {
+      release();
+    }
+    _releases.clear();
+  }
+
+  /// Tracks [load] like [add], and additionally takes ownership of it, so
+  /// [dispose] gives the claim back.
+  ///
+  /// Use this for the source-path loaders whose results live in a shared
+  /// cache ([loadScene], [loadTexture]). [add] only waits for a load; this
+  /// also scopes it to the group's lifetime.
+  ///
+  /// ```dart
+  /// final level = ResourceGroup();
+  /// final terrain = level.track(loadScene('levels/ice.fsceneb'),
+  ///     release: () => releaseScene('levels/ice.fsceneb'));
+  /// // ...
+  /// level.dispose(); // gives the template's claim back
+  /// ```
+  Future<T> track<T>(
+    Future<T> load, {
+    required Future<void> Function() release,
+  }) {
+    _releases.add(release);
+    return add(load);
+  }
 
   void _markSettled() {
     _completed++;
@@ -111,6 +160,11 @@ class ResourceGroup {
   }
 
   void _updateProgress() {
+    // A group is routinely disposed while loads are still in flight (a level
+    // torn down mid-load), and those loads still settle afterwards. Reporting
+    // progress into a disposed notifier would throw from a future nobody is
+    // awaiting.
+    if (_disposed) return;
     _progress.value = _total == 0 ? 1.0 : _completed / _total;
   }
 }

--- a/packages/flutter_scene/lib/src/texture/texture_registry.dart
+++ b/packages/flutter_scene/lib/src/texture/texture_registry.dart
@@ -3,6 +3,7 @@
 /// texture counterpart of `loadScene` / `loadFmatMaterial`).
 library;
 
+import 'package:flutter/foundation.dart' show internal;
 import 'package:flutter/services.dart';
 
 import '../gpu/gpu.dart' as gpu;
@@ -57,7 +58,26 @@ final class TextureEntry {
 /// Uploaded textures shared across [loadTexture] calls, keyed by asset key,
 /// so repeated loads of the same source share one GPU texture (and every
 /// holder sees the same hot-reload swap).
-final Map<String, Future<_ReloadableTextureSource>> _textureCache = {};
+final Map<String, _TextureCacheEntry> _textureCache = {};
+
+/// One cached texture plus the number of outstanding [loadTexture] calls that
+/// have not been released. The count exists so releasing one holder's claim
+/// cannot pull the texture out from under another holder that is still
+/// drawing with it.
+final class _TextureCacheEntry {
+  _TextureCacheEntry(this.source) {
+    // Kept so the footprint can be read synchronously; a texture still loading
+    // has no size to report yet.
+    // A failed load leaves it unresolved and uncounted.
+    source.then<void>((s) => _resolved = s).catchError((Object _) {});
+  }
+
+  final Future<_ReloadableTextureSource> source;
+  int holders = 0;
+  _ReloadableTextureSource? _resolved;
+
+  gpu.Texture? get resolvedTexture => _resolved?.sampledTexture;
+}
 
 /// The live handle [loadTexture] returns. Materials re-resolve
 /// [sampledTexture] at bind time, so swapping the GPU texture here (the
@@ -204,29 +224,105 @@ Future<TextureSource> loadTexture(
 
   final registry = await TextureRegistry.load(bundle: bundle);
   final key = registry.resolveKey(sourcePath, package: package);
-  final future = _textureCache.putIfAbsent(key, () async {
-    final source = _ReloadableTextureSource(
-      await gpuTextureFromKtx2Async(await loadBytes(key)),
-    );
-    HotReloadCoordinator.instance.registerTexture(
-      source,
-      assetKey: key,
-      bundle: assetBundle,
-      onReload: () async =>
-          source._swap(await gpuTextureFromKtx2Async(await loadBytes(key))),
-    );
-    return source;
-  });
+  final entry = _textureCache.putIfAbsent(
+    key,
+    () => _TextureCacheEntry(() async {
+      final source = _ReloadableTextureSource(
+        await gpuTextureFromKtx2Async(await loadBytes(key)),
+      );
+      HotReloadCoordinator.instance.registerTexture(
+        source,
+        assetKey: key,
+        bundle: assetBundle,
+        onReload: () async =>
+            source._swap(await gpuTextureFromKtx2Async(await loadBytes(key))),
+      );
+      return source;
+    }()),
+  );
+  entry.holders++;
   final _ReloadableTextureSource source;
   try {
-    source = await future;
+    source = await entry.source;
   } catch (_) {
     // Do not pin a failed load; the next call retries it.
-    if (identical(_textureCache[key], future)) {
+    entry.holders--;
+    if (identical(_textureCache[key], entry)) {
       _textureCache.remove(key);
     }
     rethrow;
   }
   if (sampling == null) return source;
   return _SampledTextureView(source, sampling.toSamplerOptions());
+}
+
+/// Releases one claim on the texture [loadTexture] returned for [sourcePath],
+/// dropping it from the shared cache when no claims remain.
+///
+/// Returns whether the cache entry was dropped. Every [loadTexture] call takes
+/// a claim, so a texture two callers loaded needs two releases before it
+/// leaves the cache; releasing one holder's claim never pulls the texture out
+/// from under the other.
+///
+/// Dropping the entry releases the engine's reference, not the memory. A
+/// texture a live material still points at stays resident until that reference
+/// goes too, and the GPU allocation is reclaimed after that on the engine's
+/// schedule rather than at this call. See `Scene.memoryReport` for what is
+/// actually resident.
+/// {@category Assets and loading}
+Future<bool> releaseTexture(
+  String sourcePath, {
+  String? package,
+  AssetBundle? bundle,
+}) async {
+  final registry = await TextureRegistry.load(bundle: bundle);
+  final key = registry.resolveKey(sourcePath, package: package);
+  return releaseTextureByAssetKey(key);
+}
+
+/// [releaseTexture] by resolved asset key, for callers that already have one.
+@internal
+bool releaseTextureByAssetKey(String assetKey) {
+  final entry = _textureCache[assetKey];
+  if (entry == null) return false;
+  entry.holders--;
+  if (entry.holders > 0) return false;
+  _textureCache.remove(assetKey);
+  return true;
+}
+
+/// Drops every cached texture, whatever their outstanding claims.
+///
+/// The blunt instrument, for tearing down a whole world at once. Prefer
+/// [releaseTexture] where the caller knows what it loaded. Textures a live
+/// scene still references stay resident until those references go.
+/// {@category Assets and loading}
+void clearTextureCache() => _textureCache.clear();
+
+/// Resident bytes and count of the textures held by the shared cache.
+///
+/// Sums each texture's whole mip chain, so it is the real GPU footprint of
+/// what the cache is pinning rather than an estimate. Textures still loading
+/// are not counted, since their size is not known yet.
+@internal
+({int bytes, int count}) textureCacheFootprint() {
+  var bytes = 0;
+  var count = 0;
+  for (final entry in _textureCache.values) {
+    final texture = entry.resolvedTexture;
+    if (texture == null) continue;
+    count++;
+    bytes += gpuTextureBytes(texture);
+  }
+  return (bytes: bytes, count: count);
+}
+
+/// The resident size of [texture], summed across its mip chain.
+@internal
+int gpuTextureBytes(gpu.Texture texture) {
+  var bytes = 0;
+  for (var level = 0; level < texture.mipLevelCount; level++) {
+    bytes += texture.getMipLevelSizeInBytes(level);
+  }
+  return bytes;
 }

--- a/packages/flutter_scene/test/memory_ownership_test.dart
+++ b/packages/flutter_scene/test/memory_ownership_test.dart
@@ -1,0 +1,89 @@
+// Covers the ownership half of the GPU memory story: a ResourceGroup gives
+// back the claims it took, and the memory report's value types. The registry
+// refcounts are exercised through the loaders, which need an asset bundle and
+// a GPU, so they are covered by the example app rather than here.
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ResourceGroup ownership', () {
+    test('dispose gives back every tracked claim', () async {
+      final released = <String>[];
+      final group = ResourceGroup();
+      group.track(
+        Future<int>.value(1),
+        release: () async => released.add('terrain'),
+      );
+      group.track(
+        Future<int>.value(2),
+        release: () async => released.add('props'),
+      );
+      await group.ready;
+
+      expect(released, isEmpty, reason: 'nothing is released before dispose');
+      group.dispose();
+      expect(released, ['terrain', 'props']);
+    });
+
+    test('release can be called without disposing, and is idempotent', () {
+      var releases = 0;
+      final group = ResourceGroup();
+      group.track(Future<int>.value(1), release: () async => releases++);
+
+      group.release();
+      expect(releases, 1);
+      // A second release must not hand the same claim back twice, which would
+      // drop a cache entry another holder still owns.
+      group.release();
+      expect(releases, 1);
+      group.dispose();
+      expect(releases, 1);
+    });
+
+    test('track still counts toward progress like add', () async {
+      final group = ResourceGroup();
+      group.track(Future<int>.value(1), release: () async {});
+      expect(group.total, 1);
+      await group.ready;
+      expect(group.completed, 1);
+      expect(group.isReady, isTrue);
+      group.dispose();
+    });
+
+    test('a failed tracked load still releases its claim', () async {
+      var releases = 0;
+      final group = ResourceGroup();
+      group.track(
+        Future<int>.error(StateError('boom')),
+        release: () async => releases++,
+      );
+      await group.ready;
+
+      expect(group.hasFailures, isTrue);
+      group.dispose();
+      expect(releases, 1, reason: 'a load that failed may still have cached');
+    });
+  });
+
+  group('memory report', () {
+    test('totals only the categories that can report a size', () {
+      const report = MemoryReport([
+        MemoryCategory(name: 'textures', bytes: 2 * 1024 * 1024, count: 3),
+        MemoryCategory(name: 'scene templates', bytes: null, count: 2),
+      ]);
+      expect(report.totalBytes, 2 * 1024 * 1024);
+      expect(report.toString(), contains('2.00 MiB'));
+      expect(report.toString(), contains('scene templates: 2'));
+    });
+
+    test('reports empty caches rather than throwing', () {
+      final report = takeMemoryReport();
+      expect(report.categories, isNotEmpty);
+      expect(report.totalBytes, 0);
+      for (final category in report.categories) {
+        expect(category.count, 0);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Part of https://github.com/bdero/flutter_scene/issues/285, the first three steps of the plan there.

The asset registries kept every texture and scene template they loaded for the life of the process, with no way to see them and no way to drop them, so an app that streams levels grew until it was killed. Both now refcount their entries, so `releaseTexture` and `releaseScene` give one claim back and drop the entry when the last one goes, and `clearTextureCache`/`clearSceneTemplateCache` are the blunt version for tearing down a world.

`ResourceGroup.track` scopes a load to the group, so `dispose()` releases the claims it took. That is the ownership model apps already reach for, and it also fixes the trap where `dispose()` released only the progress notifier despite its name.

`takeMemoryReport()` reports what the shared caches pin, exact for textures since each one's mip chain is measurable through the existing reflection, so it needs nothing upstream and works on every backend.

Deliberately not here: a bound on the pipeline cache. Instrumenting it across the smoke suite gave 15 pipelines for 14 scenes, and Impeller holds the real pipeline objects in its own unbounded map, so evicting ours would free a map entry and nothing else. Reasoning is in the issue.

Releasing drops the engine's references, not the memory. A resource a live scene still points at stays resident until that reference goes too, and reclamation happens on the engine's schedule after that. The dartdoc says so at each entry point.