### PR TITLE
Require Flutter 3.47.0, the first stable that carries Flutter GPU

### DIFF
--- a/.github/workflows/codemagic_smoke.yml
+++ b/.github/workflows/codemagic_smoke.yml
@@ -239,6 +239,13 @@ jobs:
           find staging -type f -name '*.png' -exec cp {} smoke/ \;
           status_file=$(find staging -type f -name 'smoke-status.txt' | head -1)
           [ -n "$status_file" ] && cp "$status_file" smoke-status.txt
+          version_file=$(find staging -type f -name 'flutter-version.txt' | head -1)
+          if [ -n "$version_file" ]; then
+            echo "Rendered with:"
+            cat "$version_file"
+          else
+            echo "The build published no Flutter version file."
+          fi
 
           count=$(find smoke -type f -name '*.png' | wc -l | tr -d ' ')
           echo "frames: $count"

--- a/.github/workflows/codemagic_smoke.yml
+++ b/.github/workflows/codemagic_smoke.yml
@@ -24,6 +24,19 @@ on:
   workflow_run:
     workflows: ["Flutter CI"]
     types: [in_progress]
+  # A release check renders the Apple shards against a stable Flutter. Dispatch
+  # needs write access, so it carries its own gate; the fork approval below is
+  # only about pull requests.
+  workflow_dispatch:
+    inputs:
+      flutter_channel:
+        description: "Flutter channel for the Apple shards"
+        required: false
+        default: master
+      argos_prefix:
+        description: "Argos name prefix, keeps a non-master run off the baseline"
+        required: false
+        default: ""
 
 concurrency:
   group: >-
@@ -48,6 +61,7 @@ jobs:
     # is re-checked because the trigger alone is not the gate.
     if: >
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.event == 'pull_request' &&
        github.event.workflow_run.status == 'in_progress')
     outputs:
@@ -71,7 +85,7 @@ jobs:
           HEAD_REF: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # The pushed branch already exists on the remote, so Codemagic can
             # resolve it and no mirror is needed.
             echo "branch=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
@@ -120,7 +134,7 @@ jobs:
           echo "base_ref=$base" >> "$GITHUB_OUTPUT"
 
   render:
-    name: ${{ matrix.build_name }} (Flutter master)
+    name: ${{ inputs.argos_prefix || '' }}${{ matrix.build_name }} (Flutter ${{ inputs.flutter_channel || 'master' }})
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -140,11 +154,20 @@ jobs:
           CODEMAGIC_APP_ID: ${{ secrets.CODEMAGIC_APP_ID }}
         run: |
           set -euo pipefail
+          # The usual master render sends the payload it always sent. Only a
+          # channel override adds the environment block, so a wrong guess about
+          # that field cannot take the whole matrix down with it.
+          channel="${{ inputs.flutter_channel || 'master' }}"
           body=$(jq -nc \
             --arg appId "$CODEMAGIC_APP_ID" \
             --arg workflowId "${{ matrix.workflow_id }}" \
             --arg branch "${{ needs.prepare.outputs.branch }}" \
             '{appId: $appId, workflowId: $workflowId, branch: $branch}')
