### PR TITLE
fix(importer): release template claims after load failures

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -3,6 +3,7 @@
 * GPU memory can be inspected and released. `takeMemoryReport()` reports what the engine's shared caches are pinning, `releaseTexture`/`releaseScene` give a claim back, and `clearTextureCache`/`clearSceneTemplateCache` drop everything.
 * `ResourceGroup.track` scopes a load to the group's lifetime, so `dispose()` releases the claims it took. Previously `dispose()` only released the progress notifier despite the name.
 * Fixed `ResourceGroup` throwing when it was disposed while a tracked load was still in flight, which is what tearing down a level mid-load does.
+* Fixed `loadScene` keeping a scene template claim when it threw after the template loaded, so a caller that got no `Node` no longer has to issue a compensating `releaseScene`.
 
 * `PhysicallyBasedMaterial` and glTF import support every ratified `KHR_materials_*` extension with scene-native property names.
 * Scene startup loads the shared physical-material shader bundle so every `PhysicallyBasedMaterial` property remains synchronous.

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -229,13 +229,22 @@ final class SceneRegistry {
     }
 
     final pending = _sceneTemplates[key] ??= loadTemplate();
-    // This provisional claim keeps a template resident while this caller is
-    // still realizing an instance. It becomes the caller's lease only when a
-    // root is successfully returned below.
+    // Claimed before the await so a concurrent release cannot evict the
+    // shared pending template while this caller is still realizing.
     _sceneTemplateHolders.update(key, (n) => n + 1, ifAbsent: () => 1);
