### PR TITLE
Reverse triangle winding through a mirroring transform

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.21.0
 
 * `Node.extractMeshData` flattens a subtree's geometry into one `MeshData` with the descendant transforms baked in, and `MeshData.toTriMeshShape`/`toConvexHullShape` turn that into a collider, so an imported model no longer needs a hand-written walk to collide.
-* `MeshData.transformed` places a snapshot by a matrix, carrying normals by the inverse transpose and flipping tangent handedness through a mirror.
+* `MeshData.transformed` places a snapshot by a matrix, carrying normals by the inverse transpose and, through a mirror, flipping both tangent handedness and triangle winding.
 * The lit shaders declare one prefiltered-radiance sampler instead of one per layout, freeing two fragment texture units so a skinned shadow-casting draw fits GLES drivers reporting the 16-unit minimum.
 * Breaking change for raw `ShaderMaterial` shaders that sample the environment, they declare `prefiltered_radiance` as `RadianceSampler` and supply a `radianceCubeFragmentShader` variant built with `FLUTTER_SCENE_RADIANCE_CUBE`. `.fmat` materials are unaffected.
 * A material or sky that samples the environment without a cubemap-radiance variant now keeps its 2D sampler and is bound a placeholder instead of a mismatched cubemap, and says so in debug builds. `PreprocessedMaterial` takes `radianceCubeFragmentShader` for code that builds one directly rather than through a loader.

--- a/packages/flutter_scene/lib/src/geometry/mesh_data.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_data.dart
@@ -252,9 +252,14 @@ class MeshData {
   ///
   /// Positions move as points. [normals] are carried by the inverse
   /// transpose, so a non-uniform scale leaves them perpendicular to the
-  /// surface, and [tangents] by [transform] itself; both are renormalized,
-  /// and a mirroring transform flips the tangent handedness. Indices and
-  /// every other attribute carry through untouched.
+  /// surface, and [tangents] by [transform] itself; both are renormalized.
+  /// Every other attribute carries through untouched.
+  ///
+  /// A mirroring [transform] reverses orientation, so it flips the tangent
+  /// handedness and reverses triangle winding to match. The renderer flips
+  /// winding per node for a mirrored node transform, which cannot help once
+  /// the mirror lives in the vertices. An unindexed triangle list comes back
+  /// indexed, since that is where its winding lives.
   MeshData transformed(vm.Matrix4 transform) {
     final m = transform.storage;
     final outPositions = Float32List(vertexCount * 3);
@@ -304,10 +309,28 @@ class MeshData {
       texCoords1: texCoords1,
       colors: colors,
       tangents: outTangents,
-      indices: indices,
+      indices: mirrored ? _reversedWinding() : indices,
       primitiveType: primitiveType,
       customAttributes: customAttributes,
     );
+  }
+
+  /// This mesh's triangle corners with each triangle's last two swapped, or
+  /// [indices] unchanged when winding does not apply. Synthesizes the corners
+  /// for an unindexed list, which has no other place to carry winding.
+  List<int>? _reversedWinding() {
+    if (primitiveType != gpu.PrimitiveType.triangle) return indices;
+    final source = indices;
+    final cornerCount = source?.length ?? vertexCount;
+    // A partial triangle has no winding to preserve; leave it as it came.
+    if (cornerCount == 0 || cornerCount % 3 != 0) return indices;
+    final out = List<int>.filled(cornerCount, 0);
+    for (var t = 0; t < cornerCount; t += 3) {
+      out[t] = source?[t] ?? t;
+      out[t + 1] = source?[t + 2] ?? t + 2;
+      out[t + 2] = source?[t + 1] ?? t + 1;
+    }
+    return out;
   }
 
   /// A collision triangle mesh over this mesh's triangles.

--- a/packages/flutter_scene/test/mesh_data_ops_test.dart
+++ b/packages/flutter_scene/test/mesh_data_ops_test.dart
@@ -29,6 +29,25 @@ class _StubGeometry extends Geometry {
   }
 }
 
