### PR TITLE
Drive the Apple smoke shards from GitHub Actions

### DIFF
--- a/.github/workflows/codemagic_smoke.yml
+++ b/.github/workflows/codemagic_smoke.yml
@@ -1,0 +1,233 @@
+name: codemagic smoke render
+
+# Drives the macOS and iOS smoke shards, which run on Codemagic because GitHub's
+# macOS runners give the harness no virtual display. Codemagic only renders and
+# publishes frames; every credential and the decision to run at all stay here.
+#
+# Why pull_request_target: starting a Codemagic build needs an API token, and
+# GitHub withholds secrets from fork pull_request runs. pull_request_target runs
+# in this repository's context with secrets available, which is only safe
+# because nothing below executes contributor code. It moves refs, calls an API,
+# and downloads images. Contributor source runs on Codemagic, where the
+# `Assert the build holds no credentials` step fails the build if a secret ever
+# appears.
+#
+# Fork pull requests need the `safe to test` label, standing in for the Actions
+# approval button, which does not apply to pull_request_target. Pull requests
+# from this repository run without it.
+
+on:
+  push:
+    branches: [master]
+  pull_request_target:
+    branches: [master]
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: codemagic-smoke-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+env:
+  ARGOS_PROJECT: scene/flutter_scene
+
+jobs:
+  prepare:
+    name: Prepare the build ref
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(github.event.pull_request.labels.*.name, 'safe to test')
+    outputs:
+      branch: ${{ steps.ref.outputs.branch }}
+      temp_branch: ${{ steps.ref.outputs.temp_branch }}
+      argos_branch: ${{ steps.ref.outputs.argos_branch }}
+      argos_commit: ${{ steps.ref.outputs.argos_commit }}
+    steps:
+      # Always the base repository's code. Never the pull request's.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve the ref to build
+        id: ref
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # master already exists on the remote, so Codemagic can build it.
+            echo "branch=master" >> "$GITHUB_OUTPUT"
+            echo "temp_branch=" >> "$GITHUB_OUTPUT"
+            echo "argos_branch=master" >> "$GITHUB_OUTPUT"
+            echo "argos_commit=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Codemagic's API starts a build from a branch name in the connected
+          # repository, and it cannot see a fork's branch. Mirror the pull
+          # request head to a short-lived branch here so it has something to
+          # resolve, and force codemagic.yaml back to the base version so the
+          # build script is always ours.
+          temp="codemagic-pr-${PR_NUMBER}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "pull/${PR_NUMBER}/head:${temp}"
+          git checkout "$temp"
+          git checkout "$GITHUB_SHA" -- codemagic.yaml
+          git commit -q -m "Pin the build config to the base revision" \
+            -- codemagic.yaml || true
+          git push -f origin "$temp"
+
+          echo "branch=$temp" >> "$GITHUB_OUTPUT"
+          echo "temp_branch=$temp" >> "$GITHUB_OUTPUT"
+          echo "argos_branch=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "argos_commit=$PR_HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+  render:
+    name: ${{ matrix.build_name }} (Flutter master)
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - workflow_id: smoke-macos
+            build_name: macos
+          - workflow_id: smoke-ios
+            build_name: ios
+    steps:
+      - name: Start the Codemagic build
+        id: start
+        env:
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+          CODEMAGIC_APP_ID: ${{ secrets.CODEMAGIC_APP_ID }}
+        run: |
+          set -euo pipefail
+          body=$(jq -nc \
+            --arg appId "$CODEMAGIC_APP_ID" \
+            --arg workflowId "${{ matrix.workflow_id }}" \
+            --arg branch "${{ needs.prepare.outputs.branch }}" \
+            '{appId: $appId, workflowId: $workflowId, branch: $branch}')
+          out=$(curl -sS -X POST https://api.codemagic.io/builds \
+            -H "Content-Type: application/json" \
+            -H "x-auth-token: $CODEMAGIC_API_TOKEN" \
+            --data "$body")
+          echo "$out"
+          id=$(printf '%s' "$out" | jq -r '.buildId // empty')
+          if [ -z "$id" ]; then
+            echo "Codemagic did not return a build id."
+            exit 1
+          fi
+          echo "build_id=$id" >> "$GITHUB_OUTPUT"
+          echo "Started https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$id"
+
+      - name: Wait for the build
+        id: wait
+        env:
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+          BUILD_ID: ${{ steps.start.outputs.build_id }}
+        run: |
+          set -euo pipefail
+          # The job timeout is the real deadline; this cap only stops an
+          # unbounded poll if Codemagic stops answering.
+          for _ in $(seq 1 180); do
+            sleep 20
+            out=$(curl -sS "https://api.codemagic.io/builds/$BUILD_ID" \
+              -H "x-auth-token: $CODEMAGIC_API_TOKEN") || continue
+            # finishedAt is the terminal signal. The status vocabulary is not
+            # documented, so it is compared only after the build has ended.
+            finished=$(printf '%s' "$out" | jq -r '.build.finishedAt // empty')
+            status=$(printf '%s' "$out" | jq -r '.build.status // "unknown"')
+            if [ -n "$finished" ]; then
+              echo "Codemagic build $BUILD_ID ended with status $status"
+              printf '%s' "$out" > build.json
+              echo "status=$status" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "status $status, still waiting"
+          done
+          echo "Codemagic build $BUILD_ID never reported a finish."
+          exit 1
+
+      - name: Download the frames
+        id: frames
+        env:
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p smoke
+          # The response spells it "artefacts"; keep both spellings so a rename
+          # upstream does not silently yield zero frames.
+          jq -r '(.build.artefacts // .build.artifacts // [])[] | "\(.name)\t\(.url)"' \
+            build.json > artefacts.tsv
+          cat artefacts.tsv
+          while IFS=$'\t' read -r name url; do
+            [ -z "$url" ] && continue
+            case "$name" in
+              *.png) dest="smoke/$name" ;;
+              smoke-status.txt) dest="smoke-status.txt" ;;
+              *) continue ;;
+            esac
+            curl -sSL -H "x-auth-token: $CODEMAGIC_API_TOKEN" -o "$dest" "$url"
+          done < artefacts.tsv
+          count=$(find smoke -type f -name '*.png' | wc -l | tr -d ' ')
+          echo "frames: $count"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to Argos
+        id: argos
+        env:
+          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+          ARGOS_BRANCH: ${{ needs.prepare.outputs.argos_branch }}
+          ARGOS_COMMIT: ${{ needs.prepare.outputs.argos_commit }}
+          ARGOS_PR_NUMBER: ${{ github.event.pull_request.number }}
+          ARGOS_PR_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          # Never upload an empty or partial build; a failed render must not
+          # overwrite the baseline. See notes/ci/argos_visual_baseline_tracking.md.
+          if [ "${{ steps.frames.outputs.count }}" -eq 0 ]; then
+            echo "No frames came back; skipping Argos upload."
+            exit 0
+          fi
+          status=0
+          npx --yes @argos-ci/cli upload smoke \
+            --project "$ARGOS_PROJECT" \
+            --build-name "${{ matrix.build_name }}" > argos.log 2>&1 || status=$?
+          cat argos.log
+          grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' argos.log \
+            | head -1 >> "$GITHUB_STEP_SUMMARY" || true
+          exit "$status"
+
+      - name: Report the render result
+        # Last so the frames reach Argos first. A failed render is exactly when
+        # they are wanted for visual triage.
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.wait.outputs.status }}" != "finished" ] \
+             && [ "${{ steps.wait.outputs.status }}" != "success" ]; then
+            echo "Codemagic build ended as ${{ steps.wait.outputs.status }}"
+            exit 1
+          fi
+          render=$(cat smoke-status.txt 2>/dev/null || echo 1)
+          if [ "$render" -ne 0 ]; then
+            echo "flutter drive exited $render"
+            exit 1
+          fi
+          echo "Rendered ${{ steps.frames.outputs.count }} frames."
+
+  cleanup:
+    name: Delete the temporary ref
+    needs: [prepare, render]
+    if: always() && needs.prepare.outputs.temp_branch != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: git push origin --delete "${{ needs.prepare.outputs.temp_branch }}" || true

