### PR TITLE
Track the Flutter master windowing rename in the editor

### DIFF
--- a/apps/flutter_scene_editor_app/lib/main.dart
+++ b/apps/flutter_scene_editor_app/lib/main.dart
@@ -31,7 +31,7 @@ void main() {
     exit(1);
   }
   WidgetsFlutterBinding.ensureInitialized();
-  final controller = RegularWindowController(
+  final controller = WindowController(
     size: const Size(1280, 800),
     // The runner styles the window with a hidden title bar by this title
     // (see AppDelegate.swift); keep the two in sync.
@@ -39,13 +39,13 @@ void main() {
     delegate: _MainWindowDelegate(),
   );
   runWidget(
-    RegularWindow(controller: controller, child: const FlutterSceneEditorApp()),
+    Window(controller: controller, child: const FlutterSceneEditorApp()),
   );
 }
 
 /// Quits the app when the main editor window closes, taking any floating
 /// panel windows with it.
-class _MainWindowDelegate with RegularWindowControllerDelegate {
+class _MainWindowDelegate with WindowControllerDelegate {
   @override
   void onWindowDestroyed() {
     exit(0);

--- a/packages/flutter_scene_editor/lib/src/panels/outliner_panel.dart
+++ b/packages/flutter_scene_editor/lib/src/panels/outliner_panel.dart
@@ -5,7 +5,6 @@ import 'package:scene/scene.dart';
 // ignore: implementation_imports
 import 'package:flutter/material.dart';
 // Not re-exported through material.dart on 3.47 stable.
-import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/services.dart';
 
 import '../controller/editor_controller.dart';

--- a/packages/flutter_scene_editor/lib/src/shell/docking_shell.dart
+++ b/packages/flutter_scene_editor/lib/src/shell/docking_shell.dart
@@ -81,7 +81,7 @@ class _DockingShellState extends State<DockingShell> {
 
   // One native window per floating panel, keyed by panel id and kept in sync
   // with the layout's floating list.
-  final Map<String, RegularWindowController> _floatControllers = {};
+  final Map<String, WindowController> _floatControllers = {};
 
   @override
   void initState() {
@@ -139,7 +139,7 @@ class _DockingShellState extends State<DockingShell> {
     for (final id in _layout.floating) {
       _floatControllers.putIfAbsent(
         id,
-        () => RegularWindowController(
+        () => WindowController(
           size: const Size(480, 640),
           title: _panelById(id)?.title ?? id,
           delegate: _FloatWindowDelegate(() => _redock(id)),
@@ -168,7 +168,7 @@ class _DockingShellState extends State<DockingShell> {
         views: [
           for (final id in _layout.floating)
             if (_floatControllers[id] != null)
-              RegularWindow(
+              Window(
                 controller: _floatControllers[id]!,
                 child: _FloatWindowScaffold(
                   theme: theme,
@@ -226,13 +226,13 @@ class _DockingShellState extends State<DockingShell> {
 
 /// Re-docks the panel instead of destroying the window outright when the user
 /// clicks the native close button; the shell then tears the window down.
-class _FloatWindowDelegate with RegularWindowControllerDelegate {
+class _FloatWindowDelegate with WindowControllerDelegate {
   _FloatWindowDelegate(this.onCloseRequested);
 
   final VoidCallback onCloseRequested;
 
   @override
-  void onWindowCloseRequested(RegularWindowController controller) {
+  void onWindowCloseRequested(WindowController controller) {
     onCloseRequested();
   }
 }


### PR DESCRIPTION
The Flutter master channel dropped the `Regular` prefix from its experimental multi-window API, so the editor's floating-panel code stopped analyzing on the master lane (and master's own CI is red on it). `RegularWindowController` is now `WindowController`, `RegularWindow` is `Window`, `RegularWindowControllerDelegate` is `WindowControllerDelegate`, and `ScrollCacheExtent` is re-exported from `material.dart`. Signatures and delegate methods are unchanged, so this is a straight rename.

Verified against flutter/flutter at the framework revision the failing run used; it could not be compiled locally since local Flutter is on stable, which still has the old names, so the master Lint check here is the real confirmation.
