### PR TITLE
Add physics rollback prediction and the arena example

### DIFF
--- a/examples/flutter_app/lib/example_multiplayer.dart
+++ b/examples/flutter_app/lib/example_multiplayer.dart
@@ -2,12 +2,12 @@ import 'dart:async';
 
 import 'package:dashwire/dashwire.dart';
 import 'package:dashwire_replication/dashwire_replication.dart' hide Authority;
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_scene/physics.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_scene_rapier/flutter_scene_rapier.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 
 import 'example_overlay.dart';
@@ -125,9 +125,28 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
     ),
   );
 
+  /// Whether the physics backend on this platform can rollback-predict.
+  /// True on native; on the web it needs a wasm module carrying the
+  /// snapshot exports (an older published module degrades to interpolation).
+  Future<bool> _predictionSupported() async {
+    try {
+      await RapierWorld.ensureInitialized();
+      final probe = RapierWorld();
+      try {
+        probe.snapshot();
+      } finally {
+        probe.dispose();
+      }
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   Future<void> _start(Future<WireConnection> Function() connect) async {
     setState(() => _status = 'connecting');
     try {
+      final canPredict = await _predictionSupported();
       final session = await connectSession(
         await connect(),
         schemaHash: multiplayerRegistry().schemaHash,
@@ -142,10 +161,8 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
         // the world back to the acked tick and replay unacked inputs. Remote
         // players stay interpolated. When prediction is off the local player
         // interpolates too, so it visibly lags input under latency.
-        // TODO(wasm): enable on web once the rapier wasm carries the
-        // snapshot/restore exports and the Dart-side marshalling lands.
         localPrediction: (replica) {
-          if (!_predict || kIsWeb) return null;
+          if (!_predict || !canPredict) return null;
           final controller = _PlayerController(_pressed, replica as NetPlayer);
           _clientWorlds.add(controller.simulation);
           return controller;

--- a/examples/flutter_app/lib/example_multiplayer.dart
+++ b/examples/flutter_app/lib/example_multiplayer.dart
@@ -129,6 +129,19 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
     ),
   );
 
+  /// Rendered poses of every player this client does not own, fed to the
+  /// prediction world as collision proxies.
+  Iterable<(Object, vm.Vector3)> _remotePlayerPoses() {
+    final replication = _replication;
+    if (replication == null) return const [];
+    return [
+      for (final other in replication.replicas.whereType<NetPlayer>())
+        if (other.owner != replication.localPeerId && other.id != null)
+          if (replication.nodeFor(other.id!) case final node?)
+            (other.id!, node.localTransform.getTranslation()),
+    ];
+  }
+
   /// Whether the physics backend on this platform can rollback-predict.
   /// True on native; on the web it needs a wasm module carrying the
   /// snapshot exports (an older published module degrades to interpolation).
@@ -165,9 +178,17 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
         // the world back to the acked tick and replay unacked inputs. Remote
         // players stay interpolated. When prediction is off the local player
         // interpolates too, so it visibly lags input under latency.
+        // Remote players render ~2.5 ticks in the past; a tighter buffer
+        // narrows the visible gap between a predicted self and the
+        // interpolated ball it collides with.
+        interpolationDelay: const Duration(milliseconds: 75),
         localPrediction: (replica) {
           if (!_predict || !canPredict) return null;
-          final controller = _PlayerController(_pressed, replica as NetPlayer);
+          final controller = _PlayerController(
+            _pressed,
+            replica as NetPlayer,
+            _remotePlayerPoses,
+          );
           _clientWorlds.add(controller.simulation);
           return controller;
         },
@@ -433,9 +454,11 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
 
 /// Samples keyboard movement and drives a client-side copy of the arena
 /// world, the same physics the server runs, so the local ball is
-/// rollback-predicted and reconciled.
+/// rollback-predicted and reconciled. Remote players are mirrored in as
+/// kinematic proxies at their rendered poses, so a bump responds locally
+/// against what this player sees instead of waiting a round trip.
 class _PlayerController implements PredictedPhysicsController {
-  _PlayerController(this._pressed, this.player)
+  _PlayerController(this._pressed, this.player, this._remotePoses)
     : simulation = buildArenaWorld() {
     bodyHandle = createPlayerBody(simulation, player.positionVector);
   }
@@ -448,6 +471,62 @@ class _PlayerController implements PredictedPhysicsController {
 
   @override
   late final int bodyHandle;
+
+  /// Rendered (interpolated) poses of the other players, keyed by a stable
+  /// per-player identity.
+  final Iterable<(Object, vm.Vector3)> Function() _remotePoses;
+
+  final Map<Object, int> _proxies = {};
+
+  /// Every proxy handle ever created. A rollback restore resurrects
+  /// whatever proxies the retained snapshot held, so a rebuild destroys
+  /// all of these (dead handles no-op) before recreating the current set.
+  /// TODO(prediction): replace with a body-aliveness or lifecycle API on
+  /// the seam instead of this bookkeeping.
+  final List<int> _everCreated = [];
+  bool _proxiesStale = false;
+
+  @override
+  void onWorldRestored() => _proxiesStale = true;
+
+  // Mirrors the other players as kinematic proxies at their rendered
+  // poses. Runs on fresh ticks only; world snapshots retain the proxies,
+  // so rollback replays collide against their historical poses.
+  void _syncProxies() {
+    if (_proxiesStale) {
+      _proxiesStale = false;
+      for (final handle in _everCreated) {
+        simulation.destroyBody(handle);
+      }
+      _proxies.clear();
+    }
+    final present = <Object>{};
+    for (final (id, position) in _remotePoses()) {
+      present.add(id);
+      var proxy = _proxies[id];
+      if (proxy == null) {
+        proxy = createPlayerProxy(simulation, position);
+        _proxies[id] = proxy;
+        _everCreated.add(proxy);
+        if (_everCreated.length > 256) _everCreated.removeAt(0);
+      }
+      simulation.setBodyKinematicTargetPose(proxy, position, _noRotation);
+    }
+    // A leaver's proxy parks out of reach; destroying it here would let an
+    // older snapshot resurrect it unmanaged.
+    for (final entry in _proxies.entries) {
+      if (!present.contains(entry.key)) {
+        simulation.setBodyKinematicTargetPose(
+          entry.value,
+          _parked,
+          _noRotation,
+        );
+      }
+    }
+  }
+
+  static final vm.Quaternion _noRotation = vm.Quaternion.identity();
+  static final vm.Vector3 _parked = vm.Vector3(0, -100, 0);
 
   @override
   void applyInput(Uint8List input, double dt) =>
@@ -479,6 +558,7 @@ class _PlayerController implements PredictedPhysicsController {
 
   @override
   Uint8List sampleInput() {
+    _syncProxies();
     // Screen-right is world -X under the fixed overhead camera, so negate the
     // strafe axis to keep A left and D right.
     final strafe = -_axis(

--- a/examples/flutter_app/lib/example_multiplayer.dart
+++ b/examples/flutter_app/lib/example_multiplayer.dart
@@ -178,10 +178,11 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
         // the world back to the acked tick and replay unacked inputs. Remote
         // players stay interpolated. When prediction is off the local player
         // interpolates too, so it visibly lags input under latency.
-        // Remote players render ~2.5 ticks in the past; a tighter buffer
-        // narrows the visible gap between a predicted self and the
-        // interpolated ball it collides with.
-        interpolationDelay: const Duration(milliseconds: 75),
+        // The interpolation delay adapts to the measured snapshot cadence
+        // under its default ceiling; a shallow input buffer trades jitter
+        // headroom for a tick less input latency, right for a local or
+        // LAN demo (the sim-latency toggle shows the degraded-link case).
+        inputTargetDepth: 1,
         localPrediction: (replica) {
           if (!_predict || !canPredict) return null;
           final controller = _PlayerController(

--- a/examples/flutter_app/lib/example_multiplayer.dart
+++ b/examples/flutter_app/lib/example_multiplayer.dart
@@ -176,6 +176,9 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
         if (mounted && _replication != null) _leave();
       });
       setState(() => _status = null);
+      // Clicking Host/Join focused the button (notably on web); reclaim the
+      // keyboard so movement keys reach the listener without another click.
+      _focus.requestFocus();
     } catch (error) {
       setState(() => _status = 'failed: $error');
     }

--- a/examples/flutter_app/lib/example_multiplayer.dart
+++ b/examples/flutter_app/lib/example_multiplayer.dart
@@ -462,6 +462,14 @@ class _PlayerController implements PredictedPhysicsController {
   _PlayerController(this._pressed, this.player, this._remotePoses)
     : simulation = buildArenaWorld() {
     bodyHandle = createPlayerBody(simulation, player.positionVector);
+    // Allocate every proxy up front, before the first world snapshot, so no
+    // body is ever created or destroyed afterward. A restore rewinds to the
+    // body set its snapshot captured, so a proxy created later would be
+    // reconciled away mid-replay and leave the rollback colliding with
+    // nothing.
+    for (var i = 0; i < _proxySlots; i++) {
+      _proxyPool.add(createPlayerProxy(simulation, _parked));
+    }
   }
 
   final Set<LogicalKeyboardKey> _pressed;
@@ -477,53 +485,66 @@ class _PlayerController implements PredictedPhysicsController {
   /// per-player identity.
   final Iterable<(Object, vm.Vector3)> Function() _remotePoses;
 
+  /// Remote players other than this one that the arena mirrors at once.
+  /// TODO(prediction): size this from the room's player cap once one exists,
+  /// instead of a constant the arena can outgrow.
+  static const int _proxySlots = 8;
+
+  /// The fixed proxy bodies, parked out of reach until a player claims one.
+  final List<int> _proxyPool = [];
+
+  /// Pool slot driving each remote player.
   final Map<Object, int> _proxies = {};
 
-  /// Every proxy handle ever created. A rollback restore resurrects
-  /// whatever proxies the retained snapshot held, so a rebuild destroys
-  /// all of these (dead handles no-op) before recreating the current set.
-  /// TODO(prediction): replace with a body-aliveness or lifecycle API on
-  /// the seam instead of this bookkeeping.
-  final List<int> _everCreated = [];
-  bool _proxiesStale = false;
-
   @override
-  void onWorldRestored() => _proxiesStale = true;
+  void onWorldRestored() {
+    // Nothing to do. The proxy pool is allocated before the first snapshot
+    // and never changes, so a restore leaves it intact.
+  }
 
-  // Mirrors the other players as kinematic proxies at their rendered
-  // poses. Runs on fresh ticks only; world snapshots retain the proxies,
-  // so rollback replays collide against their historical poses.
+  // Mirrors the other players onto pool proxies at their rendered poses.
+  // Runs on fresh ticks only; world snapshots retain the proxies, so
+  // rollback replays collide against their historical poses.
   void _syncProxies() {
-    if (_proxiesStale) {
-      _proxiesStale = false;
-      for (final handle in _everCreated) {
-        simulation.destroyBody(handle);
-      }
-      _proxies.clear();
-    }
     final present = <Object>{};
     for (final (id, position) in _remotePoses()) {
+      var slot = _proxies[id];
+      if (slot == null) {
+        slot = _freeSlot();
+        // Out of proxies, so this player is not mirrored locally and its
+        // bumps wait for the server.
+        if (slot == null) continue;
+        _proxies[id] = slot;
+        // Teleport into place, so claiming a parked slot does not read as a
+        // tick of travel from under the arena.
+        simulation.setBodyPose(_proxyPool[slot], position, _noRotation);
+      }
       present.add(id);
-      var proxy = _proxies[id];
-      if (proxy == null) {
-        proxy = createPlayerProxy(simulation, position);
-        _proxies[id] = proxy;
-        _everCreated.add(proxy);
-        if (_everCreated.length > 256) _everCreated.removeAt(0);
-      }
-      simulation.setBodyKinematicTargetPose(proxy, position, _noRotation);
+      simulation.setBodyKinematicTargetPose(
+        _proxyPool[slot],
+        position,
+        _noRotation,
+      );
     }
-    // A leaver's proxy parks out of reach; destroying it here would let an
-    // older snapshot resurrect it unmanaged.
-    for (final entry in _proxies.entries) {
-      if (!present.contains(entry.key)) {
-        simulation.setBodyKinematicTargetPose(
-          entry.value,
-          _parked,
-          _noRotation,
-        );
-      }
+    // Park a leaver's proxy and release its slot for the next joiner.
+    _proxies.removeWhere((id, slot) {
+      if (present.contains(id)) return false;
+      simulation.setBodyPose(_proxyPool[slot], _parked, _noRotation);
+      simulation.setBodyKinematicTargetPose(
+        _proxyPool[slot],
+        _parked,
+        _noRotation,
+      );
+      return true;
+    });
+  }
+
+  int? _freeSlot() {
+    final taken = _proxies.values.toSet();
+    for (var i = 0; i < _proxyPool.length; i++) {
+      if (!taken.contains(i)) return i;
     }
+    return null;
   }
 
   static final vm.Quaternion _noRotation = vm.Quaternion.identity();

--- a/examples/flutter_app/lib/example_multiplayer.dart
+++ b/examples/flutter_app/lib/example_multiplayer.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 
 import 'package:dashwire/dashwire.dart';
 import 'package:dashwire_replication/dashwire_replication.dart' hide Authority;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_scene/physics.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene_net/flutter_scene_net.dart';
 import 'package:vector_math/vector_math.dart' as vm;
@@ -13,8 +15,9 @@ import 'example_panel.dart';
 import 'net/multiplayer_game.dart';
 
 /// Multiplayer arena. Host a game in-app (desktop/mobile) and join it from
-/// other instances by address, including web builds; movement is
-/// server-authoritative with interpolated remote poses.
+/// other instances by address, including web builds; players are balls in a
+/// server-authoritative rapier world, remote poses interpolate and the local
+/// ball is rollback-predicted in a matching client-side world.
 class ExampleMultiplayer extends StatefulWidget {
   const ExampleMultiplayer({super.key});
 
@@ -33,6 +36,8 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
 
   SceneHost? _host;
   SceneReplication? _replication;
+  PhysicsSimulation? _serverWorld;
+  final List<PhysicsSimulation> _clientWorlds = [];
   String? _status;
   Timer? _hud;
 
@@ -50,13 +55,27 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
     final ground = Node(
       mesh: Mesh(
         CuboidGeometry(
-          vm.Vector3(fieldHalfSize * 2 + 2, 0.4, fieldHalfSize * 2 + 2),
+          vm.Vector3(fieldHalfSize * 2 + 5, 0.4, fieldHalfSize * 2 + 5),
         ),
         PhysicallyBasedMaterial()
           ..baseColorFactor = vm.Vector4(0.16, 0.19, 0.23, 1),
       ),
     )..localTransform = vm.Matrix4.translation(vm.Vector3(0, -0.2, 0));
     scene.add(ground);
+    // Visuals matching the arena's wall colliders (see buildArenaWorld).
+    final wallMaterial = PhysicallyBasedMaterial()
+      ..baseColorFactor = vm.Vector4(0.22, 0.26, 0.31, 1);
+    for (final (x, z, size) in [
+      (fieldHalfSize + 1, 0.0, vm.Vector3(1, 1.5, fieldHalfSize * 2 + 3)),
+      (-fieldHalfSize - 1, 0.0, vm.Vector3(1, 1.5, fieldHalfSize * 2 + 3)),
+      (0.0, fieldHalfSize + 1, vm.Vector3(fieldHalfSize * 2 + 3, 1.5, 1)),
+      (0.0, -fieldHalfSize - 1, vm.Vector3(fieldHalfSize * 2 + 3, 1.5, 1)),
+    ]) {
+      scene.add(
+        Node(mesh: Mesh(CuboidGeometry(size), wallMaterial))
+          ..localTransform = vm.Matrix4.translation(vm.Vector3(x, 0.75, z)),
+      );
+    }
     scene.add(arena);
     // A 2 Hz HUD refresh; scene state itself never triggers rebuilds.
     _hud = Timer.periodic(
@@ -118,13 +137,19 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
         session: session,
         root: arena,
         builders: {'net.player': _playerNode, 'net.pellet': _pelletNode},
-        // Predict the local player from its own input so movement is instant,
-        // running the same integration the server does and reconciling by
-        // replaying unacked inputs; remote players stay interpolated. When
-        // prediction is off the local player interpolates too, so it visibly
-        // lags input under latency.
-        localPrediction: (replica) =>
-            _predict ? _PlayerController(_pressed) : null,
+        // Predict the local ball in a client-side copy of the arena world so
+        // movement is instant; mispredictions (a bump from another ball) roll
+        // the world back to the acked tick and replay unacked inputs. Remote
+        // players stay interpolated. When prediction is off the local player
+        // interpolates too, so it visibly lags input under latency.
+        // TODO(wasm): enable on web once the rapier wasm carries the
+        // snapshot/restore exports and the Dart-side marshalling lands.
+        localPrediction: (replica) {
+          if (!_predict || kIsWeb) return null;
+          final controller = _PlayerController(_pressed, replica as NetPlayer);
+          _clientWorlds.add(controller.simulation);
+          return controller;
+        },
       );
       session.done.whenComplete(() {
         if (mounted && _replication != null) _leave();
@@ -136,10 +161,9 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
   }
 
   Future<void> _hostGame() async {
-    final host = await SceneHost.start(
-      room: buildMultiplayerRoom(),
-      port: gamePort,
-    );
+    final (room, world) = buildMultiplayerRoom();
+    _serverWorld = world;
+    final host = await SceneHost.start(room: room, port: gamePort);
     _host = host;
     await _start(() async {
       final connection = await host.connectLocal();
@@ -167,6 +191,12 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
     _host = null;
     await replication?.close();
     await host?.stop();
+    for (final world in _clientWorlds) {
+      world.dispose();
+    }
+    _clientWorlds.clear();
+    _serverWorld?.dispose();
+    _serverWorld = null;
     if (mounted) setState(() => _status = null);
   }
 
@@ -217,12 +247,14 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
                   ),
                   const SizedBox(height: 10),
                   const Text(
-                    'Host on this device, then move with WASD or arrows. Add '
-                    'simulated latency and toggle prediction to feel the '
-                    'difference, predicted input stays instant and reconciles, '
-                    'while an interpolated local player lags by the round trip. '
-                    'For two clients, open a second copy and Join the address '
-                    'the host shows.',
+                    'Host on this device, then push your ball with WASD or '
+                    'arrows; players are physics bodies that shove each other. '
+                    'Add simulated latency and toggle prediction to feel the '
+                    'difference, the predicted ball stays instant and rolls '
+                    'back to replay on a mispredicted bump, while an '
+                    'interpolated local player lags by the round trip. For two '
+                    'clients, open a second copy and Join the address the host '
+                    'shows.',
                     style: TextStyle(
                       color: Colors.white70,
                       fontSize: 12,
@@ -375,12 +407,39 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
   }
 }
 
-/// Samples keyboard movement and integrates it, the same integration the
-/// server runs, so the local player is predicted and reconciled.
-class _PlayerController implements PredictedController {
-  _PlayerController(this._pressed);
+/// Samples keyboard movement and drives a client-side copy of the arena
+/// world, the same physics the server runs, so the local ball is
+/// rollback-predicted and reconciled.
+class _PlayerController implements PredictedPhysicsController {
+  _PlayerController(this._pressed, this.player)
+    : simulation = buildArenaWorld() {
+    bodyHandle = createPlayerBody(simulation, player.positionVector);
+  }
 
   final Set<LogicalKeyboardKey> _pressed;
+  final NetPlayer player;
+
+  @override
+  final PhysicsSimulation simulation;
+
+  @override
+  late final int bodyHandle;
+
+  @override
+  void applyInput(Uint8List input, double dt) =>
+      applyPlayerInput(simulation, bodyHandle, input);
+
+  @override
+  vm.Vector3? get authoritativeLinearVelocity {
+    final (x, y, z) = player.velocity.value;
+    return vm.Vector3(x, y, z);
+  }
+
+  @override
+  vm.Vector3? get authoritativeAngularVelocity {
+    final (x, y, z) = player.angularVelocity.value;
+    return vm.Vector3(x, y, z);
+  }
 
   double _axis(
     LogicalKeyboardKey minus,
@@ -411,25 +470,5 @@ class _PlayerController implements PredictedController {
       LogicalKeyboardKey.arrowDown,
     );
     return encodePlayerInput(strafe, forward);
-  }
-
-  @override
-  (vm.Vector3, vm.Quaternion) step(
-    vm.Vector3 position,
-    vm.Quaternion rotation,
-    Uint8List input,
-    double dt,
-  ) {
-    final (dx, dz) = decodePlayerInput(input);
-    final (p, r) = advancePlayer(
-      (position.x, position.y, position.z),
-      (rotation.x, rotation.y, rotation.z, rotation.w),
-      (dx, 0.0, dz),
-      dt,
-    );
-    return (
-      vm.Vector3(p.$1, p.$2, p.$3),
-      vm.Quaternion(r.$1, r.$2, r.$3, r.$4),
-    );
   }
 }

--- a/examples/flutter_app/lib/example_multiplayer.dart
+++ b/examples/flutter_app/lib/example_multiplayer.dart
@@ -49,6 +49,10 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
   /// like a remote (renders in the past). Toggle to feel the difference.
   bool _predict = true;
 
+  /// Whether the physics backend actually supports prediction here, probed
+  /// at connect time; the HUD reports the real mode.
+  bool _canPredict = false;
+
   @override
   void initState() {
     super.initState();
@@ -146,7 +150,7 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
   Future<void> _start(Future<WireConnection> Function() connect) async {
     setState(() => _status = 'connecting');
     try {
-      final canPredict = await _predictionSupported();
+      final canPredict = _canPredict = await _predictionSupported();
       final session = await connectSession(
         await connect(),
         schemaHash: multiplayerRegistry().schemaHash,
@@ -397,7 +401,7 @@ class _ExampleMultiplayerState extends State<ExampleMultiplayer> {
                     Text(
                       'rtt ${_replication!.session.clock.rttMillis.toStringAsFixed(0)}ms'
                       '${_simLatencyMs > 0 ? ' (+$_simLatencyMs sim)' : ''}'
-                      '  ${_predict ? 'predicted' : 'interpolated'}',
+                      '  ${_predict && _canPredict ? 'predicted' : 'interpolated'}',
                     ),
                     const Text(
                       'move with WASD or arrows',

--- a/examples/flutter_app/lib/net/multiplayer_game.dart
+++ b/examples/flutter_app/lib/net/multiplayer_game.dart
@@ -1,7 +1,9 @@
 /// Shared multiplayer schema and server simulation.
 ///
 /// Pure Dart on purpose, the in-app host uses it directly, and the same file
-/// could drive a headless `dart run` server unchanged.
+/// could drive a headless `dart run` server unchanged. The arena is a rapier
+/// world built identically on the server and on each predicting client, so
+/// client rollback prediction replays the same physics the server runs.
 library;
 
 import 'dart:math';
@@ -9,21 +11,37 @@ import 'dart:typed_data';
 
 import 'package:dashwire/dashwire.dart';
 import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene_rapier/flutter_scene_rapier.dart';
+import 'package:scene/physics.dart';
+import 'package:vector_math/vector_math.dart';
 
 /// Half-extent of the square play field on the XZ plane.
 const double fieldHalfSize = 11;
-const double moveSpeed = 8;
 const double playerRadius = 0.5;
 const double pelletPickupRadius = 1.0;
 const int pelletTotal = 24;
 const int gameTickRate = 30;
 const int gamePort = 8123;
 
+/// Force pushing the ball toward the input direction, newtons.
+const double playerForce = 8;
+
+/// Linear damping so a released ball settles instead of coasting.
+const double playerDamping = 1.5;
+
 final class NetPlayer extends TransformReplica {
   NetPlayer() {
     hue = rep('hue', 0.0, codec: Codecs.quantized(1), mode: SendMode.spawnOnly);
     name = rep('name', '', codec: Codecs.string, mode: SendMode.onChange);
     score = rep('score', 0, codec: Codecs.varUint, mode: SendMode.onChange);
+    // Velocities let a predicting client rebuild the full authoritative body
+    // state at the acked tick, so a rollback replay is exact.
+    velocity = rep('velocity', (0.0, 0.0, 0.0), codec: Codecs.vec3(0.001));
+    angularVelocity = rep('angularVelocity', (
+      0.0,
+      0.0,
+      0.0,
+    ), codec: Codecs.vec3(0.001));
   }
 
   @override
@@ -32,11 +50,13 @@ final class NetPlayer extends TransformReplica {
   late final Rep<double> hue;
   late final Rep<String> name;
   late final Rep<int> score;
+  late final Rep<Vec3> velocity;
+  late final Rep<Vec3> angularVelocity;
 }
 
 /// Encodes a player's movement intent for an input command. The client sends
 /// these tick-stamped; the server and the client prediction both decode and
-/// feed them to [advancePlayer].
+/// feed them to [applyPlayerInput].
 Uint8List encodePlayerInput(double strafe, double forward) =>
     (ByteWriter(8)
           ..writeF32(strafe)
@@ -60,39 +80,75 @@ ReplicaRegistry multiplayerRegistry() => ReplicaRegistry()
   ..register(NetPlayer.new)
   ..register(NetPellet.new);
 
-/// Advances a player pose by [dt] under movement [input] on the XZ plane.
-///
-/// Shared by the authoritative server tick and client-side prediction so the
-/// two integrate motion identically.
-(Vec3, Quat) advancePlayer(
-  Vec3 position,
-  Quat rotation,
-  Vec3 input,
-  double dt,
-) {
-  var (dx, _, dz) = input;
+/// Builds the arena physics world, a ground slab and four containing walls.
+/// Built identically by the server room and by each predicting client, so
+/// both sides simulate the same static environment. Await
+/// `RapierWorld.ensureInitialized()` first on the web.
+PhysicsSimulation buildArenaWorld() {
+  final world = RapierWorld();
+  const wall = 0.5; // wall half-thickness
+  final reach = fieldHalfSize + wall; // inner wall face
+  final ground = world.createBody(
+    target: SimplePoseTarget(translation: Vector3(0, -0.2, 0)),
+    type: BodyType.fixed,
+  );
+  world.createColliders(
+    ground,
+    BoxShape(halfExtents: Vector3(reach + 2 * wall, 0.2, reach + 2 * wall)),
+  );
+  for (final (x, z, half) in [
+    (reach + wall, 0.0, Vector3(wall, 0.75, reach + 2 * wall)),
+    (-reach - wall, 0.0, Vector3(wall, 0.75, reach + 2 * wall)),
+    (0.0, reach + wall, Vector3(reach + 2 * wall, 0.75, wall)),
+    (0.0, -reach - wall, Vector3(reach + 2 * wall, 0.75, wall)),
+  ]) {
+    final body = world.createBody(
+      target: SimplePoseTarget(translation: Vector3(x, 0.75, z)),
+      type: BodyType.fixed,
+    );
+    world.createColliders(body, BoxShape(halfExtents: half));
+  }
+  return world;
+}
+
+/// Creates a player ball resting at [position] and returns its body handle.
+int createPlayerBody(PhysicsSimulation world, Vector3 position) {
+  final body = world.createBody(
+    target: SimplePoseTarget(translation: position),
+    type: BodyType.dynamic_,
+  );
+  world.setBodyLinearDamping(body, playerDamping);
+  world.createColliders(
+    body,
+    const SphereShape(radius: playerRadius),
+    material: const PhysicsMaterial(friction: 0.8, restitution: 0.3),
+  );
+  return body;
+}
+
+/// Applies one tick of movement input to a player ball, a horizontal push
+/// the next step integrates. Shared by the authoritative server tick and
+/// client prediction so the two simulate identically.
+void applyPlayerInput(PhysicsSimulation world, int body, Uint8List input) {
+  var (dx, dz) = decodePlayerInput(input);
   final length = sqrt(dx * dx + dz * dz);
   if (length > 1) {
     dx /= length;
     dz /= length;
   }
-  final (x, y, z) = position;
-  final moved = (
-    (x + dx * moveSpeed * dt).clamp(-fieldHalfSize, fieldHalfSize),
-    y,
-    (z + dz * moveSpeed * dt).clamp(-fieldHalfSize, fieldHalfSize),
-  );
-  if (length <= 0.01) return (moved, rotation);
-  // Face the travel direction (yaw about +Y).
-  final yaw = atan2(dx, dz);
-  return (moved, (0, sin(yaw / 2), 0, cos(yaw / 2)));
+  if (length < 0.01) return;
+  world.applyForce(body, Vector3(dx * playerForce, 0, dz * playerForce));
 }
 
-/// Builds the authoritative game room, join/leave spawns players, the tick
-/// integrates owner input and awards pellet pickups.
-Room buildMultiplayerRoom({Random? random}) {
+/// Builds the authoritative game room and its physics world. Join/leave
+/// spawns player balls, the tick applies owner input, steps the world,
+/// publishes body state, and awards pellet pickups. The caller owns the
+/// returned world and disposes it after the room stops.
+(Room, PhysicsSimulation) buildMultiplayerRoom({Random? random}) {
   final rng = random ?? Random();
+  final world = buildArenaWorld();
   final players = <int, NetPlayer>{};
+  final bodies = <int, int>{};
   final pellets = <NetPellet>[];
   late final Room room;
 
@@ -110,31 +166,42 @@ Room buildMultiplayerRoom({Random? random}) {
         ..hue.value = rng.nextDouble() * 360
         ..name.value = 'player ${session.peerId}';
       player.position.value = scatter(playerRadius);
+      final (x, y, z) = player.position.value;
+      bodies[session.peerId] = createPlayerBody(world, Vector3(x, y, z));
       room.host.spawn(player, owner: session.peerId);
       players[session.peerId] = player;
     },
     onLeave: (session) {
+      final body = bodies.remove(session.peerId);
+      if (body != null) world.destroyBody(body);
       final player = players.remove(session.peerId);
       if (player?.id != null) room.host.despawn(player!.id!);
     },
     onTick: (tick) {
       const dt = 1.0 / gameTickRate;
+      // Consume each peer's authoritative input for the tick (hold-last on a
+      // gap), then advance the whole world one step.
+      for (final entry in players.entries) {
+        final command = room.input(entry.key, tick);
+        if (command == null) continue;
+        applyPlayerInput(world, bodies[entry.key]!, command);
+      }
+      world.step(dt);
       for (final entry in players.entries) {
         final player = entry.value;
-        // Consume this peer's authoritative input for the tick, hold-last on
-        // a gap. The same advancePlayer the client predicts with runs here.
-        final command = room.input(entry.key, tick);
-        final (dx, dz) = command == null
-            ? (0.0, 0.0)
-            : decodePlayerInput(command);
-        final (position, rotation) = advancePlayer(
-          player.position.value,
-          player.rotation.value,
-          (dx, 0.0, dz),
-          dt,
+        final body = bodies[entry.key]!;
+        final (position, rotation) = world.readBodyPose(body);
+        player.position.value = (position.x, position.y, position.z);
+        player.rotation.value = (
+          rotation.x,
+          rotation.y,
+          rotation.z,
+          rotation.w,
         );
-        player.position.value = position;
-        player.rotation.value = rotation;
+        final linear = world.readBodyLinearVelocity(body);
+        final angular = world.readBodyAngularVelocity(body);
+        player.velocity.value = (linear.x, linear.y, linear.z);
+        player.angularVelocity.value = (angular.x, angular.y, angular.z);
         for (final pellet in pellets) {
           final (px, _, pz) = pellet.position.value;
           final (cx, _, cz) = player.position.value;
@@ -155,5 +222,5 @@ Room buildMultiplayerRoom({Random? random}) {
     room.host.spawn(pellet, importance: 0.3);
     pellets.add(pellet);
   }
-  return room;
+  return (room, world);
 }

--- a/examples/flutter_app/lib/net/multiplayer_game.dart
+++ b/examples/flutter_app/lib/net/multiplayer_game.dart
@@ -20,7 +20,10 @@ const double fieldHalfSize = 11;
 const double playerRadius = 0.5;
 const double pelletPickupRadius = 1.0;
 const int pelletTotal = 24;
-const int gameTickRate = 30;
+// 60Hz halves every tick-denominated latency (input buffering, snapshot
+// cadence, alignment) at double the bandwidth and sim cost, the
+// competitive-feel configuration.
+const int gameTickRate = 60;
 const int gamePort = 8123;
 
 /// Force pushing the ball toward the input direction, newtons.

--- a/examples/flutter_app/lib/net/multiplayer_game.dart
+++ b/examples/flutter_app/lib/net/multiplayer_game.dart
@@ -126,6 +126,22 @@ int createPlayerBody(PhysicsSimulation world, Vector3 position) {
   return body;
 }
 
+/// Creates a kinematic stand-in for a remote player ball at [position], so
+/// a predicting client collides locally with the players it renders instead
+/// of passing through them until the server correction arrives.
+int createPlayerProxy(PhysicsSimulation world, Vector3 position) {
+  final body = world.createBody(
+    target: SimplePoseTarget(translation: position),
+    type: BodyType.kinematic,
+  );
+  world.createColliders(
+    body,
+    const SphereShape(radius: playerRadius),
+    material: const PhysicsMaterial(friction: 0.8, restitution: 0.3),
+  );
+  return body;
+}
+
 /// Applies one tick of movement input to a player ball, a horizontal push
 /// the next step integrates. Shared by the authoritative server tick and
 /// client prediction so the two simulate identically.

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   dashwire: ^0.1.0
   dashwire_replication: ^0.2.1
   flutter_scene_net: ^0.1.0
+  # The physics contract, used headlessly by the multiplayer arena sim.
+  scene: ^0.2.0
   # Native Rapier physics backend, used by the Physics example. Pulls
   # in a Rust build hook, so building this app now requires cargo.
   flutter_scene_rapier:

--- a/examples/flutter_app/tool/multiplayer_host.dart
+++ b/examples/flutter_app/tool/multiplayer_host.dart
@@ -1,0 +1,27 @@
+/// Headless multiplayer arena server.
+///
+/// `dart run tool/multiplayer_host.dart` hosts the same authoritative room
+/// the in-app host runs (rapier world, input commands, pellets), so clients
+/// on any platform, including web builds, can join `ws://<host>:8123`.
+library;
+
+import 'dart:io';
+
+import 'package:dashwire/server.dart';
+import 'package:example_app/net/multiplayer_game.dart';
+
+Future<void> main() async {
+  final (room, world) = buildMultiplayerRoom();
+  final server = await WebSocketWireServer.bind(
+    InternetAddress.anyIPv4,
+    gamePort,
+  );
+  room
+    ..accept(server.connections)
+    ..start();
+  stdout.writeln('hosting the multiplayer arena on ws://localhost:$gamePort');
+  await ProcessSignal.sigint.watch().first;
+  await room.stop();
+  await server.close();
+  world.dispose();
+}

--- a/packages/flutter_scene_net/CHANGELOG.md
+++ b/packages/flutter_scene_net/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - `PredictedTransformComponent` with `PredictedController`, client-side prediction of an owned entity with authoritative input-replay reconciliation, so local input renders instantly while the sim stays server-authoritative. Selected per entity through `SceneReplication`'s `localPrediction` seam.
-- `PredictedPhysicsComponent` with `PredictedPhysicsController`, rollback prediction for an owned physics body. Mispredictions restore a retained world snapshot, adopt the authoritative pose, and replay pending inputs through the simulation. Needs a snapshot-capable backend (rapier).
+- `PredictedPhysicsComponent` with `PredictedPhysicsController`, rollback prediction for an owned physics body. Mispredictions restore a retained world snapshot, adopt the authoritative pose, and replay pending inputs through the simulation; `onWorldRestored` tells the controller so dynamically created bodies (remote-player proxies) can be revalidated. Needs a snapshot-capable backend (rapier).
 - `PhysicsWorldHistory`, a server-side per-tick world snapshot ring that rewinds hit queries to the client-rendered tick and restores the present, capped by `maxRewindTicks`.
 - `NetworkTransformComponent` re-anchors its interpolation buffer after an idle gap, so a resuming remote eases in instead of snapping.
 - Requires the input-command and prediction substrate from the next `dashwire`/`dashwire_replication` release.

--- a/packages/flutter_scene_net/CHANGELOG.md
+++ b/packages/flutter_scene_net/CHANGELOG.md
@@ -6,6 +6,8 @@
 - `PredictedPhysicsComponent` with `PredictedPhysicsController`, rollback prediction for an owned physics body. Mispredictions restore a retained world snapshot, adopt the authoritative pose, and replay pending inputs through the simulation; `onWorldRestored` tells the controller so dynamically created bodies (remote-player proxies) can be revalidated. Needs a snapshot-capable backend (rapier).
 - `PhysicsWorldHistory`, a server-side per-tick world snapshot ring that rewinds hit queries to the client-rendered tick and restores the present, capped by `maxRewindTicks`.
 - `NetworkTransformComponent` re-anchors its interpolation buffer after an idle gap, so a resuming remote eases in instead of snapping.
+- The interpolation delay adapts to measured arrival cadence and jitter, easing between `minDelay` and the configured ceiling, so clean links render remotes barely behind while jittery ones buffer deep.
+- `SceneReplication.inputTargetDepth` passes the input buffer depth through to the client (1 suits local or stable links).
 - Requires the input-command and prediction substrate from the next `dashwire`/`dashwire_replication` release.
 
 ## 0.1.0

--- a/packages/flutter_scene_net/CHANGELOG.md
+++ b/packages/flutter_scene_net/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - `PredictedTransformComponent` with `PredictedController`, client-side prediction of an owned entity with authoritative input-replay reconciliation, so local input renders instantly while the sim stays server-authoritative. Selected per entity through `SceneReplication`'s `localPrediction` seam.
+- `PredictedPhysicsComponent` with `PredictedPhysicsController`, rollback prediction for an owned physics body. Mispredictions restore a retained world snapshot, adopt the authoritative pose, and replay pending inputs through the simulation. Needs a snapshot-capable backend (rapier).
+- `PhysicsWorldHistory`, a server-side per-tick world snapshot ring that rewinds hit queries to the client-rendered tick and restores the present, capped by `maxRewindTicks`.
 - `NetworkTransformComponent` re-anchors its interpolation buffer after an idle gap, so a resuming remote eases in instead of snapping.
 - Requires the input-command and prediction substrate from the next `dashwire`/`dashwire_replication` release.
 

--- a/packages/flutter_scene_net/lib/flutter_scene_net.dart
+++ b/packages/flutter_scene_net/lib/flutter_scene_net.dart
@@ -11,8 +11,11 @@ export 'src/hosting/hosting.dart' show SceneHost;
 export 'src/network_transform_codec.dart'
     show NetworkTransformCodec, registerNetComponentCodecs;
 export 'src/network_transform.dart' show NetworkTransformComponent;
+export 'src/physics_world_history.dart' show PhysicsWorldHistory;
+export 'src/predicted_physics.dart'
+    show PredictedPhysicsComponent, PredictedPhysicsController;
 export 'src/predicted_transform.dart'
-    show PredictedController, PredictedTransformComponent;
+    show PredictedController, PredictedTransformComponent, PredictionController;
 export 'src/scene_replication.dart'
     show LocalPredictionBuilder, ReplicaNodeBuilder, SceneReplication;
 export 'src/transform_replica.dart' show TransformReplicaVectors;

--- a/packages/flutter_scene_net/lib/src/network_transform.dart
+++ b/packages/flutter_scene_net/lib/src/network_transform.dart
@@ -9,9 +9,12 @@ import 'transform_replica.dart';
 
 /// Drives the owning node's transform from a [TransformReplica].
 ///
-/// Replicated poses arrive at packet rate; rendering [delay] in the past
+/// Replicated poses arrive at packet rate; rendering a little in the past
 /// through a small sample buffer turns them into smooth motion, the
-/// standard snapshot-interpolation tradeoff of latency for continuity.
+/// standard snapshot-interpolation tradeoff of latency for continuity. The
+/// delay sizes itself from the measured arrival cadence and jitter, easing
+/// between [minDelay] and [delay] (the ceiling and starting value), so a
+/// clean local link renders barely behind while a jittery one buffers deep.
 // TODO(prediction): owned replicas currently render on the same delayed
 // timeline as everything else; input-replay prediction needs the tick
 // infrastructure wired through here.
@@ -19,8 +22,11 @@ final class NetworkTransformComponent extends Component {
   NetworkTransformComponent(
     this.replica, {
     this.delay = const Duration(milliseconds: 100),
+    this.minDelay = const Duration(milliseconds: 25),
+    this.adaptive = true,
     NowMicros now = defaultNowMicros,
-  }) : _now = now {
+  }) : _now = now,
+       _delayMicros = delay.inMicroseconds {
     _push();
     // TODO(replication-unsubscribe): dashwire_replication 0.2.0 has no
     // listener removal, so these subscriptions (and through them this
@@ -32,32 +38,71 @@ final class NetworkTransformComponent extends Component {
 
   final TransformReplica replica;
 
-  /// How far in the past remote poses render.
+  /// The deepest (and initial) render delay; the fixed delay when
+  /// [adaptive] is off.
   final Duration delay;
+
+  /// The shallowest the adaptive delay will go.
+  final Duration minDelay;
+
+  /// Whether the delay tracks measured arrival cadence and jitter.
+  final bool adaptive;
 
   final NowMicros _now;
 
   final List<(int, Vector3, Quaternion)> _samples = [];
+  int _delayMicros;
+  int _lastArrival = 0;
+  double _intervalEwma = 0;
+  double _jitterEwma = 0;
+
+  /// How far in the past remote poses currently render.
+  Duration get currentDelay => Duration(microseconds: _delayMicros);
 
   void _push() {
     final now = _now();
     // Samples are only pushed on pose change, so after an idle stretch the
     // newest one is stale. Re-anchor the held pose at now - delay before
-    // appending the fresh one, so resuming motion eases in over `delay`
+    // appending the fresh one, so resuming motion eases in over the delay
     // instead of interpolating across the whole gap (which snaps forward).
+    // Idleness is judged against the fixed ceiling, not the adapted delay,
+    // so a jitter spike is measured rather than mistaken for a gap.
     if (_samples.isNotEmpty && now - _samples.last.$1 > delay.inMicroseconds) {
       final (_, p, q) = _samples.last;
       _samples
         ..clear()
-        ..add((now - delay.inMicroseconds, p, q));
+        ..add((now - _delayMicros, p, q));
+      _lastArrival = 0; // The cadence measurement restarts after a gap.
     }
+    _adapt(now);
     _samples.add((now, replica.positionVector, replica.rotationQuaternion));
     if (_samples.length > 64) _samples.removeAt(0);
   }
 
+  // Sizes the delay off the arrival stream, enough to bridge one and a half
+  // typical intervals plus a few deviations, eased so the render timeline
+  // never jumps.
+  void _adapt(int now) {
+    if (!adaptive) return;
+    if (_lastArrival != 0) {
+      final interval = (now - _lastArrival).toDouble();
+      _intervalEwma = _intervalEwma == 0
+          ? interval
+          : _intervalEwma + (interval - _intervalEwma) * 0.1;
+      final deviation = (interval - _intervalEwma).abs();
+      _jitterEwma += (deviation - _jitterEwma) * 0.1;
+      final target = (_intervalEwma * 1.5 + _jitterEwma * 4).clamp(
+        minDelay.inMicroseconds.toDouble(),
+        delay.inMicroseconds.toDouble(),
+      );
+      _delayMicros += ((target - _delayMicros) * 0.05).round();
+    }
+    _lastArrival = now;
+  }
+
   @override
   void update(double deltaSeconds) {
-    final (position, rotation) = sampleAt(_now() - delay.inMicroseconds);
+    final (position, rotation) = sampleAt(_now() - _delayMicros);
     node.localTransform = Matrix4.compose(position, rotation, _unitScale);
   }
 

--- a/packages/flutter_scene_net/lib/src/physics_world_history.dart
+++ b/packages/flutter_scene_net/lib/src/physics_world_history.dart
@@ -35,16 +35,29 @@ final class PhysicsWorldHistory {
     _snapshots.removeWhere((t, _) => _newestTick - t > maxRewindTicks);
   }
 
-  /// Runs [query] against the world as recorded at [tick] and returns its
-  /// result, or null when [tick] is outside the retained window. The present
-  /// world is restored before returning.
-  T? rewind<T>(int tick, T Function(PhysicsSimulation simulation) query) {
+  /// Runs [query] against the world as recorded at [tick], restoring the
+  /// present before returning.
+  ///
+  /// `rewound` is false when [tick] is outside the retained window, which a
+  /// null `result` alone cannot distinguish from a query that legitimately
+  /// found nothing (no raycast hit against a peer too far behind to
+  /// compensate, say).
+  ///
+  /// The present it restores is the newest recording, so apply world
+  /// mutations after a tick's rewinds rather than between them, or [record]
+  /// again first.
+  ({bool rewound, T? result}) rewind<T>(
+    int tick,
+    T Function(PhysicsSimulation simulation) query,
+  ) {
     final past = _snapshots[tick];
-    if (past == null) return null;
-    final present = simulation.snapshot();
+    final present = _snapshots[_newestTick];
+    if (past == null || present == null) {
+      return (rewound: false, result: null);
+    }
     simulation.restore(past);
     try {
-      return query(simulation);
+      return (rewound: true, result: query(simulation));
     } finally {
       simulation.restore(present);
     }

--- a/packages/flutter_scene_net/lib/src/physics_world_history.dart
+++ b/packages/flutter_scene_net/lib/src/physics_world_history.dart
@@ -1,0 +1,52 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/physics.dart';
+
+/// Server-side per-tick world snapshot ring for lag-compensated rewind.
+///
+/// Record once per authoritative tick after stepping. [rewind] restores the
+/// retained world at the client-rendered tick, runs a query against it (a
+/// raycast for hit registration, say), then restores the present before
+/// returning. Retention doubles as the rewind cap, [maxRewindTicks] bounds
+/// how far back a high-latency peer can drag everyone else.
+///
+/// For fractional-tick precision on individual poses, pair this with the
+/// interpolating `LagCompensation` history from `dashwire_replication`.
+/// TODO(lagcomp): fractional world rewind by nudging tracked bodies between
+/// the two bracketing snapshots via `PhysicsSimulation.setBodyPose`.
+final class PhysicsWorldHistory {
+  PhysicsWorldHistory(this.simulation, {this.maxRewindTicks = 8});
+
+  final PhysicsSimulation simulation;
+
+  /// Oldest rewindable age, in ticks behind the newest recording.
+  final int maxRewindTicks;
+
+  final Map<int, Uint8List> _snapshots = {};
+  int _newestTick = -1;
+
+  /// Ticks currently rewindable.
+  int get depth => _snapshots.length;
+
+  /// Snapshots the present world as [tick].
+  void record(int tick) {
+    _snapshots[tick] = simulation.snapshot();
+    _newestTick = tick;
+    _snapshots.removeWhere((t, _) => _newestTick - t > maxRewindTicks);
+  }
+
+  /// Runs [query] against the world as recorded at [tick] and returns its
+  /// result, or null when [tick] is outside the retained window. The present
+  /// world is restored before returning.
+  T? rewind<T>(int tick, T Function(PhysicsSimulation simulation) query) {
+    final past = _snapshots[tick];
+    if (past == null) return null;
+    final present = simulation.snapshot();
+    simulation.restore(past);
+    try {
+      return query(simulation);
+    } finally {
+      simulation.restore(present);
+    }
+  }
+}

--- a/packages/flutter_scene_net/lib/src/predicted_physics.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_physics.dart
@@ -190,7 +190,14 @@ final class PredictedPhysicsComponent extends Component {
   void update(double deltaSeconds) {
     final clock = client.session.clock;
     if (!clock.isSynchronized) return;
-    final target = clock.inputTickAt(_now());
+    // Pace the send-ahead from the client's adaptive lead. Passing an
+    // explicit tick to sendInput bypasses the sender's own pacing, so
+    // sampling the lead here is what keeps the server's buffer-depth control
+    // loop closed and lets the lead deepen under jitter.
+    final target = clock.inputTickAt(
+      _now(),
+      marginTicks: client.inputLeadTicks.toDouble(),
+    );
 
     if (!_predictor.isSeeded) {
       _predictor.reset(target - 1, _capture());

--- a/packages/flutter_scene_net/lib/src/predicted_physics.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_physics.dart
@@ -196,9 +196,15 @@ final class PredictedPhysicsComponent extends Component {
       _predictor.reset(target - 1, _capture());
     }
 
-    // Reconcile against the authoritative pose the server has confirmed
-    // applying input through.
-    final acked = client.lastAppliedInputTick;
+    // Reconcile against the authoritative pose, at the tick that pose
+    // actually belongs to. The input ack goes out every tick while snapshots
+    // are priority-packed against a byte budget and can be deferred or
+    // dropped, so the replica's pose is often older than the ack; adopting it
+    // at the ack's tick would discard the motion in between and re-predict
+    // it, tugging backward on every snapshot.
+    final applied = client.lastAppliedInputTick;
+    final carried = replica.snapshotTick;
+    final acked = carried > 0 && carried < applied ? carried : applied;
     if (acked > _reconciledTick &&
         acked > 0 &&
         acked <= _predictor.currentTick) {

--- a/packages/flutter_scene_net/lib/src/predicted_physics.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_physics.dart
@@ -88,6 +88,7 @@ final class PredictedPhysicsComponent extends Component {
     this.smoothing = const Duration(milliseconds: 120),
     this.correctionThreshold = 0.05,
     int historyTicks = 64,
+    this.maxCatchUpTicks = 16,
     NowMicros now = defaultNowMicros,
   }) : _dt = 1 / tickRate,
        _now = now {
@@ -110,6 +111,16 @@ final class PredictedPhysicsComponent extends Component {
   /// Positional divergence (metres) beyond which a snapshot triggers a replay
   /// correction.
   final double correctionThreshold;
+
+  /// Most ticks predicted in one [update] before the prediction snaps to
+  /// authority instead of catching up.
+  ///
+  /// The target tick comes from the wall clock, so a stall (a backgrounded
+  /// tab, a long hitch, a resume from pause) would otherwise step and snapshot
+  /// the world once per missed tick in a single frame. Lower than the
+  /// transform component's cap because each tick here costs a world step plus
+  /// a full snapshot.
+  final int maxCatchUpTicks;
 
   final double _dt;
   final NowMicros _now;
@@ -190,6 +201,24 @@ final class PredictedPhysicsComponent extends Component {
       final corrected = _predictor.reconcile(acked, _authoritativeState(acked));
       _reconciledTick = acked;
       if (corrected) _error.setFrom(rendered - _predictor.current.position);
+    }
+
+    // Too far behind to catch up tick by tick, so teleport the owned body to
+    // the newest authoritative pose and resume predicting from there.
+    if (target - _predictor.currentTick > maxCatchUpTicks) {
+      final sim = controller.simulation;
+      final handle = controller.bodyHandle;
+      sim.setBodyPose(
+        handle,
+        replica.positionVector,
+        replica.rotationQuaternion,
+      );
+      final linear = controller.authoritativeLinearVelocity;
+      final angular = controller.authoritativeAngularVelocity;
+      if (linear != null) sim.setBodyLinearVelocity(handle, linear);
+      if (angular != null) sim.setBodyAngularVelocity(handle, angular);
+      _predictor.reset(target - 1, _capture());
+      _error.setZero();
     }
 
     // Predict forward to the target tick, one input sampled and sent per tick.

--- a/packages/flutter_scene_net/lib/src/predicted_physics.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_physics.dart
@@ -34,6 +34,13 @@ abstract interface class PredictedPhysicsController
 
   void applyInput(Uint8List input, double dt);
 
+  /// Called after a rollback correction restores a retained world snapshot,
+  /// before pending inputs replay. Bodies the controller created after that
+  /// snapshot no longer exist (their handles dangle silently), so mark any
+  /// dynamically managed bodies, remote-player proxies, say, for recreation
+  /// on the next fresh tick.
+  void onWorldRestored();
+
   Vector3? get authoritativeLinearVelocity;
 
   Vector3? get authoritativeAngularVelocity;
@@ -117,7 +124,10 @@ final class PredictedPhysicsComponent extends Component {
 
   _WorldState _step(_WorldState state, Uint8List input, double dt) {
     final sim = controller.simulation;
-    if (!identical(state.world, _liveWorld)) sim.restore(state.world);
+    if (!identical(state.world, _liveWorld)) {
+      sim.restore(state.world);
+      controller.onWorldRestored();
+    }
     // The state's body fields override the restored world, so an
     // authoritative base injected by reconcile takes effect here.
     sim.setBodyPose(controller.bodyHandle, state.position, state.rotation);

--- a/packages/flutter_scene_net/lib/src/predicted_physics.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_physics.dart
@@ -1,0 +1,207 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:dashwire/dashwire.dart';
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/physics.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' hide Colors;
+
+import 'predicted_transform.dart';
+import 'transform_replica.dart';
+
+/// Client-side driver for an owned entity simulated by a physics world.
+///
+/// The controller owns a [simulation] dedicated to prediction (the arena plus
+/// the owned body, built the same way as the server's world) with
+/// `supportsSnapshot`. [applyInput] applies a decoded input command to the
+/// body before a step and must match the server's application exactly so
+/// replay reconciliation converges. Encode one-frame events as counters, not
+/// booleans, so a resent command reproduces them.
+///
+/// The authoritative velocity getters read velocity reps off the replica at
+/// reconcile time; return null when velocity is not replicated and the
+/// predicted velocity at the acked tick is kept (corrections then converge
+/// over subsequent snapshots instead of in one replay).
+abstract interface class PredictedPhysicsController
+    implements PredictionController {
+  PhysicsSimulation get simulation;
+
+  /// Handle of the owned body inside [simulation].
+  int get bodyHandle;
+
+  Uint8List sampleInput();
+
+  void applyInput(Uint8List input, double dt);
+
+  Vector3? get authoritativeLinearVelocity;
+
+  Vector3? get authoritativeAngularVelocity;
+}
+
+/// A retained per-tick prediction, the serialized world plus the owned
+/// body's state read back after the step.
+final class _WorldState {
+  _WorldState(
+    this.world,
+    this.position,
+    this.rotation,
+    this.linearVelocity,
+    this.angularVelocity,
+  );
+
+  final Uint8List world;
+  final Vector3 position;
+  final Quaternion rotation;
+  final Vector3 linearVelocity;
+  final Vector3 angularVelocity;
+}
+
+/// Drives the node of an owned [TransformReplica] by physics rollback
+/// prediction with authoritative input-replay reconciliation.
+///
+/// Each fixed tick it samples and sends an input command, applies it to the
+/// owned body, steps the controller's prediction world, and retains the tick's
+/// world snapshot. When the server confirms the authoritative pose after an
+/// input tick, a diverged prediction is corrected by restoring the snapshot at
+/// that tick, teleporting the body to the authoritative pose (and velocity
+/// when replicated), and replaying the not-yet-applied inputs through the
+/// world. A correction decays through a visual error offset over [smoothing]
+/// rather than popping.
+///
+/// Snapshots are whole-world, so keep the prediction world small (the owned
+/// body plus static geometry). TODO(prediction): per-island snapshots to
+/// bound cost in larger predicted scenes.
+final class PredictedPhysicsComponent extends Component {
+  PredictedPhysicsComponent(
+    this.replica, {
+    required this.controller,
+    required this.client,
+    required int tickRate,
+    this.smoothing = const Duration(milliseconds: 120),
+    this.correctionThreshold = 0.05,
+    int historyTicks = 64,
+    NowMicros now = defaultNowMicros,
+  }) : _dt = 1 / tickRate,
+       _now = now {
+    _predictor = Predictor<Uint8List, _WorldState>(
+      step: _step,
+      dt: _dt,
+      diverged: (a, b) =>
+          (a.position - b.position).length > correctionThreshold,
+      historyLength: historyTicks,
+    );
+  }
+
+  final TransformReplica replica;
+  final PredictedPhysicsController controller;
+  final ReplicationClient client;
+
+  /// Time constant over which an authoritative correction eases in.
+  final Duration smoothing;
+
+  /// Positional divergence (metres) beyond which a snapshot triggers a replay
+  /// correction.
+  final double correctionThreshold;
+
+  final double _dt;
+  final NowMicros _now;
+
+  late final Predictor<Uint8List, _WorldState> _predictor;
+  final Vector3 _error = Vector3.zero();
+  int _reconciledTick = -1;
+
+  /// The snapshot the live world currently equals, so the fresh-prediction
+  /// hot path skips the restore and only replay pays for it.
+  Uint8List? _liveWorld;
+
+  _WorldState _step(_WorldState state, Uint8List input, double dt) {
+    final sim = controller.simulation;
+    if (!identical(state.world, _liveWorld)) sim.restore(state.world);
+    // The state's body fields override the restored world, so an
+    // authoritative base injected by reconcile takes effect here.
+    sim.setBodyPose(controller.bodyHandle, state.position, state.rotation);
+    sim.setBodyLinearVelocity(controller.bodyHandle, state.linearVelocity);
+    sim.setBodyAngularVelocity(controller.bodyHandle, state.angularVelocity);
+    controller.applyInput(input, dt);
+    sim.step(dt);
+    return _capture();
+  }
+
+  _WorldState _capture() {
+    final sim = controller.simulation;
+    final (position, rotation) = sim.readBodyPose(controller.bodyHandle);
+    final state = _WorldState(
+      sim.snapshot(),
+      position,
+      rotation,
+      sim.readBodyLinearVelocity(controller.bodyHandle),
+      sim.readBodyAngularVelocity(controller.bodyHandle),
+    );
+    _liveWorld = state.world;
+    return state;
+  }
+
+  /// The replay base for a reconcile, the retained world at [ackedTick] with
+  /// the authoritative pose (and velocity when replicated) overriding the
+  /// owned body.
+  _WorldState _authoritativeState(int ackedTick) {
+    final predicted = _predictor.stateAt(ackedTick);
+    return _WorldState(
+      predicted?.world ?? _predictor.current.world,
+      replica.positionVector,
+      replica.rotationQuaternion,
+      controller.authoritativeLinearVelocity ??
+          predicted?.linearVelocity ??
+          _predictor.current.linearVelocity,
+      controller.authoritativeAngularVelocity ??
+          predicted?.angularVelocity ??
+          _predictor.current.angularVelocity,
+    );
+  }
+
+  @override
+  void update(double deltaSeconds) {
+    final clock = client.session.clock;
+    if (!clock.isSynchronized) return;
+    final target = clock.inputTickAt(_now());
+
+    if (!_predictor.isSeeded) {
+      _predictor.reset(target - 1, _capture());
+    }
+
+    // Reconcile against the authoritative pose the server has confirmed
+    // applying input through.
+    final acked = client.lastAppliedInputTick;
+    if (acked > _reconciledTick &&
+        acked > 0 &&
+        acked <= _predictor.currentTick) {
+      final rendered = _predictor.current.position + _error;
+      final corrected = _predictor.reconcile(acked, _authoritativeState(acked));
+      _reconciledTick = acked;
+      if (corrected) _error.setFrom(rendered - _predictor.current.position);
+    }
+
+    // Predict forward to the target tick, one input sampled and sent per tick.
+    while (_predictor.currentTick < target) {
+      final tick = _predictor.currentTick + 1;
+      final input = controller.sampleInput();
+      _predictor.advance(tick, input);
+      client.sendInput(input, tick: tick);
+    }
+
+    if (smoothing.inMicroseconds > 0) {
+      _error.scale(exp(-deltaSeconds * 1e6 / smoothing.inMicroseconds));
+    } else {
+      _error.setZero();
+    }
+    final state = _predictor.current;
+    node.localTransform = Matrix4.compose(
+      state.position + _error,
+      state.rotation,
+      _unitScale,
+    );
+  }
+
+  static final Vector3 _unitScale = Vector3(1, 1, 1);
+}

--- a/packages/flutter_scene_net/lib/src/predicted_physics.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_physics.dart
@@ -35,10 +35,15 @@ abstract interface class PredictedPhysicsController
   void applyInput(Uint8List input, double dt);
 
   /// Called after a rollback correction restores a retained world snapshot,
-  /// before pending inputs replay. Bodies the controller created after that
-  /// snapshot no longer exist (their handles dangle silently), so mark any
-  /// dynamically managed bodies, remote-player proxies, say, for recreation
-  /// on the next fresh tick.
+  /// before pending inputs replay.
+  ///
+  /// A restore rewinds to the body set its snapshot captured, so bodies
+  /// created since are gone and their handles dangle. Recreating them here or
+  /// on the next fresh tick does not hold, since the next correction restores
+  /// an older snapshot that knows only the previous handles and reconciles
+  /// both sets away. Allocate a fixed pool before the first snapshot instead,
+  /// parking unused bodies out of reach, so the body set never changes and
+  /// this hook has nothing to repair.
   void onWorldRestored();
 
   Vector3? get authoritativeLinearVelocity;

--- a/packages/flutter_scene_net/lib/src/predicted_physics.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_physics.dart
@@ -209,9 +209,12 @@ final class PredictedPhysicsComponent extends Component {
     // dropped, so the replica's pose is often older than the ack; adopting it
     // at the ack's tick would discard the motion in between and re-predict
     // it, tugging backward on every snapshot.
+    // Before the first snapshot the pose is the spawn's, belonging to no tick
+    // the predictor knows, so a zero snapshot tick skips reconciliation
+    // through the guard below rather than anchoring it to the ack.
     final applied = client.lastAppliedInputTick;
     final carried = replica.snapshotTick;
-    final acked = carried > 0 && carried < applied ? carried : applied;
+    final acked = carried < applied ? carried : applied;
     if (acked > _reconciledTick &&
         acked > 0 &&
         acked <= _predictor.currentTick) {

--- a/packages/flutter_scene_net/lib/src/predicted_transform.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_transform.dart
@@ -8,6 +8,10 @@ import 'package:vector_math/vector_math.dart' hide Colors;
 
 import 'transform_replica.dart';
 
+/// A client-side prediction driver for an owned entity, either the analytic
+/// [PredictedController] or the physics-rollback `PredictedPhysicsController`.
+abstract interface class PredictionController {}
+
 /// Client-side driver for an owned, predicted entity.
 ///
 /// [sampleInput] captures and encodes this tick's local input for the wire.
@@ -15,7 +19,7 @@ import 'transform_replica.dart';
 /// match the server's integration exactly (share one function) so replay
 /// reconciliation converges. Encode one-frame events (a jump, a shot) as
 /// counters, not booleans, so a resent command reproduces them.
-abstract interface class PredictedController {
+abstract interface class PredictedController implements PredictionController {
   Uint8List sampleInput();
 
   (Vector3 position, Quaternion rotation) step(

--- a/packages/flutter_scene_net/lib/src/scene_replication.dart
+++ b/packages/flutter_scene_net/lib/src/scene_replication.dart
@@ -33,6 +33,7 @@ final class SceneReplication {
     required this.root,
     required Map<String, ReplicaNodeBuilder> builders,
     this.interpolationDelay = const Duration(milliseconds: 100),
+    int inputTargetDepth = 2,
     LocalPredictionBuilder? localPrediction,
     void Function(Replica replica, Node node)? onSpawn,
     void Function(Replica replica, Node node)? onDespawn,
@@ -43,6 +44,7 @@ final class SceneReplication {
     client = ReplicationClient(
       registry: registry,
       session: session,
+      inputTargetDepth: inputTargetDepth,
       onSpawn: _spawned,
       onDespawn: _despawned,
     );
@@ -54,6 +56,9 @@ final class SceneReplication {
   final Node root;
 
   final Map<String, ReplicaNodeBuilder> _builders;
+
+  /// Ceiling for the remote-pose render delay; the interpolation buffer
+  /// sizes itself below this from measured arrival cadence and jitter.
   final Duration interpolationDelay;
   final LocalPredictionBuilder? _localPrediction;
   final void Function(Replica, Node)? _onSpawn;

--- a/packages/flutter_scene_net/lib/src/scene_replication.dart
+++ b/packages/flutter_scene_net/lib/src/scene_replication.dart
@@ -6,15 +6,18 @@ import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart' hide Colors;
 
 import 'network_transform.dart';
+import 'predicted_physics.dart';
 import 'predicted_transform.dart';
 import 'transform_replica.dart';
 
 /// Builds the scene subtree representing [replica] at spawn time.
 typedef ReplicaNodeBuilder = Node Function(Replica replica);
 
-/// Supplies the client-side prediction controller for an owned [replica], or
-/// null to interpolate it like any other entity.
-typedef LocalPredictionBuilder = PredictedController? Function(Replica replica);
+/// Supplies the client-side prediction controller for an owned [replica]
+/// (a [PredictedController] or a [PredictedPhysicsController]), or null to
+/// interpolate it like any other entity.
+typedef LocalPredictionBuilder =
+    PredictionController? Function(Replica replica);
 
 /// Binds a replication client to a scene graph.
 ///
@@ -85,16 +88,21 @@ final class SceneReplication {
       final controller = replica.owner == localPeerId
           ? _localPrediction?.call(replica)
           : null;
-      node.addComponent(
-        controller != null
-            ? PredictedTransformComponent(
-                replica,
-                controller: controller,
-                client: client,
-                tickRate: session.tickRate,
-              )
-            : NetworkTransformComponent(replica, delay: interpolationDelay),
-      );
+      node.addComponent(switch (controller) {
+        PredictedPhysicsController physics => PredictedPhysicsComponent(
+          replica,
+          controller: physics,
+          client: client,
+          tickRate: session.tickRate,
+        ),
+        PredictedController analytic => PredictedTransformComponent(
+          replica,
+          controller: analytic,
+          client: client,
+          tickRate: session.tickRate,
+        ),
+        _ => NetworkTransformComponent(replica, delay: interpolationDelay),
+      });
     }
     root.add(node);
     _nodes[replica.id!] = node;

--- a/packages/flutter_scene_net/test/flutter_scene_net_test.dart
+++ b/packages/flutter_scene_net/test/flutter_scene_net_test.dart
@@ -160,6 +160,33 @@ void main() {
     expect(late_.x, 10);
   });
 
+  test('the interpolation delay adapts to arrival cadence and jitter', () {
+    var nowMicros = 1000000;
+    var x = 0.0;
+    final pawn = _Pawn()..position.value = (0.0, 0.0, 0.0);
+    final component = NetworkTransformComponent(pawn, now: () => nowMicros);
+    expect(component.currentDelay.inMilliseconds, 100); // starts at the cap
+
+    // A metronomic 30Hz stream converges well under the ceiling.
+    for (var i = 0; i < 300; i++) {
+      nowMicros += 33333;
+      pawn.position.value = (x += 0.1, 0.0, 0.0);
+    }
+    expect(component.currentDelay.inMilliseconds, lessThan(70));
+    expect(
+      component.currentDelay,
+      greaterThanOrEqualTo(const Duration(milliseconds: 25)),
+    );
+    final settled = component.currentDelay;
+
+    // Heavy jitter under the idle threshold deepens the buffer again.
+    for (var i = 0; i < 300; i++) {
+      nowMicros += i.isEven ? 8000 : 58000;
+      pawn.position.value = (x += 0.1, 0.0, 0.0);
+    }
+    expect(component.currentDelay, greaterThan(settled));
+  });
+
   test('resuming after an idle gap eases in instead of snapping', () {
     var nowMicros = 1000000;
     final pawn = _Pawn()..position.value = (0.0, 0.0, 0.0);

--- a/packages/flutter_scene_net/test/flutter_scene_net_test.dart
+++ b/packages/flutter_scene_net/test/flutter_scene_net_test.dart
@@ -106,6 +106,10 @@ void main() {
   });
 
   test('SceneHost serves loopback and WebSocket joiners', () async {
+    if (!SceneHost.isSupported) {
+      markTestSkipped('in-app hosting requires dart:io');
+      return;
+    }
     final room = Room(registry: _registry());
     final host = await SceneHost.start(room: room);
     room.host.spawn(_Pawn()..position.value = (7.0, 0.0, 0.0));

--- a/packages/flutter_scene_net/test/predicted_physics_test.dart
+++ b/packages/flutter_scene_net/test/predicted_physics_test.dart
@@ -159,13 +159,11 @@ void main() {
       );
       await admitted;
 
-      _FakeController? controller;
       final replication = SceneReplication(
         registry: _registry(),
         session: session,
         root: Node(),
         builders: {'pawn': (replica) => Node()},
-        localPrediction: (replica) => controller = _FakeController(_FakeSim()),
       );
 
       final sw = Stopwatch()..start();
@@ -174,12 +172,31 @@ void main() {
         await _pump(1);
       }
       final pawn = replication.replicas.whereType<_Pawn>().first;
-      final component = replication
-          .nodeFor(pawn.id!)!
-          .getComponent<PredictedPhysicsComponent>()!;
 
+      // Drive the prediction from a clock held a few ticks ahead of the
+      // server. A correction only replays when unacked inputs remain, so a
+      // client that happens to sit level with the server would adopt the
+      // authoritative pose without ever restoring a world, which is what the
+      // send-ahead lead exists to prevent.
+      const aheadTicks = 4;
+      final controller = _FakeController(_FakeSim());
+      final component = PredictedPhysicsComponent(
+        pawn,
+        controller: controller,
+        client: replication.client,
+        tickRate: tickRate,
+        now: () => defaultNowMicros() + aheadTicks * 1000000 ~/ tickRate,
+      );
+      replication.nodeFor(pawn.id!)!.addComponent(component);
+
+      // Drive the client render loop and the server tick until the shove has
+      // been applied and the rollback correction it forces has landed. Waiting
+      // on the outcome rather than on a fixed wall-clock window keeps the run
+      // off the scheduler's timing.
       final run = Stopwatch()..start();
-      while (run.elapsedMilliseconds < 800) {
+      while (run.elapsedMilliseconds < 800 ||
+          (run.elapsedMilliseconds < 5000 &&
+              !(shoved && controller.worldRestores > 0))) {
         component.update(1 / 60);
         room.advance(dt);
         await Future<void>.delayed(const Duration(milliseconds: 16));
@@ -197,7 +214,7 @@ void main() {
       // the restore hook told the controller about the rollback.
       expect(shoved, isTrue);
       expect((predictedX - pawn.position.value.$1).abs(), lessThan(3));
-      expect(controller!.worldRestores, greaterThan(0));
+      expect(controller.worldRestores, greaterThan(0));
 
       await replication.close();
       await room.stop();

--- a/packages/flutter_scene_net/test/predicted_physics_test.dart
+++ b/packages/flutter_scene_net/test/predicted_physics_test.dart
@@ -83,8 +83,13 @@ final class _FakeController implements PredictedPhysicsController {
   @override
   final _FakeSim simulation;
 
+  int worldRestores = 0;
+
   @override
   int get bodyHandle => 0;
+
+  @override
+  void onWorldRestored() => worldRestores++;
 
   @override
   Uint8List sampleInput() => _encodeVel(1);
@@ -154,12 +159,13 @@ void main() {
       );
       await admitted;
 
+      _FakeController? controller;
       final replication = SceneReplication(
         registry: _registry(),
         session: session,
         root: Node(),
         builders: {'pawn': (replica) => Node()},
-        localPrediction: (replica) => _FakeController(_FakeSim()),
+        localPrediction: (replica) => controller = _FakeController(_FakeSim()),
       );
 
       final sw = Stopwatch()..start();
@@ -187,9 +193,11 @@ void main() {
       // Local input moved the predicted body right immediately.
       expect(predictedX, greaterThan(1));
       // The unpredictable shove happened and the rollback correction adopted
-      // it; the prediction tracks authority within the send-ahead lead.
+      // it; the prediction tracks authority within the send-ahead lead, and
+      // the restore hook told the controller about the rollback.
       expect(shoved, isTrue);
       expect((predictedX - pawn.position.value.$1).abs(), lessThan(3));
+      expect(controller!.worldRestores, greaterThan(0));
 
       await replication.close();
       await room.stop();

--- a/packages/flutter_scene_net/test/predicted_physics_test.dart
+++ b/packages/flutter_scene_net/test/predicted_physics_test.dart
@@ -1,0 +1,218 @@
+import 'dart:typed_data';
+
+import 'package:dashwire/dashwire.dart';
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/physics.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+final class _Pawn extends TransformReplica {
+  _Pawn();
+
+  @override
+  String get typeKey => 'pawn';
+}
+
+ReplicaRegistry _registry() => ReplicaRegistry()..register(_Pawn.new);
+
+const double _speed = 5;
+
+Uint8List _encodeVel(double v) => (ByteWriter(4)..writeF32(v)).toBytes();
+double _decodeVel(Uint8List b) => ByteReader(b).readF32();
+
+/// A 1D world, one body with position x and velocity v, snapshot-round-trip
+/// through two doubles. Deterministic stand-in for a physics backend.
+final class _FakeSim extends PhysicsSimulation {
+  double x = 0;
+  double v = 0;
+
+  @override
+  String get backendName => 'fake1d';
+
+  @override
+  bool get supportsSnapshot => true;
+
+  @override
+  Uint8List snapshot() =>
+      Float64List.fromList([x, v]).buffer.asUint8List().sublist(0);
+
+  @override
+  bool restore(Uint8List snapshot) {
+    final data = Uint8List.fromList(snapshot).buffer.asFloat64List();
+    x = data[0];
+    v = data[1];
+    return true;
+  }
+
+  @override
+  void step(double fixedDt) => x += v * fixedDt;
+
+  @override
+  void setBodyPose(
+    int bodyHandle,
+    vm.Vector3 translation,
+    vm.Quaternion rotation,
+  ) => x = translation.x;
+
+  @override
+  (vm.Vector3, vm.Quaternion) readBodyPose(int bodyHandle) =>
+      (vm.Vector3(x, 0, 0), vm.Quaternion.identity());
+
+  @override
+  vm.Vector3 readBodyLinearVelocity(int bodyHandle) => vm.Vector3(v, 0, 0);
+
+  @override
+  vm.Vector3 readBodyAngularVelocity(int bodyHandle) => vm.Vector3.zero();
+
+  @override
+  void setBodyLinearVelocity(int bodyHandle, vm.Vector3 velocity) =>
+      v = velocity.x;
+
+  @override
+  void setBodyAngularVelocity(int bodyHandle, vm.Vector3 velocity) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _FakeController implements PredictedPhysicsController {
+  _FakeController(this.simulation);
+
+  @override
+  final _FakeSim simulation;
+
+  @override
+  int get bodyHandle => 0;
+
+  @override
+  Uint8List sampleInput() => _encodeVel(1);
+
+  @override
+  void applyInput(Uint8List input, double dt) => simulation
+      .setBodyLinearVelocity(0, vm.Vector3(_decodeVel(input) * _speed, 0, 0));
+
+  @override
+  vm.Vector3? get authoritativeLinearVelocity => null;
+
+  @override
+  vm.Vector3? get authoritativeAngularVelocity => null;
+}
+
+Future<void> _pump([int rounds = 4]) async {
+  for (var i = 0; i < rounds; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 3));
+  }
+}
+
+void main() {
+  test(
+    'an owned physics body is predicted and survives a server shove',
+    () async {
+      const tickRate = 30;
+      const dt = 1 / tickRate;
+
+      // The server runs the same 1D integration the fake sim predicts with,
+      // plus one displacement the client cannot predict (a collision stand-in).
+      late final Room room;
+      final players = <int, _Pawn>{};
+      final serverX = <int, double>{};
+      var consumedTicks = 0;
+      var shoved = false;
+      room = Room(
+        registry: _registry(),
+        tickRate: tickRate,
+        onJoin: (session) {
+          final pawn = _Pawn();
+          room.host.spawn(pawn, owner: session.peerId);
+          players[session.peerId] = pawn;
+          serverX[session.peerId] = 0;
+        },
+        onTick: (tick) {
+          for (final entry in players.entries) {
+            final command = room.input(entry.key, tick);
+            if (command == null) continue;
+            consumedTicks++;
+            var x = serverX[entry.key]! + _decodeVel(command) * _speed * dt;
+            if (consumedTicks == 10 && !shoved) {
+              shoved = true;
+              x += 3;
+            }
+            serverX[entry.key] = x;
+            entry.value.position.value = (x, 0.0, 0.0);
+          }
+        },
+      );
+
+      final (clientEnd, serverEnd) = LoopbackConnection.pair();
+      final admitted = room.admit(serverEnd);
+      final session = await connectSession(
+        clientEnd,
+        schemaHash: _registry().schemaHash,
+        pingInterval: const Duration(milliseconds: 20),
+      );
+      await admitted;
+
+      final replication = SceneReplication(
+        registry: _registry(),
+        session: session,
+        root: Node(),
+        builders: {'pawn': (replica) => Node()},
+        localPrediction: (replica) => _FakeController(_FakeSim()),
+      );
+
+      final sw = Stopwatch()..start();
+      while (replication.replicas.isEmpty && sw.elapsedMilliseconds < 2000) {
+        room.advance(dt);
+        await _pump(1);
+      }
+      final pawn = replication.replicas.whereType<_Pawn>().first;
+      final component = replication
+          .nodeFor(pawn.id!)!
+          .getComponent<PredictedPhysicsComponent>()!;
+
+      final run = Stopwatch()..start();
+      while (run.elapsedMilliseconds < 800) {
+        component.update(1 / 60);
+        room.advance(dt);
+        await Future<void>.delayed(const Duration(milliseconds: 16));
+      }
+
+      final predictedX = replication
+          .nodeFor(pawn.id!)!
+          .localTransform
+          .getTranslation()
+          .x;
+      // Local input moved the predicted body right immediately.
+      expect(predictedX, greaterThan(1));
+      // The unpredictable shove happened and the rollback correction adopted
+      // it; the prediction tracks authority within the send-ahead lead.
+      expect(shoved, isTrue);
+      expect((predictedX - pawn.position.value.$1).abs(), lessThan(3));
+
+      await replication.close();
+      await room.stop();
+    },
+  );
+
+  test('world history rewinds a query and restores the present', () {
+    final sim = _FakeSim()..v = 1;
+    final history = PhysicsWorldHistory(sim, maxRewindTicks: 8);
+
+    for (var tick = 1; tick <= 12; tick++) {
+      sim.step(1);
+      history.record(tick);
+    }
+    expect(sim.x, 12);
+    expect(history.depth, 9); // ticks 4..12 retained
+
+    final rewound = history.rewind(9, (s) => (s as _FakeSim).x);
+    expect(rewound, 9);
+    expect(sim.x, 12); // present restored
+    expect(sim.v, 1);
+
+    expect(history.rewind(3, (s) => 0), isNull); // beyond the cap
+    expect(history.rewind(99, (s) => 0), isNull); // never recorded
+  });
+}

--- a/packages/flutter_scene_net/test/predicted_physics_test.dart
+++ b/packages/flutter_scene_net/test/predicted_physics_test.dart
@@ -216,11 +216,16 @@ void main() {
     expect(history.depth, 9); // ticks 4..12 retained
 
     final rewound = history.rewind(9, (s) => (s as _FakeSim).x);
-    expect(rewound, 9);
+    expect(rewound.rewound, isTrue);
+    expect(rewound.result, 9);
     expect(sim.x, 12); // present restored
     expect(sim.v, 1);
 
-    expect(history.rewind(3, (s) => 0), isNull); // beyond the cap
-    expect(history.rewind(99, (s) => 0), isNull); // never recorded
+    // A miss reports itself rather than looking like a null query result.
+    expect(history.rewind(3, (s) => 0).rewound, isFalse); // beyond the cap
+    expect(history.rewind(99, (s) => 0).rewound, isFalse); // never recorded
+    final empty = history.rewind(9, (s) => null);
+    expect(empty.rewound, isTrue);
+    expect(empty.result, isNull);
   });
 }


### PR DESCRIPTION
Stacked on #287 and #288; it carries their commits and rebases to just its own once they merge.

`PredictedPhysicsComponent` rollback-predicts an owned body in a dedicated snapshot-capable world, restoring the acked tick, adopting the authoritative pose and velocity, and replaying pending inputs, with `onWorldRestored` telling the controller to revalidate bodies it manages. `PhysicsWorldHistory` rewinds server-side hit queries to the client-rendered tick. Remote players mirror into the prediction world as kinematic proxies at their rendered poses, and the interpolation delay now adapts to measured arrival cadence and jitter. The Multiplayer example becomes a 60Hz physics arena (players are balls that shove each other) with a headless `dart run` host tool, and prediction runs on the web behind a runtime capability probe.