### PR TITLE
Require Flutter CI to have actually run

### DIFF
--- a/.github/workflows/codemagic_smoke.yml
+++ b/.github/workflows/codemagic_smoke.yml
@@ -40,9 +40,15 @@ jobs:
   prepare:
     name: Prepare the build ref
     runs-on: ubuntu-latest
+    # A run awaiting the approval button reports as completed with an
+    # `action_required` conclusion, so the trigger alone is not the gate. Only a
+    # conclusion that means Flutter CI actually executed counts. `failure` is
+    # allowed because a lint break should still get its frames rendered.
     if: >
       github.event_name == 'push' ||
-      github.event.workflow_run.event == 'pull_request'
+      (github.event.workflow_run.event == 'pull_request' &&
+       (github.event.workflow_run.conclusion == 'success' ||
+        github.event.workflow_run.conclusion == 'failure'))
     outputs:
       branch: ${{ steps.ref.outputs.branch }}
       temp_branch: ${{ steps.ref.outputs.temp_branch }}


### PR DESCRIPTION
Follow-up to #309. A workflow run waiting on the approval button reports as completed with an `action_required` conclusion, so triggering on completion alone would have let the Apple shards start before anyone approved anything.

The gate now also requires a conclusion that means Flutter CI executed. `failure` counts, since a lint break should still get its frames rendered.