-    try {
-      final template = await pending;
 
+    final _SceneTemplate template;
+    try {
+      template = await pending;
+    } catch (_) {
+      // Don't leave a failed load cached; the next call retries. A later
+      // load may already have replaced it, so only drop this one.
+      if (identical(_sceneTemplates[key], pending)) _sceneTemplates.remove(key);
+      _releaseSceneTemplateClaim(key);
+      rethrow;
+    }
+
+    try {
       final root = await realizeSceneAsync(
         template.document,
         registry: registry,
@@ -298,7 +307,7 @@ final class SceneRegistry {
       return root;
     } catch (_) {
       // The caller has no Node to pair with releaseScene after a failed
-      // template load, realization, stage application, or registration.
+      // realization, stage application, or registration.
       _releaseSceneTemplateClaim(key);
       rethrow;
     }

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -229,73 +229,79 @@ final class SceneRegistry {
     }
 
     final pending = _sceneTemplates[key] ??= loadTemplate();
+    // This provisional claim keeps a template resident while this caller is
+    // still realizing an instance. It becomes the caller's lease only when a
+    // root is successfully returned below.
     _sceneTemplateHolders.update(key, (n) => n + 1, ifAbsent: () => 1);
-    _SceneTemplate template;
     try {
-      template = await pending;
-    } catch (_) {
-      // Don't cache a failed load; the next call retries.
-      _sceneTemplates.remove(key);
-      _sceneTemplateHolders.remove(key);
-      rethrow;
-    }
+      final template = await pending;
 
-    final root = await realizeSceneAsync(
-      template.document,
-      registry: registry,
-      bundle: assetBundle,
-      resources: template.resources,
-    );
-    if (applyStageTo != null) {
-      await realizeStage(template.document, applyStageTo, bundle: assetBundle);
-    }
-
-    // Patch the live graph in place when the scene's `.fsceneb` (or one of
-    // the prefab `.fsceneb`s it is composed from) changes (debug only; a
-    // no-op registration in release). The dependency set is shared with the
-    // coordinator and refreshed on each reload. The closure must hold the
-    // root (and the stage scene) weakly: the registration owns the closure,
-    // so a strong capture would keep every discarded instance alive forever,
-    // accumulating registrations that re-patch dead graphs on each reload.
-    var current = template.document;
-    final dependencies = {...template.dependencies};
-    final weakRoot = WeakReference(root);
-    final weakStageScene = applyStageTo == null
-        ? null
-        : WeakReference(applyStageTo);
-    if (onReload != null) _reloadCallbacks[root] = onReload;
-    HotReloadCoordinator.instance.registerScene(
-      root,
-      assetKey: key,
-      dependencies: dependencies,
-      bundle: assetBundle,
-      onReload: () async {
-        final liveRoot = weakRoot.target;
-        if (liveRoot == null) return;
-        // The cached template no longer matches the edited assets; drop it
-        // so future loads re-read them.
-        _sceneTemplates.remove(key);
-        final seen = <String>{key};
-        final next = await readComposed(seen);
-        dependencies
-          ..clear()
-          ..addAll(seen);
-        final diff = await reloadScene(
-          liveRoot,
-          current,
-          next,
-          registry: registry,
+      final root = await realizeSceneAsync(
+        template.document,
+        registry: registry,
+        bundle: assetBundle,
+        resources: template.resources,
+      );
+      if (applyStageTo != null) {
+        await realizeStage(
+          template.document,
+          applyStageTo,
           bundle: assetBundle,
         );
-        current = next;
-        final stageScene = weakStageScene?.target;
-        if (diff.stageChanged && stageScene != null) {
-          await realizeStage(next, stageScene, bundle: assetBundle);
-        }
-        _reloadCallbacks[liveRoot]?.call(liveRoot);
-      },
-    );
-    return root;
+      }
+
+      // Patch the live graph in place when the scene's `.fsceneb` (or one of
+      // the prefab `.fsceneb`s it is composed from) changes (debug only; a
+      // no-op registration in release). The dependency set is shared with the
+      // coordinator and refreshed on each reload. The closure must hold the
+      // root (and the stage scene) weakly: the registration owns the closure,
+      // so a strong capture would keep every discarded instance alive forever,
+      // accumulating registrations that re-patch dead graphs on each reload.
+      var current = template.document;
+      final dependencies = {...template.dependencies};
+      final weakRoot = WeakReference(root);
+      final weakStageScene = applyStageTo == null
+          ? null
+          : WeakReference(applyStageTo);
+      if (onReload != null) _reloadCallbacks[root] = onReload;
+      HotReloadCoordinator.instance.registerScene(
+        root,
+        assetKey: key,
+        dependencies: dependencies,
+        bundle: assetBundle,
+        onReload: () async {
+          final liveRoot = weakRoot.target;
+          if (liveRoot == null) return;
+          // The cached template no longer matches the edited assets; drop it
+          // so future loads re-read them.
+          _sceneTemplates.remove(key);
+          final seen = <String>{key};
+          final next = await readComposed(seen);
+          dependencies
+            ..clear()
+            ..addAll(seen);
+          final diff = await reloadScene(
+            liveRoot,
+            current,
+            next,
+            registry: registry,
+            bundle: assetBundle,
+          );
+          current = next;
+          final stageScene = weakStageScene?.target;
+          if (diff.stageChanged && stageScene != null) {
+            await realizeStage(next, stageScene, bundle: assetBundle);
+          }
+          _reloadCallbacks[liveRoot]?.call(liveRoot);
+        },
+      );
+      return root;
+    } catch (_) {
+      // The caller has no Node to pair with releaseScene after a failed
+      // template load, realization, stage application, or registration.
+      _releaseSceneTemplateClaim(key);
+      rethrow;
+    }
   }
 
   /// Streams a lazy placeholder [node]'s prefab content under it, resolving
@@ -516,6 +522,18 @@ Future<void> loadSceneSubtree(
   );
 }
 
+// Releases one claim, dropping the cached template only when it was the last.
+bool _releaseSceneTemplateClaim(String key) {
+  final holders = _sceneTemplateHolders[key];
+  if (holders == null) return false;
+  if (holders > 1) {
+    _sceneTemplateHolders[key] = holders - 1;
+    return false;
+  }
+  _sceneTemplateHolders.remove(key);
+  return _sceneTemplates.remove(key) != null;
+}
+
 /// Releases one claim on the template [loadScene] built for [sourcePath],
 /// dropping it from the shared cache when no claims remain.
 ///
@@ -535,14 +553,7 @@ Future<bool> releaseScene(
 }) async {
   final registry = await SceneRegistry.load(bundle: bundle);
   final key = registry.resolveKey(sourcePath, package: package);
-  final holders = _sceneTemplateHolders[key];
-  if (holders == null) return false;
-  if (holders > 1) {
-    _sceneTemplateHolders[key] = holders - 1;
-    return false;
-  }
-  _sceneTemplateHolders.remove(key);
-  return _sceneTemplates.remove(key) != null;
+  return _releaseSceneTemplateClaim(key);
 }
 
 /// Drops every cached scene template, whatever their outstanding claims.

--- a/packages/flutter_scene/test/fscene/scene_registry_test.dart
+++ b/packages/flutter_scene/test/fscene/scene_registry_test.dart
@@ -346,6 +346,49 @@ void main() {
       }
     });
 