--- a/.github/workflows/codemagic_smoke.yml
+++ b/.github/workflows/codemagic_smoke.yml
@@ -18,7 +18,12 @@ name: codemagic smoke render
 
 on:
   push:
-    branches: [master]
+    # TODO(codemagic-smoke): drop bdero/codemagic-orchestrated before merging.
+    # pull_request_target runs the workflow file from the base branch, so this
+    # cannot be exercised from a pull request until it is on master. A push
+    # event runs the file from the pushed commit, which is the only way to test
+    # it beforehand.
+    branches: [master, bdero/codemagic-orchestrated]
   pull_request_target:
     branches: [master]
     types: [opened, synchronize, reopened, labeled]
@@ -61,10 +66,11 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
-            # master already exists on the remote, so Codemagic can build it.
-            echo "branch=master" >> "$GITHUB_OUTPUT"
+            # The pushed branch already exists on the remote, so Codemagic can
+            # resolve it and no mirror is needed.
+            echo "branch=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
             echo "temp_branch=" >> "$GITHUB_OUTPUT"
-            echo "argos_branch=master" >> "$GITHUB_OUTPUT"
+            echo "argos_branch=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
             echo "argos_commit=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -197,6 +203,10 @@ jobs:
             echo "No frames came back; skipping Argos upload."
             exit 0
           fi
