### PR TITLE
Run the netcode tests on CI and prepare flutter_scene_net 0.2.0

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -49,6 +49,7 @@ jobs:
         package:
           - packages/scene
           - packages/flutter_scene
+          - packages/flutter_scene_net
     steps:
       - uses: actions/checkout@v7
       - name: Set up Flutter

--- a/examples/flutter_app/pubspec.yaml
+++ b/examples/flutter_app/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   # Multiplayer example.
   dashwire: ^0.1.0
   dashwire_replication: ^0.2.1
-  flutter_scene_net: ^0.1.0
+  flutter_scene_net: ^0.2.0
   # The physics contract, used headlessly by the multiplayer arena sim.
   scene: ^0.2.0
   # Native Rapier physics backend, used by the Physics example. Pulls

--- a/packages/flutter_scene_net/CHANGELOG.md
+++ b/packages/flutter_scene_net/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - `PredictedTransformComponent` with `PredictedController`, client-side prediction of an owned entity with authoritative input-replay reconciliation, so local input renders instantly while the sim stays server-authoritative. Selected per entity through `SceneReplication`'s `localPrediction` seam.
 - `PredictedPhysicsComponent` with `PredictedPhysicsController`, rollback prediction for an owned physics body. Mispredictions restore a retained world snapshot, adopt the authoritative pose, and replay pending inputs through the simulation; `onWorldRestored` tells the controller so dynamically created bodies (remote-player proxies) can be revalidated. Needs a snapshot-capable backend (rapier).
-- `PhysicsWorldHistory`, a server-side per-tick world snapshot ring that rewinds hit queries to the client-rendered tick and restores the present, capped by `maxRewindTicks`.
 - `NetworkTransformComponent` re-anchors its interpolation buffer after an idle gap, so a resuming remote eases in instead of snapping.
 - The interpolation delay adapts to measured arrival cadence and jitter, easing between `minDelay` and the configured ceiling, so clean links render remotes barely behind while jittery ones buffer deep.
 - `SceneReplication.inputTargetDepth` passes the input buffer depth through to the client (1 suits local or stable links).

--- a/packages/flutter_scene_net/CHANGELOG.md
+++ b/packages/flutter_scene_net/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
 
-## Unreleased
+## 0.2.0
 
 - `PredictedTransformComponent` with `PredictedController`, client-side prediction of an owned entity with authoritative input-replay reconciliation, so local input renders instantly while the sim stays server-authoritative. Selected per entity through `SceneReplication`'s `localPrediction` seam.
-- `PredictedPhysicsComponent` with `PredictedPhysicsController`, rollback prediction for an owned physics body. Mispredictions restore a retained world snapshot, adopt the authoritative pose, and replay pending inputs through the simulation; `onWorldRestored` tells the controller so dynamically created bodies (remote-player proxies) can be revalidated. Needs a snapshot-capable backend (rapier).
+- `PredictedPhysicsComponent` with `PredictedPhysicsController`, rollback prediction for an owned physics body. Mispredictions restore a retained world snapshot, adopt the authoritative pose, and replay pending inputs through the simulation. Needs a snapshot-capable backend (rapier).
+- `PredictedPhysicsController.onWorldRestored` fires after a rollback restore. A restore rewinds to the body set its snapshot captured, so a controller managing bodies dynamically (remote-player proxies) allocates a fixed pool before the first snapshot rather than recreating them.
 - `NetworkTransformComponent` re-anchors its interpolation buffer after an idle gap, so a resuming remote eases in instead of snapping.
 - The interpolation delay adapts to measured arrival cadence and jitter, easing between `minDelay` and the configured ceiling, so clean links render remotes barely behind while jittery ones buffer deep.
 - `SceneReplication.inputTargetDepth` passes the input buffer depth through to the client (1 suits local or stable links).
-- Requires the input-command and prediction substrate from the next `dashwire`/`dashwire_replication` release.
+- `SceneReplication.minInterpolationDelay` and `SceneReplication.adaptiveInterpolation` reach the interpolation buffer, so an app can floor the adaptive delay or hold it fixed.
+- Both predicted components reconcile at the tick the authoritative pose was snapshotted at, not the input ack's, so a deferred snapshot no longer discards the travel in between. They wait for a snapshot to date the pose before reconciling at all.
+- Both predicted components take `maxCatchUpTicks` and snap to authority past it, so a backgrounded tab or a long hitch does not replay every missed tick in one frame.
+- Requires `dashwire_replication` 0.2.1 for the input-command and prediction substrate.
 
 ## 0.1.0
 

--- a/packages/flutter_scene_net/lib/flutter_scene_net.dart
+++ b/packages/flutter_scene_net/lib/flutter_scene_net.dart
@@ -11,7 +11,10 @@ export 'src/hosting/hosting.dart' show SceneHost;
 export 'src/network_transform_codec.dart'
     show NetworkTransformCodec, registerNetComponentCodecs;
 export 'src/network_transform.dart' show NetworkTransformComponent;
-export 'src/physics_world_history.dart' show PhysicsWorldHistory;
+// TODO(lagcomp): export PhysicsWorldHistory once something consumes it. The
+// server-side rewind needs the peer's last acked tick, which the host does
+// not record yet, and rewind lands on whole ticks where hit registration
+// wants the two bracketing snapshots interpolated.
 export 'src/predicted_physics.dart'
     show PredictedPhysicsComponent, PredictedPhysicsController;
 export 'src/predicted_transform.dart'

--- a/packages/flutter_scene_net/lib/src/network_transform.dart
+++ b/packages/flutter_scene_net/lib/src/network_transform.dart
@@ -15,9 +15,9 @@ import 'transform_replica.dart';
 /// delay sizes itself from the measured arrival cadence and jitter, easing
 /// between [minDelay] and [delay] (the ceiling and starting value), so a
 /// clean local link renders barely behind while a jittery one buffers deep.
