### PR TITLE
Declare one prefiltered-radiance sampler per layout

### DIFF
--- a/MATERIALS.md
+++ b/MATERIALS.md
@@ -584,6 +584,35 @@ name (`frag_info`). Set `ShaderMaterial.useEnvironment = true` to have the engin
 bind `prefiltered_radiance` and `brdf_lut` if your shader declares them (the
 diffuse-irradiance SH coefficients are not bound generically).
 
+### The prefiltered radiance layout
+
+Backends differ in the radiance layout they can build, a roughness-mip cubemap
+where the engine can render into mip levels and a 2D equirect elsewhere, so
+`prefiltered_radiance` is declared as `RadianceSampler` (from `texture.glsl`),
+which is `samplerCube` under `FLUTTER_SCENE_RADIANCE_CUBE` and `sampler2D`
+without it. Declaring one sampler instead of one per layout keeps a dead
+sampler off the per-stage texture-unit budget, which the lit framework sits
+close to.
+
+A `.fmat` material needs no action; the build hook emits both variants and the
+runtime picks the one matching the bound environment. A raw `ShaderMaterial`
+that samples the environment has to build both itself, adding a second bundle
+entry that defines `FLUTTER_SCENE_RADIANCE_CUBE` ahead of its includes, and
+pass it as `radianceCubeFragmentShader`:
+
+```dart
+final material = ShaderMaterial(
+  fragmentShader: library['MyEffect']!,
+  radianceCubeFragmentShader: library['MyEffectCube']!,
+  useEnvironment: true,
+);
+```
+
+Sample through `SampleRadianceEnv(prefiltered_radiance, direction, roughness)`
+so the same source compiles either way. Without the cube variant the material
+samples a 2D slot on a backend that binds a cubemap, and reflections come out
+wrong.
+
 ## std140 packing (raw `ShaderMaterial` only)
 
 With `ShaderMaterial` you fill a single byte buffer per uniform block, and its
@@ -813,6 +842,10 @@ packing mismatch; declare blocks without `vec3` members to rule it out. With a
 environment and/or a directional light. For raw `ShaderMaterial`, check
 `useEnvironment` and that all declared samplers are bound (unbound samplers read
 garbage on some backends).
+
+**Wrong reflections on one backend only (raw `ShaderMaterial`).** The material
+is probably missing its `radianceCubeFragmentShader`, so it samples the 2D
+radiance slot where the backend builds a cubemap.
 
 ---
 

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -186,6 +186,7 @@ PreprocessedMaterial _fmatMaterial(String name) {
         };
   return PreprocessedMaterial(
     fragmentShader: _materialsLibrary![name]!,
+    radianceCubeFragmentShader: _materialsLibrary!['${name}Cube'],
     metadata: metadata,
     vertexShaders: vertexShaders,
   );

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.21.0
 
+* The lit shaders declare one prefiltered-radiance sampler instead of one per layout, freeing two fragment texture units so a skinned shadow-casting draw fits GLES drivers reporting the 16-unit minimum.
+* Breaking change for raw `ShaderMaterial` shaders that sample the environment, they declare `prefiltered_radiance` as `RadianceSampler` and supply a `radianceCubeFragmentShader` variant built with `FLUTTER_SCENE_RADIANCE_CUBE`. `.fmat` materials are unaffected.
 * Breaking change, the fscene component codec API is declarative. `ComponentCodec.serialize` is abstract, `ComponentPropertyDef` moved to the `scene` schema model (constraints replace `min`/`max`/`read`), and flat codecs extend `DeclarativeComponentCodec`, deriving schema, realization, and delta serialization from one `ComponentField` list.
 * `.fscene` version 3. Component properties delta-serialize (values equal to their schema default are omitted) and audio attenuation settings nest; version 2 documents read unchanged.
 * `package:flutter_scene/annotations.dart`, `@SceneComponent` and typed property annotations that lower to schema constraints for generated codecs.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * The lit shaders declare one prefiltered-radiance sampler instead of one per layout, freeing two fragment texture units so a skinned shadow-casting draw fits GLES drivers reporting the 16-unit minimum.
 * Breaking change for raw `ShaderMaterial` shaders that sample the environment, they declare `prefiltered_radiance` as `RadianceSampler` and supply a `radianceCubeFragmentShader` variant built with `FLUTTER_SCENE_RADIANCE_CUBE`. `.fmat` materials are unaffected.
+* A material or sky that samples the environment without a cubemap-radiance variant now keeps its 2D sampler and is bound a placeholder instead of a mismatched cubemap, and says so in debug builds. `PreprocessedMaterial` takes `radianceCubeFragmentShader` for code that builds one directly rather than through a loader.
 * Breaking change, the fscene component codec API is declarative. `ComponentCodec.serialize` is abstract, `ComponentPropertyDef` moved to the `scene` schema model (constraints replace `min`/`max`/`read`), and flat codecs extend `DeclarativeComponentCodec`, deriving schema, realization, and delta serialization from one `ComponentField` list.
 * `.fscene` version 3. Component properties delta-serialize (values equal to their schema default are omitted) and audio attenuation settings nest; version 2 documents read unchanged.
 * `package:flutter_scene/annotations.dart`, `@SceneComponent` and typed property annotations that lower to schema constraints for generated codecs.

--- a/packages/flutter_scene/lib/src/fmat/build_materials.dart
+++ b/packages/flutter_scene/lib/src/fmat/build_materials.dart
@@ -8,6 +8,7 @@ import 'package:hooks/hooks.dart';
 import 'package:flutter_scene/src/importer/build_cache.dart';
 
 import 'fmat.dart';
+import 'fmat_emitter.dart' show kRadianceCubeDefine, materialSamplesEnvironment;
 import 'target_shader_bundle.dart';
 
 /// Controls how [buildMaterials] exposes generated `.fmat` shader assets.