+    test('a failed load leaves nothing cached for the next one', () async {
+      clearSceneTemplateCache();
+      const key = 'packages/app/flutter_scene/scene/assets/retry.fsceneb';
+      Uint8List named(String name) {
+        final doc = SceneDocument();
+        doc.addNode(NodeSpec(id: const LocalId(3, 5), name: name), root: true);
+        return writeFsceneb(doc);
+      }
+
+      final bundle = _BytesAssetBundle({key: named('one')});
+      final registry = await SceneRegistry.load(assetKeys: const [key]);
+
+      try {
+        final root = await registry.loadScene('assets/retry', bundle: bundle);
+        expect(root.getChildByName('one'), isNotNull);
+
+        // A hot reload drops the cached template while the first load still
+        // holds its claim, so the next load rebuilds it under that claim.
+        bundle.assets[key] = named('two');
+        HotReloadCoordinator.instance.onReassemble();
+        await _settle(() => root.getChildByName('two') != null);
+        expect(sceneTemplateCacheCount(), 0);
+
+        bundle.failLoads = true;
+        Object? error;
+        try {
+          await registry.loadScene('assets/retry', bundle: bundle);
+        } catch (e) {
+          error = e;
+        }
+        expect(error, isA<StateError>());
+        expect(sceneTemplateCacheCount(), 0);
+
+        // The read succeeds again, so the next load retries rather than
+        // replaying the cached failure.
+        bundle.failLoads = false;
+        final fresh = await registry.loadScene('assets/retry', bundle: bundle);
+        expect(fresh.getChildByName('two'), isNotNull);
+      } finally {
+        clearSceneTemplateCache();
+      }
+    });
+
     test('release during another load keeps the shared template', () async {
       clearSceneTemplateCache();
       const key = 'packages/app/flutter_scene/scene/assets/pending.fsceneb';
@@ -439,6 +482,10 @@ final class _BytesAssetBundle extends CachingAssetBundle {
   /// Successful [load] calls per key.
   final Map<String, int> loadCounts = {};
 
+  /// Fails every scene read while set, standing in for a transient asset
+  /// read error.
+  bool failLoads = false;
+
   @override
   Future<ByteData> load(String key) async {
     if (key == 'AssetManifest.bin') {
@@ -447,6 +494,7 @@ final class _BytesAssetBundle extends CachingAssetBundle {
       };
       return const StandardMessageCodec().encodeMessage(manifest)!;
     }
+    if (failLoads) throw StateError('Asset read failed: $key');
     final bytes = assets[key];
     if (bytes == null) {
       throw StateError('Missing test asset: $key');

--- a/packages/flutter_scene/test/fscene/scene_registry_test.dart
+++ b/packages/flutter_scene/test/fscene/scene_registry_test.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:scene/scene.dart';
+import 'package:flutter_scene/src/components/component.dart';
+import 'package:flutter_scene/src/fscene/realize/component_codec.dart';
 import 'package:flutter_scene/src/fscene/stream/stream.dart' show unloadSubtree;
 import 'package:flutter_scene/src/hot_reload/hot_reload_coordinator.dart';
 import 'package:flutter_scene/src/importer/scene_registry.dart';
@@ -309,6 +313,66 @@ void main() {
   });
 
   group('scene templates', () {
+    test('does not retain a claim when realization throws', () async {
+      clearSceneTemplateCache();
+      const key = 'packages/app/flutter_scene/scene/assets/throwing.fsceneb';
+      final document = SceneDocument();
+      document.addNode(
+        NodeSpec(
+          id: const LocalId(3, 3),
+          name: 'throwing-root',
+          components: [ComponentSpec('throwing')],
+        ),
+        root: true,
+      );
+      final bundle = _BytesAssetBundle({key: writeFsceneb(document)});
+      final registry = await SceneRegistry.load(assetKeys: const [key]);
+      final codecs = FsceneComponentRegistry()..register(_ThrowingCodec());
+
+      try {
+        await expectLater(
+          registry.loadScene(
+            'assets/throwing',
+            bundle: bundle,
+            registry: codecs,
+          ),
+          throwsA(isA<StateError>()),
+        );
+
+        expect(await releaseScene('assets/throwing', bundle: bundle), isFalse);
+        expect(sceneTemplateCacheCount(), 0);
+      } finally {
+        clearSceneTemplateCache();
+      }
+    });
+
+    test('release during another load keeps the shared template', () async {
+      clearSceneTemplateCache();
+      const key = 'packages/app/flutter_scene/scene/assets/pending.fsceneb';
+      final document = SceneDocument();
+      document.addNode(
+        NodeSpec(id: const LocalId(3, 4), name: 'pending-root'),
+        root: true,
+      );
+      final bundle = _DeferredSceneBundle(key);
+      final registry = await SceneRegistry.load(assetKeys: const [key]);
+
+      try {
+        final first = registry.loadScene('assets/pending', bundle: bundle);
+        await bundle.waitUntilSceneRead();
+        final second = registry.loadScene('assets/pending', bundle: bundle);
+
+        expect(await releaseScene('assets/pending', bundle: bundle), isFalse);
+        bundle.completeScene(writeFsceneb(document));
+        await Future.wait([first, second]);
+
+        expect(sceneTemplateCacheCount(), 1);
+        expect(await releaseScene('assets/pending', bundle: bundle), isTrue);
+      } finally {
+        clearSceneTemplateCache();
+      }
+    });
+
     test('repeat loads share the cached template', () async {
       const key = 'packages/app/flutter_scene/scene/assets/shared.fsceneb';
       final doc = SceneDocument();
@@ -377,11 +441,53 @@ final class _BytesAssetBundle extends CachingAssetBundle {
 
   @override
   Future<ByteData> load(String key) async {
+    if (key == 'AssetManifest.bin') {
+      final manifest = <String, Object>{
+        for (final asset in assets.keys) asset: <Object>[],
+      };
+      return const StandardMessageCodec().encodeMessage(manifest)!;
+    }
     final bytes = assets[key];
     if (bytes == null) {
       throw StateError('Missing test asset: $key');
     }
     loadCounts[key] = (loadCounts[key] ?? 0) + 1;
     return ByteData.sublistView(bytes);
+  }
+}
+
+final class _ThrowingCodec extends ComponentCodec {
+  @override
+  String get type => 'throwing';
+
+  @override
+  Component? realize(ComponentSpec spec, RealizeContext context) {
+    throw StateError('intentional realization failure');
+  }
+}
+
+final class _DeferredSceneBundle extends CachingAssetBundle {
+  _DeferredSceneBundle(this.sceneKey);
+
+  final String sceneKey;
+  final _sceneRead = Completer<void>();
+  final _sceneBytes = Completer<ByteData>();
+
+  Future<void> waitUntilSceneRead() => _sceneRead.future;
+
+  void completeScene(Uint8List bytes) {
+    _sceneBytes.complete(ByteData.sublistView(bytes));
+  }
+
+  @override
+  Future<ByteData> load(String key) async {
+    if (key == 'AssetManifest.bin') {
+      return const StandardMessageCodec().encodeMessage({
+        sceneKey: <Object>[],
+      })!;
+    }
+    if (key != sceneKey) throw StateError('Unknown test asset: $key');
+    _sceneRead.complete();
+    return _sceneBytes.future;
   }
 }


### PR DESCRIPTION
Fixes #300 

## Problem

`loadScene()` increments the shared template holder count before awaiting and realizing a scene. Previously, cleanup covered only template-load failures. If a custom component codec, node realization, stage application, or reload registration threw after the template was available, the caller received no `Node` to pair with `releaseScene()`, while its holder claim remained cached.

## Change

Keep the early holder increment as a provisional claim so concurrent loads continue to protect a shared pending template. Extend the `try/catch` to cover template loading, realization, optional stage application, and hot-reload registration. On failure, release exactly one claim through a private helper. `releaseScene()` uses the same helper, so normal release and failure cleanup share the same decrement-and-evict behavior.

## Validation

- From `packages/flutter_scene`: `flutter test` (1129 passed, 31 skipped).
- From `packages/flutter_scene`: `flutter test test/fscene/scene_registry_test.dart` (13 passed).
- The new throwing-codec regression was verified red and green: the old implementation failed its post-error release assertion with `Expected: false` and `Actual: true`; the fixed implementation passes and leaves zero cached templates.
- The new deferred-bundle test verifies that releasing one claim while another caller is waiting on the shared template does not evict it early; the final release evicts it.
- From `packages/flutter_scene`: `flutter analyze` completed with no issues.

## Scope and limitation

This fixes template claim accounting; it does not add per-request cancellation to `loadScene()`. `releaseScene(path)` remains key-based rather than a cancellation API for one particular in-flight request. 