+          # On a push there is no pull request, and an empty value reads
+          # differently from an absent one.
+          if [ -z "$ARGOS_PR_NUMBER" ]; then unset ARGOS_PR_NUMBER; fi
+          if [ -z "$ARGOS_PR_BASE_BRANCH" ]; then unset ARGOS_PR_BASE_BRANCH; fi
           status=0
           npx --yes @argos-ci/cli upload smoke \
             --project "$ARGOS_PROJECT" \

--- a/.github/workflows/codemagic_smoke.yml
+++ b/.github/workflows/codemagic_smoke.yml
@@ -168,21 +168,31 @@ jobs:
           CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
         run: |
           set -euo pipefail
-          mkdir -p smoke
+          mkdir -p smoke staging
           # The response spells it "artefacts"; keep both spellings so a rename
           # upstream does not silently yield zero frames.
           jq -r '(.build.artefacts // .build.artifacts // [])[] | "\(.name)\t\(.url)"' \
             build.json > artefacts.tsv
           cat artefacts.tsv
+
+          # Codemagic collects every artifact path into one zip per build rather
+          # than exposing the files individually, so unpack whatever arrives and
+          # find the frames by name instead of trusting the layout.
+          i=0
           while IFS=$'\t' read -r name url; do
-            [ -z "$url" ] && continue
+            [ -z "${url:-}" ] && continue
+            i=$((i + 1))
+            curl -sSL -H "x-auth-token: $CODEMAGIC_API_TOKEN" \
+              -o "staging/$i-$name" "$url"
             case "$name" in
-              *.png) dest="smoke/$name" ;;
-              smoke-status.txt) dest="smoke-status.txt" ;;
-              *) continue ;;
+              *.zip) unzip -q -o "staging/$i-$name" -d staging ;;
             esac
-            curl -sSL -H "x-auth-token: $CODEMAGIC_API_TOKEN" -o "$dest" "$url"
           done < artefacts.tsv
+
+          find staging -type f -name '*.png' -exec cp {} smoke/ \;
+          status_file=$(find staging -type f -name 'smoke-status.txt' | head -1)
+          [ -n "$status_file" ] && cp "$status_file" smoke-status.txt
+
           count=$(find smoke -type f -name '*.png' | wc -l | tr -d ' ')
           echo "frames: $count"
           echo "count=$count" >> "$GITHUB_OUTPUT"
@@ -226,7 +236,11 @@ jobs:
             echo "Codemagic build ended as ${{ steps.wait.outputs.status }}"
             exit 1
           fi
-          render=$(cat smoke-status.txt 2>/dev/null || echo 1)
+          if [ ! -f smoke-status.txt ]; then
+            echo "The build produced no status file, so it died before rendering."
+            exit 1
+          fi
+          render=$(cat smoke-status.txt)
           if [ "$render" -ne 0 ]; then
             echo "flutter drive exited $render"
             exit 1

--- a/.github/workflows/codemagic_smoke.yml
+++ b/.github/workflows/codemagic_smoke.yml
@@ -18,12 +18,7 @@ name: codemagic smoke render
 
 on:
   push:
-    # TODO(codemagic-smoke): drop bdero/codemagic-orchestrated before merging.
-    # pull_request_target runs the workflow file from the base branch, so this
-    # cannot be exercised from a pull request until it is on master. A push
-    # event runs the file from the pushed commit, which is the only way to test
-    # it beforehand.
-    branches: [master, bdero/codemagic-orchestrated]
+    branches: [master]
   pull_request_target:
     branches: [master]
     types: [opened, synchronize, reopened, labeled]
