### PR TITLE
Add rapier world snapshot, restore, and body teleport

### DIFF
--- a/packages/flutter_scene_rapier/CHANGELOG.md
+++ b/packages/flutter_scene_rapier/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 * Requires flutter_scene 0.20.0.
 * BREAKING: implements the `scene` package's `PhysicsSimulation` contract and no longer depends on Flutter, so the simulation runs headless. Drive it with the generic `PhysicsWorld(RapierWorld())`, `RigidBody`, and `Collider` from flutter_scene; the backend-specific `Rapier*` component classes are removed.
-* No native changes; reuses the 0.1.0 prebuilt binaries and wasm.
+* `RapierWorld.snapshot`/`restore`, full world serialization for rollback prediction and lag-compensation rewind (native only until the wasm marshalling lands).
+* `RapierWorld.setBodyPose`, immediate body teleport for rollback correction.
+* Ships new native binaries and wasm (new `fsr_world_snapshot`/`fsr_world_restore`/`fsr_body_set_pose` exports).
 
 ## 0.2.2
 

--- a/packages/flutter_scene_rapier/CHANGELOG.md
+++ b/packages/flutter_scene_rapier/CHANGELOG.md
@@ -1,10 +1,14 @@
+## Unreleased
+
+* `RapierWorld.snapshot`/`restore`, full world serialization for rollback prediction and lag-compensation rewind, on native and web.
+* `RapierWorld.setBodyPose`, immediate body teleport for rollback correction.
+* Ships new native binaries and wasm (new `fsr_world_snapshot`/`fsr_world_restore`/`fsr_body_set_pose` exports).
+
 ## 0.3.0
 
 * Requires flutter_scene 0.20.0.
 * BREAKING: implements the `scene` package's `PhysicsSimulation` contract and no longer depends on Flutter, so the simulation runs headless. Drive it with the generic `PhysicsWorld(RapierWorld())`, `RigidBody`, and `Collider` from flutter_scene; the backend-specific `Rapier*` component classes are removed.
-* `RapierWorld.snapshot`/`restore`, full world serialization for rollback prediction and lag-compensation rewind (native only until the wasm marshalling lands).
-* `RapierWorld.setBodyPose`, immediate body teleport for rollback correction.
-* Ships new native binaries and wasm (new `fsr_world_snapshot`/`fsr_world_restore`/`fsr_body_set_pose` exports).
+* No native changes; reuses the 0.1.0 prebuilt binaries and wasm.
 
 ## 0.2.2
 

--- a/packages/flutter_scene_rapier/lib/src/ffi/bindings.dart
+++ b/packages/flutter_scene_rapier/lib/src/ffi/bindings.dart
@@ -555,6 +555,31 @@ external void bodySetNextKinematicPose(
 );
 
 @Native<
