### PR TITLE
Flatten a subtree's geometry into one collision-ready snapshot

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.21.0
 
+* `Node.extractMeshData` flattens a subtree's geometry into one `MeshData` with the descendant transforms baked in, and `MeshData.toTriMeshShape`/`toConvexHullShape` turn that into a collider, so an imported model no longer needs a hand-written walk to collide.
+* `MeshData.transformed` places a snapshot by a matrix, carrying normals by the inverse transpose and flipping tangent handedness through a mirror.
 * The lit shaders declare one prefiltered-radiance sampler instead of one per layout, freeing two fragment texture units so a skinned shadow-casting draw fits GLES drivers reporting the 16-unit minimum.
 * Breaking change for raw `ShaderMaterial` shaders that sample the environment, they declare `prefiltered_radiance` as `RadianceSampler` and supply a `radianceCubeFragmentShader` variant built with `FLUTTER_SCENE_RADIANCE_CUBE`. `.fmat` materials are unaffected.
 * A material or sky that samples the environment without a cubemap-radiance variant now keeps its 2D sampler and is bound a placeholder instead of a mismatched cubemap, and says so in debug builds. `PreprocessedMaterial` takes `radianceCubeFragmentShader` for code that builds one directly rather than through a loader.

--- a/packages/flutter_scene/lib/src/geometry/mesh_data.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_data.dart
@@ -5,6 +5,7 @@ import 'package:vector_math/vector_math.dart' as vm;
 
 import 'package:flutter_scene/src/geometry/interleaved_layout.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:scene/physics.dart' show ConvexHullShape, TriMeshShape;
 
 /// One named per-vertex attribute stream carried by a [MeshData], matching a
 /// custom material's `attributes` entry (see `Geometry.setCustomAttribute`).
@@ -245,6 +246,133 @@ class MeshData {
       final c = _cornerIndex(t * 3 + 2);
       yield MeshTriangle(t, a, b, c, _position(a), _position(b), _position(c));
     }