@@ -246,6 +241,18 @@ jobs:
             exit 1
           fi
           echo "Rendered ${{ steps.frames.outputs.count }} frames."
+
+      - name: Cancel the Codemagic build
+        # Superseding this run cancels the job but not the build it started,
+        # which would otherwise hold a mac mini until it finished on its own.
+        if: cancelled() && steps.start.outputs.build_id != ''
+        env:
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+          BUILD_ID: ${{ steps.start.outputs.build_id }}
+        run: |
+          curl -sS -X POST "https://api.codemagic.io/builds/$BUILD_ID/cancel" \
+            -H "x-auth-token: $CODEMAGIC_API_TOKEN" || true
+          echo "Requested cancellation of Codemagic build $BUILD_ID"
 
   cleanup:
     name: Delete the temporary ref

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,17 +1,17 @@
-# Renders the deterministic smoke scenes on Apple GPUs and uploads the frames to
-# Argos for visual diffing. Covers the two backends GitHub Actions cannot reach
-# (Metal on macOS and on the iOS simulator); linux, android, web, and windows
-# stay in .github/workflows/smoke_render_jobs.yml.
+# Renders the deterministic smoke scenes on Apple GPUs and publishes the frames
+# as build artifacts. Covers the two Metal backends GitHub Actions cannot host,
+# because its macOS runners give the harness no virtual display; linux, android,
+# web, and windows stay in .github/workflows/smoke_render_jobs.yml.
 #
-# Requires two environment variable groups in the Codemagic UI, `argos` holding
-# ARGOS_TOKEN and `discord` holding DISCORD_WEBHOOK_URL, both marked secure.
+# Nothing here triggers on its own and nothing here holds a credential. Builds
+# are started by .github/workflows/codemagic_smoke.yml, which collects the
+# frames afterwards and uploads them to Argos. Keeping the secrets on the GitHub
+# side is what lets a pull request from a fork render safely, since the config
+# a contributor could edit never runs next to a token.
 
 definitions:
   environment: &smoke_environment
     flutter: master
-    groups:
-      - argos
-      - discord
     vars:
       FLUTTER_DART_DATA_ASSETS: "true"
 
@@ -19,165 +19,60 @@ definitions:
     cache_paths:
       - ~/.pub-cache
 
-  triggering: &smoke_triggering
-    events:
-      - push
-      - pull_request
-    branch_patterns:
-      # A push to master (a merge) refreshes the Argos baseline.
-      - pattern: master
-        include: true
-        source: true
-      # `source` applies only to pull requests, so this second entry is what
-      # matches a PR by its target branch rather than by its head branch.
-      - pattern: master
-        include: true
-        source: false
-    cancel_previous_builds: true
-
   scripts:
     - &script_versions
       name: Flutter and engine revision
       script: flutter --version
 
-    - &script_report_build_trust
-      name: Report build trust
-      # Answers whether this provider hands secure variables to a build from a
-      # contributor fork, which decides whether fork pull requests can produce a
-      # visual diff. Prints a fingerprint of the token, never its value.
+    - &script_assert_no_credentials
+      name: Assert the build holds no credentials
+      # Guards the invariant this whole split exists for. A credential reaching
+      # a build that runs contributor source is the failure worth catching
+      # loudly, so it fails rather than warns.
       script: |
-        echo "repo=$CM_REPO_SLUG branch=$CM_BRANCH"
-        echo "pull_request=${CM_PULL_REQUEST:-false} number=${CM_PULL_REQUEST_NUMBER:-none} dest=${CM_PULL_REQUEST_DEST:-none}"
-        if [ -n "$ARGOS_TOKEN" ]; then
-          fp=$(printf '%s' "$ARGOS_TOKEN" | shasum -a 256 | cut -c1-8)
-          echo "ARGOS_TOKEN present, length ${#ARGOS_TOKEN}, sha256 prefix $fp"
-        else
-          echo "ARGOS_TOKEN absent"
+        leaked=""
+        for name in ARGOS_TOKEN DISCORD_WEBHOOK_URL CODEMAGIC_API_TOKEN; do
+          eval "value=\${$name:-}"
+          [ -n "$value" ] && leaked="$leaked $name"
+        done
+        if [ -n "$leaked" ]; then
+          echo "Credentials present in a build that should have none,$leaked"
+          exit 1
         fi
+        echo "No credentials in this build, as expected."
 
     - &script_pub_get
       name: Resolve the workspace
       script: flutter pub get
 
