### PR TITLE
Prep scene 0.1.1 and flutter_scene_rapier 0.4.0

### DIFF
--- a/packages/flutter_scene_rapier/CHANGELOG.md
+++ b/packages/flutter_scene_rapier/CHANGELOG.md
@@ -1,5 +1,6 @@
-## Unreleased
+## 0.4.0
 
+* Requires the scene 0.1.1 physics contract.
 * `RapierWorld.snapshot`/`restore`, full world serialization for rollback prediction and lag-compensation rewind, on native and web.
 * `RapierWorld.setBodyPose`, immediate body teleport for rollback correction.
 * Ships new native binaries and wasm (new `fsr_world_snapshot`/`fsr_world_restore`/`fsr_body_set_pose` exports).

--- a/packages/flutter_scene_rapier/pubspec.yaml
+++ b/packages/flutter_scene_rapier/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_scene_rapier
 description: Rapier 3D physics backend for flutter_scene. Implements the scene package's physics simulation contract against Rapier via FFI.
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
-version: 0.3.0
+version: 0.4.0
 
 topics:
   - physics
@@ -32,7 +32,7 @@ dependencies:
     sdk: flutter
   hooks: ^2.0.0
   # The engine-agnostic physics contract this package implements.
-  scene: ^0.1.0
+  scene: ^0.1.1
   vector_math: ^2.1.4
 
 dev_dependencies:

--- a/packages/scene/CHANGELOG.md
+++ b/packages/scene/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## Unreleased
+## 0.1.1
 
 - `PhysicsSimulation.snapshot`/`restore` (opt-in via `supportsSnapshot`), world serialization for rollback prediction and lag-compensation rewind.
 - `PhysicsSimulation.setBodyPose`, immediate body teleport for rollback correction (default throws on backends without it).
-
-## 0.1.1
-
 - `TextureResource` carries a `content` role (`color`, `data`, `normal`) describing what its pixels represent.
 
 ## 0.1.0

--- a/packages/scene/pubspec.yaml
+++ b/packages/scene/pubspec.yaml
@@ -1,6 +1,6 @@
 name: scene
 description: The engine-agnostic scene document core, the .fscene document model, stable ids, serialization, prefab composition, and diffing.
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/bdero/flutter_scene
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Version bumps and changelogs for the physics snapshot release. The scene 0.1.1 entry folds the pending texture-content bullet together with the new simulation seam; rapier floors its scene constraint at the seam.