### PR TITLE
Clamp stale ranges when updatable meshes shrink

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Cooked textures build their mip chain on a background isolate, so a large uncompressed scene no longer pays for it on the calling thread.
 * Devices measured to sample every texture at its base mip skip mip chains entirely, reclaiming the memory and transcode time they were spending on levels the sampler ignores, and say so once at startup.
 * Loose images cook to compressed, mipmapped `.fstex` through `buildTextures`, loaded by source path with `loadTexture` (shipped in 0.20.0, missing from its notes).
+* Fixed a `RangeError` when an updatable mesh rebuilds at a smaller vertex count.
 
 ## 0.20.0
 

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -824,7 +824,14 @@ class _RingBufferStream {
     // The caller's change makes every buffer stale over that span.
     final change = (start: dirtyStart, end: dirtyEnd);
     for (var i = 0; i < _stale.length; i++) {
-      _stale[i] = unionVertexRange(_stale[i], change);
+      final stale = unionVertexRange(_stale[i], change);
+      // A previous, larger mesh can leave a stale span beyond this snapshot's
+      // byte array. Those vertices are no longer rendered, and a later growth
+      // will mark them stale again through its full-stream change range.
+      _stale[i] = (
+        start: stale.start > vertexCount ? vertexCount : stale.start,
+        end: stale.end > vertexCount ? vertexCount : stale.end,
+      );
     }
 
     final buffer = _buffers[_cursor];

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -753,6 +753,19 @@ int nextBufferCapacity(int needed, {int minimum = 16}) {
   );
 }
 
+/// [range] with both ends pulled back to [vertexCount].
+///
+/// A mesh that shrank leaves a stale span reaching past the current
+/// snapshot's byte array. Those vertices are no longer rendered, and a later
+/// growth marks them stale again through its full-stream change range.
+({int start, int end}) clampVertexRange(
+  ({int start, int end}) range,
+  int vertexCount,
+) => (
+  start: range.start > vertexCount ? vertexCount : range.start,
+  end: range.end > vertexCount ? vertexCount : range.end,
+);
+
 // A ring of host-visible device buffers for one updatable attribute stream.
 //
 // Vertex data must be CPU-written every update, and `hostVisible` is the
@@ -821,16 +834,13 @@ class _RingBufferStream {
       _cursor = (_cursor + 1) % _ringDepth;
     }
 
-    // The caller's change makes every buffer stale over that span.
+    // The caller's change makes every buffer stale over that span. A mesh that
+    // shrank leaves spans reaching past the new snapshot, so clamp them back.
     final change = (start: dirtyStart, end: dirtyEnd);
     for (var i = 0; i < _stale.length; i++) {
-      final stale = unionVertexRange(_stale[i], change);
-      // A previous, larger mesh can leave a stale span beyond this snapshot's
-      // byte array. Those vertices are no longer rendered, and a later growth
-      // will mark them stale again through its full-stream change range.
-      _stale[i] = (
-        start: stale.start > vertexCount ? vertexCount : stale.start,
-        end: stale.end > vertexCount ? vertexCount : stale.end,
+      _stale[i] = clampVertexRange(
+        unionVertexRange(_stale[i], change),
+        vertexCount,
       );
     }
 

--- a/packages/flutter_scene/test/mesh_geometry_test.dart
+++ b/packages/flutter_scene/test/mesh_geometry_test.dart
@@ -194,4 +194,33 @@ void main() {
       expect(stale, span);
     });
   });
+
+  group('clampVertexRange', () {
+    test('a range within the snapshot is unchanged', () {
+      expect(clampVertexRange((start: 2, end: 5), 8), (start: 2, end: 5));
+      expect(clampVertexRange((start: 0, end: 8), 8), (start: 0, end: 8));
+    });
+
+    test('a range past the snapshot is pulled back', () {
+      expect(clampVertexRange((start: 0, end: 64), 1), (start: 0, end: 1));
+      // A span that starts past the snapshot clamps to empty.
+      final empty = clampVertexRange((start: 30, end: 64), 1);
+      expect(empty.end <= empty.start, isTrue);
+    });
+
+    test('a shrink leaves no stale span past the current snapshot', () {
+      // Mirrors a ring buffer's stale bookkeeping across 64 -> 1 -> 64.
+      // Unclamped, the shrink kept the 64-vertex span and the upload read
+      // past the 1-vertex CPU array.
+      var stale = (start: 0, end: 64);
+      stale = clampVertexRange(unionVertexRange(stale, (start: 0, end: 1)), 1);
+      expect(stale, (start: 0, end: 1));
+      // Growing back marks the restored vertices stale again.
+      stale = clampVertexRange(
+        unionVertexRange(stale, (start: 0, end: 64)),
+        64,
+      );
+      expect(stale, (start: 0, end: 64));
+    });
+  });
 }


### PR DESCRIPTION
Fixes #292

## Problem

An updatable mesh can retain a stale ring-buffer range from a previous, larger snapshot. After the mesh shrinks, that range can extend past the current CPU byte array and `ByteData.sublistView` throws a `RangeError` during upload.

## Change

Clamp each unioned stale range to the current `vertexCount` before calculating the upload byte range. Vertices outside the current snapshot are not rendered, and a later growth marks the newly present range stale again through the normal full-stream change path.

## Validation

- The [Updatable Mesh Shrink case](https://github.com/Ram-Dawson/flutter_scene_repros/tree/main/docs/cases/updatable_mesh_shrink) runs the same `64 -> 1 -> 64` sequence on its [failing baseline tag](https://github.com/Ram-Dawson/flutter_scene_repros/tree/repro/updatable-mesh-shrink-before) and [fixed tag](https://github.com/Ram-Dawson/flutter_scene_repros/tree/repro/updatable-mesh-shrink-fixed).
- On Android, the fixed engine commit `a172305b3e64b974bcb6bb7afacd453d4147986f` passed the focused device regression recorded in `after-android-pass.txt`.
- A post-fix manual Android interaction sample completed a 342-event slider gesture with no `RangeError` in the supplied log excerpt.

## Scope and limitation

This PR changes only `_RingBufferStream` stale-range handling for the current mesh snapshot. It does not add an application-specific path, change material or texture behavior, establish an Android performance baseline, or validate iOS and other GPU backends.

## Visual evidence

The [companion reproduction repository](https://github.com/Ram-Dawson/flutter_scene_repros) has supporting before and after Android UI screenshots. They were captured at different cube counts, so they should be presented as interaction-state samples rather than a pixel-for-pixel comparison. The focused regression result is the correctness evidence.