@@ -500,19 +501,38 @@ Map<String, String> emitFragmentShaderVariants(
   FmatCompilation compiled, {
   required bool generateShadowVariant,
 }) {
-  final entryName = compiled.material.name;
-  if (!generateShadowVariant) {
-    return {entryName: compiled.glsl};
-  }
+  final material = compiled.material;
+  final entryName = material.name;
   // The unsuffixed entry is the no-shadow fast path. The Shadow entry keeps
   // the complete sampler layout used when the scene binds a shadow atlas.
-  return {
-    entryName: emitFragmentGlsl(
-      compiled.material,
-      defines: const ['FLUTTER_SCENE_SKIP_SHADOWS'],
-    ),
-    '${entryName}Shadow': compiled.glsl,
-  };
+  final byShadow = generateShadowVariant
+      ? <String, String>{
+          entryName: emitFragmentGlsl(
+            material,
+            defines: const ['FLUTTER_SCENE_SKIP_SHADOWS'],
+          ),
+          '${entryName}Shadow': compiled.glsl,
+        }
+      : <String, String>{entryName: compiled.glsl};
+  if (!materialSamplesEnvironment(material)) {
+    return byShadow;
+  }
+  // Backends build the prefiltered radiance in one of two layouts and each
+  // entry declares only its own sampler, so every entry gets a Cube twin that
+  // the runtime picks from the bound environment.
+  final variants = <String, String>{};
+  byShadow.forEach((name, glsl) {
+    variants[name] = glsl;
+    variants['${name}Cube'] = emitFragmentGlsl(
+      material,
+      defines: [
+        if (generateShadowVariant && !name.endsWith('Shadow'))
+          'FLUTTER_SCENE_SKIP_SHADOWS',
+        kRadianceCubeDefine,
+      ],
+    );
+  });
+  return variants;
 }
 
 bool _sameBytes(List<int> a, List<int> b) {

--- a/packages/flutter_scene/lib/src/fmat/fmat_bytes_library.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_bytes_library.dart
@@ -9,6 +9,8 @@
 library;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_scene/src/fmat/fmat_emitter.dart'
+    show radianceCubeEntryName, sidecarSamplesEnvironment;
 import 'package:flutter_scene/src/fmat/material_registry.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/hot_reload/hot_reloadable_fmat.dart';
@@ -82,6 +84,11 @@ final class FmatBytesLibrary {
       metadata: metadata,
       vertexShaders: _vertexShaders(metadata),
     );
+    if (sidecarSamplesEnvironment(metadata)) {
+      material.setRadianceCubeFragmentShaders(
+        _shaderFor(radianceCubeEntryName(entryName)),
+      );
+    }
     if (sourcePath != null) setFmatSourcePath(material, sourcePath);
     _instances.add((entryName: entryName, instance: WeakReference(material)));
     return material;
@@ -98,6 +105,11 @@ final class FmatBytesLibrary {
       fragmentShader: _shaderFor(entryName),
       metadata: metadata,
     );
+    if (sidecarSamplesEnvironment(metadata)) {
+      sky.radianceCubeFragmentShader = _shaderFor(
+        radianceCubeEntryName(entryName),
+      );
+    }
     if (sourcePath != null) setFmatSourcePath(sky, sourcePath);
     _instances.add((entryName: entryName, instance: WeakReference(sky)));
     return sky;

--- a/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
@@ -79,6 +79,11 @@ void _writeVaryings(StringBuffer sb, FmatMaterial material, String direction) {
 /// layout's sampler is declared, so a material that samples the environment
 /// ships one entry per layout and the runtime picks the one matching the
 /// bound environment.
+///
+/// This doubles the entries a material that samples the environment
+/// contributes. TODO(radiance-layout): remove it with the define in
+/// `texture.glsl` once the engine's combined-limit validation is in every
+/// supported stable, which halves those entries again.
 const String kRadianceCubeDefine = 'FLUTTER_SCENE_RADIANCE_CUBE';
 
 /// Whether [material] declares the prefiltered-radiance sampler, and so needs

--- a/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
@@ -75,6 +75,25 @@ void _writeVaryings(StringBuffer sb, FmatMaterial material, String direction) {
 ///
 /// [defines] are written after the generated-file banner and before framework
 /// includes.
+/// Selects the cubemap prefiltered-radiance layout. Only the selected
+/// layout's sampler is declared, so a material that samples the environment
+/// ships one entry per layout and the runtime picks the one matching the
+/// bound environment.
+const String kRadianceCubeDefine = 'FLUTTER_SCENE_RADIANCE_CUBE';
+
+/// Whether [material] declares the prefiltered-radiance sampler, and so needs
+/// an entry per radiance layout.
+bool materialSamplesEnvironment(FmatMaterial material) =>
+    material.shadingModel != FmatShadingModel.unlit || material.useEnvironment;
+
+/// The bundle entry name of [entryName]'s cubemap-radiance twin.
+String radianceCubeEntryName(String entryName) => '${entryName}Cube';
+
+/// Whether the material described by sidecar [metadata] samples the
+/// environment, and so ships a [radianceCubeEntryName] twin.
+bool sidecarSamplesEnvironment(Map<String, Object?> metadata) =>
+    metadata['shading_model'] != 'unlit' || metadata['use_environment'] == true;
+
 String emitFragmentGlsl(
   FmatMaterial material, {
   Iterable<String> defines = const [],
@@ -435,12 +454,12 @@ String _emitSkyGlsl(
       '// whichever layout it uses (2D equirect or cube). Sample through',
     );
     sb.writeln('// SampleEnvironment(direction, roughness).');
-    sb.writeln('uniform sampler2D prefiltered_radiance;');
-    sb.writeln('uniform samplerCube prefiltered_radiance_cube;');
+    sb.writeln('uniform RadianceSampler prefiltered_radiance;');
     sb.writeln();
     sb.writeln('vec3 SampleEnvironment(vec3 direction, float roughness) {');
-    sb.writeln('  return SampleRadianceEnv(prefiltered_radiance,');
-    sb.writeln('      prefiltered_radiance_cube, direction, roughness);');
+    sb.writeln(
+      '  return SampleRadianceEnv(prefiltered_radiance, direction, roughness);',
+    );
     sb.writeln('}');
     sb.writeln();
   }

--- a/packages/flutter_scene/lib/src/fmat/material_registry.dart
+++ b/packages/flutter_scene/lib/src/fmat/material_registry.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart' show internal;
 import 'package:flutter/services.dart';
+import 'package:flutter_scene/src/fmat/fmat_emitter.dart'
+    show radianceCubeEntryName, sidecarSamplesEnvironment;
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/hot_reload/hot_reload_coordinator.dart';
 import 'package:flutter_scene/src/material/preprocessed_material.dart';
@@ -203,6 +205,13 @@ final class FmatMaterialRegistry {
           metadata: metadata,
           vertexShaders: vertexShaders,
         );
+    _applyRadianceCubeShader(
+      material,
+      metadata,
+      resolution.entry.entryName,
+      shaderLibrary,
+      index.shaderBundleAssetKey,
+    );
     _fmatSourcePaths[material] = sourcePath;
     // Track for in-place hot reload: a `.fmat` edit refreshes this material
     // from its regenerated sidecar without rebuilding the scene. Debug-only.
@@ -270,6 +279,17 @@ final class FmatMaterialRegistry {
       );
     }
     final sky = PreprocessedSky(fragmentShader: shader, metadata: metadata);
+    if (sidecarSamplesEnvironment(metadata)) {
+      final cubeEntry = radianceCubeEntryName(resolution.entry.entryName);
+      final cubeShader = shaderLibrary[cubeEntry];
+      if (cubeShader == null) {
+        throw StateError(
+          'Radiance cube shader entry "$cubeEntry" was missing from '
+          '${index.shaderBundleAssetKey}. Rebuild the material bundle.',
+        );
+      }
+      sky.radianceCubeFragmentShader = cubeShader;
+    }
     _fmatSourcePaths[sky] = sourcePath;
     HotReloadCoordinator.instance.registerFmat(
       sky,
@@ -381,4 +401,26 @@ final class FmatMaterialResolution {
 
   final FmatMaterialBundleIndex index;
   final FmatMaterialIndexEntry entry;
+}
+
+/// Resolves the cubemap-radiance twin of [entryName] and attaches it, so a
+/// draw against a cube environment picks a shader declaring the matching
+/// sampler type. Materials that do not sample the environment have none.
+void _applyRadianceCubeShader(
+  PreprocessedMaterial material,
+  Map<String, Object?> metadata,
+  String entryName,
+  gpu.ShaderLibrary shaderLibrary,
+  String shaderBundleAssetKey,
+) {
+  if (!sidecarSamplesEnvironment(metadata)) return;
+  final cubeEntry = radianceCubeEntryName(entryName);
+  final shader = shaderLibrary[cubeEntry];
+  if (shader == null) {
+    throw StateError(
+      'Radiance cube shader entry "$cubeEntry" was missing from '
+      '$shaderBundleAssetKey. Rebuild the material bundle.',
+    );
+  }
+  material.setRadianceCubeFragmentShaders(shader);
 }

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -324,10 +324,38 @@ class EngineLightingUniforms {
   static void bindPrefilteredRadiance(
     gpu.RenderPass pass,
     gpu.Shader shader,
-    EnvironmentMap env,
-  ) {
-    final cubeLayout = env.usesCubeRadianceLayout;
+    EnvironmentMap env, {
+    bool? cubeShader,
+  }) {
+    final cubeLayout = cubeShader ?? env.usesCubeRadianceLayout;
     final mipLayout = env.usesMipRadianceLayout;
+    // A material built without the cube variant keeps its 2D sampler, which
+    // cannot read a cubemap. Bind a 2D placeholder rather than a texture the
+    // sampler would misread, and say so once.
+    if (cubeLayout != env.usesCubeRadianceLayout) {
+      assert(() {
+        if (!_warnedLayoutMismatch) {
+          _warnedLayoutMismatch = true;
+          debugPrint(
+            'flutter_scene: a material that samples the environment has no '
+            'cubemap-radiance variant, so it contributes no image-based '
+            'specular. Pass radianceCubeFragmentShader (the entry built with '
+            'FLUTTER_SCENE_RADIANCE_CUBE) when constructing it.',
+          );
+        }
+        return true;
+      }());
+      pass.bindTexture(
+        shader.getUniformSlot('prefiltered_radiance'),
+        Material.getBlackPlaceholderTexture(),
+        sampler: _radianceSampler(false),
+      );
+      pass.bindUniform(
+        shader.getUniformSlot('RadianceLayoutInfo'),
+        _layoutAtlas,
+      );
+      return;
+    }
     // The cube wants mip-linear for the roughness textureLod and clamped
     // faces. The 2D mip equirect needs the linear mip filter too; the legacy
     // band atlas has a single level, where the mip filter is inert, and both
@@ -385,6 +413,7 @@ class EngineLightingUniforms {
     EnvironmentMap env, {
     bool bindSsao = true,
     bool bindShadows = true,
+    bool? cubeShader,
   }) {
     if (_memoPassIs(pass)) {
       final previous = _texturesMemo[shader];
@@ -395,7 +424,7 @@ class EngineLightingUniforms {
       }
     }
     _texturesMemo[shader] = (lighting, env);
-    bindPrefilteredRadiance(pass, shader, env);
+    bindPrefilteredRadiance(pass, shader, env, cubeShader: cubeShader);
     pass.bindTexture(
       shader.getUniformSlot('brdf_lut'),
       Material.getBrdfLutTexture(),
@@ -431,6 +460,7 @@ class EngineLightingUniforms {
       shader,
       lighting.environmentMapB ?? env,
       primary: env,
+      cubeShader: cubeShader,
     );
     // Punctual light parameters (all scene lights) and the per-object light
     // index buffer, both RGBA32F data textures, point-sampled (each texel is
@@ -503,12 +533,23 @@ class EngineLightingUniforms {
   /// other layout cannot be bound. It falls back to [primary], which leaves
   /// the cross-fade sampling one environment instead of binding a cube to a 2D
   /// sampler.
+  static bool _warnedLayoutMismatch = false;
+
   static void bindSecondaryRadiance(
     gpu.RenderPass pass,
     gpu.Shader shader,
     EnvironmentMap env, {
     required EnvironmentMap primary,
+    bool? cubeShader,
   }) {
+    if (cubeShader != null && cubeShader != primary.usesCubeRadianceLayout) {
+      pass.bindTexture(
+        shader.getUniformSlot('prefiltered_radiance_b'),
+        Material.getBlackPlaceholderTexture(),
+        sampler: _radianceSampler(false),
+      );
+      return;
+    }
     final source = env.usesCubeRadianceLayout == primary.usesCubeRadianceLayout
         ? env
         : primary;

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show debugPrint;
+
 import 'package:flutter_scene/src/fog.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
@@ -253,22 +255,17 @@ class EngineLightingUniforms {
     );
   }
 
-  // Tiny constant uniform blocks (std140, 16 bytes) selecting the bound
-  // prefiltered radiance's layout in the shader (RadianceLayoutInfo in
-  // texture.glsl); device-resident so binding needs no per-frame buffer.
-  // (mip_layout, cube_layout). Cube: read the samplerCube. Mip: the 2D mip
-  // equirect. Atlas: the legacy 2D stacked-band equirect.
-  static final gpu.BufferView _layoutCube = _layoutFlagBuffer(0.0, 1.0);
-  static final gpu.BufferView _layoutMip = _layoutFlagBuffer(1.0, 0.0);
-  static final gpu.BufferView _layoutAtlas = _layoutFlagBuffer(0.0, 0.0);
+  // Tiny constant uniform blocks (std140, 16 bytes) telling the two 2D
+  // radiance layouts apart in the shader (RadianceLayoutInfo in texture.glsl);
+  // device-resident so binding needs no per-frame buffer. Mip: the 2D mip
+  // equirect. Atlas: the legacy 2D stacked-band equirect. The cube layout has
+  // its own shader variant and reads neither.
+  static final gpu.BufferView _layoutMip = _layoutFlagBuffer(1.0);
+  static final gpu.BufferView _layoutAtlas = _layoutFlagBuffer(0.0);
 
-  static gpu.BufferView _layoutFlagBuffer(double mip, double cube) {
+  static gpu.BufferView _layoutFlagBuffer(double mip) {
     final buffer = gpu.gpuContext.createDeviceBufferWithCopy(
-      ByteData.sublistView(
-        Float32List(4)
-          ..[0] = mip
-          ..[1] = cube,
-      ),
+      ByteData.sublistView(Float32List(4)..[0] = mip),
     );
     return gpu.BufferView(buffer, offsetInBytes: 0, lengthInBytes: 16);
   }
@@ -331,26 +328,25 @@ class EngineLightingUniforms {
   ) {
     final cubeLayout = env.usesCubeRadianceLayout;
     final mipLayout = env.usesMipRadianceLayout;
-    // 2D atlas (real on the equirect layouts, a dummy on the cube layout).
-    // Horizontal repeat (longitude wraps), vertical clamp. The mip layout
-    // needs a linear mip filter for textureLod to take effect; the legacy
-    // band atlas has a single level, where the mip filter is inert.
+    // The cube wants mip-linear for the roughness textureLod and clamped
+    // faces. The 2D mip equirect needs the linear mip filter too; the legacy
+    // band atlas has a single level, where the mip filter is inert, and both
+    // repeat horizontally (longitude wraps) and clamp vertically.
     pass.bindTexture(
       shader.getUniformSlot('prefiltered_radiance'),
-      env.prefilteredRadianceTexture,
-      sampler: _radianceSampler(mipLayout),
+      env.prefilteredRadiance,
+      sampler: cubeLayout ? _cubeSampler : _radianceSampler(mipLayout),
     );
-    // Radiance cubemap (real on the cube layout, a dummy otherwise). Mip-linear
-    // for the roughness textureLod; clamp the faces.
-    pass.bindTexture(
-      shader.getUniformSlot('prefiltered_radiance_cube'),
-      env.prefilteredRadianceCube,
-      sampler: _cubeSampler,
-    );
-    pass.bindUniform(
-      shader.getUniformSlot('RadianceLayoutInfo'),
-      cubeLayout ? _layoutCube : (mipLayout ? _layoutMip : _layoutAtlas),
-    );
+    // Only the 2D variants read the layout flag, to tell the mip equirect from
+    // the legacy band atlas. The cube variant declares the block through the
+    // shared include but never samples it, so it has no live binding to fill
+    // and binding one anyway is rejected.
+    if (!cubeLayout) {
+      pass.bindUniform(
+        shader.getUniformSlot('RadianceLayoutInfo'),
+        mipLayout ? _layoutMip : _layoutAtlas,
+      );
+    }
   }
 
   // Pass-scoped memo for the engine-constant bind set. Bindings persist
@@ -430,7 +426,12 @@ class EngineLightingUniforms {
     // When no cross-fade is active the primary is bound here too (a valid
     // no-op, since frag_info.radiance_blend.x is 0 and the shader never
     // reads it).
-    bindSecondaryRadiance(pass, shader, lighting.environmentMapB ?? env);
+    bindSecondaryRadiance(
+      pass,
+      shader,
+      lighting.environmentMapB ?? env,
+      primary: env,
+    );
     // Punctual light parameters (all scene lights) and the per-object light
     // index buffer, both RGBA32F data textures, point-sampled (each texel is
     // packed data). White placeholders are bound when there are no lights or no
@@ -494,25 +495,39 @@ class EngineLightingUniforms {
   }
 
   /// Binds the secondary cross-fade environment's prefiltered radiance to the
-  /// `prefiltered_radiance_b` / `prefiltered_radiance_cube_b` samplers (the
-  /// specular pair only, no diffuse SH). Shared by the lit material and the
-  /// environment skybox; both share the primary's [RadianceLayoutInfo], so the
-  /// layout flag is not re-bound here.
+  /// `prefiltered_radiance_b` sampler (the specular term only, no diffuse SH).
+  /// Shared by the lit material and the environment skybox; both share the
+  /// primary's [RadianceLayoutInfo], so the layout flag is not re-bound here.
+  ///
+  /// [primary] selects the shader variant in use, so a secondary built in the
+  /// other layout cannot be bound. It falls back to [primary], which leaves
+  /// the cross-fade sampling one environment instead of binding a cube to a 2D
+  /// sampler.
   static void bindSecondaryRadiance(
     gpu.RenderPass pass,
     gpu.Shader shader,
-    EnvironmentMap env,
-  ) {
-    final mipLayout = env.usesMipRadianceLayout;
+    EnvironmentMap env, {
+    required EnvironmentMap primary,
+  }) {
+    final source = env.usesCubeRadianceLayout == primary.usesCubeRadianceLayout
+        ? env
+        : primary;
+    assert(() {
+      if (!identical(source, env)) {
+        debugPrint(
+          'flutter_scene: the cross-faded environment uses a different '
+          'prefiltered radiance layout than the primary; its specular '
+          'contribution is skipped.',
+        );
+      }
+      return true;
+    }());
     pass.bindTexture(
       shader.getUniformSlot('prefiltered_radiance_b'),
-      env.prefilteredRadianceTexture,
-      sampler: _radianceSampler(mipLayout),
-    );
-    pass.bindTexture(
-      shader.getUniformSlot('prefiltered_radiance_cube_b'),
-      env.prefilteredRadianceCube,
-      sampler: _cubeSampler,
+      source.prefilteredRadiance,
+      sampler: source.usesCubeRadianceLayout
+          ? _cubeSampler
+          : _radianceSampler(source.usesMipRadianceLayout),
     );
   }
 }

--- a/packages/flutter_scene/lib/src/material/environment.dart
+++ b/packages/flutter_scene/lib/src/material/environment.dart
@@ -855,17 +855,10 @@ base class EnvironmentMap {
   bool get usesCubeRadianceLayout =>
       _prefilteredRadianceTexture.textureType == gpu.TextureType.textureCube;
 
-  /// The 2D prefiltered radiance for the equirect layouts, or a dummy when the
-  /// radiance is a cube (the material's `samplerCube` is used instead). Both
-  /// the 2D and cube samplers are always bound; the layout flag selects one.
-  gpu.Texture get prefilteredRadianceTexture => usesCubeRadianceLayout
-      ? Material.getBlackPlaceholderTexture()
-      : _prefilteredRadianceTexture;
-
-  /// The prefiltered radiance cubemap (roughness band per mip), or a dummy
-  /// when the radiance is the equirect 2D layout.
-  gpu.Texture get prefilteredRadianceCube =>
-      usesCubeRadianceLayout ? _prefilteredRadianceTexture : _blackCube();
+  /// The prefiltered radiance, in whichever layout it was built. Bound to the
+  /// single `prefiltered_radiance` sampler of the shader variant matching
+  /// [usesCubeRadianceLayout].
+  gpu.Texture get prefilteredRadiance => _prefilteredRadianceTexture;
 
   /// Whether this environment has a full-resolution source equirect for its
   /// background (image environments do; sky-baked / GPU-supplied ones do not).
@@ -880,7 +873,7 @@ base class EnvironmentMap {
   /// than sRGB-encoded color.
   bool get backgroundIsLinear => _backgroundIsLinear;
 
-  /// Whether the 2D [prefilteredRadianceTexture] stores its roughness bands as
+  /// Whether the 2D [prefilteredRadiance] stores its roughness bands as
   /// mip levels (see [useMipRadianceLayout]). Always false for the cube layout.
   bool get usesMipRadianceLayout =>
       !usesCubeRadianceLayout && _prefilteredRadianceTexture.mipLevelCount > 1;
@@ -902,20 +895,6 @@ base class EnvironmentMap {
           sourceIsLinear: sourceIsLinear,
           mipLayout: false,
         );
-
-  // A 1x1 black cube bound to the material's samplerCube when the active
-  // radiance is the 2D layout (the sampler must be complete even though the
-  // layout flag makes the shader ignore it).
-  static gpu.Texture? _blackCubeTexture;
-  static gpu.Texture _blackCube() =>
-      _blackCubeTexture ??= gpu.gpuContext.createTexture(
-        gpu.StorageMode.devicePrivate,
-        1,
-        1,
-        format: gpu.PixelFormat.r16g16b16a16Float,
-        textureType: gpu.TextureType.textureCube,
-        enableShaderReadUsage: true,
-      );
 
   /// The [kDiffuseShCoefficientCount] RGB L2 spherical-harmonic
   /// coefficients describing the diffuse (Lambertian) irradiance.

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -255,14 +255,46 @@ abstract class Material {
   /// material can be constructed before [Scene.initializeStaticResources]
   /// has loaded the base shader bundle. The shader is only needed at render
   /// time, which the engine already defers until the bundle is ready.
-  void setFragmentShaderName(String name) {
+  ///
+  /// [cubeName] is the twin built for the cubemap radiance layout, needed by
+  /// any shader that samples the environment (see [radianceCubeFragmentShader]).
+  void setFragmentShaderName(String name, {String? cubeName}) {
     _fragmentShaderName = name;
     _fragmentShader = null;
+    _radianceCubeFragmentShaderName = cubeName;
+    _radianceCubeFragmentShader = null;
   }
+
+  gpu.Shader? _radianceCubeFragmentShader;
+  String? _radianceCubeFragmentShaderName;
+
+  /// Assigns the already-loaded variant built with
+  /// `FLUTTER_SCENE_RADIANCE_CUBE`, the counterpart of [setFragmentShader]
+  /// for a material that samples the environment.
+  void setRadianceCubeFragmentShader(gpu.Shader? shader) {
+    _radianceCubeFragmentShader = shader;
+    _radianceCubeFragmentShaderName = null;
+  }
+
+  /// The variant compiled for a cubemap prefiltered radiance, or null when
+  /// this material does not sample the environment.
+  ///
+  /// Backends differ in the radiance layout they can build and each variant
+  /// declares only its own sampler type, so a material that reads the
+  /// environment carries one shader per layout and picks by the environment
+  /// bound for the draw.
+  @internal
+  gpu.Shader? get radianceCubeFragmentShader =>
+      _radianceCubeFragmentShader ??= _radianceCubeFragmentShaderName == null
+      ? null
+      : baseShaderLibrary[_radianceCubeFragmentShaderName!];
 
   /// Selects this material's fragment shader for the frame lighting state.
   @internal
-  gpu.Shader fragmentShaderForLighting(Lighting lighting) => fragmentShader;
+  gpu.Shader fragmentShaderForLighting(Lighting lighting) =>
+      lighting.environmentMap.usesCubeRadianceLayout
+      ? (radianceCubeFragmentShader ?? fragmentShader)
+      : fragmentShader;
 
   /// The vertex shader this material supplies for a geometry's [variant]
   /// (`'unskinned'` / `'skinned'` for the color pass, `'depth'` for the

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -295,6 +295,12 @@ abstract class Material {
   /// False when the material carries no cube variant, so a material that was
   /// built without one keeps its 2D sampler and is bound a 2D texture rather
   /// than a mismatched cubemap.
+  ///
+  /// Both decisions must come from here. Picking the shader and the texture
+  /// separately lets a material fall back to its 2D sampler while the bound
+  /// environment hands it a cubemap, which no sampler can read; it then
+  /// samples whatever texture the unit still held, which is silent on
+  /// backends that leave nothing there and garbage on the ones that do.
   @internal
   bool usesRadianceCubeVariant(Lighting lighting) =>
       lighting.environmentMap.usesCubeRadianceLayout &&

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -289,11 +289,22 @@ abstract class Material {
       ? null
       : baseShaderLibrary[_radianceCubeFragmentShaderName!];
 
+  /// Whether this material draws with its cubemap-radiance variant for
+  /// [lighting], which is also what decides the radiance texture bound to it.
+  ///
+  /// False when the material carries no cube variant, so a material that was
+  /// built without one keeps its 2D sampler and is bound a 2D texture rather
+  /// than a mismatched cubemap.
+  @internal
+  bool usesRadianceCubeVariant(Lighting lighting) =>
+      lighting.environmentMap.usesCubeRadianceLayout &&
+      radianceCubeFragmentShader != null;
+
   /// Selects this material's fragment shader for the frame lighting state.
   @internal
   gpu.Shader fragmentShaderForLighting(Lighting lighting) =>
-      lighting.environmentMap.usesCubeRadianceLayout
-      ? (radianceCubeFragmentShader ?? fragmentShader)
+      usesRadianceCubeVariant(lighting)
+      ? radianceCubeFragmentShader!
       : fragmentShader;
 
   /// The vertex shader this material supplies for a geometry's [variant]

--- a/packages/flutter_scene/lib/src/material/physical_material_variant.dart
+++ b/packages/flutter_scene/lib/src/material/physical_material_variant.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show debugPrint, internal;
 import 'package:flutter/services.dart' show AssetManifest, rootBundle;
 import 'package:vector_math/vector_math.dart';
 
+import '../fmat/fmat_emitter.dart' show radianceCubeEntryName;
 import '../gpu/gpu.dart' as gpu;
 import 'physical_material.dart';
 import 'physically_based_material.dart' show AlphaMode, TextureTransform;
@@ -95,22 +96,26 @@ class PhysicalMaterialVariant extends PreprocessedMaterial {
         'Scene.initializeStaticResources() before preparing materials.',
       );
     }
-    final shader = assets.library[entry];
-    if (shader == null) {
-      throw StateError('Physical shader entry "$entry" is missing.');
+    gpu.Shader require(String name) {
+      final shader = assets.library[name];
+      if (shader == null) {
+        throw StateError('Physical shader entry "$name" is missing.');
+      }
+      return shader;
     }
-    final shadowShader = assets.library['${entry}Shadow'];
-    if (shadowShader == null) {
-      throw StateError(
-        'Physical shadow shader entry "${entry}Shadow" is missing.',
-      );
-    }
+
     final metadata = (assets.metadata[entry] as Map).cast<String, Object?>();
-    final material = PhysicalMaterialVariant._(
-      fragmentShader: shader,
-      metadata: metadata,
-      transmissive: transmissive,
-    )..setShadowFragmentShader(shadowShader);
+    final material =
+        PhysicalMaterialVariant._(
+            fragmentShader: require(entry),
+            metadata: metadata,
+            transmissive: transmissive,
+          )
+          ..setShadowFragmentShader(require('${entry}Shadow'))
+          ..setRadianceCubeFragmentShaders(
+            require(radianceCubeEntryName(entry)),
+            shadow: require(radianceCubeEntryName('${entry}Shadow')),
+          );
     material.updateDescriptor(descriptor);
     return material;
   }

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -1484,7 +1484,13 @@ class PhysicallyBasedMaterial extends Material {
     // PreprocessedMaterial: the sampler choices (radiance repeat/clamp, LUT
     // clamp/clamp, shadow nearest/clamp) and the white shadow placeholder
     // live in EngineLightingUniforms.
-    EngineLightingUniforms.bindEngineTextures(pass, shader, lighting, env);
+    EngineLightingUniforms.bindEngineTextures(
+      pass,
+      shader,
+      lighting,
+      env,
+      cubeShader: usesRadianceCubeVariant(lighting),
+    );
     EngineLightingUniforms.bindFog(pass, shader, transientsBuffer, lighting);
   }
 

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -98,7 +98,7 @@ class PhysicallyBasedMaterial extends Material {
        _normalTexture = normalTexture,
        _emissiveTexture = emissiveTexture,
        _occlusionTexture = occlusionTexture {
-    setFragmentShaderName('StandardFragment');
+    setFragmentShaderName('StandardFragment', cubeName: 'StandardCubeFragment');
   }
 
   /// Creates a material from normalized imported properties.
@@ -1379,6 +1379,10 @@ class PhysicallyBasedMaterial extends Material {
     }
     super.bind(pass, transientsBuffer, lighting);
 
+    // The variant the pipeline was built from, which differs from
+    // [fragmentShader] when the bound environment picks the cube radiance
+    // layout. Slots must come from the shader actually drawn with.
+    final shader = fragmentShaderForLighting(lighting);
     final EnvironmentMap env = environment ?? lighting.environmentMap;
 
     // FragInfo std140 layout (624 bytes / 156 floats). EngineLightingUniforms
@@ -1426,7 +1430,7 @@ class PhysicallyBasedMaterial extends Material {
     fragInfo[162] = lightListCount.toDouble();
     fragInfo[163] = lightListOffset.toDouble();
     pass.bindUniform(
-      fragmentShader.getUniformSlot("FragInfo"),
+      shader.getUniformSlot("FragInfo"),
       transientsBuffer.emplace(_fragInfoBytes),
     );
 
@@ -1462,31 +1466,26 @@ class PhysicallyBasedMaterial extends Material {
       occlusionTextureTexCoord,
     );
     pass.bindUniform(
-      fragmentShader.getUniformSlot('TextureTransforms'),
+      shader.getUniformSlot('TextureTransforms'),
       transientsBuffer.emplace(ByteData.sublistView(textureTransforms)),
     );
 
-    _bindSlot(pass, 'base_color_texture', baseColorTexture);
-    _bindSlot(pass, 'emissive_texture', emissiveTexture);
-    _bindSlot(pass, 'metallic_roughness_texture', metallicRoughnessTexture);
-    _bindSlot(pass, 'normal_texture', normalTexture, normal: true);
-    _bindSlot(pass, 'occlusion_texture', occlusionTexture);
+    _bindSlot(pass, shader, 'base_color_texture', baseColorTexture);
+    _bindSlot(pass, shader, 'emissive_texture', emissiveTexture);
+    _bindSlot(
+      pass,
+      shader,
+      'metallic_roughness_texture',
+      metallicRoughnessTexture,
+    );
+    _bindSlot(pass, shader, 'normal_texture', normalTexture, normal: true);
+    _bindSlot(pass, shader, 'occlusion_texture', occlusionTexture);
     // Image-based-lighting atlas, BRDF LUT, and shadow map. Shared with
     // PreprocessedMaterial: the sampler choices (radiance repeat/clamp, LUT
     // clamp/clamp, shadow nearest/clamp) and the white shadow placeholder
     // live in EngineLightingUniforms.
-    EngineLightingUniforms.bindEngineTextures(
-      pass,
-      fragmentShader,
-      lighting,
-      env,
-    );
-    EngineLightingUniforms.bindFog(
-      pass,
-      fragmentShader,
-      transientsBuffer,
-      lighting,
-    );
+    EngineLightingUniforms.bindEngineTextures(pass, shader, lighting, env);
+    EngineLightingUniforms.bindFog(pass, shader, transientsBuffer, lighting);
   }
 
   static final Float32List _fragInfoScratch = Float32List(
@@ -1523,13 +1522,14 @@ class PhysicallyBasedMaterial extends Material {
   // material's repeat default.
   void _bindSlot(
     gpu.RenderPass pass,
+    gpu.Shader shader,
     String name,
     TextureSource? source, {
     bool normal = false,
   }) {
     final resolved = resolveTextureSource(source);
     pass.bindTexture(
-      fragmentShader.getUniformSlot(name),
+      shader.getUniformSlot(name),
       normal
           ? Material.normalPlaceholder(resolved)
           : Material.whitePlaceholder(resolved),

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -64,6 +64,8 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
 
   Set<RenderInput> _sceneInputs;
   gpu.Shader? _shadowFragmentShader;
+  gpu.Shader? _cubeFragmentShader;
+  gpu.Shader? _cubeShadowFragmentShader;
 
   /// Sets the fragment shader used when a shadow atlas is active.
   @internal
@@ -71,11 +73,36 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
     _shadowFragmentShader = shader;
   }
 
+  /// Sets the variants compiled for a cubemap prefiltered radiance, used when
+  /// the bound environment carries that layout. [shadow] is the twin for a
+  /// draw that also binds a shadow atlas.
+  @internal
+  void setRadianceCubeFragmentShaders(gpu.Shader shader, {gpu.Shader? shadow}) {
+    _cubeFragmentShader = shader;
+    _cubeShadowFragmentShader = shadow;
+  }
+
   @override
-  gpu.Shader fragmentShaderForLighting(Lighting lighting) =>
-      lighting.shadowMap == null
-      ? fragmentShader
-      : (_shadowFragmentShader ?? fragmentShader);
+  gpu.Shader? get radianceCubeFragmentShader =>
+      _cubeFragmentShader ?? super.radianceCubeFragmentShader;
+
+  @override
+  gpu.Shader fragmentShaderForLighting(Lighting lighting) {
+    final shadow = lighting.shadowMap != null;
+    // A layout mismatch binds a cube to a 2D sampler, so the layout variant
+    // wins over the shadow one when a material somehow carries only the
+    // latter. Materials that sample the environment ship all four.
+    if (lighting.environmentMap.usesCubeRadianceLayout) {
+      if (shadow) {
+        return _cubeShadowFragmentShader ??
+            _cubeFragmentShader ??
+            _shadowFragmentShader ??
+            fragmentShader;
+      }
+      return _cubeFragmentShader ?? fragmentShader;
+    }
+    return shadow ? (_shadowFragmentShader ?? fragmentShader) : fragmentShader;
+  }
 
   static final Float32List _fragInfoScratch = Float32List(
     EngineLightingUniforms.fragInfoFloatCount,

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -35,7 +35,9 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
     required gpu.Shader fragmentShader,
     required Map<String, Object?> metadata,
     Map<String, gpu.Shader>? vertexShaders,
-  }) : _shadingModel = _parseShadingModel(metadata['shading_model']),
+    gpu.Shader? radianceCubeFragmentShader,
+  }) : _cubeFragmentShader = radianceCubeFragmentShader,
+       _shadingModel = _parseShadingModel(metadata['shading_model']),
        _blending = _parseBlending(metadata['blending']),
        _culling = _parseCulling(metadata['culling']),
        _depthWrite = metadata['depth_write'] == true,
@@ -89,17 +91,13 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
   @override
   gpu.Shader fragmentShaderForLighting(Lighting lighting) {
     final shadow = lighting.shadowMap != null;
-    // A layout mismatch binds a cube to a 2D sampler, so the layout variant
-    // wins over the shadow one when a material somehow carries only the
-    // latter. Materials that sample the environment ship all four.
-    if (lighting.environmentMap.usesCubeRadianceLayout) {
-      if (shadow) {
-        return _cubeShadowFragmentShader ??
-            _cubeFragmentShader ??
-            _shadowFragmentShader ??
-            fragmentShader;
-      }
-      return _cubeFragmentShader ?? fragmentShader;
+    // The layout variant wins over the shadow one: a shadow variant in the
+    // wrong layout would be handed a texture its sampler cannot read, while
+    // dropping the shadow variant only loses the shadow term.
+    if (usesRadianceCubeVariant(lighting)) {
+      return shadow
+          ? (_cubeShadowFragmentShader ?? _cubeFragmentShader!)
+          : _cubeFragmentShader!;
     }
     return shadow ? (_shadowFragmentShader ?? fragmentShader) : fragmentShader;
   }
@@ -249,6 +247,7 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
         env,
         bindSsao: !_sceneInputs.contains(RenderInput.filteredSceneColor),
         bindShadows: lighting.shadowMap != null,
+        cubeShader: usesRadianceCubeVariant(lighting),
       );
       if (_sceneInputs.isNotEmpty) {
         EngineLightingUniforms.bindSceneInputTextures(

--- a/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
@@ -83,6 +83,7 @@ class PreprocessedSky extends ShaderSkySource implements HotReloadableFmat {
         pass,
         shader,
         sampledEnvironment ?? environment,
+        cubeShader: usesRadianceCubeVariant(environment),
       );
     }
   }

--- a/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_sky.dart
@@ -59,26 +59,29 @@ class PreprocessedSky extends ShaderSkySource implements HotReloadableFmat {
     TransientWriter transientsBuffer,
     EnvironmentMap environment,
   ) {
+    // The variant the sky is drawn with, which differs from [fragmentShader]
+    // when the environment's radiance is a cubemap.
+    final shader = shaderForEnvironment(environment);
     // Parameters (the MaterialParams block plus any declared samplers) carry
     // the sky's inputs; the raw uniform-block path is unused here.
-    parameters.bind(pass, fragmentShader, transientsBuffer);
+    parameters.bind(pass, shader, transientsBuffer);
     // Zero keep-alive, mirroring PreprocessedMaterial; the generated sky
     // references every declared parameter resource through it so none can be
     // optimized out. Environment skies always declare the block (it keeps
     // the radiance samplers live even when the author never samples them).
     if (parameters.hasAnyParameters || useEnvironment) {
       pass.bindUniform(
-        fragmentShader.getUniformSlot('FragmentKeepAlive'),
+        shader.getUniformSlot('FragmentKeepAlive'),
         transientsBuffer.emplace(_zeroKeepAlive),
       );
     }
     // A `requires: [environment]` sky samples the prefiltered radiance
     // through SampleEnvironment, bound the same way the standard material
-    // binds it (both layout samplers plus the layout selector block).
+    // binds it (the layout's sampler plus the layout selector block).
     if (useEnvironment) {
       EngineLightingUniforms.bindPrefilteredRadiance(
         pass,
-        fragmentShader,
+        shader,
         sampledEnvironment ?? environment,
       );
     }

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -400,6 +400,7 @@ class ShaderMaterial extends Material {
       pass,
       shader,
       lighting.environmentMap,
+      cubeShader: usesRadianceCubeVariant(lighting),
     );
     pass.bindTexture(
       shader.getUniformSlot('brdf_lut'),

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -92,6 +92,7 @@ class ShaderMaterial extends Material {
   /// names.
   ShaderMaterial({
     gpu.Shader? fragmentShader,
+    gpu.Shader? radianceCubeFragmentShader,
     gpu.Shader? vertexShader,
     gpu.Shader? skinnedVertexShader,
     gpu.Shader? depthVertexShader,
@@ -103,6 +104,7 @@ class ShaderMaterial extends Material {
     if (fragmentShader != null) {
       setFragmentShader(fragmentShader);
     }
+    setRadianceCubeFragmentShader(radianceCubeFragmentShader);
     setVertexShader(vertexShader);
     setVertexShader(skinnedVertexShader, variant: MeshVariant.skinned);
     setVertexShader(depthVertexShader, variant: MeshVariant.depth);
@@ -335,8 +337,13 @@ class ShaderMaterial extends Material {
     pass.setCullMode(cullingMode);
     pass.setWindingOrder(windingOrder);
 
+    // The variant the pipeline was built from, which differs from
+    // [fragmentShader] when an environment-sampling material supplied a
+    // cube-layout twin and the bound environment uses that layout.
+    final shader = fragmentShaderForLighting(lighting);
+
     for (final entry in _uniformBlocks.entries) {
-      final slot = fragmentShader.getUniformSlot(entry.key);
+      final slot = shader.getUniformSlot(entry.key);
       assert(_checkBlock(slot, entry.key, entry.value, ShaderStage.fragment));
       pass.bindUniform(slot, transientsBuffer.emplace(entry.value));
     }
@@ -346,7 +353,7 @@ class ShaderMaterial extends Material {
       // placeholder so the sampler slot is never left dangling.
       final resolved = _resolveShaderTexture(entry.value.source);
       pass.bindTexture(
-        fragmentShader.getUniformSlot(entry.key),
+        shader.getUniformSlot(entry.key),
         Material.whitePlaceholder(resolved),
         sampler:
             entry.value.sampler ??
@@ -356,7 +363,7 @@ class ShaderMaterial extends Material {
     }
 
     if (useEnvironment) {
-      _bindEnvironmentTextures(pass, lighting);
+      _bindEnvironmentTextures(pass, shader, lighting);
     }
   }
 
@@ -384,14 +391,18 @@ class ShaderMaterial extends Material {
     }
   }
 
-  void _bindEnvironmentTextures(gpu.RenderPass pass, Lighting lighting) {
+  void _bindEnvironmentTextures(
+    gpu.RenderPass pass,
+    gpu.Shader shader,
+    Lighting lighting,
+  ) {
     EngineLightingUniforms.bindPrefilteredRadiance(
       pass,
-      fragmentShader,
+      shader,
       lighting.environmentMap,
     );
     pass.bindTexture(
-      fragmentShader.getUniformSlot('brdf_lut'),
+      shader.getUniformSlot('brdf_lut'),
       Material.getBrdfLutTexture(),
       sampler: gpu.SamplerOptions(
         minFilter: gpu.MinMagFilter.linear,

--- a/packages/flutter_scene/lib/src/render/skybox_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/skybox_encoder.dart
@@ -213,6 +213,7 @@ void _bindEnvironmentSource(
     renderPass,
     fragmentShader,
     environment,
+    cubeShader: environment.usesCubeRadianceLayout,
   );
   // The secondary cross-fade environment (the `_b` specular pair). The visible
   // sky mixes toward it by radiance_blend, matching the lit IBL cross-fade.

--- a/packages/flutter_scene/lib/src/render/skybox_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/skybox_encoder.dart
@@ -56,9 +56,12 @@ void encodeSkybox(
   final vertexShader = baseShaderLibrary['SkyboxVertex']!;
   final gpu.Shader fragmentShader;
   if (source is EnvironmentSkySource) {
-    fragmentShader = baseShaderLibrary['SkyboxEnvironmentFragment']!;
+    // The variant declaring the sampler type of the bound radiance layout.
+    fragmentShader = environment.usesCubeRadianceLayout
+        ? baseShaderLibrary['SkyboxEnvironmentCubeFragment']!
+        : baseShaderLibrary['SkyboxEnvironmentFragment']!;
   } else if (source is ShaderSkySource) {
-    fragmentShader = source.fragmentShader;
+    fragmentShader = source.shaderForEnvironment(environment);
   } else {
     return;
   }
@@ -217,6 +220,7 @@ void _bindEnvironmentSource(
     renderPass,
     fragmentShader,
     environmentB,
+    primary: environment,
   );
   // The full-res source equirect for a sharp background (a dummy when the
   // environment has none; the SkyboxInfo flag gates its use).

--- a/packages/flutter_scene/lib/src/skybox.dart
+++ b/packages/flutter_scene/lib/src/skybox.dart
@@ -110,9 +110,16 @@ class ShaderSkySource extends SkySource {
   /// ([sampledEnvironment] when set). The encoder builds the pipeline from
   /// this, and [bind] fills that pipeline's slots, so both must agree.
   gpu.Shader shaderForEnvironment(EnvironmentMap environment) =>
-      (sampledEnvironment ?? environment).usesCubeRadianceLayout
-      ? (radianceCubeFragmentShader ?? fragmentShader)
+      usesRadianceCubeVariant(environment)
+      ? radianceCubeFragmentShader!
       : fragmentShader;
+
+  /// Whether [shaderForEnvironment] picks the cube variant, which is also what
+  /// decides the radiance texture bound to it. False without a cube variant,
+  /// so a sky built with only the 2D entry is never handed a cubemap.
+  bool usesRadianceCubeVariant(EnvironmentMap environment) =>
+      (sampledEnvironment ?? environment).usesCubeRadianceLayout &&
+      radianceCubeFragmentShader != null;
 
   /// The full-screen sky fragment shader, typically loaded from a
   /// `.shaderbundle`. When the source was constructed by name, the shader is
@@ -210,6 +217,7 @@ class ShaderSkySource extends SkySource {
         pass,
         shader,
         sampledEnvironment ?? environment,
+        cubeShader: usesRadianceCubeVariant(environment),
       );
       pass.bindTexture(
         shader.getUniformSlot('brdf_lut'),

--- a/packages/flutter_scene/lib/src/skybox.dart
+++ b/packages/flutter_scene/lib/src/skybox.dart
@@ -85,6 +85,7 @@ class ShaderSkySource extends SkySource {
   ShaderSkySource({
     gpu.Shader? fragmentShader,
     String? fragmentShaderName,
+    this.radianceCubeFragmentShader,
     this.useEnvironment = false,
   }) : assert(
          (fragmentShader == null) != (fragmentShaderName == null),
@@ -95,6 +96,23 @@ class ShaderSkySource extends SkySource {
 
   gpu.Shader? _fragmentShader;
   final String? _fragmentShaderName;
+
+  /// The variant of [fragmentShader] built with `FLUTTER_SCENE_RADIANCE_CUBE`,
+  /// used when the active environment's radiance is a cubemap.
+  ///
+  /// Required only for a [useEnvironment] sky, whose `prefiltered_radiance`
+  /// sampler is a `sampler2D` or a `samplerCube` depending on the layout the
+  /// backend builds. Without it such a sky samples nothing on a cube backend.
+  gpu.Shader? radianceCubeFragmentShader;
+
+  /// The shader to draw with against [environment], picking the variant whose
+  /// radiance sampler matches the layout of the environment actually sampled
+  /// ([sampledEnvironment] when set). The encoder builds the pipeline from
+  /// this, and [bind] fills that pipeline's slots, so both must agree.
+  gpu.Shader shaderForEnvironment(EnvironmentMap environment) =>
+      (sampledEnvironment ?? environment).usesCubeRadianceLayout
+      ? (radianceCubeFragmentShader ?? fragmentShader)
+      : fragmentShader;
 
   /// The full-screen sky fragment shader, typically loaded from a
   /// `.shaderbundle`. When the source was constructed by name, the shader is
@@ -171,15 +189,18 @@ class ShaderSkySource extends SkySource {
     TransientWriter transientsBuffer,
     EnvironmentMap environment,
   ) {
+    // The variant the sky is drawn with, matching the pipeline the encoder
+    // built for this environment's radiance layout.
+    final shader = shaderForEnvironment(environment);
     for (final entry in _uniformBlocks.entries) {
       pass.bindUniform(
-        fragmentShader.getUniformSlot(entry.key),
+        shader.getUniformSlot(entry.key),
         transientsBuffer.emplace(entry.value),
       );
     }
     for (final entry in _textures.entries) {
       pass.bindTexture(
-        fragmentShader.getUniformSlot(entry.key),
+        shader.getUniformSlot(entry.key),
         entry.value.texture,
         sampler: entry.value.sampler ?? gpu.SamplerOptions(),
       );
@@ -187,11 +208,11 @@ class ShaderSkySource extends SkySource {
     if (useEnvironment) {
       EngineLightingUniforms.bindPrefilteredRadiance(
         pass,
-        fragmentShader,
+        shader,
         sampledEnvironment ?? environment,
       );
       pass.bindTexture(
-        fragmentShader.getUniformSlot('brdf_lut'),
+        shader.getUniformSlot('brdf_lut'),
         Material.getBrdfLutTexture(),
         sampler: gpu.SamplerOptions(
           minFilter: gpu.MinMagFilter.linear,

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -31,6 +31,10 @@
     "type": "fragment",
     "file": "shaders/flutter_scene_standard.frag"
   },
+  "StandardCubeFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_standard_cube.frag"
+  },
   "DepthOnlyFragment": {
     "type": "fragment",
     "file": "shaders/flutter_scene_depth_only.frag"
@@ -162,6 +166,10 @@
   "SkyboxEnvironmentFragment": {
     "type": "fragment",
     "file": "shaders/flutter_scene_skybox_environment.frag"
+  },
+  "SkyboxEnvironmentCubeFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_skybox_environment_cube.frag"
   },
   "CubeToEquirectFragment": {
     "type": "fragment",

--- a/packages/flutter_scene/shaders/flutter_scene_skybox_environment.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_skybox_environment.frag
@@ -9,14 +9,15 @@
 // IBL samples, so the background stays consistent with reflections: 0.0 is
 // the sharp environment, 1.0 the fully-blurred band.
 
-uniform sampler2D prefiltered_radiance;
-uniform samplerCube prefiltered_radiance_cube;
+#include <pbr.glsl>      // SRGBToLinear
+#include <texture.glsl>  // SampleRadianceEnv, RadianceSampler
+
+uniform RadianceSampler prefiltered_radiance;
 // The secondary cross-fade environment, sampled the same way and mixed toward
 // by radiance_blend so the visible sky transitions instead of switching at the
 // midpoint. The primary is bound here too when no cross-fade is active (blend
 // 0), so this is always a valid sample.
-uniform sampler2D prefiltered_radiance_b;
-uniform samplerCube prefiltered_radiance_cube_b;
+uniform RadianceSampler prefiltered_radiance_b;
 // The full-resolution source equirect of an image environment, sampled
 // directly so the visible sky is sharp (decoupled from the small reflection
 // cube). A dummy when has_background is 0 (sky-baked environments).
@@ -41,8 +42,6 @@ in vec3 v_ray;
 
 out vec4 frag_color;
 
-#include <pbr.glsl>      // SRGBToLinear
-#include <texture.glsl>  // SampleRadianceEnv, SphericalToEquirectangular
 
 // Blurriness band over which the visible sky hands off from the full-res sharp
 // source to the convolved cube. Above it the cube's roughness LOD carries the
@@ -54,8 +53,7 @@ void main() {
   vec3 direction = normalize(v_ray);
   float blurriness = clamp(skybox_info.blurriness, 0.0, 1.0);
   // The convolved cube/atlas gives the blurred background (and reflections).
-  vec3 blurred = SampleRadianceEnv(
-      prefiltered_radiance, prefiltered_radiance_cube, direction, blurriness);
+  vec3 blurred = SampleRadianceEnv(prefiltered_radiance, direction, blurriness);
 
   vec3 radiance;
   if (skybox_info.has_background > 0.5) {
@@ -81,8 +79,7 @@ void main() {
   // spatial environment transition fades the background instead of popping at
   // the midpoint (the secondary is static, so its cube is its background).
   if (skybox_info.radiance_blend > 0.0) {
-    vec3 blurred_b = SampleRadianceEnv(prefiltered_radiance_b,
-        prefiltered_radiance_cube_b, direction, blurriness);
+    vec3 blurred_b = SampleRadianceEnv(prefiltered_radiance_b, direction, blurriness);
     radiance = mix(radiance, blurred_b, clamp(skybox_info.radiance_blend, 0.0, 1.0));
   }
   frag_color = vec4(radiance * skybox_info.intensity, 1.0);

--- a/packages/flutter_scene/shaders/flutter_scene_skybox_environment_cube.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_skybox_environment_cube.frag
@@ -1,0 +1,5 @@
+// The environment skybox for backends whose prefiltered radiance is a
+// roughness-mip cubemap. Same body as flutter_scene_skybox_environment.frag,
+// with the cube sampler selected.
+#define FLUTTER_SCENE_RADIANCE_CUBE
+#include <flutter_scene_skybox_environment.frag>

--- a/packages/flutter_scene/shaders/flutter_scene_standard_cube.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard_cube.frag
@@ -1,0 +1,6 @@
+// The standard lit fragment shader for backends whose prefiltered radiance is
+// a roughness-mip cubemap. Same body as flutter_scene_standard.frag; the
+// define picks the cube sampler so the 2D one is never declared and costs no
+// texture unit.
+#define FLUTTER_SCENE_RADIANCE_CUBE
+#include <flutter_scene_standard.frag>

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -131,10 +131,9 @@ uniform FragInfo {
 }
 frag_info;
 
-uniform sampler2D prefiltered_radiance; // PMREM-style roughness-band atlas
-// Roughness-mip prefiltered radiance cubemap (sampled instead of the 2D atlas
-// when RadianceLayoutInfo.cube_layout is set; no pole distortion).
-uniform samplerCube prefiltered_radiance_cube;
+// The prefiltered radiance in whichever layout this backend builds, a
+// roughness-mip cubemap or the 2D equirect atlas (see RadianceSampler).
+uniform RadianceSampler prefiltered_radiance;
 uniform sampler2D brdf_lut;
 #ifndef FLUTTER_SCENE_SKIP_SHADOWS
 uniform sampler2D shadow_map;
@@ -147,11 +146,10 @@ uniform sampler2D shadow_map;
 // row coordinates land on its single row.
 uniform sampler2D sh_coefficients;
 // The secondary environment cross-faded in by frag_info.radiance_blend.x: its
-// prefiltered radiance (2D atlas and cubemap, the same layout pair as the
-// primary). Its diffuse SH rides in sh_coefficients row 1. A dummy is bound
-// when no cross-fade is active.
-uniform sampler2D prefiltered_radiance_b;
-uniform samplerCube prefiltered_radiance_cube_b;
+// prefiltered radiance, in the same layout as the primary. Its diffuse SH
+// rides in sh_coefficients row 1. A dummy is bound when no cross-fade is
+// active.
+uniform RadianceSampler prefiltered_radiance_b;
 // Screen-space ambient occlusion (occlusion factor in .r). A white
 // placeholder is bound when occlusion is disabled, so the sample is a
 // no-op; frag_info.ssao_params.x gates it regardless.

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -720,7 +720,7 @@ vec4 EvaluateLighting(MaterialInputs material) {
       EvaluateDiffuseSH(sh_coefficients, -env_normal, 0.0), vec3(0.0));
 #endif
   vec3 prefiltered_color =
-      SampleRadianceEnv(prefiltered_radiance, prefiltered_radiance_cube,
+      SampleRadianceEnv(prefiltered_radiance,
                         env_reflection, roughness);
   // Cross-fade a secondary environment in (area transitions) when active. Both
   // share the bound layout, so the same samplers' _b pair is read.
@@ -729,7 +729,7 @@ vec4 EvaluateLighting(MaterialInputs material) {
     vec3 irradiance_b = max(EvaluateDiffuseSH(sh_coefficients, env_normal, 1.0),
                             vec3(0.0));
     vec3 prefiltered_b =
-        SampleRadianceEnv(prefiltered_radiance_b, prefiltered_radiance_cube_b,
+        SampleRadianceEnv(prefiltered_radiance_b,
                           env_reflection, roughness);
     irradiance = mix(irradiance, irradiance_b, env_blend);
 #ifdef FLUTTER_SCENE_PHYSICAL_MATERIAL
@@ -850,12 +850,10 @@ vec4 EvaluateLighting(MaterialInputs material) {
              transmitted_irradiance * occlusion * ambient_shadow;
   if (material.clearcoat > 0.0) {
     vec3 coat_reflection = reflect(-camera_normal, coat_normal);
-    vec3 coat_prefiltered = SampleRadianceEnv(
-        prefiltered_radiance, prefiltered_radiance_cube,
+    vec3 coat_prefiltered = SampleRadianceEnv(prefiltered_radiance,
         environment_transform * coat_reflection, coat_roughness);
     if (env_blend > 0.0) {
-      vec3 coat_prefiltered_b = SampleRadianceEnv(
-          prefiltered_radiance_b, prefiltered_radiance_cube_b,
+      vec3 coat_prefiltered_b = SampleRadianceEnv(prefiltered_radiance_b,
           environment_transform * coat_reflection, coat_roughness);
       coat_prefiltered = mix(coat_prefiltered, coat_prefiltered_b, env_blend);
     }
@@ -1039,13 +1037,12 @@ vec4 EvaluateLighting(MaterialInputs material) {
     // extra roughness blur on top of the bake.
     const float kSkyFogRoughness = 0.0;
     vec3 sky_dir = environment_transform * normalize(-v_viewvector);
-    sky_fog_color = SampleRadianceEnv(
-        prefiltered_radiance, prefiltered_radiance_cube, sky_dir,
+    sky_fog_color = SampleRadianceEnv(prefiltered_radiance, sky_dir,
         kSkyFogRoughness);
     if (env_blend > 0.0) {
       sky_fog_color = mix(
           sky_fog_color,
-          SampleRadianceEnv(prefiltered_radiance_b, prefiltered_radiance_cube_b,
+          SampleRadianceEnv(prefiltered_radiance_b,
                             sky_dir, kSkyFogRoughness),
           env_blend);
     }

--- a/packages/flutter_scene/shaders/texture.glsl
+++ b/packages/flutter_scene/shaders/texture.glsl
@@ -69,6 +69,15 @@ const float kPrefilterBandEdgeClamp = 1.0 / kPrefilterBandHeight;
 // into mip levels (see EnvironmentMap.effectiveMipRadianceLayout); the rest
 // build a 2D equirect. Declaring only one keeps a dead sampler off the
 // per-stage texture-unit budget.
+//
+// TODO(radiance-layout): drop the define and declare both samplers again,
+// selecting the layout at runtime, once every supported Flutter stable
+// carries the engine's combined-limit validation
+// (https://github.com/flutter/flutter/pull/189332, first stable 3.49). Older
+// engines reject a skinned shadow-casting draw at 16 fragment samplers
+// because they compare the running unit index, which starts after the vertex
+// stage's, against the per-stage limit. Reverting collapses the per-material
+// entry count back by half.
 #ifdef FLUTTER_SCENE_RADIANCE_CUBE
 #define RadianceSampler samplerCube
 #else

--- a/packages/flutter_scene/shaders/texture.glsl
+++ b/packages/flutter_scene/shaders/texture.glsl
@@ -51,8 +51,11 @@ vec3 EquirectangularToSpherical(vec2 uv) {
 ///    textureLod (hardware trilinear between bands).
 ///  * legacy band atlas: the bands stacked vertically in one texture,
 ///    sampled with a manual two-band lerp.
+///  * cube layout: a roughness-mip cubemap, mip level i is band i, with no
+///    pole distortion. Selected by FLUTTER_SCENE_RADIANCE_CUBE, which also
+///    picks the prefiltered_radiance sampler type (see RadianceSampler).
 /// The engine binds RadianceLayoutInfo alongside the prefiltered_radiance
-/// sampler to select the bound texture's layout.
+/// sampler to tell the two 2D layouts apart.
 ///
 
 const float kPrefilterBands = 8.0;
@@ -61,13 +64,22 @@ const float kPrefilterBandHeight = 256.0;
 // in-band V to one texel from each edge (legacy band-atlas layout only).
 const float kPrefilterBandEdgeClamp = 1.0 / kPrefilterBandHeight;
 
+// The prefiltered radiance sampler type for the layout this backend builds.
+// The engine defines FLUTTER_SCENE_RADIANCE_CUBE on backends that can render
+// into mip levels (see EnvironmentMap.effectiveMipRadianceLayout); the rest
+// build a 2D equirect. Declaring only one keeps a dead sampler off the
+// per-stage texture-unit budget.
+#ifdef FLUTTER_SCENE_RADIANCE_CUBE
+#define RadianceSampler samplerCube
+#else
+#define RadianceSampler sampler2D
+#endif
+
 uniform RadianceLayoutInfo {
   // 1.0 when the bound prefiltered_radiance stores its roughness bands as
-  // mip levels; 0.0 for the legacy stacked-band atlas.
+  // mip levels; 0.0 for the legacy stacked-band atlas. Unread by the cube
+  // variant, whose bands are always mip levels.
   float mip_layout;
-  // 1.0 when the radiance is a roughness-mip cubemap (sample the bound
-  // samplerCube); 0.0 to sample the 2D prefiltered_radiance instead.
-  float cube_layout;
 }
 radiance_layout_info;
 
@@ -110,13 +122,15 @@ vec3 SamplePrefilteredRadianceCube(samplerCube radiance, vec3 direction,
   return textureLod(radiance, direction, lod).rgb;
 }
 
-// Samples the prefiltered radiance for `direction`, dispatching on the bound
-// layout (see RadianceLayoutInfo): the cubemap when present, otherwise the 2D
-// equirect atlas. Both samplers are always bound; only one is read.
-vec3 SampleRadianceEnv(sampler2D atlas, samplerCube cube, vec3 direction,
+// Samples the prefiltered radiance for `direction` at the given perceptual
+// `roughness`. FLUTTER_SCENE_RADIANCE_CUBE selects the roughness-mip cubemap
+// layout; without it the 2D equirect atlas is read. Only the selected layout's
+// sampler is declared, so the other costs no texture unit.
+vec3 SampleRadianceEnv(RadianceSampler radiance, vec3 direction,
                        float roughness) {
-  if (radiance_layout_info.cube_layout > 0.5) {
-    return SamplePrefilteredRadianceCube(cube, direction, roughness);
-  }
-  return SamplePrefilteredRadiance(atlas, direction, roughness);
+#ifdef FLUTTER_SCENE_RADIANCE_CUBE
+  return SamplePrefilteredRadianceCube(radiance, direction, roughness);
+#else
+  return SamplePrefilteredRadiance(radiance, direction, roughness);
+#endif
 }

--- a/packages/flutter_scene/shaders/texture.glsl
+++ b/packages/flutter_scene/shaders/texture.glsl
@@ -71,13 +71,14 @@ const float kPrefilterBandEdgeClamp = 1.0 / kPrefilterBandHeight;
 // per-stage texture-unit budget.
 //
 // TODO(radiance-layout): drop the define and declare both samplers again,
-// selecting the layout at runtime, once every supported Flutter stable
-// carries the engine's combined-limit validation
-// (https://github.com/flutter/flutter/pull/189332, first stable 3.49). Older
-// engines reject a skinned shadow-casting draw at 16 fragment samplers
-// because they compare the running unit index, which starts after the vertex
-// stage's, against the per-stage limit. Reverting collapses the per-material
-// entry count back by half.
+// selecting the layout at runtime, once 3.50 is the oldest supported stable.
+// The engine's combined-limit validation
+// (https://github.com/flutter/flutter/pull/189332) landed in the 3.49 minor,
+// and stables step every third minor, so 3.50 is the first stable carrying
+// it. Older engines reject a skinned shadow-casting draw at 16 fragment
+// samplers because they compare the running unit index, which starts after
+// the vertex stage's, against the per-stage limit. Reverting collapses the
+// per-material entry count back by half.
 #ifdef FLUTTER_SCENE_RADIANCE_CUBE
 #define RadianceSampler samplerCube
 #else

--- a/packages/flutter_scene/shaders/texture.glsl
+++ b/packages/flutter_scene/shaders/texture.glsl
@@ -75,10 +75,14 @@ const float kPrefilterBandEdgeClamp = 1.0 / kPrefilterBandHeight;
 #define RadianceSampler sampler2D
 #endif
 
+#ifndef FLUTTER_SCENE_RADIANCE_CUBE
+// Tells the two 2D layouts apart. The cube variant's bands are always mip
+// levels, so it declares neither this block nor the 2D samplers below.
+// Leaving them declared keeps a block whose liveness backends disagree on,
+// and the engine then has no binding choice that satisfies all of them.
 uniform RadianceLayoutInfo {
   // 1.0 when the bound prefiltered_radiance stores its roughness bands as
-  // mip levels; 0.0 for the legacy stacked-band atlas. Unread by the cube
-  // variant, whose bands are always mip levels.
+  // mip levels; 0.0 for the legacy stacked-band atlas.
   float mip_layout;
 }
 radiance_layout_info;
@@ -113,6 +117,8 @@ vec3 SamplePrefilteredRadiance(sampler2D atlas, vec3 direction,
   return mix(texture(atlas, vec2(eq.x, v0)).rgb,
              texture(atlas, vec2(eq.x, v1)).rgb, t);
 }
+
+#endif  // FLUTTER_SCENE_RADIANCE_CUBE
 
 // Samples a roughness-mip prefiltered radiance cubemap (mip i = band i) for
 // reflection `direction`. The cube has no pole distortion and seamless edges.

--- a/packages/flutter_scene/test/fmat_test.dart
+++ b/packages/flutter_scene/test/fmat_test.dart
@@ -658,8 +658,8 @@ sky {
       final m = parseFmat(envSky);
       expect(m.useEnvironment, isTrue);
       final glsl = emitFragmentGlsl(m);
-      expect(glsl, contains('uniform sampler2D prefiltered_radiance;'));
-      expect(glsl, contains('uniform samplerCube prefiltered_radiance_cube;'));
+      expect(glsl, contains('uniform RadianceSampler prefiltered_radiance;'));
+      expect(glsl, isNot(contains('prefiltered_radiance_cube')));
       expect(glsl, contains('vec3 SampleEnvironment('));
       expect(buildSidecar(m)['use_environment'], isTrue);
     });
@@ -679,7 +679,7 @@ sky { vec3 Sky(vec3 direction) { return vec3(0.0); } }
       expect(m.useEnvironment, isFalse);
       expect(
         emitFragmentGlsl(m),
-        isNot(contains('uniform sampler2D prefiltered_radiance;')),
+        isNot(contains('uniform RadianceSampler prefiltered_radiance;')),
       );
       expect(buildSidecar(m).containsKey('use_environment'), isFalse);
     });

--- a/packages/flutter_scene/test/physical_material_sources_test.dart
+++ b/packages/flutter_scene/test/physical_material_sources_test.dart
@@ -81,7 +81,12 @@ void main() {
     );
     expect(
       variants.keys,
-      unorderedEquals({'PhysicalOpaque', 'PhysicalOpaqueShadow'}),
+      unorderedEquals({
+        'PhysicalOpaque',
+        'PhysicalOpaqueShadow',
+        'PhysicalOpaqueCube',
+        'PhysicalOpaqueShadowCube',
+      }),
     );
     final temp = Directory.systemTemp.createTempSync('physical_variants');
     try {
@@ -103,6 +108,101 @@ void main() {
     } finally {
       temp.deleteSync(recursive: true);
     }
+  });
+
+  // The GLES backend allocates fragment texture units after the vertex
+  // stage's, so a skinned draw (which spends one on joints_texture) leaves 15
+  // for the fragment stage on a driver reporting the ES 3.0 minimum of 16.
+  // Engines older than the combined-limit fix reject the draw outright, so
+  // every lit variant has to fit.
+  const maxFragmentSamplers = 15;
+
+  test('lit material variants fit the fragment texture-unit budget', () async {
+    final temp = Directory.systemTemp.createTempSync('sampler_budget');
+    try {
+      final impellerc = await findImpellerC();
+      for (final name in ['physical_opaque', 'physical_transmission']) {
+        final variants = emitFragmentShaderVariants(
+          _compile(name),
+          generateShadowVariant: true,
+        );
+        for (final variant in variants.entries) {
+          final reflection =
+              await _compileReflection(
+                    impellerc,
+                    temp,
+                    variant.key,
+                    variant.value,
+                  )
+                  as Map<String, Object?>;
+          final samplers = reflection['sampled_images']! as List<Object?>;
+          expect(
+            samplers,
+            hasLength(lessThanOrEqualTo(maxFragmentSamplers)),
+            reason:
+                '${variant.key} declares ${samplers.length} fragment '
+                'samplers, over the $maxFragmentSamplers budget.',
+          );
+        }
+      }
+    } finally {
+      temp.deleteSync(recursive: true);
+    }
+  });
+
+  test('base lit shaders fit the fragment texture-unit budget', () async {
+    final temp = Directory.systemTemp.createTempSync('base_sampler_budget');
+    try {
+      final impellerc = await findImpellerC();
+      for (final entry in [
+        'flutter_scene_standard',
+        'flutter_scene_standard_cube',
+      ]) {
+        final reflection =
+            await _compileReflection(
+                  impellerc,
+                  temp,
+                  entry,
+                  File('shaders/$entry.frag').readAsStringSync(),
+                )
+                as Map<String, Object?>;
+        final samplers = reflection['sampled_images']! as List<Object?>;
+        expect(
+          samplers,
+          hasLength(lessThanOrEqualTo(maxFragmentSamplers)),
+          reason:
+              '$entry declares ${samplers.length} fragment samplers, over '
+              'the $maxFragmentSamplers budget.',
+        );
+      }
+    } finally {
+      temp.deleteSync(recursive: true);
+    }
+  });
+
+  test('lit variants select their radiance layout by define', () {
+    final variants = emitFragmentShaderVariants(
+      _compile('physical_opaque'),
+      generateShadowVariant: true,
+    );
+    variants.forEach((entry, glsl) {
+      expect(
+        glsl.contains('#define FLUTTER_SCENE_RADIANCE_CUBE'),
+        entry.endsWith('Cube'),
+        reason: '$entry should define the cube layout only when named Cube.',
+      );
+    });
+    // One sampler, whose type the define picks, so the layout the backend
+    // does not build costs no texture unit.
+    final lighting = File(
+      'shaders/material_engine_lighting.glsl',
+    ).readAsStringSync();
+    expect(lighting, contains('uniform RadianceSampler prefiltered_radiance;'));
+    expect(
+      lighting,
+      contains('uniform RadianceSampler prefiltered_radiance_b;'),
+    );
+    expect(lighting, isNot(contains('prefiltered_radiance_cube')));
   });
 
   test('lit materials reverse normals on back-facing fragments', () {

--- a/packages/flutter_scene/test/physical_material_sources_test.dart
+++ b/packages/flutter_scene/test/physical_material_sources_test.dart
@@ -115,6 +115,10 @@ void main() {
   // for the fragment stage on a driver reporting the ES 3.0 minimum of 16.
   // Engines older than the combined-limit fix reject the draw outright, so
   // every lit variant has to fit.
+  //
+  // Raising this needs the engine fix in every supported stable; see the
+  // TODO(radiance-layout) in shaders/texture.glsl. Until then, a new engine
+  // sampler has to displace an existing one rather than extend the set.
   const maxFragmentSamplers = 15;
 
   test('lit material variants fit the fragment texture-unit budget', () async {


### PR DESCRIPTION
The lit shaders declared a 2D and a cube prefiltered-radiance sampler and bound a placeholder to whichever layout the backend does not build, twice over for the cross-fade pair, spending four fragment texture units to use two. `FLUTTER_SCENE_RADIANCE_CUBE` now selects the sampler type, so only the live layout is declared and materials that sample the environment ship an entry per layout that the runtime picks by the bound environment.

The lit variants drop from 16 fragment samplers to 14. That matters on the GLES backend, where Impeller allocates fragment texture units after the vertex stage's, so a skinned shadow-casting draw needed 17 units on a driver reporting the ES 3.0 minimum of 16 and was rejected outright. New tests assert every lit variant stays inside that budget.

The variant choice is made once, in `usesRadianceCubeVariant`, and both the shader pick and the radiance bind follow it, so a material built without the cube variant keeps its 2D sampler and is bound a placeholder rather than a cubemap it cannot read. The cube variant also compiles out `RadianceLayoutInfo` entirely, since backends disagree about whether a declared-but-unread block leaves a live binding.

Breaking for a raw `ShaderMaterial` that samples the environment, which now supplies a `radianceCubeFragmentShader` built with the define. `.fmat` materials loaded through `loadFmatMaterial` or the bytes library are unaffected; code constructing `PreprocessedMaterial` directly passes the new `radianceCubeFragmentShader` argument.
