### PR TITLE
DO NOT MERGE: probe tokenless Argos auth

### DIFF
--- a/.github/workflows/smoke_render_jobs.yml
+++ b/.github/workflows/smoke_render_jobs.yml
@@ -84,7 +84,7 @@ jobs:
         if: ${{ !cancelled() && (github.event_name != 'push' || inputs.upload_argos_on_push) }}
         working-directory: examples/smoke_render
         env:
-          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+          ARGOS_TOKEN: ""
         run: |
           # Never upload an empty/partial build: a failed render must not
           # overwrite the Argos baseline (see the android job, and
@@ -140,6 +140,7 @@ jobs:
           - backend: vulkan
             expected_backend: vulkan
             emulator_options: -no-window -gpu swiftshader -no-snapshot -noaudio -no-boot-anim -camera-back none
+    if: false
     steps:
       - uses: actions/checkout@v7
         if: ${{ inputs.checkout_ref != '' }}
@@ -278,6 +279,7 @@ jobs:
     name: ${{ inputs.argos_prefix }}web (${{ inputs.label }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: false
     steps:
       - uses: actions/checkout@v7
         if: ${{ inputs.checkout_ref != '' }}
@@ -350,6 +352,7 @@ jobs:
     name: ${{ inputs.argos_prefix }}windows (${{ inputs.label }})
     runs-on: windows-latest
     timeout-minutes: 30
+    if: false
     steps:
       - uses: actions/checkout@v7
         if: ${{ inputs.checkout_ref != '' }}


### PR DESCRIPTION
Throwaway probe. Blanks ARGOS_TOKEN on the linux shard so the CLI falls through to tokenless authentication, the path a fork pull request takes, and disables the other four shards to keep it to one upload.

Close without merging once the linux upload result is known.