### PR TITLE
Predict the owned player with input-replay reconciliation

### DIFF
--- a/examples/flutter_app/lib/example_multiplayer.dart
+++ b/examples/flutter_app/lib/example_multiplayer.dart
@@ -8,6 +8,8 @@ import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene_net/flutter_scene_net.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
+import 'example_overlay.dart';
+import 'example_panel.dart';
 import 'net/multiplayer_game.dart';
 
 /// Multiplayer arena. Host a game in-app (desktop/mobile) and join it from
@@ -108,6 +110,24 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
         session: session,
         root: arena,
         builders: {'net.player': _playerNode, 'net.pellet': _pelletNode},
+        // Predict the local player from its own input so movement is instant,
+        // running the same integration the server does; remote players stay
+        // interpolated. Corrections from the server ease in.
+        localPrediction: (replica) {
+          final player = replica as NetPlayer;
+          return (position, rotation, dt) {
+            final (p, r) = advancePlayer(
+              (position.x, position.y, position.z),
+              (rotation.x, rotation.y, rotation.z, rotation.w),
+              player.input.value,
+              dt,
+            );
+            return (
+              vm.Vector3(p.$1, p.$2, p.$3),
+              vm.Quaternion(r.$1, r.$2, r.$3, r.$4),
+            );
+          };
+        },
       );
       session.done.whenComplete(() {
         if (mounted && _replication != null) _leave();
@@ -167,7 +187,9 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
     }
 
     replication.owned<NetPlayer>()?.input.value = (
-      axis(
+      // Screen-right is world -X under the fixed overhead camera, so negate
+      // the strafe axis to keep A left and D right.
+      -axis(
         LogicalKeyboardKey.keyA,
         LogicalKeyboardKey.keyD,
         LogicalKeyboardKey.arrowLeft,
@@ -206,52 +228,86 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
           ),
         ),
         if (!connected)
-          Center(
-            child: Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    const Text('Multiplayer arena'),
-                    const SizedBox(height: 12),
-                    if (SceneHost.isSupported)
-                      FilledButton(
-                        onPressed: _hostGame,
-                        child: const Text('Host on this device'),
+          ExampleStatusCard(
+            child: DefaultTextStyle.merge(
+              style: const TextStyle(color: Colors.white),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const Text(
+                    'Multiplayer arena',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  const Text(
+                    'To test with two clients, open a second copy of this app '
+                    '(another window, device, or browser tab). Tap "Host on '
+                    'this device" in one, then tap Join in the other. On one '
+                    'machine the default localhost address works; across '
+                    'devices, use the join address the host shows.',
+                    style: TextStyle(
+                      color: Colors.white70,
+                      fontSize: 12,
+                      height: 1.35,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  if (SceneHost.isSupported)
+                    FilledButton(
+                      onPressed: _hostGame,
+                      child: const Text('Host on this device'),
+                    ),
+                  if (!SceneHost.isSupported)
+                    const Text(
+                      'Hosting needs a desktop or mobile build.',
+                      style: TextStyle(color: Colors.white70),
+                    ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _address,
+                    style: const TextStyle(color: Colors.white),
+                    cursorColor: Colors.white,
+                    decoration: const InputDecoration(
+                      labelText: 'host address',
+                      labelStyle: TextStyle(color: Colors.white70),
+                      enabledBorder: OutlineInputBorder(
+                        borderSide: BorderSide(color: Colors.white38),
                       ),
-                    if (!SceneHost.isSupported)
-                      const Text('Hosting needs a desktop or mobile build.'),
-                    const SizedBox(height: 12),
-                    SizedBox(
-                      width: 260,
-                      child: TextField(
-                        controller: _address,
-                        decoration: const InputDecoration(
-                          labelText: 'host address',
-                          border: OutlineInputBorder(),
-                        ),
+                      focusedBorder: OutlineInputBorder(
+                        borderSide: BorderSide(color: Colors.white),
                       ),
                     ),
-                    const SizedBox(height: 8),
-                    OutlinedButton(
-                      onPressed: _joinGame,
-                      child: const Text('Join'),
+                  ),
+                  const SizedBox(height: 10),
+                  OutlinedButton(
+                    onPressed: _joinGame,
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: Colors.white,
+                      side: const BorderSide(color: Colors.white54),
                     ),
-                    if (_status != null) ...[
-                      const SizedBox(height: 8),
-                      Text(_status!, style: const TextStyle(fontSize: 12)),
-                    ],
+                    child: const Text('Join'),
+                  ),
+                  if (_status != null) ...[
+                    const SizedBox(height: 10),
+                    Text(
+                      _status!,
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 12,
+                      ),
+                    ),
                   ],
-                ),
+                ],
               ),
             ),
           )
         else
-          Positioned(
-            left: 12,
-            top: 12,
+          ExampleOverlay.topCenter(
             child: DefaultTextStyle(
               style: const TextStyle(color: Colors.white, fontSize: 13),
               child: Container(

--- a/examples/flutter_app/lib/example_multiplayer.dart
+++ b/examples/flutter_app/lib/example_multiplayer.dart
@@ -36,6 +36,14 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
   String? _status;
   Timer? _hud;
 
+  /// Artificial round-trip latency injected on the hosted (loopback)
+  /// connection, so prediction is demonstrable on one machine.
+  int _simLatencyMs = 0;
+
+  /// Whether the local player is predicted (instant input) or interpolated
+  /// like a remote (renders in the past). Toggle to feel the difference.
+  bool _predict = true;
+
   @override
   void initState() {
     super.initState();
@@ -111,23 +119,12 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
         root: arena,
         builders: {'net.player': _playerNode, 'net.pellet': _pelletNode},
         // Predict the local player from its own input so movement is instant,
-        // running the same integration the server does; remote players stay
-        // interpolated. Corrections from the server ease in.
-        localPrediction: (replica) {
-          final player = replica as NetPlayer;
-          return (position, rotation, dt) {
-            final (p, r) = advancePlayer(
-              (position.x, position.y, position.z),
-              (rotation.x, rotation.y, rotation.z, rotation.w),
-              player.input.value,
-              dt,
-            );
-            return (
-              vm.Vector3(p.$1, p.$2, p.$3),
-              vm.Quaternion(r.$1, r.$2, r.$3, r.$4),
-            );
-          };
-        },
+        // running the same integration the server does and reconciling by
+        // replaying unacked inputs; remote players stay interpolated. When
+        // prediction is off the local player interpolates too, so it visibly
+        // lags input under latency.
+        localPrediction: (replica) =>
+            _predict ? _PlayerController(_pressed) : null,
       );
       session.done.whenComplete(() {
         if (mounted && _replication != null) _leave();
@@ -144,7 +141,18 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
       port: gamePort,
     );
     _host = host;
-    await _start(host.connectLocal);
+    await _start(() async {
+      final connection = await host.connectLocal();
+      if (_simLatencyMs == 0) return connection;
+      return SimulatorConnection(
+        connection,
+        SimulatedConditions(
+          latency: Duration(milliseconds: _simLatencyMs ~/ 2),
+          jitter: const Duration(milliseconds: 10),
+          unreliableLoss: 0.02,
+        ),
+      );
+    });
   }
 
   Future<void> _joinGame() async {
@@ -171,41 +179,6 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
     super.dispose();
   }
 
-  void _onTick(Duration elapsed, double deltaSeconds) {
-    final replication = _replication;
-    if (replication == null) return;
-    double axis(
-      LogicalKeyboardKey minus,
-      LogicalKeyboardKey plus,
-      LogicalKeyboardKey minusAlt,
-      LogicalKeyboardKey plusAlt,
-    ) {
-      var value = 0.0;
-      if (_pressed.contains(minus) || _pressed.contains(minusAlt)) value -= 1;
-      if (_pressed.contains(plus) || _pressed.contains(plusAlt)) value += 1;
-      return value;
-    }
-
-    replication.owned<NetPlayer>()?.input.value = (
-      // Screen-right is world -X under the fixed overhead camera, so negate
-      // the strafe axis to keep A left and D right.
-      -axis(
-        LogicalKeyboardKey.keyA,
-        LogicalKeyboardKey.keyD,
-        LogicalKeyboardKey.arrowLeft,
-        LogicalKeyboardKey.arrowRight,
-      ),
-      0.0,
-      axis(
-        LogicalKeyboardKey.keyW,
-        LogicalKeyboardKey.keyS,
-        LogicalKeyboardKey.arrowUp,
-        LogicalKeyboardKey.arrowDown,
-      ),
-    );
-    replication.flush();
-  }
-
   @override
   Widget build(BuildContext context) {
     final connected = _replication != null;
@@ -220,7 +193,6 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
           },
           child: SceneView(
             scene,
-            onTick: _onTick,
             cameraBuilder: (elapsed) => PerspectiveCamera(
               position: vm.Vector3(0, 22, 18),
               target: vm.Vector3(0, 0, 0),
@@ -245,18 +217,65 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
                   ),
                   const SizedBox(height: 10),
                   const Text(
-                    'To test with two clients, open a second copy of this app '
-                    '(another window, device, or browser tab). Tap "Host on '
-                    'this device" in one, then tap Join in the other. On one '
-                    'machine the default localhost address works; across '
-                    'devices, use the join address the host shows.',
+                    'Host on this device, then move with WASD or arrows. Add '
+                    'simulated latency and toggle prediction to feel the '
+                    'difference, predicted input stays instant and reconciles, '
+                    'while an interpolated local player lags by the round trip. '
+                    'For two clients, open a second copy and Join the address '
+                    'the host shows.',
                     style: TextStyle(
                       color: Colors.white70,
                       fontSize: 12,
                       height: 1.35,
                     ),
                   ),
-                  const SizedBox(height: 16),
+                  const SizedBox(height: 14),
+                  Row(
+                    children: [
+                      const Text(
+                        'Local prediction',
+                        style: TextStyle(color: Colors.white, fontSize: 13),
+                      ),
+                      const Spacer(),
+                      Switch(
+                        value: _predict,
+                        onChanged: (v) => setState(() => _predict = v),
+                      ),
+                    ],
+                  ),
+                  Row(
+                    children: [
+                      const Text(
+                        'Sim latency',
+                        style: TextStyle(color: Colors.white, fontSize: 13),
+                      ),
+                      const Spacer(),
+                      for (final ms in const [0, 100, 250])
+                        Padding(
+                          padding: const EdgeInsets.only(left: 6),
+                          child: OutlinedButton(
+                            onPressed: () => setState(() => _simLatencyMs = ms),
+                            style: OutlinedButton.styleFrom(
+                              foregroundColor: Colors.white,
+                              backgroundColor: _simLatencyMs == ms
+                                  ? Colors.white24
+                                  : null,
+                              side: BorderSide(
+                                color: _simLatencyMs == ms
+                                    ? Colors.white
+                                    : Colors.white38,
+                              ),
+                              minimumSize: const Size(0, 32),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 10,
+                              ),
+                            ),
+                            child: Text(ms == 0 ? 'off' : '${ms}ms'),
+                          ),
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 14),
                   if (SceneHost.isSupported)
                     FilledButton(
                       onPressed: _hostGame,
@@ -328,7 +347,12 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
                       ),
                     Text(
                       'rtt ${_replication!.session.clock.rttMillis.toStringAsFixed(0)}ms'
-                      ', move with WASD/arrows',
+                      '${_simLatencyMs > 0 ? ' (+$_simLatencyMs sim)' : ''}'
+                      '  ${_predict ? 'predicted' : 'interpolated'}',
+                    ),
+                    const Text(
+                      'move with WASD or arrows',
+                      style: TextStyle(color: Colors.white70, fontSize: 11),
                     ),
                     for (final player
                         in _replication!.replicas.whereType<NetPlayer>())
@@ -347,6 +371,65 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
             ),
           ),
       ],
+    );
+  }
+}
+
+/// Samples keyboard movement and integrates it, the same integration the
+/// server runs, so the local player is predicted and reconciled.
+class _PlayerController implements PredictedController {
+  _PlayerController(this._pressed);
+
+  final Set<LogicalKeyboardKey> _pressed;
+
+  double _axis(
+    LogicalKeyboardKey minus,
+    LogicalKeyboardKey plus,
+    LogicalKeyboardKey minusAlt,
+    LogicalKeyboardKey plusAlt,
+  ) {
+    var value = 0.0;
+    if (_pressed.contains(minus) || _pressed.contains(minusAlt)) value -= 1;
+    if (_pressed.contains(plus) || _pressed.contains(plusAlt)) value += 1;
+    return value;
+  }
+
+  @override
+  Uint8List sampleInput() {
+    // Screen-right is world -X under the fixed overhead camera, so negate the
+    // strafe axis to keep A left and D right.
+    final strafe = -_axis(
+      LogicalKeyboardKey.keyA,
+      LogicalKeyboardKey.keyD,
+      LogicalKeyboardKey.arrowLeft,
+      LogicalKeyboardKey.arrowRight,
+    );
+    final forward = _axis(
+      LogicalKeyboardKey.keyW,
+      LogicalKeyboardKey.keyS,
+      LogicalKeyboardKey.arrowUp,
+      LogicalKeyboardKey.arrowDown,
+    );
+    return encodePlayerInput(strafe, forward);
+  }
+
+  @override
+  (vm.Vector3, vm.Quaternion) step(
+    vm.Vector3 position,
+    vm.Quaternion rotation,
+    Uint8List input,
+    double dt,
+  ) {
+    final (dx, dz) = decodePlayerInput(input);
+    final (p, r) = advancePlayer(
+      (position.x, position.y, position.z),
+      (rotation.x, rotation.y, rotation.z, rotation.w),
+      (dx, 0.0, dz),
+      dt,
+    );
+    return (
+      vm.Vector3(p.$1, p.$2, p.$3),
+      vm.Quaternion(r.$1, r.$2, r.$3, r.$4),
     );
   }
 }

--- a/examples/flutter_app/lib/net/multiplayer_game.dart
+++ b/examples/flutter_app/lib/net/multiplayer_game.dart
@@ -53,6 +53,34 @@ ReplicaRegistry multiplayerRegistry() => ReplicaRegistry()
   ..register(NetPlayer.new)
   ..register(NetPellet.new);
 
+/// Advances a player pose by [dt] under movement [input] on the XZ plane.
+///
+/// Shared by the authoritative server tick and client-side prediction so the
+/// two integrate motion identically.
+(Vec3, Quat) advancePlayer(
+  Vec3 position,
+  Quat rotation,
+  Vec3 input,
+  double dt,
+) {
+  var (dx, _, dz) = input;
+  final length = sqrt(dx * dx + dz * dz);
+  if (length > 1) {
+    dx /= length;
+    dz /= length;
+  }
+  final (x, y, z) = position;
+  final moved = (
+    (x + dx * moveSpeed * dt).clamp(-fieldHalfSize, fieldHalfSize),
+    y,
+    (z + dz * moveSpeed * dt).clamp(-fieldHalfSize, fieldHalfSize),
+  );
+  if (length <= 0.01) return (moved, rotation);
+  // Face the travel direction (yaw about +Y).
+  final yaw = atan2(dx, dz);
+  return (moved, (0, sin(yaw / 2), 0, cos(yaw / 2)));
+}
+
 /// Builds the authoritative game room, join/leave spawns players, the tick
 /// integrates owner input and awards pellet pickups.
 Room buildMultiplayerRoom({Random? random}) {
@@ -85,23 +113,14 @@ Room buildMultiplayerRoom({Random? random}) {
     onTick: (tick) {
       const dt = 1.0 / gameTickRate;
       for (final player in players.values) {
-        var (dx, _, dz) = player.input.value;
-        final length = sqrt(dx * dx + dz * dz);
-        if (length > 1) {
-          dx /= length;
-          dz /= length;
-        }
-        final (x, y, z) = player.position.value;
-        player.position.value = (
-          (x + dx * moveSpeed * dt).clamp(-fieldHalfSize, fieldHalfSize),
-          y,
-          (z + dz * moveSpeed * dt).clamp(-fieldHalfSize, fieldHalfSize),
+        final (position, rotation) = advancePlayer(
+          player.position.value,
+          player.rotation.value,
+          player.input.value,
+          dt,
         );
-        if (length > 0.01) {
-          // Face the travel direction (yaw about +Y).
-          final yaw = atan2(dx, dz);
-          player.rotation.value = (0, sin(yaw / 2), 0, cos(yaw / 2));
-        }
+        player.position.value = position;
+        player.rotation.value = rotation;
         for (final pellet in pellets) {
           final (px, _, pz) = pellet.position.value;
           final (cx, _, cz) = player.position.value;

--- a/examples/flutter_app/lib/net/multiplayer_game.dart
+++ b/examples/flutter_app/lib/net/multiplayer_game.dart
@@ -5,7 +5,9 @@
 library;
 
 import 'dart:math';
+import 'dart:typed_data';
 
+import 'package:dashwire/dashwire.dart';
 import 'package:dashwire_replication/dashwire_replication.dart';
 
 /// Half-extent of the square play field on the XZ plane.
@@ -22,13 +24,6 @@ final class NetPlayer extends TransformReplica {
     hue = rep('hue', 0.0, codec: Codecs.quantized(1), mode: SendMode.spawnOnly);
     name = rep('name', '', codec: Codecs.string, mode: SendMode.onChange);
     score = rep('score', 0, codec: Codecs.varUint, mode: SendMode.onChange);
-    input = rep(
-      'input',
-      (0.0, 0.0, 0.0),
-      codec: Codecs.vec3(0.05),
-      write: Authority.owner,
-      validate: (peer, v) => v.$1.abs() <= 1.05 && v.$3.abs() <= 1.05,
-    );
   }
 
   @override
@@ -37,9 +32,21 @@ final class NetPlayer extends TransformReplica {
   late final Rep<double> hue;
   late final Rep<String> name;
   late final Rep<int> score;
+}
 
-  /// Owner-written movement intent on the XZ plane, clamped server-side.
-  late final Rep<Vec3> input;
+/// Encodes a player's movement intent for an input command. The client sends
+/// these tick-stamped; the server and the client prediction both decode and
+/// feed them to [advancePlayer].
+Uint8List encodePlayerInput(double strafe, double forward) =>
+    (ByteWriter(8)
+          ..writeF32(strafe)
+          ..writeF32(forward))
+        .toBytes();
+
+/// Decodes an input command payload to a clamped XZ movement vector.
+(double, double) decodePlayerInput(Uint8List bytes) {
+  final r = ByteReader(bytes);
+  return (r.readF32().clamp(-1.0, 1.0), r.readF32().clamp(-1.0, 1.0));
 }
 
 final class NetPellet extends TransformReplica {
@@ -112,11 +119,18 @@ Room buildMultiplayerRoom({Random? random}) {
     },
     onTick: (tick) {
       const dt = 1.0 / gameTickRate;
-      for (final player in players.values) {
+      for (final entry in players.entries) {
+        final player = entry.value;
+        // Consume this peer's authoritative input for the tick, hold-last on
+        // a gap. The same advancePlayer the client predicts with runs here.
+        final command = room.input(entry.key, tick);
+        final (dx, dz) = command == null
+            ? (0.0, 0.0)
+            : decodePlayerInput(command);
         final (position, rotation) = advancePlayer(
           player.position.value,
           player.rotation.value,
-          player.input.value,
+          (dx, 0.0, dz),
           dt,
         );
         player.position.value = position;

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_scene: ^0.21.0
   # Multiplayer example.
   dashwire: ^0.1.0
-  dashwire_replication: ^0.2.0
+  dashwire_replication: ^0.2.1
   flutter_scene_net: ^0.1.0
   # Native Rapier physics backend, used by the Physics example. Pulls
   # in a Rust build hook, so building this app now requires cargo.

--- a/packages/flutter_scene_net/CHANGELOG.md
+++ b/packages/flutter_scene_net/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- `PredictedTransformComponent` with `PredictedController`, client-side prediction of an owned entity with authoritative input-replay reconciliation, so local input renders instantly while the sim stays server-authoritative. Selected per entity through `SceneReplication`'s `localPrediction` seam.
+- `NetworkTransformComponent` re-anchors its interpolation buffer after an idle gap, so a resuming remote eases in instead of snapping.
+- Requires the input-command and prediction substrate from the next `dashwire`/`dashwire_replication` release.
+
 ## 0.1.0
 
 - `SceneReplication` binds replicas to scene nodes through per-type builders and detaches them on despawn.

--- a/packages/flutter_scene_net/lib/flutter_scene_net.dart
+++ b/packages/flutter_scene_net/lib/flutter_scene_net.dart
@@ -1,8 +1,9 @@
 /// dashwire multiplayer for flutter_scene.
 ///
 /// Replicas whose types extend [TransformReplica] become scene nodes through
-/// a [SceneReplication] binding; remote poses render slightly in the past
-/// through interpolation. [SceneHost] runs a room inside the app on
+/// a [SceneReplication] binding. Poses you do not own render slightly in the
+/// past through interpolation; the entity you own can instead be predicted so
+/// local input renders instantly. [SceneHost] runs a room inside the app on
 /// dart:io platforms so a game can host without a separate server.
 library;
 
@@ -10,5 +11,7 @@ export 'src/hosting/hosting.dart' show SceneHost;
 export 'src/network_transform_codec.dart'
     show NetworkTransformCodec, registerNetComponentCodecs;
 export 'src/network_transform.dart' show NetworkTransformComponent;
+export 'src/predicted_transform.dart'
+    show PredictStep, PredictedTransformComponent;
 export 'src/scene_replication.dart' show ReplicaNodeBuilder, SceneReplication;
 export 'src/transform_replica.dart' show TransformReplicaVectors;

--- a/packages/flutter_scene_net/lib/flutter_scene_net.dart
+++ b/packages/flutter_scene_net/lib/flutter_scene_net.dart
@@ -12,6 +12,7 @@ export 'src/network_transform_codec.dart'
     show NetworkTransformCodec, registerNetComponentCodecs;
 export 'src/network_transform.dart' show NetworkTransformComponent;
 export 'src/predicted_transform.dart'
-    show PredictStep, PredictedTransformComponent;
-export 'src/scene_replication.dart' show ReplicaNodeBuilder, SceneReplication;
+    show PredictedController, PredictedTransformComponent;
+export 'src/scene_replication.dart'
+    show LocalPredictionBuilder, ReplicaNodeBuilder, SceneReplication;
 export 'src/transform_replica.dart' show TransformReplicaVectors;

--- a/packages/flutter_scene_net/lib/src/network_transform.dart
+++ b/packages/flutter_scene_net/lib/src/network_transform.dart
@@ -19,7 +19,8 @@ final class NetworkTransformComponent extends Component {
   NetworkTransformComponent(
     this.replica, {
     this.delay = const Duration(milliseconds: 100),
-  }) {
+    NowMicros now = defaultNowMicros,
+  }) : _now = now {
     _push();
     // TODO(replication-unsubscribe): dashwire_replication 0.2.0 has no
     // listener removal, so these subscriptions (and through them this
@@ -34,22 +35,29 @@ final class NetworkTransformComponent extends Component {
   /// How far in the past remote poses render.
   final Duration delay;
 
+  final NowMicros _now;
+
   final List<(int, Vector3, Quaternion)> _samples = [];
 
   void _push() {
-    _samples.add((
-      defaultNowMicros(),
-      replica.positionVector,
-      replica.rotationQuaternion,
-    ));
+    final now = _now();
+    // Samples are only pushed on pose change, so after an idle stretch the
+    // newest one is stale. Re-anchor the held pose at now - delay before
+    // appending the fresh one, so resuming motion eases in over `delay`
+    // instead of interpolating across the whole gap (which snaps forward).
+    if (_samples.isNotEmpty && now - _samples.last.$1 > delay.inMicroseconds) {
+      final (_, p, q) = _samples.last;
+      _samples
+        ..clear()
+        ..add((now - delay.inMicroseconds, p, q));
+    }
+    _samples.add((now, replica.positionVector, replica.rotationQuaternion));
     if (_samples.length > 64) _samples.removeAt(0);
   }
 
   @override
   void update(double deltaSeconds) {
-    final (position, rotation) = sampleAt(
-      defaultNowMicros() - delay.inMicroseconds,
-    );
+    final (position, rotation) = sampleAt(_now() - delay.inMicroseconds);
     node.localTransform = Matrix4.compose(position, rotation, _unitScale);
   }
 

--- a/packages/flutter_scene_net/lib/src/predicted_transform.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_transform.dart
@@ -44,6 +44,7 @@ final class PredictedTransformComponent extends Component {
     required int tickRate,
     this.smoothing = const Duration(milliseconds: 120),
     this.correctionThreshold = 0.05,
+    this.maxCatchUpTicks = 32,
     NowMicros now = defaultNowMicros,
   }) : _dt = 1 / tickRate,
        _now = now {
@@ -65,6 +66,16 @@ final class PredictedTransformComponent extends Component {
   /// Positional divergence (metres) beyond which a snapshot triggers a replay
   /// correction.
   final double correctionThreshold;
+
+  /// Most ticks predicted in one [update] before the prediction snaps to
+  /// authority instead of catching up.
+  ///
+  /// The target tick comes from the wall clock, so a stall (a backgrounded
+  /// tab, a long hitch, a resume from pause) would otherwise sample, step and
+  /// send every missed tick in a single frame. The server's input buffer
+  /// drops commands older than its window anyway, so most of that catch-up is
+  /// discarded on arrival.
+  final int maxCatchUpTicks;
 
   final double _dt;
   final NowMicros _now;
@@ -99,6 +110,16 @@ final class PredictedTransformComponent extends Component {
       ));
       _reconciledTick = acked;
       if (corrected) _error.setFrom(rendered - _predictor.current.$1);
+    }
+
+    // Too far behind to catch up tick by tick, so snap to the newest
+    // authoritative pose and resume predicting from there.
+    if (target - _predictor.currentTick > maxCatchUpTicks) {
+      _predictor.reset(target - 1, (
+        replica.positionVector,
+        replica.rotationQuaternion,
+      ));
+      _error.setZero();
     }
 
     // Predict forward to the target tick, one input sampled and sent per tick.

--- a/packages/flutter_scene_net/lib/src/predicted_transform.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_transform.dart
@@ -97,9 +97,15 @@ final class PredictedTransformComponent extends Component {
       ));
     }
 
-    // Reconcile against the authoritative pose the server has confirmed
-    // applying input through.
-    final acked = client.lastAppliedInputTick;
+    // Reconcile against the authoritative pose, at the tick that pose
+    // actually belongs to. The input ack goes out every tick while snapshots
+    // are priority-packed against a byte budget and can be deferred or
+    // dropped, so the replica's pose is often older than the ack; adopting it
+    // at the ack's tick would discard the motion in between and re-predict
+    // it, tugging backward on every snapshot.
+    final applied = client.lastAppliedInputTick;
+    final carried = replica.snapshotTick;
+    final acked = carried > 0 && carried < applied ? carried : applied;
     if (acked > _reconciledTick &&
         acked > 0 &&
         acked <= _predictor.currentTick) {

--- a/packages/flutter_scene_net/lib/src/predicted_transform.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_transform.dart
@@ -1,0 +1,95 @@
+import 'dart:math';
+
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' hide Colors;
+
+import 'transform_replica.dart';
+
+/// Advances a predicted pose by [deltaSeconds] from local input.
+///
+/// The same movement code should run on the authoritative server so the
+/// prediction and the server agree; the client feeds its local input, the
+/// server feeds the owner's replicated input.
+typedef PredictStep =
+    (Vector3 position, Quaternion rotation) Function(
+      Vector3 position,
+      Quaternion rotation,
+      double deltaSeconds,
+    );
+
+/// Drives the owning node from a client-side prediction of a [TransformReplica]
+/// this client owns, so local input renders instantly instead of a round trip
+/// in the past.
+///
+/// Each frame it advances the predicted pose with [step] and renders it. When
+/// an authoritative snapshot arrives (the replica's server-owned pose changes)
+/// it adopts that pose and lets the visible discrepancy decay over [smoothing],
+/// so corrections ease in rather than pop.
+///
+/// This is the client half. It adopts each snapshot as truth, which is exact
+/// at low latency; it does not yet replay the inputs the server has not acked,
+/// so under high latency the correction lags by about the round trip.
+// TODO(prediction): replay unacked inputs on top of each authoritative
+// snapshot. That needs a sequenced input command stream (client tags inputs,
+// server echoes the last-applied sequence), which the replication layer does
+// not expose yet. Server-side lag compensation (rewinding other entities to
+// the shooter's view) is a separate server concern built on a pose history.
+final class PredictedTransformComponent extends Component {
+  PredictedTransformComponent(
+    this.replica, {
+    required this.step,
+    this.smoothing = const Duration(milliseconds: 120),
+  }) {
+    _position = replica.positionVector;
+    _rotation = replica.rotationQuaternion;
+    replica.position.onChanged((_, _) => _serverPending = true);
+    replica.rotation.onChanged((_, _) => _serverPending = true);
+  }
+
+  final TransformReplica replica;
+  final PredictStep step;
+
+  /// Time constant over which an authoritative correction eases in.
+  final Duration smoothing;
+
+  late Vector3 _position;
+  late Quaternion _rotation;
+
+  /// Rendered-minus-authoritative offset, decays toward zero.
+  final Vector3 _error = Vector3.zero();
+  bool _serverPending = false;
+
+  @override
+  void update(double deltaSeconds) {
+    if (_serverPending) {
+      _serverPending = false;
+      _reconcile();
+    }
+    final (position, rotation) = step(_position, _rotation, deltaSeconds);
+    _position = position;
+    _rotation = rotation;
+    if (smoothing.inMicroseconds > 0) {
+      _error.scale(exp(-deltaSeconds * 1e6 / smoothing.inMicroseconds));
+    } else {
+      _error.setZero();
+    }
+    node.localTransform = Matrix4.compose(
+      _position + _error,
+      _rotation,
+      _unitScale,
+    );
+  }
+
+  void _reconcile() {
+    final serverPosition = replica.positionVector;
+    // Keep drawing where we were, then let the gap to the authoritative pose
+    // decay through [_error] so the correction eases in.
+    final rendered = _position + _error;
+    _position = serverPosition;
+    _error.setFrom(rendered - serverPosition);
+    _rotation = replica.rotationQuaternion;
+  }
+
+  static final Vector3 _unitScale = Vector3(1, 1, 1);
+}

--- a/packages/flutter_scene_net/lib/src/predicted_transform.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_transform.dart
@@ -88,7 +88,14 @@ final class PredictedTransformComponent extends Component {
   void update(double deltaSeconds) {
     final clock = client.session.clock;
     if (!clock.isSynchronized) return;
-    final target = clock.inputTickAt(_now());
+    // Pace the send-ahead from the client's adaptive lead. Passing an
+    // explicit tick to sendInput bypasses the sender's own pacing, so
+    // sampling the lead here is what keeps the server's buffer-depth control
+    // loop closed and lets the lead deepen under jitter.
+    final target = clock.inputTickAt(
+      _now(),
+      marginTicks: client.inputLeadTicks.toDouble(),
+    );
 
     if (!_predictor.isSeeded) {
       _predictor.reset(target - 1, (

--- a/packages/flutter_scene_net/lib/src/predicted_transform.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_transform.dart
@@ -1,94 +1,125 @@
 import 'dart:math';
+import 'dart:typed_data';
 
+import 'package:dashwire/dashwire.dart';
 import 'package:dashwire_replication/dashwire_replication.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' hide Colors;
 
 import 'transform_replica.dart';
 
-/// Advances a predicted pose by [deltaSeconds] from local input.
+/// Client-side driver for an owned, predicted entity.
 ///
-/// The same movement code should run on the authoritative server so the
-/// prediction and the server agree; the client feeds its local input, the
-/// server feeds the owner's replicated input.
-typedef PredictStep =
-    (Vector3 position, Quaternion rotation) Function(
-      Vector3 position,
-      Quaternion rotation,
-      double deltaSeconds,
-    );
+/// [sampleInput] captures and encodes this tick's local input for the wire.
+/// [step] integrates a pose one fixed tick under a decoded input and must
+/// match the server's integration exactly (share one function) so replay
+/// reconciliation converges. Encode one-frame events (a jump, a shot) as
+/// counters, not booleans, so a resent command reproduces them.
+abstract interface class PredictedController {
+  Uint8List sampleInput();
 
-/// Drives the owning node from a client-side prediction of a [TransformReplica]
-/// this client owns, so local input renders instantly instead of a round trip
-/// in the past.
+  (Vector3 position, Quaternion rotation) step(
+    Vector3 position,
+    Quaternion rotation,
+    Uint8List input,
+    double dt,
+  );
+}
+
+/// Drives the node of an owned [TransformReplica] by client-side prediction
+/// with authoritative input-replay reconciliation, so local input renders
+/// instantly while the sim stays server-authoritative.
 ///
-/// Each frame it advances the predicted pose with [step] and renders it. When
-/// an authoritative snapshot arrives (the replica's server-owned pose changes)
-/// it adopts that pose and lets the visible discrepancy decay over [smoothing],
-/// so corrections ease in rather than pop.
-///
-/// This is the client half. It adopts each snapshot as truth, which is exact
-/// at low latency; it does not yet replay the inputs the server has not acked,
-/// so under high latency the correction lags by about the round trip.
-// TODO(prediction): replay unacked inputs on top of each authoritative
-// snapshot. That needs a sequenced input command stream (client tags inputs,
-// server echoes the last-applied sequence), which the replication layer does
-// not expose yet. Server-side lag compensation (rewinding other entities to
-// the shooter's view) is a separate server concern built on a pose history.
+/// Each fixed tick it samples and sends an input command, advances the
+/// prediction, and stores `(tick, input, pose)`. When the server confirms the
+/// authoritative pose after an input tick (via the input-command ack) it rolls
+/// the prediction back to that pose and replays the not-yet-applied inputs.
+/// A correction decays through a visual error offset over [smoothing] rather
+/// than popping.
 final class PredictedTransformComponent extends Component {
   PredictedTransformComponent(
     this.replica, {
-    required this.step,
+    required this.controller,
+    required this.client,
+    required int tickRate,
     this.smoothing = const Duration(milliseconds: 120),
-  }) {
-    _position = replica.positionVector;
-    _rotation = replica.rotationQuaternion;
-    replica.position.onChanged((_, _) => _serverPending = true);
-    replica.rotation.onChanged((_, _) => _serverPending = true);
+    this.correctionThreshold = 0.05,
+    NowMicros now = defaultNowMicros,
+  }) : _dt = 1 / tickRate,
+       _now = now {
+    _predictor = Predictor<Uint8List, (Vector3, Quaternion)>(
+      step: (state, input, dt) =>
+          controller.step(state.$1, state.$2, input, dt),
+      dt: _dt,
+      diverged: (a, b) => (a.$1 - b.$1).length > correctionThreshold,
+    );
   }
 
   final TransformReplica replica;
-  final PredictStep step;
+  final PredictedController controller;
+  final ReplicationClient client;
 
   /// Time constant over which an authoritative correction eases in.
   final Duration smoothing;
 
-  late Vector3 _position;
-  late Quaternion _rotation;
+  /// Positional divergence (metres) beyond which a snapshot triggers a replay
+  /// correction.
+  final double correctionThreshold;
 
-  /// Rendered-minus-authoritative offset, decays toward zero.
+  final double _dt;
+  final NowMicros _now;
+
+  late final Predictor<Uint8List, (Vector3, Quaternion)> _predictor;
   final Vector3 _error = Vector3.zero();
-  bool _serverPending = false;
+  int _reconciledTick = -1;
 
   @override
   void update(double deltaSeconds) {
-    if (_serverPending) {
-      _serverPending = false;
-      _reconcile();
+    final clock = client.session.clock;
+    if (!clock.isSynchronized) return;
+    final target = clock.inputTickAt(_now());
+
+    if (!_predictor.isSeeded) {
+      _predictor.reset(target - 1, (
+        replica.positionVector,
+        replica.rotationQuaternion,
+      ));
     }
-    final (position, rotation) = step(_position, _rotation, deltaSeconds);
-    _position = position;
-    _rotation = rotation;
+
+    // Reconcile against the authoritative pose the server has confirmed
+    // applying input through.
+    final acked = client.lastAppliedInputTick;
+    if (acked > _reconciledTick &&
+        acked > 0 &&
+        acked <= _predictor.currentTick) {
+      final rendered = _predictor.current.$1 + _error;
+      final corrected = _predictor.reconcile(acked, (
+        replica.positionVector,
+        replica.rotationQuaternion,
+      ));
+      _reconciledTick = acked;
+      if (corrected) _error.setFrom(rendered - _predictor.current.$1);
+    }
+
+    // Predict forward to the target tick, one input sampled and sent per tick.
+    while (_predictor.currentTick < target) {
+      final tick = _predictor.currentTick + 1;
+      final input = controller.sampleInput();
+      _predictor.advance(tick, input);
+      client.sendInput(input, tick: tick);
+    }
+
     if (smoothing.inMicroseconds > 0) {
       _error.scale(exp(-deltaSeconds * 1e6 / smoothing.inMicroseconds));
     } else {
       _error.setZero();
     }
+    final (position, rotation) = _predictor.current;
     node.localTransform = Matrix4.compose(
-      _position + _error,
-      _rotation,
+      position + _error,
+      rotation,
       _unitScale,
     );
-  }
-
-  void _reconcile() {
-    final serverPosition = replica.positionVector;
-    // Keep drawing where we were, then let the gap to the authoritative pose
-    // decay through [_error] so the correction eases in.
-    final rendered = _position + _error;
-    _position = serverPosition;
-    _error.setFrom(rendered - serverPosition);
-    _rotation = replica.rotationQuaternion;
   }
 
   static final Vector3 _unitScale = Vector3(1, 1, 1);

--- a/packages/flutter_scene_net/lib/src/scene_replication.dart
+++ b/packages/flutter_scene_net/lib/src/scene_replication.dart
@@ -12,9 +12,9 @@ import 'transform_replica.dart';
 /// Builds the scene subtree representing [replica] at spawn time.
 typedef ReplicaNodeBuilder = Node Function(Replica replica);
 
-/// Supplies the client-side prediction step for an owned [replica], or null to
-/// interpolate it like any other entity.
-typedef LocalPredictionBuilder = PredictStep? Function(Replica replica);
+/// Supplies the client-side prediction controller for an owned [replica], or
+/// null to interpolate it like any other entity.
+typedef LocalPredictionBuilder = PredictedController? Function(Replica replica);
 
 /// Binds a replication client to a scene graph.
 ///
@@ -82,12 +82,17 @@ final class SceneReplication {
       );
       // Predict the entity this client owns so its input renders instantly;
       // interpolate everything else in the past for smoothness.
-      final predict = replica.owner == localPeerId
+      final controller = replica.owner == localPeerId
           ? _localPrediction?.call(replica)
           : null;
       node.addComponent(
-        predict != null
-            ? PredictedTransformComponent(replica, step: predict)
+        controller != null
+            ? PredictedTransformComponent(
+                replica,
+                controller: controller,
+                client: client,
+                tickRate: session.tickRate,
+              )
             : NetworkTransformComponent(replica, delay: interpolationDelay),
       );
     }

--- a/packages/flutter_scene_net/lib/src/scene_replication.dart
+++ b/packages/flutter_scene_net/lib/src/scene_replication.dart
@@ -6,16 +6,23 @@ import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' hide Colors;
 
 import 'network_transform.dart';
+import 'predicted_transform.dart';
 import 'transform_replica.dart';
 
 /// Builds the scene subtree representing [replica] at spawn time.
 typedef ReplicaNodeBuilder = Node Function(Replica replica);
 
+/// Supplies the client-side prediction step for an owned [replica], or null to
+/// interpolate it like any other entity.
+typedef LocalPredictionBuilder = PredictStep? Function(Replica replica);
+
 /// Binds a replication client to a scene graph.
 ///
-/// Spawned replicas become nodes under [root] through per-type builders;
-/// [TransformReplica]s additionally get a [NetworkTransformComponent] so
-/// their poses render interpolated. Despawns detach the node.
+/// Spawned replicas become nodes under [root] through per-type builders.
+/// [TransformReplica]s get a [NetworkTransformComponent] that renders their
+/// pose interpolated in the past; the entity this client owns is instead
+/// driven by a [PredictedTransformComponent] when a `localPrediction` step is
+/// supplied, so local input renders instantly. Despawns detach the node.
 final class SceneReplication {
   SceneReplication({
     required ReplicaRegistry registry,
@@ -23,9 +30,11 @@ final class SceneReplication {
     required this.root,
     required Map<String, ReplicaNodeBuilder> builders,
     this.interpolationDelay = const Duration(milliseconds: 100),
+    LocalPredictionBuilder? localPrediction,
     void Function(Replica replica, Node node)? onSpawn,
     void Function(Replica replica, Node node)? onDespawn,
   }) : _builders = builders,
+       _localPrediction = localPrediction,
        _onSpawn = onSpawn,
        _onDespawn = onDespawn {
     client = ReplicationClient(
@@ -43,6 +52,7 @@ final class SceneReplication {
 
   final Map<String, ReplicaNodeBuilder> _builders;
   final Duration interpolationDelay;
+  final LocalPredictionBuilder? _localPrediction;
   final void Function(Replica, Node)? _onSpawn;
   final void Function(Replica, Node)? _onDespawn;
   late final ReplicationClient client;
@@ -70,8 +80,15 @@ final class SceneReplication {
         replica.rotationQuaternion,
         Vector3(1, 1, 1),
       );
+      // Predict the entity this client owns so its input renders instantly;
+      // interpolate everything else in the past for smoothness.
+      final predict = replica.owner == localPeerId
+          ? _localPrediction?.call(replica)
+          : null;
       node.addComponent(
-        NetworkTransformComponent(replica, delay: interpolationDelay),
+        predict != null
+            ? PredictedTransformComponent(replica, step: predict)
+            : NetworkTransformComponent(replica, delay: interpolationDelay),
       );
     }
     root.add(node);

--- a/packages/flutter_scene_net/pubspec.yaml
+++ b/packages/flutter_scene_net/pubspec.yaml
@@ -24,7 +24,7 @@ environment:
 resolution: workspace
 dependencies:
   dashwire: ^0.1.0
-  dashwire_replication: ^0.2.0
+  dashwire_replication: ^0.2.1
   flutter:
     sdk: flutter
   flutter_scene: ^0.21.0

--- a/packages/flutter_scene_net/test/flutter_scene_net_test.dart
+++ b/packages/flutter_scene_net/test/flutter_scene_net_test.dart
@@ -24,8 +24,13 @@ Uint8List _encodeVel(double v) => (ByteWriter(4)..writeF32(v)).toBytes();
 double _decodeVel(Uint8List b) => ByteReader(b).readF32();
 
 class _ConstantController implements PredictedController {
+  int samples = 0;
+
   @override
-  Uint8List sampleInput() => _encodeVel(1);
+  Uint8List sampleInput() {
+    samples++;
+    return _encodeVel(1);
+  }
 
   @override
   (vm.Vector3, vm.Quaternion) step(
@@ -247,4 +252,54 @@ void main() {
     await replication.close();
     await room.stop();
   });
+
+  test(
+    'a stalled client snaps forward instead of replaying every tick',
+    () async {
+      const tickRate = 30;
+      final room = Room(registry: _registry(), tickRate: tickRate);
+      final (clientEnd, serverEnd) = LoopbackConnection.pair();
+      final admitted = room.admit(serverEnd);
+      final session = await connectSession(
+        clientEnd,
+        schemaHash: _registry().schemaHash,
+        pingInterval: const Duration(milliseconds: 20),
+      );
+      await admitted;
+      await _pump();
+
+      final client = ReplicationClient(registry: _registry(), session: session);
+      final pawn = _Pawn()
+        ..id = NetId(1, 1)
+        ..owner = client.localPeerId;
+      final controller = _ConstantController();
+      var now = defaultNowMicros();
+      final component = PredictedTransformComponent(
+        pawn,
+        controller: controller,
+        client: client,
+        tickRate: tickRate,
+        maxCatchUpTicks: 8,
+        now: () => now,
+      );
+      Node().addComponent(component);
+
+      // Seed the prediction, then stall for ten seconds of wall clock (300
+      // ticks at this rate) before the next frame.
+      component.update(1 / 60);
+      controller.samples = 0;
+      now += const Duration(seconds: 10).inMicroseconds;
+      component.update(1 / 60);
+
+      // Only the clamp's worth of ticks is sampled and sent, not the 300 the
+      // clock skipped.
+      expect(controller.samples, lessThanOrEqualTo(8));
+
+      // Drain the inputs this test sent before tearing the room down.
+      await _pump();
+      await session.close();
+      await _pump();
+      await room.stop();
+    },
+  );
 }

--- a/packages/flutter_scene_net/test/flutter_scene_net_test.dart
+++ b/packages/flutter_scene_net/test/flutter_scene_net_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:dashwire/dashwire.dart';
 import 'package:dashwire_replication/dashwire_replication.dart';
 import 'package:flutter_scene/scene.dart';
@@ -13,6 +15,29 @@ final class _Pawn extends TransformReplica {
 }
 
 ReplicaRegistry _registry() => ReplicaRegistry()..register(_Pawn.new);
+
+// A trivial 1D controller, hold a constant +X velocity, integrated the same
+// way on the server so prediction converges.
+const double _testSpeed = 5;
+
+Uint8List _encodeVel(double v) => (ByteWriter(4)..writeF32(v)).toBytes();
+double _decodeVel(Uint8List b) => ByteReader(b).readF32();
+
+class _ConstantController implements PredictedController {
+  @override
+  Uint8List sampleInput() => _encodeVel(1);
+
+  @override
+  (vm.Vector3, vm.Quaternion) step(
+    vm.Vector3 position,
+    vm.Quaternion rotation,
+    Uint8List input,
+    double dt,
+  ) => (
+    vm.Vector3(position.x + _decodeVel(input) * _testSpeed * dt, 0, 0),
+    rotation,
+  );
+}
 
 Future<void> _pump([int rounds = 4]) async {
   for (var i = 0; i < rounds; i++) {
@@ -149,46 +174,77 @@ void main() {
     expect(mid.x, lessThan(8));
   });
 
-  test('prediction renders local input instantly and eases in corrections', () {
-    final pawn = _Pawn()..position.value = (0.0, 0.0, 0.0);
-    var input = 0.0;
-    final node = Node()
-      ..addComponent(
-        PredictedTransformComponent(
-          pawn,
-          smoothing: const Duration(milliseconds: 100),
-          step: (position, rotation, dt) =>
-              (position + vm.Vector3(input * 5 * dt, 0, 0), rotation),
-        ),
-      );
-    final component = node.getComponent<PredictedTransformComponent>()!;
+  test('an owned player is predicted from local input and converges', () async {
+    const tickRate = 30;
+    const dt = 1 / tickRate;
 
-    // No input holds position.
-    component.update(1 / 60);
-    expect(node.localTransform.getTranslation().x, closeTo(0, 1e-6));
+    late final Room room;
+    final players = <int, _Pawn>{};
+    room = Room(
+      registry: _registry(),
+      tickRate: tickRate,
+      onJoin: (session) {
+        final pawn = _Pawn();
+        room.host.spawn(pawn, owner: session.peerId);
+        players[session.peerId] = pawn;
+      },
+      onTick: (tick) {
+        for (final entry in players.entries) {
+          final command = room.input(entry.key, tick);
+          final vx = command == null ? 0.0 : _decodeVel(command);
+          final (x, _, _) = entry.value.position.value;
+          entry.value.position.value = (x + vx * _testSpeed * dt, 0, 0);
+        }
+      },
+    );
 
-    // Input moves the very next frame, no round trip.
-    input = 1.0;
-    component.update(1 / 60);
-    expect(node.localTransform.getTranslation().x, greaterThan(0));
-    for (var i = 0; i < 20; i++) {
-      component.update(1 / 60);
+    final (clientEnd, serverEnd) = LoopbackConnection.pair();
+    final admitted = room.admit(serverEnd);
+    final session = await connectSession(
+      clientEnd,
+      schemaHash: _registry().schemaHash,
+      pingInterval: const Duration(milliseconds: 20),
+    );
+    await admitted;
+
+    final replication = SceneReplication(
+      registry: _registry(),
+      session: session,
+      root: Node(),
+      builders: {'pawn': (replica) => Node()},
+      localPrediction: (replica) => _ConstantController(),
+    );
+
+    final sw = Stopwatch()..start();
+    while (replication.replicas.isEmpty && sw.elapsedMilliseconds < 2000) {
+      room.advance(dt);
+      await _pump(1);
     }
-    final predicted = node.localTransform.getTranslation().x;
-    expect(predicted, greaterThan(0.5));
-    expect(predicted, lessThan(3));
+    final pawn = replication.replicas.whereType<_Pawn>().first;
+    final component = replication
+        .nodeFor(pawn.id!)!
+        .getComponent<PredictedTransformComponent>()!;
 
-    // An authoritative snapshot that disagrees does not pop the render; the
-    // first frame after it stays near where prediction had it.
-    input = 0.0;
-    pawn.position.value = (3.0, 0.0, 0.0);
-    component.update(1 / 60);
-    expect(node.localTransform.getTranslation().x, lessThan(predicted + 0.5));
-
-    // Then it eases onto the authoritative pose.
-    for (var i = 0; i < 200; i++) {
+    // Drive the client render loop and the server tick over real time.
+    final run = Stopwatch()..start();
+    while (run.elapsedMilliseconds < 800) {
       component.update(1 / 60);
+      room.advance(dt);
+      await Future<void>.delayed(const Duration(milliseconds: 16));
     }
-    expect(node.localTransform.getTranslation().x, closeTo(3, 0.05));
+
+    final predictedX = replication
+        .nodeFor(pawn.id!)!
+        .localTransform
+        .getTranslation()
+        .x;
+    // Local input moved the predicted node right immediately, not stuck at 0.
+    expect(predictedX, greaterThan(1));
+    // And it stays near the server's authoritative position (reconciled), the
+    // prediction leads by roughly the send-ahead, never diverging.
+    expect((predictedX - pawn.position.value.$1).abs(), lessThan(3));
+
+    await replication.close();
+    await room.stop();
   });
 }

--- a/packages/flutter_scene_net/test/flutter_scene_net_test.dart
+++ b/packages/flutter_scene_net/test/flutter_scene_net_test.dart
@@ -3,6 +3,7 @@ import 'package:dashwire_replication/dashwire_replication.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene_net/flutter_scene_net.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart' as vm;
 
 final class _Pawn extends TransformReplica {
   _Pawn();
@@ -123,5 +124,71 @@ void main() {
     expect(mid.x, lessThan(9.5));
     final (late_, _) = component.sampleAt(end + 1000);
     expect(late_.x, 10);
+  });
+
+  test('resuming after an idle gap eases in instead of snapping', () {
+    var nowMicros = 1000000;
+    final pawn = _Pawn()..position.value = (0.0, 0.0, 0.0);
+    final component = NetworkTransformComponent(
+      pawn,
+      delay: const Duration(milliseconds: 100),
+      now: () => nowMicros,
+    );
+
+    // Sit idle well past the delay, then start moving.
+    nowMicros += 2000000;
+    pawn.position.value = (10.0, 0.0, 0.0);
+
+    // Without re-anchoring this would snap toward 10; the held pose is
+    // anchored at now - delay, so the resume still renders near the origin.
+    final (atResume, _) = component.sampleAt(nowMicros - 100000);
+    expect(atResume.x, closeTo(0, 0.01));
+    // Halfway through the delay it has eased about halfway in.
+    final (mid, _) = component.sampleAt(nowMicros - 50000);
+    expect(mid.x, greaterThan(2));
+    expect(mid.x, lessThan(8));
+  });
+
+  test('prediction renders local input instantly and eases in corrections', () {
+    final pawn = _Pawn()..position.value = (0.0, 0.0, 0.0);
+    var input = 0.0;
+    final node = Node()
+      ..addComponent(
+        PredictedTransformComponent(
+          pawn,
+          smoothing: const Duration(milliseconds: 100),
+          step: (position, rotation, dt) =>
+              (position + vm.Vector3(input * 5 * dt, 0, 0), rotation),
+        ),
+      );
+    final component = node.getComponent<PredictedTransformComponent>()!;
+
+    // No input holds position.
+    component.update(1 / 60);
+    expect(node.localTransform.getTranslation().x, closeTo(0, 1e-6));
+
+    // Input moves the very next frame, no round trip.
+    input = 1.0;
+    component.update(1 / 60);
+    expect(node.localTransform.getTranslation().x, greaterThan(0));
+    for (var i = 0; i < 20; i++) {
+      component.update(1 / 60);
+    }
+    final predicted = node.localTransform.getTranslation().x;
+    expect(predicted, greaterThan(0.5));
+    expect(predicted, lessThan(3));
+
+    // An authoritative snapshot that disagrees does not pop the render; the
+    // first frame after it stays near where prediction had it.
+    input = 0.0;
+    pawn.position.value = (3.0, 0.0, 0.0);
+    component.update(1 / 60);
+    expect(node.localTransform.getTranslation().x, lessThan(predicted + 0.5));
+
+    // Then it eases onto the authoritative pose.
+    for (var i = 0; i < 200; i++) {
+      component.update(1 / 60);
+    }
+    expect(node.localTransform.getTranslation().x, closeTo(3, 0.05));
   });
 }


### PR DESCRIPTION
The owned entity now predicts from local input and reconciles by replaying the inputs the server has not yet applied, replacing the error-smoothing stopgap that lagged by the round trip under real latency. `SceneReplication` grows a `localPrediction` seam supplying a `PredictedController`, and the Multiplayer example consumes input commands server-side with a prediction toggle and a simulated-latency control so the difference is visible on one machine.

Draft until the next `dashwire`/`dashwire_replication` minor publishes (bdero/dashwire#1); the constraint bump from `^0.1.0` lands here once it does, so CI stays red in the meantime.