+  Void Function(
+    Pointer<NativeWorld>,
+    Uint64,
+    Float,
+    Float,
+    Float,
+    Float,
+    Float,
+    Float,
+    Float,
+  )
+>(symbol: 'fsr_body_set_pose')
+external void bodySetPose(
+  Pointer<NativeWorld> world,
+  int handle,
+  double px,
+  double py,
+  double pz,
+  double qx,
+  double qy,
+  double qz,
+  double qw,
+);
+
+@Native<
   Void Function(Pointer<NativeWorld>, Uint64, Float, Float, Float, Uint8)
 >(symbol: 'fsr_body_set_linear_velocity')
 external void bodySetLinearVelocity(

--- a/packages/flutter_scene_rapier/lib/src/ffi/bindings.dart
+++ b/packages/flutter_scene_rapier/lib/src/ffi/bindings.dart
@@ -159,6 +159,26 @@ external void worldSetGravity(
 @Native<Void Function(Pointer<NativeWorld>, Float)>(symbol: 'fsr_world_step')
 external void worldStep(Pointer<NativeWorld> world, double dt);
 
+@Native<Pointer<Uint8> Function(Pointer<NativeWorld>, Pointer<Size>)>(
+  symbol: 'fsr_world_snapshot',
+)
+external Pointer<Uint8> worldSnapshot(
+  Pointer<NativeWorld> world,
+  Pointer<Size> outLen,
+);
+
+@Native<Void Function(Pointer<Uint8>, Size)>(symbol: 'fsr_world_snapshot_free')
+external void worldSnapshotFree(Pointer<Uint8> ptr, int len);
+
+@Native<Int Function(Pointer<NativeWorld>, Pointer<Uint8>, Size)>(
+  symbol: 'fsr_world_restore',
+)
+external int worldRestore(
+  Pointer<NativeWorld> world,
+  Pointer<Uint8> ptr,
+  int len,
+);
+
 @Native<
   Uint8 Function(
     Pointer<NativeWorld>,

--- a/packages/flutter_scene_rapier/lib/src/ffi/rapier_bindings.dart
+++ b/packages/flutter_scene_rapier/lib/src/ffi/rapier_bindings.dart
@@ -145,6 +145,16 @@ abstract class RapierBindings {
     double qz,
     double qw,
   );
+  void setBodyPose(
+    int handle,
+    double px,
+    double py,
+    double pz,
+    double qx,
+    double qy,
+    double qz,
+    double qw,
+  );
   void setBodyLockedAxes(int handle, int bits);
   void setBodyGravityScale(int handle, double scale);
   void setBodyCcdEnabled(int handle, bool enabled);

--- a/packages/flutter_scene_rapier/lib/src/ffi/rapier_bindings.dart
+++ b/packages/flutter_scene_rapier/lib/src/ffi/rapier_bindings.dart
@@ -89,6 +89,17 @@ abstract class RapierBindings {
   void step(double dt);
   void dispose();
 
+  /// Serializes the world's persistent simulation state (bodies, colliders,
+  /// joints, islands, broad and narrow phase, integration params, gravity)
+  /// for a later [restore]. Handles stay valid across a snapshot/restore, so
+  /// higher layers keep their handle mapping. Used for rollback prediction and
+  /// server-side lag-compensation rewind.
+  Uint8List snapshot();
+
+  /// Restores the world from a [snapshot], returning false if the bytes could
+  /// not be decoded.
+  bool restore(Uint8List snapshot);
+
   // Bodies.
   int createBody(
     int kind,

--- a/packages/flutter_scene_rapier/lib/src/ffi/rapier_bindings_native.dart
+++ b/packages/flutter_scene_rapier/lib/src/ffi/rapier_bindings_native.dart
@@ -49,6 +49,34 @@ class NativeRapierBindings extends RapierBindings {
   void step(double dt) => native.worldStep(_handle, dt);
 
   @override
+  Uint8List snapshot() {
+    final lenPtr = calloc<Size>();
+    try {
+      final ptr = native.worldSnapshot(_handle, lenPtr);
+      final len = lenPtr.value;
+      if (ptr == nullptr || len == 0) return Uint8List(0);
+      // Copy out of native memory before freeing the buffer.
+      final bytes = Uint8List.fromList(ptr.asTypedList(len));
+      native.worldSnapshotFree(ptr, len);
+      return bytes;
+    } finally {
+      calloc.free(lenPtr);
+    }
+  }
+
+  @override
+  bool restore(Uint8List snapshot) {
+    if (snapshot.isEmpty) return false;
+    final ptr = calloc<Uint8>(snapshot.length);
+    try {
+      ptr.asTypedList(snapshot.length).setAll(0, snapshot);
+      return native.worldRestore(_handle, ptr, snapshot.length) != 0;
+    } finally {
+      calloc.free(ptr);
+    }
+  }
+
+  @override
   void dispose() {
     _finalizer.detach(this);
     native.worldDestroy(_handle);

--- a/packages/flutter_scene_rapier/lib/src/ffi/rapier_bindings_native.dart
+++ b/packages/flutter_scene_rapier/lib/src/ffi/rapier_bindings_native.dart
@@ -202,6 +202,18 @@ class NativeRapierBindings extends RapierBindings {
   );
 
   @override
+  void setBodyPose(
+    int handle,
+    double px,
+    double py,
+    double pz,
+    double qx,
+    double qy,
+    double qz,
+    double qw,
+  ) => native.bodySetPose(_handle, handle, px, py, pz, qx, qy, qz, qw);
+
+  @override
   void setBodyLockedAxes(int handle, int bits) =>
       native.bodySetLockedAxes(_handle, handle, bits);
 

--- a/packages/flutter_scene_rapier/lib/src/ffi/wasm_rapier_bindings.dart
+++ b/packages/flutter_scene_rapier/lib/src/ffi/wasm_rapier_bindings.dart
@@ -89,19 +89,39 @@ class WasmRapierBindings extends RapierBindings {
   @override
   void step(double dt) => _invoke('fsr_world_step', [_w, _f(dt)]);
 
-  // TODO(prediction): marshal the snapshot buffer through wasm linear memory
-  // once the wasm module is rebuilt with the fsr_world_snapshot/restore/free
-  // exports. Until then the web backend has no world rollback.
   @override
-  Uint8List snapshot() => throw UnsupportedError(
-    'World snapshot is not available on the web backend yet; it needs the '
-    'wasm module rebuilt with the fsr_world_snapshot exports.',
-  );
+  Uint8List snapshot() {
+    // usize is 4 bytes on wasm32; the shim allocates the buffer and
+    // fsr_world_snapshot_free releases it after the copy out.
+    final lengthPtr = _runtime.alloc(4);
+    try {
+      final ptr = _invokeInt('fsr_world_snapshot', [_w, _i(lengthPtr)]);
+      final length = _runtime.readU32(lengthPtr);
+      if (ptr == 0 || length == 0) return Uint8List(0);
+      final bytes = _runtime.readBytes(ptr, length);
+      _invoke('fsr_world_snapshot_free', [_i(ptr), _i(length)]);
+      return bytes;
+    } finally {
+      _runtime.free(lengthPtr, 4);
+    }
+  }
 
   @override
-  bool restore(Uint8List snapshot) => throw UnsupportedError(
-    'World restore is not available on the web backend yet; see snapshot().',
-  );
+  bool restore(Uint8List snapshot) {
+    if (snapshot.isEmpty) return false;
+    final ptr = _runtime.alloc(snapshot.length);
+    try {
+      _runtime.writeBytes(ptr, snapshot);
+      final ok = _invokeInt('fsr_world_restore', [
+        _w,
+        _i(ptr),
+        _i(snapshot.length),
+      ]);
+      return ok != 0;
+    } finally {
+      _runtime.free(ptr, snapshot.length);
+    }
+  }
 
   @override
   void dispose() {

--- a/packages/flutter_scene_rapier/lib/src/ffi/wasm_rapier_bindings.dart
+++ b/packages/flutter_scene_rapier/lib/src/ffi/wasm_rapier_bindings.dart
@@ -89,6 +89,20 @@ class WasmRapierBindings extends RapierBindings {
   @override
   void step(double dt) => _invoke('fsr_world_step', [_w, _f(dt)]);
 
+  // TODO(prediction): marshal the snapshot buffer through wasm linear memory
+  // once the wasm module is rebuilt with the fsr_world_snapshot/restore/free
+  // exports. Until then the web backend has no world rollback.
+  @override
+  Uint8List snapshot() => throw UnsupportedError(
+    'World snapshot is not available on the web backend yet; it needs the '
+    'wasm module rebuilt with the fsr_world_snapshot exports.',
+  );
+
+  @override
+  bool restore(Uint8List snapshot) => throw UnsupportedError(
+    'World restore is not available on the web backend yet; see snapshot().',
+  );
+
   @override
   void dispose() {
     _invoke('fsr_world_destroy', [_w]);

--- a/packages/flutter_scene_rapier/lib/src/ffi/wasm_rapier_bindings.dart
+++ b/packages/flutter_scene_rapier/lib/src/ffi/wasm_rapier_bindings.dart
@@ -252,6 +252,28 @@ class WasmRapierBindings extends RapierBindings {
   ]);
 
   @override
+  void setBodyPose(
+    int handle,
+    double px,
+    double py,
+    double pz,
+    double qx,
+    double qy,
+    double qz,
+    double qw,
+  ) => _invoke('fsr_body_set_pose', [
+    _w,
+    _h(handle),
+    _f(px),
+    _f(py),
+    _f(pz),
+    _f(qx),
+    _f(qy),
+    _f(qz),
+    _f(qw),
+  ]);
+
+  @override
   void setBodyLockedAxes(int handle, int bits) =>
       _invoke('fsr_body_set_locked_axes', [_w, _h(handle), _i(bits)]);
 

--- a/packages/flutter_scene_rapier/lib/src/ffi/wasm_runtime.dart
+++ b/packages/flutter_scene_rapier/lib/src/ffi/wasm_runtime.dart
@@ -80,6 +80,24 @@ abstract class WasmRuntime {
     );
   }
 
+  /// Copies [length] bytes starting at [pointer] out of the module.
+  Uint8List readBytes(int pointer, int length) {
+    final view = memory;
+    return Uint8List.fromList(
+      Uint8List.view(view.buffer, view.offsetInBytes + pointer, length),
+    );
+  }
+
+  /// Copies [bytes] into the module starting at [pointer].
+  void writeBytes(int pointer, Uint8List bytes) {
+    final view = memory;
+    Uint8List.view(
+      view.buffer,
+      view.offsetInBytes + pointer,
+      bytes.length,
+    ).setAll(0, bytes);
+  }
+
   /// Reads [count] consecutive 32-bit floats starting at [pointer].
   Float32List readF32List(int pointer, int count) {
     final view = memory;

--- a/packages/flutter_scene_rapier/lib/src/rapier_world.dart
+++ b/packages/flutter_scene_rapier/lib/src/rapier_world.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:flutter_scene_rapier/src/ffi/rapier_bindings.dart';
 import 'package:flutter_scene_rapier/src/ffi/rapier_bindings_factory.dart';
@@ -55,6 +56,15 @@ class RapierWorld extends PhysicsSimulation {
 
   @override
   String get backendName => 'rapier3d';
+
+  @override
+  bool get supportsSnapshot => true;
+
+  @override
+  Uint8List snapshot() => _bindings.snapshot();
+
+  @override
+  bool restore(Uint8List snapshot) => _bindings.restore(snapshot);
 
   final StreamController<SimCollisionEvent> _events =
       StreamController<SimCollisionEvent>.broadcast();

--- a/packages/flutter_scene_rapier/lib/src/rapier_world.dart
+++ b/packages/flutter_scene_rapier/lib/src/rapier_world.dart
@@ -228,6 +228,20 @@ class RapierWorld extends PhysicsSimulation {
   }
 
   @override
+  void setBodyPose(int bodyHandle, Vector3 translation, Quaternion rotation) {
+    _bindings.setBodyPose(
+      bodyHandle,
+      translation.x,
+      translation.y,
+      translation.z,
+      rotation.x,
+      rotation.y,
+      rotation.z,
+      rotation.w,
+    );
+  }
+
+  @override
   void applyForce(int bodyHandle, Vector3 force, {Vector3? atWorldPoint}) {
     final p = atWorldPoint;
     _bindings.applyBodyForce(

--- a/packages/flutter_scene_rapier/native/Cargo.lock
+++ b/packages/flutter_scene_rapier/native/Cargo.lock
@@ -30,16 +30,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bytemuck"
@@ -84,7 +99,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "flutter_scene_rapier_native"
 version = "0.0.1"
 dependencies = [
+ "bincode",
  "rapier3d",
+ "serde",
 ]
 
 [[package]]
@@ -191,6 +208,7 @@ checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 dependencies = [
  "approx",
  "libm",
+ "serde_core",
 ]
 
 [[package]]
@@ -215,6 +233,7 @@ dependencies = [
  "glam 0.30.10",
  "nalgebra",
  "num-traits",
+ "serde",
  "simba",
 ]
 
@@ -236,6 +255,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -300,6 +321,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
+ "serde",
  "simba",
  "typenum",
 ]
@@ -312,7 +334,7 @@ checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -332,6 +354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -342,7 +365,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -404,6 +427,8 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "rstar",
+ "serde",
+ "serde_arrays",
  "simba",
  "slab",
  "smallvec",
@@ -443,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -475,6 +500,7 @@ dependencies = [
  "parry3d",
  "profiling",
  "rustc-hash",
+ "serde",
  "simba",
  "static_assertions",
  "thiserror",
@@ -521,6 +547,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_arrays"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a16b99c5ea4fe3daccd14853ad260ec00ea043b2708d1fd1da3106dcd8d9df"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "simba"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +619,7 @@ dependencies = [
  "hashbrown",
  "num-traits",
  "robust",
+ "serde",
  "smallvec",
 ]
 
@@ -581,6 +647,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,7 +674,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -617,6 +694,9 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "wide"

--- a/packages/flutter_scene_rapier/native/Cargo.toml
+++ b/packages/flutter_scene_rapier/native/Cargo.toml
@@ -12,7 +12,9 @@ name = "flutter_scene_rapier_native"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-rapier3d = "0.32"
+rapier3d = { version = "0.32", features = ["serde-serialize"] }
+serde = { version = "1", features = ["derive"] }
+bincode = "1.3"
 
 [profile.release]
 lto = true

--- a/packages/flutter_scene_rapier/native/src/lib.rs
+++ b/packages/flutter_scene_rapier/native/src/lib.rs
@@ -1348,6 +1348,31 @@ pub unsafe extern "C" fn fsr_body_set_next_kinematic_pose(
     }
 }
 
+/// Teleports a body to a pose immediately, waking it. Unlike the kinematic
+/// target above this does not integrate a velocity; it is meant for rollback
+/// correction (restore a snapshot, then adopt the authoritative pose).
+///
+/// # Safety
+/// `world` must be live; `raw` must come from [`fsr_body_create`].
+#[no_mangle]
+pub unsafe extern "C" fn fsr_body_set_pose(
+    world: *mut World,
+    raw: u64,
+    px: Real,
+    py: Real,
+    pz: Real,
+    qx: Real,
+    qy: Real,
+    qz: Real,
+    qw: Real,
+) {
+    let w = &mut *world;
+    if let Some(body) = w.rigid_body_set.get_mut(handle_from_raw(raw)) {
+        let pose = Pose::from_parts(Vector::new(px, py, pz), Rotation::from_xyzw(qx, qy, qz, qw));
+        body.set_position(pose, true);
+    }
+}
+
 /// Changes a body's kind (fixed / kinematic / dynamic) at runtime. Used to
 /// park a moving kinematic platform as fixed when it stops, so a kinematic
 /// character standing on it is not stuck by the controller's

--- a/packages/flutter_scene_rapier/native/src/lib.rs
+++ b/packages/flutter_scene_rapier/native/src/lib.rs
@@ -10,7 +10,42 @@ use rapier3d::control::{
 };
 use rapier3d::parry;
 use rapier3d::prelude::*;
+use serde::{Deserialize, Serialize};
 use std::os::raw::c_int;
+
+/// The persistent simulation state captured by [`fsr_world_snapshot`], by
+/// reference so serialization does not clone. The stateless pipelines and the
+/// transient per-step result buffers are excluded; they rebuild on the next
+/// step.
+#[derive(Serialize)]
+struct WorldSnapshotRef<'a> {
+    rigid_body_set: &'a RigidBodySet,
+    collider_set: &'a ColliderSet,
+    island_manager: &'a IslandManager,
+    broad_phase: &'a BroadPhaseBvh,
+    narrow_phase: &'a NarrowPhase,
+    impulse_joints: &'a ImpulseJointSet,
+    multibody_joints: &'a MultibodyJointSet,
+    ccd_solver: &'a CCDSolver,
+    integration_parameters: &'a IntegrationParameters,
+    gravity: &'a Vector,
+}
+
+/// The owned counterpart of [`WorldSnapshotRef`], produced by
+/// [`fsr_world_restore`] when deserializing.
+#[derive(Deserialize)]
+struct WorldSnapshotOwned {
+    rigid_body_set: RigidBodySet,
+    collider_set: ColliderSet,
+    island_manager: IslandManager,
+    broad_phase: BroadPhaseBvh,
+    narrow_phase: NarrowPhase,
+    impulse_joints: ImpulseJointSet,
+    multibody_joints: MultibodyJointSet,
+    ccd_solver: CCDSolver,
+    integration_parameters: IntegrationParameters,
+    gravity: Vector,
+}
 
 /// Owns the full set of Rapier pipeline state for one simulation.
 /// Allocated by [`fsr_world_new`], freed by [`fsr_world_destroy`].
@@ -654,6 +689,96 @@ pub unsafe extern "C" fn fsr_world_destroy(world: *mut World) {
         return;
     }
     drop(Box::from_raw(world));
+}
+
+/// Serializes the world's persistent simulation state into a freshly
+/// allocated byte buffer, writing its length to `out_len` and returning the
+/// pointer (null on failure). Release the buffer with
+/// [`fsr_world_snapshot_free`]. The stateless pipelines and transient result
+/// buffers are not captured; they rebuild on the next step.
+///
+/// # Safety
+/// `world` must be live; `out_len` must be a valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn fsr_world_snapshot(world: *mut World, out_len: *mut usize) -> *mut u8 {
+    let w = &*world;
+    let snapshot = WorldSnapshotRef {
+        rigid_body_set: &w.rigid_body_set,
+        collider_set: &w.collider_set,
+        island_manager: &w.island_manager,
+        broad_phase: &w.broad_phase,
+        narrow_phase: &w.narrow_phase,
+        impulse_joints: &w.impulse_joints,
+        multibody_joints: &w.multibody_joints,
+        ccd_solver: &w.ccd_solver,
+        integration_parameters: &w.integration_parameters,
+        gravity: &w.gravity,
+    };
+    match bincode::serialize(&snapshot) {
+        Ok(bytes) => {
+            *out_len = bytes.len();
+            let mut boxed = bytes.into_boxed_slice();
+            let ptr = boxed.as_mut_ptr();
+            std::mem::forget(boxed);
+            ptr
+        }
+        Err(_) => {
+            *out_len = 0;
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// Frees a buffer returned by [`fsr_world_snapshot`]. Null is a no-op.
+///
+/// # Safety
+/// `ptr`/`len` must come from one [`fsr_world_snapshot`] call and not be
+/// reused after this call.
+#[no_mangle]
+pub unsafe extern "C" fn fsr_world_snapshot_free(ptr: *mut u8, len: usize) {
+    if ptr.is_null() {
+        return;
+    }
+    drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
+}
+
+/// Restores the world's persistent state from a buffer produced by
+/// [`fsr_world_snapshot`], returning 1 on success and 0 if the bytes could
+/// not be deserialized. Body, collider, and joint handles from the snapshotted
+/// world stay valid, so the Dart side keeps its handle mapping.
+///
+/// # Safety
+/// `world` must be live; `ptr`/`len` must describe a readable buffer.
+#[no_mangle]
+pub unsafe extern "C" fn fsr_world_restore(world: *mut World, ptr: *const u8, len: usize) -> c_int {
+    if ptr.is_null() {
+        return 0;
+    }
+    let bytes = std::slice::from_raw_parts(ptr, len);
+    match bincode::deserialize::<WorldSnapshotOwned>(bytes) {
+        Ok(s) => {
+            let w = &mut *world;
+            w.rigid_body_set = s.rigid_body_set;
+            w.collider_set = s.collider_set;
+            w.island_manager = s.island_manager;
+            w.broad_phase = s.broad_phase;
+            w.narrow_phase = s.narrow_phase;
+            w.impulse_joints = s.impulse_joints;
+            w.multibody_joints = s.multibody_joints;
+            w.ccd_solver = s.ccd_solver;
+            w.integration_parameters = s.integration_parameters;
+            w.gravity = s.gravity;
+            // Transient per-step results are meaningless after a restore.
+            w.query_hits.clear();
+            w.collision_events.clear();
+            w.contact_points.clear();
+            if let Ok(mut events) = w.collision_collector.events.lock() {
+                events.clear();
+            }
+            1
+        }
+        Err(_) => 0,
+    }
 }
 
 /// Overwrites the world's gravity vector (in world space, units per

--- a/packages/flutter_scene_rapier/test/world_snapshot_test.dart
+++ b/packages/flutter_scene_rapier/test/world_snapshot_test.dart
@@ -1,0 +1,54 @@
+// World snapshot/restore round-trip through the native FFI. Bodies run
+// without colliders, so an explicit additional mass gives gravity something
+// to act on.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene_rapier/flutter_scene_rapier.dart';
+import 'package:scene/physics.dart';
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  test('snapshot restores a body and resimulates identically', () async {
+    await RapierWorld.ensureInitialized();
+    final world = RapierWorld();
+    expect(world.supportsSnapshot, isTrue);
+
+    final body = world.createBody(
+      target: SimplePoseTarget(translation: Vector3(0, 10, 0)),
+      type: BodyType.dynamic_,
+      additionalMass: 1,
+    );
+
+    // Capture the world at rest, then let the body fall for a second.
+    final snapshot = world.snapshot();
+    expect(snapshot, isNotEmpty);
+
+    for (var i = 0; i < 60; i++) {
+      world.step(1 / 60);
+    }
+    final fallenY = world.readBodyPose(body).$1.y;
+    expect(fallenY, lessThan(9)); // it dropped
+
+    // Restore rewinds the body to the snapshot pose, handle still valid.
+    expect(world.restore(snapshot), isTrue);
+    expect(world.readBodyPose(body).$1.y, closeTo(10, 0.001));
+
+    // And the restored world integrates forward to the same place (rollback
+    // resim, the reconciliation property).
+    for (var i = 0; i < 60; i++) {
+      world.step(1 / 60);
+    }
+    expect(world.readBodyPose(body).$1.y, closeTo(fallenY, 0.001));
+
+    world.dispose();
+  });
+
+  test('restore rejects malformed bytes', () async {
+    await RapierWorld.ensureInitialized();
+    final world = RapierWorld();
+    expect(world.restore(Uint8List.fromList([1, 2, 3])), isFalse);
+    world.dispose();
+  });
+}

--- a/packages/flutter_scene_rapier/test/world_snapshot_test.dart
+++ b/packages/flutter_scene_rapier/test/world_snapshot_test.dart
@@ -45,6 +45,56 @@ void main() {
     world.dispose();
   });
 
+  test('rollback correction replays deterministically', () async {
+    await RapierWorld.ensureInitialized();
+    final world = RapierWorld();
+
+    final body = world.createBody(
+      target: SimplePoseTarget(translation: Vector3(0, 10, 0)),
+      type: BodyType.dynamic_,
+      additionalMass: 1,
+    );
+
+    // Teleport adopts a pose immediately.
+    world.setBodyPose(body, Vector3(1, 10, 0), Quaternion.identity());
+    expect(world.readBodyPose(body).$1.x, closeTo(1, 1e-6));
+
+    // Predict ten ticks under a constant push, snapshotting each tick.
+    const dt = 1 / 30.0;
+    final snapshots = <int, Uint8List>{};
+    for (var tick = 1; tick <= 10; tick++) {
+      world.applyImpulse(body, Vector3(0.5, 0, 0));
+      world.step(dt);
+      snapshots[tick] = world.snapshot();
+    }
+    final predicted = world.readBodyPose(body).$1.clone();
+
+    // The authority disagrees about tick 5. Correct by restoring the tick-5
+    // snapshot, adopting the authoritative pose and velocity, and replaying
+    // the same pending inputs, the client misprediction-rollback loop.
+    Vector3 correctAndReplay() {
+      expect(world.restore(snapshots[5]!), isTrue);
+      final (position, rotation) = world.readBodyPose(body);
+      world.setBodyPose(body, position + Vector3(0, 0, 2), rotation);
+      world.setBodyLinearVelocity(body, world.readBodyLinearVelocity(body));
+      for (var tick = 6; tick <= 10; tick++) {
+        world.applyImpulse(body, Vector3(0.5, 0, 0));
+        world.step(dt);
+      }
+      return world.readBodyPose(body).$1.clone();
+    }
+
+    final first = correctAndReplay();
+    final second = correctAndReplay();
+
+    // The correction shifted the outcome, and the replay is repeatable.
+    expect(first.z - predicted.z, closeTo(2, 0.05));
+    expect(first.x, closeTo(predicted.x, 0.05));
+    expect((first - second).length, lessThan(1e-9));
+
+    world.dispose();
+  });
+
   test('restore rejects malformed bytes', () async {
     await RapierWorld.ensureInitialized();
     final world = RapierWorld();

--- a/packages/scene/CHANGELOG.md
+++ b/packages/scene/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - `PhysicsSimulation.snapshot`/`restore` (opt-in via `supportsSnapshot`), world serialization for rollback prediction and lag-compensation rewind.
+- `PhysicsSimulation.setBodyPose`, immediate body teleport for rollback correction (default throws on backends without it).
 
 ## 0.1.1
 

--- a/packages/scene/CHANGELOG.md
+++ b/packages/scene/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `PhysicsSimulation.snapshot`/`restore` (opt-in via `supportsSnapshot`), world serialization for rollback prediction and lag-compensation rewind.
+
 ## 0.1.1
 
 - `TextureResource` carries a `content` role (`color`, `data`, `normal`) describing what its pixels represent.

--- a/packages/scene/lib/src/physics/simulation.dart
+++ b/packages/scene/lib/src/physics/simulation.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:vector_math/vector_math.dart';
 
 import 'joint_desc.dart';
@@ -28,6 +30,23 @@ abstract class PhysicsSimulation {
 
   /// Maximum number of fixed steps consumed per frame by the driver.
   int maxSubsteps = 8;
+
+  /// Whether [snapshot]/[restore] round-trip the world state. Backends with
+  /// serialization (rapier) return true; others false.
+  bool get supportsSnapshot => false;
+
+  /// Serializes the world's simulation state for a later [restore], for
+  /// rollback prediction and lag-compensation rewind. Handles stay valid
+  /// across a snapshot/restore. Throws [UnsupportedError] unless
+  /// [supportsSnapshot].
+  Uint8List snapshot() =>
+      throw UnsupportedError('$backendName has no world snapshot');
+
+  /// Restores state from a [snapshot] produced by this backend, returning
+  /// false if the bytes could not be decoded. Throws [UnsupportedError] unless
+  /// [supportsSnapshot].
+  bool restore(Uint8List snapshot) =>
+      throw UnsupportedError('$backendName has no world restore');
 
   /// Collision lifecycle events, keyed by collider handle.
   Stream<SimCollisionEvent> get collisions;

--- a/packages/scene/lib/src/physics/simulation.dart
+++ b/packages/scene/lib/src/physics/simulation.dart
@@ -93,6 +93,12 @@ abstract class PhysicsSimulation {
     Quaternion rotation,
   );
 
+  /// Teleports a body to a pose immediately, waking it. No velocity is
+  /// integrated from the displacement; meant for rollback correction on top
+  /// of a [restore]. Throws [UnsupportedError] on backends without it.
+  void setBodyPose(int bodyHandle, Vector3 translation, Quaternion rotation) =>
+      throw UnsupportedError('$backendName has no body teleport');
+
   void applyForce(int bodyHandle, Vector3 force, {Vector3? atWorldPoint});
   void applyImpulse(int bodyHandle, Vector3 impulse, {Vector3? atWorldPoint});
   void applyTorque(int bodyHandle, Vector3 torque);


### PR DESCRIPTION
Adds `fsr_world_snapshot`/`fsr_world_restore`/`fsr_body_set_pose` to the native shim and surfaces them as `PhysicsSimulation.snapshot`/`restore`/`setBodyPose` (opt-in via `supportsSnapshot`, defaults throw so other backends are unaffected), the substrate for rollback prediction and lag-compensation rewind. Restore keeps handles valid, and the web backend marshals the buffers through wasm linear memory, so the same rollback runs on native and web.

Ships as a coordinated native plus wasm re-release since the FFI surface changed; the full cross-build matrix is green on the `flutter_scene_rapier-0.4.0-citest` tag.