+  }
+
+  /// This mesh placed by [transform].
+  ///
+  /// Positions move as points. [normals] are carried by the inverse
+  /// transpose, so a non-uniform scale leaves them perpendicular to the
+  /// surface, and [tangents] by [transform] itself; both are renormalized,
+  /// and a mirroring transform flips the tangent handedness. Indices and
+  /// every other attribute carry through untouched.
+  MeshData transformed(vm.Matrix4 transform) {
+    final m = transform.storage;
+    final outPositions = Float32List(vertexCount * 3);
+    for (var v = 0; v < vertexCount; v++) {
+      final i = v * 3;
+      final x = positions[i];
+      final y = positions[i + 1];
+      final z = positions[i + 2];
+      outPositions[i] = m[0] * x + m[4] * y + m[8] * z + m[12];
+      outPositions[i + 1] = m[1] * x + m[5] * y + m[9] * z + m[13];
+      outPositions[i + 2] = m[2] * x + m[6] * y + m[10] * z + m[14];
+    }
+
+    final linear = transform.getRotation();
+    final mirrored = linear.determinant() < 0;
+
+    Float32List? outNormals;
+    final srcNormals = normals;
+    if (srcNormals != null) {
+      // A singular linear part has no inverse transpose; carrying normals
+      // through unchanged beats emitting NaNs.
+      final normalMatrix = vm.Matrix3.copy(linear);
+      if (normalMatrix.invert() == 0.0) {
+        normalMatrix.setFrom(linear);
+      } else {
+        normalMatrix.transpose();
+      }
+      outNormals = _transformVectors(srcNormals, normalMatrix, 3);
+    }
+
+    Float32List? outTangents;
+    final srcTangents = tangents;
+    if (srcTangents != null) {
+      outTangents = _transformVectors(srcTangents, linear, 4);
+      if (mirrored) {
+        for (var v = 0; v < vertexCount; v++) {
+          outTangents[v * 4 + 3] = -outTangents[v * 4 + 3];
+        }
+      }
+    }
+
+    return MeshData(
+      positions: outPositions,
+      vertexCount: vertexCount,
+      normals: outNormals,
+      texCoords: texCoords,
+      texCoords1: texCoords1,
+      colors: colors,
+      tangents: outTangents,
+      indices: indices,
+      primitiveType: primitiveType,
+      customAttributes: customAttributes,
+    );
+  }
+
+  /// A collision triangle mesh over this mesh's triangles.
+  ///
+  /// The shape holds its own copy of the positions and indices, so the
+  /// snapshot can be discarded afterwards. Triangle meshes are hollow and
+  /// carry no volume, so they collide as static environment geometry; use
+  /// [toConvexHullShape] for a dynamic body.
+  ///
+  /// Throws a [StateError] when this snapshot is not a triangle list or
+  /// has no triangles.
+  TriMeshShape toTriMeshShape() {
+    _requireTriangles('toTriMeshShape');
+    final count = triangleCount;
+    if (count == 0) {
+      throw StateError('toTriMeshShape requires at least one triangle');
+    }
+    final outIndices = Uint32List(count * 3);
+    for (var corner = 0; corner < outIndices.length; corner++) {
+      outIndices[corner] = _cornerIndex(corner);
+    }
+    return TriMeshShape(
+      vertices: Float32List.fromList(positions),
+      indices: outIndices,
+    );
+  }
+
+  /// A collision convex hull enclosing this mesh's vertices.
+  ///
+  /// The backend computes the hull from the positions, so concave detail is
+  /// filled in. Unlike [toTriMeshShape] the result is solid and works on a
+  /// dynamic body.
+  ConvexHullShape toConvexHullShape() {
+    if (vertexCount == 0) {
+      throw StateError('toConvexHullShape requires at least one vertex');
+    }
+    return ConvexHullShape(points: Float32List.fromList(positions));
+  }
+
+  Float32List _transformVectors(
+    Float32List source,
+    vm.Matrix3 matrix,
+    int stride,
+  ) {
+    final m = matrix.storage;
+    final out = Float32List.fromList(source);
+    for (var v = 0; v < vertexCount; v++) {
+      final i = v * stride;
+      final x = source[i];
+      final y = source[i + 1];
+      final z = source[i + 2];
+      var nx = m[0] * x + m[3] * y + m[6] * z;
+      var ny = m[1] * x + m[4] * y + m[7] * z;
+      var nz = m[2] * x + m[5] * y + m[8] * z;
+      final length = math.sqrt(nx * nx + ny * ny + nz * nz);
+      if (length > 0) {
+        nx /= length;
+        ny /= length;
+        nz /= length;
+      }
+      out[i] = nx;
+      out[i + 1] = ny;
+      out[i + 2] = nz;
+    }
+    return out;
   }
 
   /// A flat-shaded triangle soup derived from this mesh.

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -7,6 +7,8 @@ import 'package:flutter_scene/src/camera.dart';
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/components/instanced_mesh_component.dart';
 import 'package:flutter_scene/src/components/mesh_component.dart';
+import 'package:flutter_scene/src/geometry/mesh_data.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/runtime_importer/runtime_importer.dart';
 import 'package:flutter_scene/src/scene.dart';
 import 'package:flutter_scene/src/animation.dart';