-    - &script_list_frames
-      name: List rendered frames
-      # The driver writes the frames on the host, so this is the evidence the
-      # render produced something. iOS needs it because the app's stdout (the
-      # per-scene SMOKE stat lines) is not forwarded through the simulator.
+    - &script_publish_status
+      name: Publish the render status
+      # The render's exit code travels to GitHub as an artifact rather than as
+      # the build's own status, so a failed render still yields its frames.
+      # Those frames are exactly what visual triage needs.
       script: |
         cd "$CM_BUILD_DIR/examples/smoke_render"
         ls -l build/smoke 2>/dev/null || echo "build/smoke does not exist"
         echo "frames: $(find build/smoke -type f -name '*.png' 2>/dev/null | wc -l | tr -d ' ')"
-
-    - &script_argos_upload
-      name: Upload to Argos
-      script: |
-        cd "$CM_BUILD_DIR/examples/smoke_render"
-        echo 0 > "$CM_BUILD_DIR/smoke-argos-status"
-
-        # Never upload an empty or partial build. A failed render must not
-        # overwrite the Argos baseline, see
-        # notes/ci/argos_visual_baseline_tracking.md. The render gate is what
-        # fails the build in that case, so skipping here is not a pass.
-        if ! find build/smoke -type f -name '*.png' 2>/dev/null | grep -q .; then
-          echo "No smoke screenshots found; skipping Argos upload."
-          exit 0
-        fi
-
-        # A build with no token cannot upload, which is the expected shape of a
-        # pull request from a fork. Skip rather than fail so a contributor's PR
-        # is not red for a credential they were never going to have.
-        if [ -z "$ARGOS_TOKEN" ]; then
-          echo "No ARGOS_TOKEN in this build; skipping Argos upload."
-          exit 0
-        fi
-
-        # Argos auto-detects GitHub Actions but not this provider, so the build
-        # metadata is mapped by hand.
-        export ARGOS_BRANCH="$CM_BRANCH"
-        export ARGOS_COMMIT="$(git rev-parse HEAD)"
-        # Keyed off the number rather than the boolean, which is not reliably
-        # the literal "true". Without it Argos has no pull request to attach the
-        # build to and the shard drops out of the review comment.
-        if [ -n "$CM_PULL_REQUEST_NUMBER" ]; then
-          export ARGOS_PR_NUMBER="$CM_PULL_REQUEST_NUMBER"
-          [ -n "$CM_PULL_REQUEST_DEST" ] && \
-            export ARGOS_PR_BASE_BRANCH="$CM_PULL_REQUEST_DEST"
-        fi
-
-        log="$CM_BUILD_DIR/smoke-argos.log"
-        status=0
-        npx --yes @argos-ci/cli upload build/smoke \
-          --project "$ARGOS_PROJECT" \
-          --build-name "$SMOKE_BUILD_NAME" > "$log" 2>&1 || status=$?
-        cat "$log"
-        grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' "$log" \
-          | head -1 > "$CM_BUILD_DIR/smoke-argos-url" || true
-
-        # An upload that errors (quota, a bad token, a network fault) leaves the
-        # shard with no visual diff at all, so it fails the build rather than
-        # passing silently.
-        echo "$status" > "$CM_BUILD_DIR/smoke-argos-status"
-        if [ "$status" -ne 0 ]; then
-          echo "Argos upload exited $status"
-          exit "$status"
-        fi
-
-    - &script_render_gate
-      name: Fail the build if the render failed
-      script: |
-        status=$(cat "$CM_BUILD_DIR/smoke-status" 2>/dev/null || echo 1)
-        if [ "$status" -ne 0 ]; then
-          echo "flutter drive exited $status"
-          exit "$status"
-        fi
-
-  publishing: &smoke_publishing
-    scripts:
-      - name: Notify Discord on failure
-        script: |
-          render=$(cat "$CM_BUILD_DIR/smoke-status" 2>/dev/null || echo 1)
-          argos=$(cat "$CM_BUILD_DIR/smoke-argos-status" 2>/dev/null || echo 1)
-          reason=""
-          [ "$render" -ne 0 ] && reason="render exited $render"
-          if [ "$argos" -ne 0 ]; then
-            [ -n "$reason" ] && reason="$reason, "
-            reason="${reason}Argos upload exited $argos"
-          fi
-          [ -z "$reason" ] && exit 0
-          [ -z "$DISCORD_WEBHOOK_URL" ] && exit 0
-          url=$(cat "$CM_BUILD_DIR/smoke-argos-url" 2>/dev/null || true)
-          content="Smoke render failed ($SMOKE_BUILD_NAME, Flutter master; $reason). Build: $CM_BUILD_URL"
-          [ -n "$url" ] && content="$content  |  Argos: $url"
-          curl -sf -H "Content-Type: application/json" \
-            -d "{\"content\": \"$content\"}" "$DISCORD_WEBHOOK_URL" || true
-        ignore_failure: true
+        cp "$CM_BUILD_DIR/smoke-status" build/smoke-status.txt
+        echo "render exited $(cat build/smoke-status.txt)"
 
 workflows:
   smoke-macos:
     name: Smoke render (macOS, Metal)
     instance_type: mac_mini_m2
     max_build_duration: 45
