### PR TITLE
Say how to turn Flutter GPU on, per platform

### DIFF
--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -78,14 +78,15 @@ Scene is built by a former core Flutter engine team member who spent four years 
 
 ```sh
 flutter pub add flutter_scene
+dart run flutter_scene:init
 ```
 
-That is the whole setup. List a `.glb` under `flutter: assets:` like any other
-asset (or fetch one at runtime), import it, and render it:
+`init` sets up the asset pipeline, which is the recommended way to use Scene.
+Drop sources under `assets/`, load them by their source path, and render:
 
 ```dart
-final model = await Node.fromGlbAsset('assets/model.glb');
-scene.add(model);
+final level = await loadScene('assets/level.glb');
+scene.add(level);
 // ...
 SceneView(scene, cameraBuilder: (elapsed) => PerspectiveCamera(...));
 ```
@@ -134,13 +135,6 @@ On 3.47.0 there is no such setting, so desktop takes the command-line flags per 
 
 ### The asset pipeline
 
-Converting assets ahead of time is the upgrade, not the entry fee. Run it once
-when you want it:
-
-```sh
-dart run flutter_scene:init
-```
-
 `init` writes a `hook/build.dart` that converts your assets at build time,
 creates `flutter_scene_generated/` with a `.gitignore` for its outputs, and adds
 that one directory to `flutter.assets` in your `pubspec.yaml`. It is safe to run
@@ -159,14 +153,21 @@ final toon = await loadFmatMaterial('assets/toon.fmat');
 final ground = await loadTexture('assets/ground.png');
 ```
 
-What that buys over runtime import: `.glb` and `.fscene` models pre-converted to
-the `.fsceneb` format that loads far faster, `.fmat` custom materials,
-block-compressed textures with full mip chains, and hot reload, editing a source
-reconverts just that source and the change lands in the running app.
+A `.glb` has to be parsed and unpacked into GPU-ready form every time the app
+loads it. The pipeline does that work once, at build time, into the `.fsceneb`
+format the engine reads directly, so loading a model at runtime costs far less.
+Prefer it for anything that ships with your app. It is also how `.fmat` custom
+materials and block-compressed textures with full mip chains reach you, and
+editing any source reconverts just that source and hot reloads it.
 
 Keep your sources in version control. The generated directory holds compiled
 output tied to the Flutter engine that built it, which is why the hook manages
 its `.gitignore` for you.
+
+For a model that only exists once the app is running, because you download it or
+the user supplies it, import the `.glb` directly with
+`Node.fromGlbAsset('assets/model.glb')`. That needs no hook, and it parses the
+glTF on every load, so prefer the pipeline whenever the model ships with you.
 
 ## Requirements
 

--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -90,9 +90,35 @@ scene.add(model);
 SceneView(scene, cameraBuilder: (elapsed) => PerspectiveCamera(...));
 ```
 
-No project configuration, no flags, and the same code runs on web. The engine's
-shaders are compiled for you during the build, by flutter_scene's own build
-hook.
+The same code runs on web, and the engine's shaders are compiled for you during
+the build by flutter_scene's own build hook. Rendering goes through Flutter GPU,
+which is off by default, so enable it once per platform (below). The web needs
+nothing.
+
+### Enable Flutter GPU
+
+While developing, pass the flags on the command line:
+
+```sh
+flutter run --enable-flutter-gpu --enable-impeller
+```
+
+To turn it on permanently, for every run and for the app you ship, edit the
+platform file:
+
+| Platform | File | Add |
+| --- | --- | --- |
+| iOS | `ios/Runner/Info.plist` | `<key>FLTEnableFlutterGPU</key><true/>` |
+| Android | `android/app/src/main/AndroidManifest.xml`, in `<application>` | `<meta-data android:name="io.flutter.embedding.android.EnableFlutterGPU" android:value="true" />` |
+| macOS | `macos/Runner/Info.plist` | `<key>FLTEnableFlutterGPU</key><true/>` and `<key>FLTEnableImpeller</key><true/>` |
+| Web | nothing | |
+
+Impeller is already the default on iOS and Android, so those need only the one
+entry. Windows and Linux have no project setting on 3.47, so they take the
+command-line flags per run; release builds compile the engine's environment
+switches out, so a shipped Windows or Linux release cannot enable Flutter GPU on
+this version. The project-level setting for both is merged upstream and lands in
+a later stable.
 
 ### The asset pipeline
 
