### PR TITLE
Say what an upgrade needs without naming the old mechanism

### DIFF
--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -108,11 +108,10 @@ creates `flutter_scene_generated/` with a `.gitignore` for its outputs, and adds
 that one directory to `flutter.assets` in your `pubspec.yaml`. It is safe to run
 again.
 
-Upgrading from an earlier version, run it again. Generated assets used to be
-Dart data assets, which only master-channel toolchains build, and they now go
-into that directory on every channel. Re-running `init` migrates the hook it
-wrote and adds the pubspec entry; a hook still asking for a removed asset mode
-fails the build and names its replacement.
+Upgrading from an earlier version, run it again. Generated assets now go into
+that directory on every Flutter release, so re-running `init` migrates the hook
+it wrote and adds the pubspec entry. A hook still asking for a removed asset
+mode fails the build and names its replacement.
 
 From then on, drop sources under `assets/` and load them by source path:
 


### PR DESCRIPTION
The asset pipeline section explained an upgrade in terms of Dart data assets and the master channel, which a new reader has no reason to learn. It now says where generated assets go and what re-running init does.