@@ -474,6 +476,140 @@ base class Node implements SceneGraph {
     for (final child in children) {
       yield* child.meshNodes;
     }
+  }
+
+  /// This subtree's geometry flattened into one snapshot, with every
+  /// descendant transform baked into the vertices.
+  ///
+  /// [transform] places the result. The default identity leaves the data in
+  /// this node's local space, which is the frame a collider attached to this
+  /// node expects; pass [globalTransform] for world space instead, which is
+  /// the frame for a collider on a node that has none of its own.
+  ///
+  /// Baking matters because physics does not simulate scale, so a collider
+  /// can never pick up a scale from the graph the way a mesh does. Pick the
+  /// frame so that whatever the collider ends up on carries only a
+  /// translation and a rotation. Runtime glTF import is the case to watch,
+  /// since [fromGlbAsset] roots its model under the source handedness flip,
+  /// which has to go into the vertices rather than onto the collider:
+  ///
+  /// ```dart
+  /// final model = await Node.fromGlbAsset('assets/ground.glb');
+  /// final ground = Node(name: 'ground')..add(model);
+  /// ground.addComponent(
+  ///   Collider(
+  ///     shape: model
+  ///         .extractMeshData(transform: model.localTransform)
+  ///         .toTriMeshShape(),
+  ///   ),
+  /// );
+  /// ```
+  ///
+  /// Scenes from [loadScene] carry that flip in their vertices already, so
+  /// there the default frame is the one to use.
+  ///
+  /// An attribute missing from any one primitive is dropped from the whole
+  /// result, since the merged mesh carries a single attribute set. Skinned
+  /// geometry contributes its bind pose.
+  ///
+  /// Throws a [StateError] when the subtree holds no triangles, or holds
+  /// geometry this cannot read: caller-managed vertex buffers
+  /// (`Geometry.isReadable` is false), non-triangle primitives, or instanced
+  /// meshes, none of which can be flattened into a single mesh.
+  /// {@category Geometry}
+  MeshData extractMeshData({Matrix4? transform}) {
+    final parts = <MeshData>[];
+    _collectMeshData(transform ?? Matrix4.identity(), parts);
+    if (parts.isEmpty) {
+      throw StateError(
+        'Node "$name" has no triangle geometry in its subtree to extract',
+      );
+    }
+    return MeshData.merge(_reduceToSharedAttributes(parts));
+  }
+
+  void _collectMeshData(Matrix4 worldTransform, List<MeshData> parts) {
+    if (_instancedMeshComponents.isNotEmpty) {
+      throw StateError(
+        'Node "$name" carries an instanced mesh, which extractMeshData '
+        'cannot flatten; build the per-instance meshes yourself',
+      );
+    }
+    for (final component in _meshComponents) {
+      for (final primitive in component.mesh.primitives) {
+        final geometry = primitive.geometry;
+        if (!geometry.isReadable) {
+          throw StateError(
+            'Node "$name" has geometry with no readable CPU data; it was '
+            'built from a caller-managed vertex buffer',
+          );
+        }
+        final data = geometry.extractMeshData();
+        if (data.primitiveType != gpu.PrimitiveType.triangle) {
+          throw StateError(
+            'Node "$name" has ${data.primitiveType.name} geometry; '
+            'extractMeshData flattens triangles only',
+          );
+        }
+        if (data.triangleCount == 0) continue;
+        parts.add(
+          worldTransform.isIdentity() ? data : data.transformed(worldTransform),
+        );
+      }
+    }
+    for (final child in children) {
+      child._collectMeshData(
+        worldTransform.multiplied(child.localTransform),
+        parts,
+      );
+    }
+  }
+
+  /// Strips each part down to the attributes every part carries, so
+  /// [MeshData.merge] (which requires one shared attribute set) accepts them.
+  static List<MeshData> _reduceToSharedAttributes(List<MeshData> parts) {
+    if (parts.length == 1) return parts;
+    final normals = parts.every((p) => p.normals != null);
+    final texCoords = parts.every((p) => p.texCoords != null);
+    final texCoords1 = parts.every((p) => p.texCoords1 != null);
+    final colors = parts.every((p) => p.colors != null);
+    final tangents = parts.every((p) => p.tangents != null);
+    final shared = <String, int>{};
+    for (final entry in parts.first.customAttributes.entries) {
+      final components = entry.value.components;
+      final inAll = parts.every(
+        (p) => p.customAttributes[entry.key]?.components == components,
+      );
+      if (inAll) shared[entry.key] = components;
+    }
+
+    if (normals &&
+        texCoords &&
+        texCoords1 &&
+        colors &&
+        tangents &&
+        shared.length == parts.first.customAttributes.length &&
+        parts.every((p) => p.customAttributes.length == shared.length)) {
+      return parts;
+    }
+
+    return [
+      for (final part in parts)
+        MeshData(
+          positions: part.positions,
+          vertexCount: part.vertexCount,
+          normals: normals ? part.normals : null,
+          texCoords: texCoords ? part.texCoords : null,
+          texCoords1: texCoords1 ? part.texCoords1 : null,
+          colors: colors ? part.colors : null,
+          tangents: tangents ? part.tangents : null,
+          indices: part.indices,
+          primitiveType: part.primitiveType,
+          customAttributes: {
+            for (final name in shared.keys) name: part.customAttributes[name]!,
+          },
+        ),
+    ];
   }
 
   /// Whether this node's subtree would survive frustum culling against

