### PR TITLE
fix(rapier): reject snapshot restore after body membership changes

### DIFF
--- a/packages/flutter_scene_rapier/CHANGELOG.md
+++ b/packages/flutter_scene_rapier/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0
+
+* BREAKING: `RapierWorld.snapshot` wraps the native payload in an envelope carrying the body set it captured, so snapshots taken by 0.4.0 no longer restore.
+* `RapierWorld.restore` reconciles its body registry against the restored world. A body created after the snapshot stops being driven, and one destroyed after it is removed rather than left simulating with no pose target.
+* No native changes; reuses the 0.4.0 prebuilt binaries and wasm.
+
 ## 0.4.0
 
 * Requires the scene 0.1.1 physics contract.

--- a/packages/flutter_scene_rapier/lib/src/rapier_world.dart
+++ b/packages/flutter_scene_rapier/lib/src/rapier_world.dart
@@ -64,19 +64,38 @@ class RapierWorld extends PhysicsSimulation {
   Uint8List snapshot() =>
       _WorldSnapshot.encode(_bindings.snapshot(), _bodies.keys);
 
+  /// Restores the world from a [snapshot], returning false if the bytes
+  /// could not be decoded.
+  ///
+  /// Restoring rewinds the world to the body set the snapshot captured, so
+  /// bodies created since are gone and bodies destroyed since come back.
+  /// Their pose targets do not rewind with them, so the registry is
+  /// reconciled to match. A body created after the snapshot stops being
+  /// driven, and one destroyed after it is removed again rather than left
+  /// simulating with no owner. Recreate what the rollback needs with
+  /// [createBody]; the handles are new.
   @override
   bool restore(Uint8List snapshot) {
     final decoded = _WorldSnapshot.decode(snapshot);
-    if (decoded == null || !_hasSameBodies(decoded.bodyHandles)) return false;
-    return _bindings.restore(decoded.nativeSnapshot);
+    if (decoded == null) return false;
+    if (!_bindings.restore(decoded.nativeSnapshot)) return false;
+    _reconcileBodies(decoded.bodyHandles);
+    return true;
   }
 
-  // A native snapshot preserves handle values, but it cannot restore the
-  // Dart-side pose targets that own those handles. Reject structural changes
-  // before asking native code to restore, so both sides stay in lockstep.
-  bool _hasSameBodies(Set<int> snapshotHandles) {
-    if (_bodies.length != snapshotHandles.length) return false;
-    return _bodies.keys.every(snapshotHandles.contains);
+  // Drops records the restore invalidated, and removes bodies it brought
+  // back that no longer have a record, so the native world and the registry
+  // describe the same set.
+  //
+  // TODO(restore-reconcile-handles): colliders, joints, and anchor bodies
+  // rewind natively with no equivalent bookkeeping, so handles the app holds
+  // for those can dangle. Track them the way bodies are tracked, or hand the
+  // caller the rewound handles so it can re-adopt them.
+  void _reconcileBodies(Set<int> snapshotHandles) {
+    _bodies.removeWhere((handle, _) => !snapshotHandles.contains(handle));
+    for (final handle in snapshotHandles) {
+      if (!_bodies.containsKey(handle)) _bindings.destroyBody(handle);
+    }
   }
 
   final StreamController<SimCollisionEvent> _events =
@@ -1069,18 +1088,24 @@ class _BodyRecord {
 class _WorldSnapshot {
   _WorldSnapshot(this.nativeSnapshot, this.bodyHandles);
 
-  // Snapshot envelope marker: "FSRS" (Flutter Scene Rapier Snapshot).
-  // Encoded little-endian, so its bytes read as "SRSF".
-  static const _magic = 0x46535253;
+  // Header is 'F' 'S' 'R' 'S' then a version and a handle count, each a
+  // little-endian u32. The handle table and the native snapshot follow.
+  static const _magic = 0x53525346;
   static const _version = 1;
   static const _headerBytes = 12;
+  static const _handleBytes = 8;
+
+  // Handles are the shim's packed u64s. dart2js has no int64 and its bitwise
+  // operators are 32-bit, so each one is stored as two u32 lanes split
+  // arithmetically, matching how the wasm bindings read a handle field.
+  static const _lane = 0x100000000;
 
   final Uint8List nativeSnapshot;
   final Set<int> bodyHandles;
 
   static Uint8List encode(Uint8List nativeSnapshot, Iterable<int> handles) {
     final bodyHandles = handles.toList()..sort();
-    final payloadOffset = _headerBytes + bodyHandles.length * 8;
+    final payloadOffset = _headerBytes + bodyHandles.length * _handleBytes;
     final bytes = Uint8List(payloadOffset + nativeSnapshot.length);
     final data = ByteData.sublistView(bytes);
     data
@@ -1088,7 +1113,10 @@ class _WorldSnapshot {
       ..setUint32(4, _version, Endian.little)
       ..setUint32(8, bodyHandles.length, Endian.little);
     for (var i = 0; i < bodyHandles.length; i++) {
-      data.setUint64(_headerBytes + i * 8, bodyHandles[i], Endian.little);
+      final offset = _headerBytes + i * _handleBytes;
+      data
+        ..setUint32(offset, bodyHandles[i] % _lane, Endian.little)
+        ..setUint32(offset + 4, bodyHandles[i] ~/ _lane, Endian.little);
     }
     bytes.setRange(payloadOffset, bytes.length, nativeSnapshot);
     return bytes;
@@ -1102,13 +1130,15 @@ class _WorldSnapshot {
       return null;
     }
     final count = data.getUint32(8, Endian.little);
-    if (count > (bytes.length - _headerBytes) ~/ 8) return null;
-    final payloadOffset = _headerBytes + count * 8;
+    if (count > (bytes.length - _headerBytes) ~/ _handleBytes) return null;
+    final payloadOffset = _headerBytes + count * _handleBytes;
     final handles = <int>{};
     for (var i = 0; i < count; i++) {
-      if (!handles.add(data.getUint64(_headerBytes + i * 8, Endian.little))) {
-        return null;
-      }
+      final offset = _headerBytes + i * _handleBytes;
+      final handle =
+          data.getUint32(offset, Endian.little) +
+          data.getUint32(offset + 4, Endian.little) * _lane;
+      if (!handles.add(handle)) return null;
     }
     return _WorldSnapshot(Uint8List.sublistView(bytes, payloadOffset), handles);
   }

--- a/packages/flutter_scene_rapier/lib/src/rapier_world.dart
+++ b/packages/flutter_scene_rapier/lib/src/rapier_world.dart
@@ -1069,7 +1069,9 @@ class _BodyRecord {
 class _WorldSnapshot {
   _WorldSnapshot(this.nativeSnapshot, this.bodyHandles);
 
-  static const _magic = 0x46535253; // FSRS
+  // Snapshot envelope marker: "FSRS" (Flutter Scene Rapier Snapshot).
+  // Encoded little-endian, so its bytes read as "SRSF".
+  static const _magic = 0x46535253;
   static const _version = 1;
   static const _headerBytes = 12;
 

--- a/packages/flutter_scene_rapier/lib/src/rapier_world.dart
+++ b/packages/flutter_scene_rapier/lib/src/rapier_world.dart
@@ -61,10 +61,23 @@ class RapierWorld extends PhysicsSimulation {
   bool get supportsSnapshot => true;
 
   @override
-  Uint8List snapshot() => _bindings.snapshot();
+  Uint8List snapshot() =>
+      _WorldSnapshot.encode(_bindings.snapshot(), _bodies.keys);
 
   @override
-  bool restore(Uint8List snapshot) => _bindings.restore(snapshot);
+  bool restore(Uint8List snapshot) {
+    final decoded = _WorldSnapshot.decode(snapshot);
+    if (decoded == null || !_hasSameBodies(decoded.bodyHandles)) return false;
+    return _bindings.restore(decoded.nativeSnapshot);
+  }
+
+  // A native snapshot preserves handle values, but it cannot restore the
+  // Dart-side pose targets that own those handles. Reject structural changes
+  // before asking native code to restore, so both sides stay in lockstep.
+  bool _hasSameBodies(Set<int> snapshotHandles) {
+    if (_bodies.length != snapshotHandles.length) return false;
+    return _bodies.keys.every(snapshotHandles.contains);
+  }
 
   final StreamController<SimCollisionEvent> _events =
       StreamController<SimCollisionEvent>.broadcast();
@@ -1051,6 +1064,52 @@ class _BodyRecord {
   // Pose after the most recent physics step.
   final Vector3 currTranslation;
   final Quaternion currRotation;
+}
+
+class _WorldSnapshot {
+  _WorldSnapshot(this.nativeSnapshot, this.bodyHandles);
+
+  static const _magic = 0x46535253; // FSRS
+  static const _version = 1;
+  static const _headerBytes = 12;
+
+  final Uint8List nativeSnapshot;
+  final Set<int> bodyHandles;
+
+  static Uint8List encode(Uint8List nativeSnapshot, Iterable<int> handles) {
+    final bodyHandles = handles.toList()..sort();
+    final payloadOffset = _headerBytes + bodyHandles.length * 8;
+    final bytes = Uint8List(payloadOffset + nativeSnapshot.length);
+    final data = ByteData.sublistView(bytes);
+    data
+      ..setUint32(0, _magic, Endian.little)
+      ..setUint32(4, _version, Endian.little)
+      ..setUint32(8, bodyHandles.length, Endian.little);
+    for (var i = 0; i < bodyHandles.length; i++) {
+      data.setUint64(_headerBytes + i * 8, bodyHandles[i], Endian.little);
+    }
+    bytes.setRange(payloadOffset, bytes.length, nativeSnapshot);
+    return bytes;
+  }
+
+  static _WorldSnapshot? decode(Uint8List bytes) {
+    if (bytes.length < _headerBytes) return null;
+    final data = ByteData.sublistView(bytes);
+    if (data.getUint32(0, Endian.little) != _magic ||
+        data.getUint32(4, Endian.little) != _version) {
+      return null;
+    }
+    final count = data.getUint32(8, Endian.little);
+    if (count > (bytes.length - _headerBytes) ~/ 8) return null;
+    final payloadOffset = _headerBytes + count * 8;
+    final handles = <int>{};
+    for (var i = 0; i < count; i++) {
+      if (!handles.add(data.getUint64(_headerBytes + i * 8, Endian.little))) {
+        return null;
+      }
+    }
+    return _WorldSnapshot(Uint8List.sublistView(bytes, payloadOffset), handles);
+  }
 }
 
 /// Shortest-arc quaternion slerp between [a] and [b] by [t]. Falls

--- a/packages/flutter_scene_rapier/pubspec.yaml
+++ b/packages/flutter_scene_rapier/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_scene_rapier
 description: Rapier 3D physics backend for flutter_scene. Implements the scene package's physics simulation contract against Rapier via FFI.
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
-version: 0.4.0
+version: 0.5.0
 
 topics:
   - physics

--- a/packages/flutter_scene_rapier/test/world_snapshot_test.dart
+++ b/packages/flutter_scene_rapier/test/world_snapshot_test.dart
@@ -104,53 +104,96 @@ void main() {
     world.dispose();
   });
 
-  test('restore rejects a snapshot after a body is created', () async {
+  test('restore rejects a bare native snapshot', () async {
     await RapierWorld.ensureInitialized();
     final world = RapierWorld();
-
-    world.createBody(
-      target: SimplePoseTarget(translation: Vector3(0, 10, 0)),
-      type: BodyType.dynamic_,
-      additionalMass: 1,
-    );
-    final snapshot = world.snapshot();
-    final createdAfterSnapshot = world.createBody(
-      target: SimplePoseTarget(translation: Vector3(1, 10, 0)),
-      type: BodyType.dynamic_,
-      additionalMass: 1,
-    );
-
-    expect(world.restore(snapshot), isFalse);
-
-    // The native world was not rewound, so the newly-created Dart body
-    // remains valid for subsequent simulation.
-    world.step(1 / 60);
-    expect(world.readBodyPose(createdAfterSnapshot).$1.y, lessThan(10));
+    // Snapshots carry a membership envelope, so payloads written before it
+    // existed are not restorable.
+    final envelope = world.snapshot();
+    expect(world.restore(Uint8List.sublistView(envelope, 12)), isFalse);
     world.dispose();
   });
 
-  test('restore rejects a snapshot after a body is destroyed', () async {
+  test('restore drops bodies created after the snapshot', () async {
+    await RapierWorld.ensureInitialized();
+    final world = RapierWorld();
+
+    final kept = SimplePoseTarget(translation: Vector3(0, 10, 0));
+    world.createBody(target: kept, type: BodyType.dynamic_, additionalMass: 1);
+    final snapshot = world.snapshot();
+
+    final rewound = SimplePoseTarget(translation: Vector3(1, 10, 0));
+    world.createBody(
+      target: rewound,
+      type: BodyType.dynamic_,
+      additionalMass: 1,
+    );
+
+    expect(world.restore(snapshot), isTrue);
+
+    // The restore rewound the world past the second body, so only the body
+    // the snapshot captured is still driven.
+    world.step(1 / 60);
+    world.interpolatePoses(1);
+    expect(kept.worldTranslation.y, lessThan(10));
+    expect(rewound.worldTranslation.y, closeTo(10, 1e-9));
+    world.dispose();
+  });
+
+  test('restore removes bodies destroyed after the snapshot', () async {
     await RapierWorld.ensureInitialized();
     final world = RapierWorld();
 
     final body = world.createBody(
       target: SimplePoseTarget(translation: Vector3(0, 10, 0)),
-      type: BodyType.dynamic_,
-      additionalMass: 1,
+      type: BodyType.fixed,
+      additionalMass: 0,
     );
+    world.createColliders(body, const SphereShape(radius: 1));
+    world.step(1 / 60);
+    expect(world.overlapSphere(Vector3(0, 10, 0), 0.5), isNotEmpty);
+
     final snapshot = world.snapshot();
     world.destroyBody(body);
+    world.step(1 / 60);
+    expect(world.overlapSphere(Vector3(0, 10, 0), 0.5), isEmpty);
 
-    expect(world.restore(snapshot), isFalse);
+    // Restoring brings the body back natively, but nothing owns its pose
+    // any more, so it does not survive the reconcile as a ghost.
+    expect(world.restore(snapshot), isTrue);
+    world.step(1 / 60);
+    expect(world.overlapSphere(Vector3(0, 10, 0), 0.5), isEmpty);
+    world.dispose();
+  });
 
-    // The destroyed body is not silently resurrected in native state.
-    final replacement = world.createBody(
-      target: SimplePoseTarget(translation: Vector3(1, 10, 0)),
+  test('handles survive the envelope past the 32-bit lane', () async {
+    await RapierWorld.ensureInitialized();
+    final world = RapierWorld();
+
+    // Recycling an arena slot bumps its generation, which lives in the
+    // handle's high 32 bits.
+    final first = world.createBody(
+      target: SimplePoseTarget(translation: Vector3(0, 10, 0)),
       type: BodyType.dynamic_,
       additionalMass: 1,
     );
+    world.destroyBody(first);
+    final recycled = world.createBody(
+      target: SimplePoseTarget(translation: Vector3(0, 10, 0)),
+      type: BodyType.dynamic_,
+      additionalMass: 1,
+    );
+    expect(recycled, greaterThan(0xFFFFFFFF));
+
+    // A membership-preserving restore round-trips that handle.
+    final snapshot = world.snapshot();
+    for (var i = 0; i < 60; i++) {
+      world.step(1 / 60);
+    }
+    expect(world.restore(snapshot), isTrue);
     world.step(1 / 60);
-    expect(world.readBodyPose(replacement).$1.y, lessThan(10));
+    world.interpolatePoses(1);
+    expect(world.readBodyPose(recycled).$1.y, closeTo(10, 0.01));
     world.dispose();
   });
 }

--- a/packages/flutter_scene_rapier/test/world_snapshot_test.dart
+++ b/packages/flutter_scene_rapier/test/world_snapshot_test.dart
@@ -22,7 +22,9 @@ void main() {
     );
 
     // Capture the world at rest, then let the body fall for a second.
-    final snapshot = world.snapshot();
+    // Snapshot membership metadata travels with the bytes, not a Dart object
+    // identity, so rollback callers may copy or serialize the snapshot.
+    final snapshot = Uint8List.fromList(world.snapshot());
     expect(snapshot, isNotEmpty);
 
     for (var i = 0; i < 60; i++) {
@@ -99,6 +101,56 @@ void main() {
     await RapierWorld.ensureInitialized();
     final world = RapierWorld();
     expect(world.restore(Uint8List.fromList([1, 2, 3])), isFalse);
+    world.dispose();
+  });
+
+  test('restore rejects a snapshot after a body is created', () async {
+    await RapierWorld.ensureInitialized();
+    final world = RapierWorld();
+
+    world.createBody(
+      target: SimplePoseTarget(translation: Vector3(0, 10, 0)),
+      type: BodyType.dynamic_,
+      additionalMass: 1,
+    );
+    final snapshot = world.snapshot();
+    final createdAfterSnapshot = world.createBody(
+      target: SimplePoseTarget(translation: Vector3(1, 10, 0)),
+      type: BodyType.dynamic_,
+      additionalMass: 1,
+    );
+
+    expect(world.restore(snapshot), isFalse);
+
+    // The native world was not rewound, so the newly-created Dart body
+    // remains valid for subsequent simulation.
+    world.step(1 / 60);
+    expect(world.readBodyPose(createdAfterSnapshot).$1.y, lessThan(10));
+    world.dispose();
+  });
+
+  test('restore rejects a snapshot after a body is destroyed', () async {
+    await RapierWorld.ensureInitialized();
+    final world = RapierWorld();
+
+    final body = world.createBody(
+      target: SimplePoseTarget(translation: Vector3(0, 10, 0)),
+      type: BodyType.dynamic_,
+      additionalMass: 1,
+    );
+    final snapshot = world.snapshot();
+    world.destroyBody(body);
+
+    expect(world.restore(snapshot), isFalse);
+
+    // The destroyed body is not silently resurrected in native state.
+    final replacement = world.createBody(
+      target: SimplePoseTarget(translation: Vector3(1, 10, 0)),
+      type: BodyType.dynamic_,
+      additionalMass: 1,
+    );
+    world.step(1 / 60);
+    expect(world.readBodyPose(replacement).$1.y, lessThan(10));
     world.dispose();
   });
 }


### PR DESCRIPTION
Fixes #298

## Problem

Native Rapier snapshots can restore the native world, but do not recreate Dart pose targets or application-owned body registrations. `restore()` could accept a snapshot after a body was created or destroyed, leaving the native world and Dart body registry out of sync.

## Change

Encode the Dart body-handle set alongside the native snapshot bytes. Decode and compare that set with the current `_bodies` keys before calling native restore. Return `false` when membership differs, leaving the current native world untouched.

## Validation

- From `packages/flutter_scene_rapier`: `fvm flutter test test/world_snapshot_test.dart`
- The focused test covers a body created after snapshot and a body destroyed after snapshot; both reject restore and continue simulation safely.
- The [companion reproduction repository](https://github.com/Ram-Dawson/flutter_scene_repros) provides the [failing baseline](https://github.com/Ram-Dawson/flutter_scene_repros/tree/repro/rapier-snapshot-membership-before) and [fixed tag](https://github.com/Ram-Dawson/flutter_scene_repros/tree/repro/rapier-snapshot-membership-fixed) for the same Android interaction.

## Scope and limitation

This PR protects the low-level `RapierWorld` contract. It does not implement application-level object-graph rollback, automatically destroy Dart-owned objects, reconstruct external pose targets, or change snapshot behavior when body membership is unchanged.