+          if [ "$channel" != "master" ]; then
+            body=$(printf '%s' "$body" | jq -c \
+              --arg channel "$channel" \
+              '. + {environment: {variables: {FLUTTER_CHANNEL: $channel}}}')
+          fi
           out=$(curl -sS -X POST https://api.codemagic.io/builds \
             -H "Content-Type: application/json" \
             -H "x-auth-token: $CODEMAGIC_API_TOKEN" \
@@ -244,7 +267,7 @@ jobs:
           status=0
           npx --yes @argos-ci/cli upload smoke \
             --project "$ARGOS_PROJECT" \
-            --build-name "${{ matrix.build_name }}" > argos.log 2>&1 || status=$?
+            --build-name "${{ inputs.argos_prefix || '' }}${{ matrix.build_name }}" > argos.log 2>&1 || status=$?
           cat argos.log
           grep -oE 'https://app\.argos-ci\.com/[^[:space:]]+' argos.log \
             | head -1 >> "$GITHUB_STEP_SUMMARY" || true

--- a/.github/workflows/smoke_render.yml
+++ b/.github/workflows/smoke_render.yml
@@ -10,7 +10,19 @@ name: smoke render
 # night. Notifies Discord when a non-PR run fails.
 
 on:
+  # A manual run can pick a channel. Pass an argos_prefix for anything other
+  # than master, since manual runs always upload and an unprefixed one would
+  # overwrite the master baseline with frames from a different engine.
   workflow_dispatch:
+    inputs:
+      flutter_channel:
+        description: "Flutter channel to render against"
+        required: false
+        default: master
+      argos_prefix:
+        description: "Argos name prefix, keeps a non-master run off the baseline"
+        required: false
+        default: ""
   schedule:
     - cron: "0 7 * * *" # daily, 07:00 UTC
   push:
@@ -29,8 +41,9 @@ jobs:
   smoke_render:
     uses: ./.github/workflows/smoke_render_jobs.yml
     with:
-      flutter_channel: master
-      label: Flutter master
+      flutter_channel: ${{ inputs.flutter_channel || 'master' }}
+      label: ${{ format('Flutter {0}', inputs.flutter_channel || 'master') }}
+      argos_prefix: ${{ inputs.argos_prefix || '' }}
       # Upload on master pushes too, so a merge refreshes the Argos baseline
       # immediately (an approved rendering change lands on merge, not only at
       # the next nightly).

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -42,7 +42,11 @@ definitions:
 
     - &script_versions
       name: Flutter and engine revision
-      script: flutter --version
+      # Recorded as an artifact too, so the GitHub side can show which channel
+      # a build actually rendered on instead of trusting that the request took.
+      script: |
+        mkdir -p "$CM_BUILD_DIR/examples/smoke_render/build"
+        flutter --version | tee "$CM_BUILD_DIR/examples/smoke_render/build/flutter-version.txt"
 
     - &script_assert_no_credentials
       name: Assert the build holds no credentials
@@ -106,6 +110,7 @@ workflows:
     artifacts:
       - examples/smoke_render/build/smoke/*.png
       - examples/smoke_render/build/smoke-status.txt
+      - examples/smoke_render/build/flutter-version.txt
 
   smoke-ios:
     name: Smoke render (iOS simulator, Metal)
@@ -164,3 +169,4 @@ workflows:
     artifacts:
       - examples/smoke_render/build/smoke/*.png
       - examples/smoke_render/build/smoke-status.txt
+      - examples/smoke_render/build/flutter-version.txt

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -14,12 +14,32 @@ definitions:
     flutter: master
     vars:
       FLUTTER_DART_DATA_ASSETS: "true"
+      # The channel to render on. Codemagic's `flutter:` key takes a literal,
+      # so the image installs master and the channel script below switches when
+      # a build asks for another one. Overridden per build through the API by
+      # .github/workflows/codemagic_smoke.yml.
+      FLUTTER_CHANNEL: "master"
 
   cache: &smoke_cache
     cache_paths:
       - ~/.pub-cache
 
   scripts:
+    - &script_select_channel
+      name: Select the Flutter channel
+      # A release check renders against stable; everything else stays on the
+      # master the image ships, so this is a no-op on the usual path.
+      script: |
+        set -eu
+        channel="${FLUTTER_CHANNEL:-master}"
+        if [ "$channel" = "master" ]; then
+          echo "Staying on the image's master Flutter."
+          exit 0
+        fi
+        echo "Switching to the $channel channel."
+        flutter channel "$channel"
+        flutter upgrade --force
+
     - &script_versions
       name: Flutter and engine revision
       script: flutter --version
@@ -65,6 +85,7 @@ workflows:
     environment: *smoke_environment
     cache: *smoke_cache
     scripts:
+      - *script_select_channel
       - *script_versions
       - *script_assert_no_credentials
       - name: Enable the macOS desktop target
@@ -98,6 +119,7 @@ workflows:
         SMOKE_SIM_DEVICE: iPhone 17 Pro
     cache: *smoke_cache
     scripts:
+      - *script_select_channel
       - *script_versions
       - *script_assert_no_credentials
       - name: Generate the iOS project

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.21.0
 
+* Requires Flutter 3.47.0 or newer. That is the first stable carrying the Flutter GPU support this package needs, so the constraint is a real minimum rather than the loose value earlier releases carried. A master build numbered `3.47.0-1.0.pre.N` sorts below it and will not resolve.
 * Assets are generated into `flutter_scene_generated/` at the app root and loaded by source path, the same way on every Flutter channel. `dart run flutter_scene:init` installs the hook, creates the directory with a `.gitignore` for its outputs, and adds the one pubspec assets entry it needs.
 * `flutter pub add flutter_scene` is the whole setup. flutter_scene's own build hook compiles the engine's shaders for the app being built, on every channel, so an app with no hook of its own renders a runtime-imported `.glb` everywhere including web.
 * Compiled shader bundles record the engine that built them and are rebuilt when it changes, so switching Flutter versions cannot leave a bundle the new engine refuses to read.
@@ -9,6 +10,8 @@
 * `resolveShaderBundleKey` resolves a shader bundle built by `buildTargetShaderBundleJson` (or `flutter_gpu_shaders`) by name, for `loadShaderLibraryAsync`.
 * Build stamps fingerprint a source over a megabyte by size and modification time instead of reading it, cutting about 5 seconds per gigabyte off every build. Set `flutter_scene_strict_hashing: true` under `hooks: user_defines:` in the app pubspec to content-hash everything.
 * Switching asset modes needs a clean build. Nothing prunes assets from a previous mode out of an app bundle.
+* Breaking change, `buildScenes` and `buildTextures` no longer take `outputDirectory`. Outputs go to the app's generated tree, so a hook passing it fails to compile; drop the argument.
+* Breaking change, `FmatMaterialBundleIndex.fromJson` requires `assetKey`. The bundle and its sidecar resolve from the index's own key, so a direct caller passes the key it parsed.
 * `Node.extractMeshData` flattens a subtree's geometry into one `MeshData` with the descendant transforms baked in, and `MeshData.toTriMeshShape`/`toConvexHullShape` turn that into a collider, so an imported model no longer needs a hand-written walk to collide.
 * `MeshData.transformed` places a snapshot by a matrix, carrying normals by the inverse transpose and, through a mirror, flipping both tangent handedness and triangle winding.
 * The lit shaders declare one prefiltered-radiance sampler instead of one per layout, freeing two fragment texture units so a skinned shadow-casting draw fits GLES drivers reporting the 16-unit minimum.

--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -135,7 +135,7 @@ its `.gitignore` for you.
 
 Flutter Scene is pre-1.0 and evolving quickly. Minor releases can carry breaking changes, and every change is documented in the [CHANGELOG](https://github.com/bdero/flutter_scene/blob/master/packages/flutter_scene/CHANGELOG.md).
 
-- Flutter 3.47 (stable) or newer. Rendering is built on [Flutter GPU](https://github.com/flutter/flutter/blob/main/docs/engine/impeller/Flutter-GPU.md), and there is nothing to configure or opt into beyond `flutter pub add`.
+- Flutter 3.47 (stable) or newer. Rendering is built on [Flutter GPU](https://github.com/flutter/flutter/blob/main/docs/engine/impeller/Flutter-GPU.md), and there is nothing to configure or opt into beyond `flutter pub add`. A master build numbered `3.47.0-1.0.pre.N` sorts below `3.47.0` and will not resolve, so use the 3.48 development series or later.
 - On native platforms rendering runs on [Impeller](https://docs.flutter.dev/perf/impeller#availability), which is Flutter's default renderer on iOS and Android and enabled with a flag on desktop (`--enable-impeller --enable-flutter-gpu`). The web has no Impeller, so the package ships its own WebGL2 backend and runs there without flags.
 
 ## Features

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -24,11 +24,11 @@ resolution: workspace
 
 environment:
   sdk: ^3.10.0
-  # Pinned to the latest stable so pub.dev (which analyzes on stable) can
-  # resolve and score the package. The real requirement is newer, a Flutter
-  # master build from 2026-06-09 or later (render-to-mip-level GPU support,
-  # flutter/flutter#187685). See the README and the version-pinning note.
-  flutter: ">=3.44.0"
+  # 3.47.0 is the first stable carrying the Flutter GPU support this package
+  # needs (render-to-mip-level, flutter/flutter#187685), so the floor is a
+  # truthful minimum rather than the pana-scoring compromise it used to be.
+  # Master builds numbered 3.47.0-1.0.pre.N sort below it and are excluded.
+  flutter: ">=3.47.0"
 
 dependencies:
   code_assets: ^1.2.1


### PR DESCRIPTION
Raises the `flutter` lower bound from `>=3.44.0` to `>=3.47.0` before 0.21.0 publishes.

The old bound was a compromise. Flutter GPU was master-only, so the constraint was pinned to whatever stable pub.dev analyzed with and understated the real requirement, which the README and a version-pinning note had to explain. 3.47.0 is the first stable carrying render-to-mip-level support (flutter/flutter#187685), so the bound is now a truthful minimum and 0.21.0 is the first release that explicitly supports a stable channel.

Worth knowing for anyone on master, a build numbered `3.47.0-1.0.pre.N` sorts below `3.47.0` and will not resolve. Use the 3.48 development series or later. The README paragraph claiming master is required is rewritten, since it renders on the package page.

Verified against Flutter 3.47.0 stable locally, 1359 tests pass, analyze clean, and pana holds at 160/160 with the raised bound.