### PR TITLE
Release 0.21.1

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.1
+
+* Documentation only. The readme spells out how to turn Flutter GPU on for each platform, shows the build hook and the pubspec entry `dart run flutter_scene:init` writes, recommends converting assets ahead of time over importing glTF at runtime, and links the guides at fscene.dev.
+
 ## 0.21.0
 
 * Requires Flutter 3.47.0 or newer. That is the first stable carrying the Flutter GPU support this package needs, so the constraint is a real minimum rather than the loose value earlier releases carried. A master build numbered `3.47.0-1.0.pre.N` sorts below it and will not resolve.

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_scene
 description: A flexible realtime 3D engine for Flutter games and apps, with glTF models, physics, skeletal animation, and PBR lighting.
-version: 0.21.0
+version: 0.21.1
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
 topics:


### PR DESCRIPTION
Documentation only. The readme rewrite from #336 ships in the package archive, so it reaches pub.dev through a release.