-// TODO(prediction): owned replicas currently render on the same delayed
-// timeline as everything else; input-replay prediction needs the tick
-// infrastructure wired through here.
+///
+/// An owned, predicted entity uses `PredictedTransformComponent` instead, so
+/// local input renders instantly rather than a delay in the past.
 final class NetworkTransformComponent extends Component {
   NetworkTransformComponent(
     this.replica, {

--- a/packages/flutter_scene_net/lib/src/scene_replication.dart
+++ b/packages/flutter_scene_net/lib/src/scene_replication.dart
@@ -33,6 +33,8 @@ final class SceneReplication {
     required this.root,
     required Map<String, ReplicaNodeBuilder> builders,
     this.interpolationDelay = const Duration(milliseconds: 100),
+    this.minInterpolationDelay = const Duration(milliseconds: 25),
+    this.adaptiveInterpolation = true,
     int inputTargetDepth = 2,
     LocalPredictionBuilder? localPrediction,
     void Function(Replica replica, Node node)? onSpawn,
@@ -60,6 +62,13 @@ final class SceneReplication {
   /// Ceiling for the remote-pose render delay; the interpolation buffer
   /// sizes itself below this from measured arrival cadence and jitter.
   final Duration interpolationDelay;
+
+  /// Floor the adaptive interpolation delay eases down to.
+  final Duration minInterpolationDelay;
+
+  /// Whether the interpolation delay adapts at all. False holds it at
+  /// [interpolationDelay].
+  final bool adaptiveInterpolation;
   final LocalPredictionBuilder? _localPrediction;
   final void Function(Replica, Node)? _onSpawn;
   final void Function(Replica, Node)? _onDespawn;
@@ -106,7 +115,12 @@ final class SceneReplication {
           client: client,
           tickRate: session.tickRate,
         ),
-        _ => NetworkTransformComponent(replica, delay: interpolationDelay),
+        _ => NetworkTransformComponent(
+          replica,
+          delay: interpolationDelay,
+          minDelay: minInterpolationDelay,
+          adaptive: adaptiveInterpolation,
+        ),
       });
     }
     root.add(node);

--- a/packages/flutter_scene_net/pubspec.yaml
+++ b/packages/flutter_scene_net/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_scene_net
 description: dashwire multiplayer for flutter_scene. Replica-to-node binding, interpolated transform sync, and in-app hosting.
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
-version: 0.1.0
+version: 0.2.0
 
 topics:
   - multiplayer
@@ -28,6 +28,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_scene: ^0.21.0
+  # The physics contract, whose types this package's own API exposes.
+  scene: ^0.2.0
   vector_math: ^2.1.4
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/packages/flutter_scene_net/test/flutter_scene_net_test.dart
+++ b/packages/flutter_scene_net/test/flutter_scene_net_test.dart
@@ -105,6 +105,42 @@ void main() {
     await room.stop();
   });
 
+  test('interpolation settings reach the spawned component', () async {
+    final room = Room(registry: _registry());
+    final (clientEnd, serverEnd) = LoopbackConnection.pair();
+    final admitted = room.admit(serverEnd);
+    final session = await connectSession(
+      clientEnd,
+      schemaHash: _registry().schemaHash,
+      pingInterval: const Duration(seconds: 10),
+    );
+    await admitted;
+
+    final replication = SceneReplication(
+      registry: _registry(),
+      session: session,
+      root: Node(),
+      builders: {'pawn': (replica) => Node()},
+      interpolationDelay: const Duration(milliseconds: 80),
+      minInterpolationDelay: const Duration(milliseconds: 40),
+      adaptiveInterpolation: false,
+    );
+
+    final id = room.host.spawn(_Pawn());
+    room.advance(1 / 30);
+    await _pump();
+
+    final transform = replication
+        .nodeFor(id)!
+        .getComponent<NetworkTransformComponent>()!;
+    expect(transform.delay, const Duration(milliseconds: 80));
+    expect(transform.minDelay, const Duration(milliseconds: 40));
+    expect(transform.adaptive, isFalse);
+
+    await replication.close();
+    await room.stop();
+  });
+
   test('SceneHost serves loopback and WebSocket joiners', () async {
     if (!SceneHost.isSupported) {
       markTestSkipped('in-app hosting requires dart:io');

--- a/packages/flutter_scene_net/test/predicted_physics_test.dart
+++ b/packages/flutter_scene_net/test/predicted_physics_test.dart
@@ -5,6 +5,8 @@ import 'package:dashwire_replication/dashwire_replication.dart';
 import 'package:flutter_scene/physics.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene_net/flutter_scene_net.dart';
+// ignore: implementation_imports
+import 'package:flutter_scene_net/src/physics_world_history.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 


### PR DESCRIPTION
Picks up the review notes on #288 and #289 that were left in the review bodies rather than on diff lines, and stages the 0.2.0 release.

The test matrix never included `packages/flutter_scene_net`, so its suite has never run on a push. Adding it there is the main change. `SceneReplication` also now forwards `minInterpolationDelay` and `adaptiveInterpolation`, which were unreachable through the binding, and the stale `TODO(prediction)` in `network_transform.dart` goes with the prediction work that resolved it.

`PhysicsWorldHistory` comes back out of the barrel until something consumes it. The server-side rewind wants the peer's last acked tick, which the host does not record yet, and `rewind` lands on whole ticks where hit registration wants the two bracketing snapshots interpolated. The file and its tests stay put.

The release prep bumps to 0.2.0 and names `dashwire_replication` 0.2.1 concretely. Publishing still waits on `scene` 0.2.0 and `flutter_scene` 0.21.0 reaching pub.dev.