+/// The first triangle's normal implied by its corner order.
+Vector3 _windingNormal(MeshData data) {
+  Vector3 corner(int c) {
+    final v = data.indices?[c] ?? c;
+    return Vector3(
+      data.positions[v * 3],
+      data.positions[v * 3 + 1],
+      data.positions[v * 3 + 2],
+    );
+  }
+
+  final a = corner(0);
+  return (corner(1) - a).cross(corner(2) - a)..normalize();
+}
+
+/// The first vertex's carried normal.
+Vector3 _firstNormal(MeshData data) =>
+    Vector3(data.normals![0], data.normals![1], data.normals![2]);
+
 /// A unit quad, two triangles sharing the diagonal 0-2.
 MeshData _quad() {
   return MeshData.build(
@@ -331,6 +350,69 @@ void main() {
 
       final plain = data.transformed(Matrix4.diagonal3(Vector3(1, 1, 2)));
       expect(plain.tangents![3], 1);
+    });
+
+    test('reverses triangle winding through a mirror', () {
+      // The winding normal and the carried normal have to keep agreeing, or
+      // the mesh renders inside out and collides against its own back faces.
+      final data = MeshData.build(
+        positions: Float32List.fromList([
+          0, 0, 0, //
+          1, 0, 0, //
+          0, 0, 1,
+        ]),
+        // Matching the corner order's own normal, (0, -1, 0).
+        normals: Float32List.fromList([
+          0, -1, 0, //
+          0, -1, 0, //
+          0, -1, 0,
+        ]),
+        indices: [0, 1, 2],
+      );
+      expect(_windingNormal(data).dot(_firstNormal(data)), greaterThan(0));
+
+      // The handedness flip a glTF model carries at its root.
+      final mirrored = data.transformed(Matrix4.diagonal3(Vector3(1, 1, -1)));
+      expect(mirrored.indices, [0, 2, 1]);
+      expect(
+        _windingNormal(mirrored).dot(_firstNormal(mirrored)),
+        greaterThan(0),
+      );
+    });
+
+    test('indexes an unindexed triangle list to carry the flip', () {
+      final soup = MeshData.build(
+        positions: Float32List.fromList([
+          0, 0, 0, //
+          1, 0, 0, //
+          0, 0, 1, //
+          2, 0, 0, //
+          3, 0, 0, //
+          2, 0, 1,
+        ]),
+      );
+      expect(soup.indices, isNull);
+
+      final mirrored = soup.transformed(Matrix4.diagonal3(Vector3(1, 1, -1)));
+      expect(mirrored.indices, [0, 2, 1, 3, 5, 4]);
+    });
+
+    test('leaves winding alone without a mirror', () {
+      final scaled = _quad().transformed(Matrix4.diagonal3(Vector3(2, 3, 4)));
+      expect(scaled.indices, _quad().indices);
+
+      final points = MeshData(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        vertexCount: 3,
+        indices: [0, 1, 2],
+        primitiveType: gpu.PrimitiveType.point,
+      );
+      // Winding is meaningless off a triangle list, mirror or not.
+      expect(points.transformed(Matrix4.diagonal3(Vector3(1, 1, -1))).indices, [
+        0,
+        1,
+        2,
+      ]);
     });
 
     test('leaves a singular transform without NaN normals', () {


### PR DESCRIPTION
Related to #187.

Follow-up to #319. A mirroring transform reverses orientation, so `MeshData.transformed` left triangle winding disagreeing with the normals it had just flipped. The renderer flips winding per node for a mirrored node transform, which cannot help once the mirror is baked into the vertices, and a glTF model carries exactly that flip at its root, so the `extractMeshData` path its own docs recommend hit this every time.

An unindexed triangle list comes back indexed, since a soup has nowhere else to carry its winding.