--- a/packages/flutter_scene/test/mesh_data_ops_test.dart
+++ b/packages/flutter_scene/test/mesh_data_ops_test.dart
@@ -277,6 +277,101 @@ void main() {
     });
   });
 
+  group('transformed', () {
+    test('places positions and carries indices through', () {
+      final moved = _quad().transformed(
+        Matrix4.translation(Vector3(1, 2, 3))..scaleByDouble(2, 1, 1, 1),
+      );
+      expect(moved.positions.sublist(0, 3), [1, 2, 3]);
+      expect(moved.positions.sublist(3, 6), [3, 2, 3]);
+      expect(moved.indices, _quad().indices);
+      expect(moved.texCoords, _quad().texCoords);
+    });
+
+    test('carries normals by the inverse transpose', () {
+      // A triangle in the x = y plane, so its normal is not axis aligned and
+      // a non-uniform scale moves it somewhere the plain matrix would not.
+      final data = MeshData.build(
+        positions: Float32List.fromList([
+          0, 0, 0, //
+          1, 1, 0, //
+          0, 0, 1,
+        ]),
+      );
+      final scaled = data.transformed(Matrix4.diagonal3(Vector3(2, 1, 1)));
+
+      // Recompute the face normal from the transformed corners; the carried
+      // normal has to agree with it.
+      final p = scaled.positions;
+      final edge1 = Vector3(p[3] - p[0], p[4] - p[1], p[5] - p[2]);
+      final edge2 = Vector3(p[6] - p[0], p[7] - p[1], p[8] - p[2]);
+      final face = edge1.cross(edge2)..normalize();
+
+      final carried = Vector3(
+        scaled.normals![0],
+        scaled.normals![1],
+        scaled.normals![2],
+      );
+      expect(carried.dot(face).abs(), closeTo(1.0, 1e-5));
+    });
+
+    test('flips tangent handedness through a mirror', () {
+      final data = MeshData(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        vertexCount: 3,
+        tangents: Float32List.fromList([
+          1, 0, 0, 1, //
+          1, 0, 0, 1, //
+          1, 0, 0, -1,
+        ]),
+      );
+      final mirrored = data.transformed(Matrix4.diagonal3(Vector3(1, 1, -1)));
+      expect(mirrored.tangents![3], -1);
+      expect(mirrored.tangents![11], 1);
+
+      final plain = data.transformed(Matrix4.diagonal3(Vector3(1, 1, 2)));
+      expect(plain.tangents![3], 1);
+    });
+
+    test('leaves a singular transform without NaN normals', () {
+      final flattened = _quad().transformed(
+        Matrix4.diagonal3(Vector3(1, 1, 0)),
+      );
+      expect(flattened.normals!.every((v) => v.isFinite), isTrue);
+    });
+  });
+
+  group('collision shapes', () {
+    test('toTriMeshShape copies positions and flattens indices', () {
+      final shape = _quad().toTriMeshShape();
+      expect(shape.vertices, hasLength(12));
+      expect(shape.indices, [0, 1, 2, 0, 2, 3]);
+    });
+
+    test('toTriMeshShape synthesizes indices for a triangle soup', () {
+      final soup = MeshData.build(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      );
+      expect(soup.toTriMeshShape().indices, [0, 1, 2]);
+    });
+
+    test('toTriMeshShape rejects meshes with no triangles', () {
+      final points = MeshData(
+        positions: Float32List.fromList([0, 0, 0]),
+        vertexCount: 1,
+        primitiveType: gpu.PrimitiveType.point,
+      );
+      expect(points.toTriMeshShape, throwsStateError);
+    });
+
+    test('toConvexHullShape copies the positions', () {
+      final hull = _quad().toConvexHullShape();
+      expect(hull.points, hasLength(12));
+      hull.points[0] = 99;
+      expect(_quad().positions[0], 0);
+    });
+  });
+
   group('readback', () {
     test('isReadable is false with no retained data, and extract throws', () {
       final stub = _StubGeometry();

--- a/packages/flutter_scene/test/node_extract_mesh_data_test.dart
+++ b/packages/flutter_scene/test/node_extract_mesh_data_test.dart
@@ -1,0 +1,199 @@
+// Covers Node.extractMeshData, which flattens a subtree's geometry into one
+// snapshot with the transforms baked in. Uses stub geometry so the walk can
+// be exercised without a Flutter GPU context.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// Geometry that skips shader-library and GPU access, retaining just enough
+/// CPU data for [Geometry.extractMeshData] to read.
+class _StubGeometry extends Geometry {
+  _StubGeometry(Float32List positions, {Float32List? normals}) {
+    setRaycastAttributes(positions: positions, normals: normals);
+    setVertexStreams(const [], positions.length ~/ 3);
+  }
+
+  /// Geometry that retains nothing, standing in for a caller-managed buffer.
+  _StubGeometry.unreadable();
+
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    TransientWriter transientsBuffer,
+    Matrix4 modelTransform,
+    Matrix4 cameraTransform,
+    Vector3 cameraPosition, {
+    gpu.Shader? shaderOverride,
+    double depthBias = 0.0,
+  }) {
+    throw UnsupportedError('Stub geometry is not renderable');
+  }
+}
+
+class _StubMaterial extends Material {
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    TransientWriter transientsBuffer,
+    Lighting lighting,
+  ) {
+    throw UnsupportedError('Stub material is not renderable');
+  }
+}
+
+/// A triangle in the XZ plane, offset along X by [x].
+Mesh _triangle({double x = 0, Float32List? normals}) => Mesh(
+  _StubGeometry(
+    Float32List.fromList([
+      x, 0, 0, //
+      x + 1, 0, 0, //
+      x, 0, 1,
+    ]),
+    normals: normals,
+  ),
+  _StubMaterial(),
+);
+
+void main() {
+  test('bakes descendant transforms into the vertices', () {
+    final root = Node(name: 'root');
+    final child = Node(
+      name: 'child',
+      localTransform: Matrix4.translation(Vector3(0, 5, 0)),
+      mesh: _triangle(),
+    );
+    root.add(child);
+
+    final data = root.extractMeshData();
+    expect(data.vertexCount, 3);
+    expect(data.positions.sublist(0, 3), [0, 5, 0]);
+    expect(data.positions.sublist(3, 6), [1, 5, 0]);
+  });
+
+  test('leaves the subtree root transform out by default', () {
+    final root = Node(
+      name: 'root',
+      localTransform: Matrix4.translation(Vector3(100, 0, 0)),
+      mesh: _triangle(),
+    );
+
+    expect(root.extractMeshData().positions.sublist(0, 3), [0, 0, 0]);
+    expect(
+      root
+          .extractMeshData(transform: root.localTransform)
+          .positions
+          .sublist(0, 3),
+      [100, 0, 0],
+    );
+  });
+
+  test('the transform parameter reaches world space', () {
+    final parent = Node(
+      name: 'parent',
+      localTransform: Matrix4.translation(Vector3(0, 0, 7)),
+    );
+    final child = Node(name: 'child', mesh: _triangle());
+    parent.add(child);
+
+    final data = child.extractMeshData(transform: child.globalTransform);
+    expect(data.positions.sublist(0, 3), [0, 0, 7]);
+  });
+
+  test('merges several primitives and rebases their indices', () {
+    final node = Node(name: 'multi')
+      ..mesh = Mesh.primitives(
+        primitives: [
+          _triangle().primitives.first,
+          _triangle(x: 10).primitives.first,
+        ],
+      );
+
+    final data = node.extractMeshData();
+    expect(data.vertexCount, 6);
+    expect(data.triangleCount, 2);
+    expect(data.positions.sublist(9, 12), [10, 0, 0]);
+    // The second primitive's corners address its own vertices, not the
+    // first primitive's.
+    expect(data.toTriMeshShape().indices, [0, 1, 2, 3, 4, 5]);
+  });
+
+  test('drops an attribute that one primitive is missing', () {
+    final normals = Float32List.fromList([0, 1, 0, 0, 1, 0, 0, 1, 0]);
+    final root = Node(
+      name: 'root',
+      mesh: _triangle(normals: normals),
+    );
+    root.add(Node(name: 'bare', mesh: _triangle(x: 10)));
+
+    final data = root.extractMeshData();
+    expect(data.vertexCount, 6);
+    expect(data.normals, isNull);
+
+    // With every part carrying normals they survive.
+    final allNormals =
+        Node(
+          name: 'root',
+          mesh: _triangle(normals: normals),
+        )..add(
+          Node(
+            name: 'also',
+            mesh: _triangle(x: 10, normals: normals),
+          ),
+        );
+    expect(allNormals.extractMeshData().normals, hasLength(18));
+  });
+
+  test('a subtree with no geometry throws', () {
+    final root = Node(name: 'empty')..add(Node(name: 'also-empty'));
+    expect(root.extractMeshData, throwsStateError);
+  });
+
+  test('unreadable geometry throws rather than going missing', () {
+    final node = Node(
+      name: 'managed',
+      mesh: Mesh(_StubGeometry.unreadable(), _StubMaterial()),
+    );
+    expect(node.extractMeshData, throwsStateError);
+  });
+
+  test('non-triangle geometry throws', () {
+    final mesh = _triangle();
+    mesh.primitives.first.geometry.primitiveType = gpu.PrimitiveType.line;
+    final node = Node(name: 'lines', mesh: mesh);
+    expect(node.extractMeshData, throwsStateError);
+  });
+
+  test('instanced meshes throw', () {
+    final node = Node(name: 'instanced')
+      ..addComponent(
+        InstancedMeshComponent(
+          InstancedMesh(
+            geometry: _StubGeometry(
+              Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 0, 1]),
+            ),
+            material: _StubMaterial(),
+          ),
+        ),
+      );
+    expect(node.extractMeshData, throwsStateError);
+  });
+
+  test('feeds a collision shape in the collider node frame', () {
+    final root = Node(name: 'root');
+    root.add(
+      Node(
+        name: 'hill',
+        localTransform: Matrix4.translation(Vector3(0, 2, 0)),
+        mesh: _triangle(),
+      ),
+    );
+
+    final shape = root.extractMeshData().toTriMeshShape();
+    expect(shape.indices, [0, 1, 2]);
+    expect(shape.vertices.sublist(0, 3), [0, 2, 0]);
+  });
+}


### PR DESCRIPTION
Related to #187.

Building a collider for an imported model meant walking the node tree by hand, transforming each primitive's vertices and concatenating them with rebased indices. The rebasing is easy to get subtly wrong, and an unindexed primitive silently corrupts every later primitive's indices, which stays invisible until something falls through the floor.

`Node.extractMeshData` does that walk, baking each descendant transform into the vertices and merging the primitives into one snapshot. `MeshData.toTriMeshShape` and `toConvexHullShape` hand the result to a `Collider`, and `MeshData.transformed` is the placement op underneath, carrying normals by the inverse transpose and flipping tangent handedness through a mirror.

Baking the transforms is required rather than convenient, since physics does not simulate scale and a collider cannot inherit one from the graph the way a mesh does. The `transform` parameter picks the frame the vertices land in so that whatever the collider sits on carries only a translation and a rotation.