-    environment:
-      <<: *smoke_environment
-      vars:
-        FLUTTER_DART_DATA_ASSETS: "true"
-        ARGOS_PROJECT: scene/flutter_scene
-        SMOKE_BUILD_NAME: macos
+    environment: *smoke_environment
     cache: *smoke_cache
-    triggering: *smoke_triggering
     scripts:
       - *script_versions
-      - *script_report_build_trust
+      - *script_assert_no_credentials
       - name: Enable the macOS desktop target
         script: >
           flutter config --enable-macos-desktop --enable-native-assets
           --enable-dart-data-assets
       - *script_pub_get
       - name: Render smoke scenes
-        # The exit code is recorded rather than propagated so the Argos upload
-        # still runs. A failed sanity gate is exactly when the frames are wanted
-        # for visual triage, and the driver writes them on failure.
         script: |
           cd "$CM_BUILD_DIR/examples/smoke_render"
           flutter drive \
@@ -186,12 +81,10 @@ workflows:
             -d macos --enable-impeller --enable-flutter-gpu
           echo $? > "$CM_BUILD_DIR/smoke-status"
         ignore_failure: true
-      - *script_list_frames
-      - *script_argos_upload
-      - *script_render_gate
+      - *script_publish_status
     artifacts:
       - examples/smoke_render/build/smoke/*.png
-    publishing: *smoke_publishing
+      - examples/smoke_render/build/smoke-status.txt
 
   smoke-ios:
     name: Smoke render (iOS simulator, Metal)
@@ -202,14 +95,11 @@ workflows:
       xcode: latest
       vars:
         FLUTTER_DART_DATA_ASSETS: "true"
-        ARGOS_PROJECT: scene/flutter_scene
-        SMOKE_BUILD_NAME: ios
         SMOKE_SIM_DEVICE: iPhone 17 Pro
     cache: *smoke_cache
-    triggering: *smoke_triggering
     scripts:
       - *script_versions
-      - *script_report_build_trust
+      - *script_assert_no_credentials
       - name: Generate the iOS project
         # examples/smoke_render commits every platform except ios/, so the
         # simulator target is scaffolded per build. The project name is explicit
@@ -239,7 +129,6 @@ workflows:
           xcrun simctl bootstatus "$udid" -b
           echo "$udid" > "$CM_BUILD_DIR/smoke-sim-udid"
       - name: Render smoke scenes
-        # See the macOS workflow for why the exit code is recorded, not raised.
         script: |
           cd "$CM_BUILD_DIR/examples/smoke_render"
           flutter drive \
@@ -249,9 +138,7 @@ workflows:
             --enable-impeller --enable-flutter-gpu
           echo $? > "$CM_BUILD_DIR/smoke-status"
         ignore_failure: true
-      - *script_list_frames
-      - *script_argos_upload
-      - *script_render_gate
+      - *script_publish_status
     artifacts:
       - examples/smoke_render/build/smoke/*.png
-    publishing: *smoke_publishing
+      - examples/smoke_render/build/smoke-status.txt


### PR DESCRIPTION
Codemagic now only renders the smoke scenes and publishes the frames. GitHub Actions starts those builds, collects the frames, and uploads them to Argos, so the Apple shards are gated and credentialed the same way every other shard is.

This gives pull requests from forks a visual diff on macOS and iOS, which was not possible before because Codemagic withholds secrets from fork builds and Argos tokenless auth only works on GitHub Actions. Fork pull requests need the `safe to test` label; pull requests from this repository run without it.