@@ -134,7 +160,7 @@ its `.gitignore` for you.
 
 Flutter Scene is pre-1.0 and evolving quickly. Minor releases can carry breaking changes, and every change is documented in the [CHANGELOG](https://github.com/bdero/flutter_scene/blob/master/packages/flutter_scene/CHANGELOG.md).
 
-- Flutter 3.47 (stable) or newer. Rendering is built on [Flutter GPU](https://github.com/flutter/flutter/blob/main/docs/engine/impeller/Flutter-GPU.md), and there is nothing to configure or opt into beyond `flutter pub add`. A master build numbered `3.47.0-1.0.pre.N` sorts below `3.47.0` and will not resolve, so use the 3.48 development series or later.
+- Flutter 3.47 (stable) or newer. Rendering is built on [Flutter GPU](https://github.com/flutter/flutter/blob/main/docs/engine/impeller/Flutter-GPU.md), which every platform except the web needs turned on once (see [Enable Flutter GPU](#enable-flutter-gpu)). A master build numbered `3.47.0-1.0.pre.N` sorts below `3.47.0` and will not resolve, so use the 3.48 development series or later.
 - On native platforms rendering runs on [Impeller](https://docs.flutter.dev/perf/impeller#availability), which is Flutter's default renderer on iOS and Android and enabled with a flag on desktop (`--enable-impeller --enable-flutter-gpu`). The web has no Impeller, so the package ships its own WebGL2 backend and runs there without flags.
 
 ## Features
@@ -184,9 +210,7 @@ Flutter Scene is pre-1.0 and evolving quickly. Minor releases can carry breaking
 
 On native platforms `flutter_scene` runs anywhere [Impeller](https://docs.flutter.dev/perf/impeller#availability) does. On the web it runs on a built-in WebGL2 backend.
 
-On iOS and Android, Impeller is Flutter's default production renderer. So on these platforms, `flutter_scene` works without any additional project configuration.
-
-On MacOS, Windows, and Linux, Impeller is able to run, but is not on by default and must be enabled. When invoking `flutter run`, Impeller can be enabled by passing the `--enable-impeller` flag.
+Every native platform needs Flutter GPU turned on, and the desktop ones need Impeller turned on with it, since Impeller is only the default on iOS and Android. [Enable Flutter GPU](#enable-flutter-gpu) has the file and the key for each.
 
 On the web, no flags are needed; it works under both the CanvasKit and Skwasm renderers.
 
@@ -195,9 +219,9 @@ On the web, no flags are needed; it works under both the CanvasKit and Skwasm re
 |              iOS | 🟢 Supported                     |
 |          Android | 🟢 Supported                     |
 |              Web | 🟢 Supported                     |
-|            MacOS | 🟢 Supported (enable Impeller)   |
-|          Windows | 🟢 Supported (enable Impeller)   |
-|            Linux | 🟢 Supported (enable Impeller)   |
+|            MacOS | 🟢 Supported                     |
+|          Windows | 🟢 Supported (no project setting yet) |
+|            Linux | 🟢 Supported (no project setting yet) |
 | Custom embedders | 🟢 Supported                     |
 
 ### **Q:** How does web support work?

--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -113,12 +113,25 @@ platform file:
 | macOS | `macos/Runner/Info.plist` | `<key>FLTEnableFlutterGPU</key><true/>` and `<key>FLTEnableImpeller</key><true/>` |
 | Web | nothing | |
 
-Impeller is already the default on iOS and Android, so those need only the one
-entry. Windows and Linux have no project setting on 3.47, so they take the
-command-line flags per run; release builds compile the engine's environment
-switches out, so a shipped Windows or Linux release cannot enable Flutter GPU on
-this version. The project-level setting for both is merged upstream and lands in
-a later stable.
+Impeller is already the default on iOS and Android, so those need only the one entry.
+
+Windows and Linux set it on the `DartProject` their runner builds, alongside Impeller, which is not the default on desktop either. This needs Flutter 3.47.1.
+
+```c
+// linux/runner/my_application.cc
+g_autoptr(FlDartProject) project = fl_dart_project_new();
+fl_dart_project_set_enable_impeller(project, TRUE);
+fl_dart_project_set_enable_flutter_gpu(project, TRUE);
+```
+
+```cpp
+// windows/runner/main.cpp
+flutter::DartProject project(L"data");
+project.set_enable_impeller(true);
+project.set_enable_flutter_gpu(true);
+```
+
+On 3.47.0 there is no such setting, so desktop takes the command-line flags per run, and release builds compile the engine's environment switches out, meaning a shipped Windows or Linux release needs 3.47.1.
 
 ### The asset pipeline
 
@@ -220,8 +233,8 @@ On the web, no flags are needed; it works under both the CanvasKit and Skwasm re
 |          Android | 🟢 Supported                     |
 |              Web | 🟢 Supported                     |
 |            MacOS | 🟢 Supported                     |
-|          Windows | 🟢 Supported (no project setting yet) |
-|            Linux | 🟢 Supported (no project setting yet) |
+|          Windows | 🟢 Supported (3.47.1 to ship a release) |
+|            Linux | 🟢 Supported (3.47.1 to ship a release) |
 | Custom embedders | 🟢 Supported                     |
 
 ### **Q:** How does web support work?

--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -138,7 +138,32 @@ On 3.47.0 there is no such setting, so desktop takes the command-line flags per 
 `init` writes a `hook/build.dart` that converts your assets at build time,
 creates `flutter_scene_generated/` with a `.gitignore` for its outputs, and adds
 that one directory to `flutter.assets` in your `pubspec.yaml`. It is safe to run
-again.
+again, and it will not overwrite a `hook/build.dart` you wrote yourself. It
+prints a block to paste into your existing `build()` callback instead.
+
+The hook it writes discovers `.glb` and `.fscene` models, `.fmat` materials, and
+loose images under `assets/`, and converts each one:
+
+```dart
+// hook/build.dart
+import 'package:flutter_scene/build_hooks.dart';
+import 'package:hooks/hooks.dart';
+
+void main(List<String> args) async {
+  await build(args, (input, output) async {
+    buildScenes(buildInput: input, buildOutput: output);
+    await buildMaterials(buildInput: input, buildOutput: output);
+  });
+}
+```
+
+The one line it adds to your `pubspec.yaml`:
+
+```yaml
+flutter:
+  assets:
+    - flutter_scene_generated/
+```
 
 Upgrading from an earlier version, run it again. Generated assets now go into
 that directory on every Flutter release, so re-running `init` migrates the hook
@@ -168,6 +193,18 @@ For a model that only exists once the app is running, because you download it or
 the user supplies it, import the `.glb` directly with
 `Node.fromGlbAsset('assets/model.glb')`. That needs no hook, and it parses the
 glTF on every load, so prefer the pipeline whenever the model ships with you.
+
+### Where to go next
+
+[fscene.dev](https://fscene.dev) carries the full documentation. [Your first
+scene](https://fscene.dev/getting-started/your-first-scene/) renders something on
+screen from here, and the [guides](https://fscene.dev/guides/) cover each
+subsystem in depth with live demos, including [assets and
+loading](https://fscene.dev/guides/assets-and-loading/), [materials](https://fscene.dev/guides/materials/),
+[lighting and environment](https://fscene.dev/guides/lighting-and-environment/),
+[animation](https://fscene.dev/guides/animation/), and [cameras](https://fscene.dev/guides/cameras/).
+The [API reference](https://fscene.dev/api/flutter_scene/latest/) documents every
+public symbol.
 
 ## Requirements
 

--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -172,7 +172,7 @@ its `.gitignore` for you.
 
 Flutter Scene is pre-1.0 and evolving quickly. Minor releases can carry breaking changes, and every change is documented in the [CHANGELOG](https://github.com/bdero/flutter_scene/blob/master/packages/flutter_scene/CHANGELOG.md).
 
-- Flutter 3.47 (stable) or newer. Rendering is built on [Flutter GPU](https://github.com/flutter/flutter/blob/main/docs/engine/impeller/Flutter-GPU.md), which every platform except the web needs turned on once (see [Enable Flutter GPU](#enable-flutter-gpu)). A master build numbered `3.47.0-1.0.pre.N` sorts below `3.47.0` and will not resolve, so use the 3.48 development series or later.
+- Flutter 3.47 (stable) or newer. Rendering is built on [Flutter GPU](https://github.com/flutter/flutter/blob/main/docs/engine/impeller/Flutter-GPU.md), which every platform except the web needs turned on once (see [Enable Flutter GPU](#enable-flutter-gpu)).
 - On native platforms rendering runs on [Impeller](https://docs.flutter.dev/perf/impeller#availability), Flutter's default renderer on every native platform as of 3.47. The web has no Impeller, so the package ships its own WebGL2 backend and runs there without flags.
 
 ## Features

--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -95,12 +95,15 @@ the build by flutter_scene's own build hook. Rendering goes through Flutter GPU,
 which is off by default, so enable it once per platform (below). The web needs
 nothing.
 
+Impeller, which Flutter GPU builds on, is the default renderer on every native
+platform as of 3.47, so there is nothing to do for it.
+
 ### Enable Flutter GPU
 
 While developing, pass the flags on the command line:
 
 ```sh
-flutter run --enable-flutter-gpu --enable-impeller
+flutter run --enable-flutter-gpu
 ```
 
 To turn it on permanently, for every run and for the app you ship, edit the
@@ -110,24 +113,20 @@ platform file:
 | --- | --- | --- |
 | iOS | `ios/Runner/Info.plist` | `<key>FLTEnableFlutterGPU</key><true/>` |
 | Android | `android/app/src/main/AndroidManifest.xml`, in `<application>` | `<meta-data android:name="io.flutter.embedding.android.EnableFlutterGPU" android:value="true" />` |
-| macOS | `macos/Runner/Info.plist` | `<key>FLTEnableFlutterGPU</key><true/>` and `<key>FLTEnableImpeller</key><true/>` |
+| macOS | `macos/Runner/Info.plist` | `<key>FLTEnableFlutterGPU</key><true/>` |
 | Web | nothing | |
 
-Impeller is already the default on iOS and Android, so those need only the one entry.
-
-Windows and Linux set it on the `DartProject` their runner builds, alongside Impeller, which is not the default on desktop either. This needs Flutter 3.47.1.
+Windows and Linux set it on the `DartProject` their runner builds. This needs Flutter 3.47.1.
 
 ```c
 // linux/runner/my_application.cc
 g_autoptr(FlDartProject) project = fl_dart_project_new();
-fl_dart_project_set_enable_impeller(project, TRUE);
 fl_dart_project_set_enable_flutter_gpu(project, TRUE);
 ```
 
 ```cpp
 // windows/runner/main.cpp
 flutter::DartProject project(L"data");
-project.set_enable_impeller(true);
 project.set_enable_flutter_gpu(true);
 ```
 
@@ -174,7 +173,7 @@ its `.gitignore` for you.
 Flutter Scene is pre-1.0 and evolving quickly. Minor releases can carry breaking changes, and every change is documented in the [CHANGELOG](https://github.com/bdero/flutter_scene/blob/master/packages/flutter_scene/CHANGELOG.md).
 
 - Flutter 3.47 (stable) or newer. Rendering is built on [Flutter GPU](https://github.com/flutter/flutter/blob/main/docs/engine/impeller/Flutter-GPU.md), which every platform except the web needs turned on once (see [Enable Flutter GPU](#enable-flutter-gpu)). A master build numbered `3.47.0-1.0.pre.N` sorts below `3.47.0` and will not resolve, so use the 3.48 development series or later.
-- On native platforms rendering runs on [Impeller](https://docs.flutter.dev/perf/impeller#availability), which is Flutter's default renderer on iOS and Android and enabled with a flag on desktop (`--enable-impeller --enable-flutter-gpu`). The web has no Impeller, so the package ships its own WebGL2 backend and runs there without flags.
+- On native platforms rendering runs on [Impeller](https://docs.flutter.dev/perf/impeller#availability), Flutter's default renderer on every native platform as of 3.47. The web has no Impeller, so the package ships its own WebGL2 backend and runs there without flags.
 
 ## Features
 
@@ -223,7 +222,7 @@ Flutter Scene is pre-1.0 and evolving quickly. Minor releases can carry breaking
 
 On native platforms `flutter_scene` runs anywhere [Impeller](https://docs.flutter.dev/perf/impeller#availability) does. On the web it runs on a built-in WebGL2 backend.
 
-Every native platform needs Flutter GPU turned on, and the desktop ones need Impeller turned on with it, since Impeller is only the default on iOS and Android. [Enable Flutter GPU](#enable-flutter-gpu) has the file and the key for each.
+Every native platform needs Flutter GPU turned on. Impeller, which it builds on, is already the default everywhere. [Enable Flutter GPU](#enable-flutter-gpu) has the file and the key for each.
 
 On the web, no flags are needed; it works under both the CanvasKit and Skwasm renderers.
 


### PR DESCRIPTION
The readme told readers there was nothing to configure beyond `flutter pub add`, which is true only on the web. Flutter GPU is off by default everywhere else, so this adds the file to edit and the key to add for each platform.

Keys verified against the 3.47 engine source. iOS and macOS read `FLTEnableFlutterGPU` from Info.plist, Android reads `io.flutter.embedding.android.EnableFlutterGPU` from the manifest, and macOS needs `FLTEnableImpeller` alongside it. Windows and Linux have no project setting on 3.47, and their release builds compile the engine's environment switches out, so the readme says so rather than implying a workaround exists.