### PR TITLE
Add Node.mutateLocalTransform for a safe in-place matrix edit

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.22.0
 
 * `Node.position`, `Node.rotation`, and `Node.scale` read and write the local transform one component at a time, and editing a returned copy in place throws in debug builds rather than silently doing nothing.
+* `Node.mutateLocalTransform` edits the local matrix in place through a callback and marks the node dirty, the correct way to reach for the raw matrix.
 * A frame that draws nothing now prints once in debug builds naming the likely cause (not ready, empty region, no views composite to screen, no visible meshes, or a layer mask matching nothing).
 * Degenerate cameras now assert in debug builds, catching a view direction of zero length, an `up` parallel to it, and a field of view passed in degrees.
 * The web backend now throws on a bind to a shader uniform or texture name that does not exist, matching native, instead of silently sampling whatever was bound last.

--- a/packages/flutter_scene/lib/src/node.dart
+++ b/packages/flutter_scene/lib/src/node.dart
@@ -154,15 +154,37 @@ base class Node implements SceneGraph {
   /// The transform of this node relative to its parent: position,
   /// rotation, and scale.
   ///
-  /// Assigning marks this node and its descendants' cached world
-  /// transforms stale, and this node and its ancestors' cached bounds
-  /// stale. Mutating the returned matrix in place does not, so call
-  /// [markTransformDirty] after an in-place edit. [position], [rotation],
-  /// and [scale] read and write the same transform one component at a
-  /// time.
+  /// Prefer [position], [rotation], and [scale] for the common case, or
+  /// assign a whole matrix. Both mark this node and its descendants' cached
+  /// world transforms stale, and this node and its ancestors' cached bounds
+  /// stale.
+  ///
+  /// The getter returns the live matrix, so editing it in place does NOT
+  /// mark anything stale and the node silently will not move (debug builds
+  /// throw on the next read). To edit in place, use [mutateLocalTransform],
+  /// which dirties for you, or assign a fresh matrix
+  /// (`node.localTransform = node.localTransform.clone()..translateByVector3(...)`).
   Matrix4 get localTransform => _localTransform;
   set localTransform(Matrix4 value) {
     _localTransform = value;
+    _localTransformTrs = null;
+    markTransformDirty();
+  }
+
+  /// Edits [localTransform] in place through [edit], then marks the node
+  /// stale.
+  ///
+  /// The correct way to reach for the raw matrix, since a bare
+  /// `localTransform.translateByVector3(...)` mutates the live matrix without
+  /// dirtying the cache and the node silently will not move. [position],
+  /// [rotation], and [scale] cover most edits without a matrix.
+  ///
+  /// ```dart
+  /// node.mutateLocalTransform((m) => m.translateByVector3(Vector3(0.0, 1.0, 0.0)));
+  /// ```
+  /// {@category Scene graph}
+  void mutateLocalTransform(void Function(Matrix4 transform) edit) {
+    edit(_localTransform);
     _localTransformTrs = null;
     markTransformDirty();
   }

--- a/packages/flutter_scene/test/node_test.dart
+++ b/packages/flutter_scene/test/node_test.dart
@@ -141,6 +141,25 @@ void main() {
       expect(() => child.globalTransform, returnsNormally);
       expect(() => parent.globalTransform, throwsStateError);
     });
+
+    test('mutateLocalTransform edits in place and marks dirty', () {
+      final node = Node();
+      node.globalTransform; // Fill the cache.
+      node.mutateLocalTransform(
+        (m) => m.translateByVector3(Vector3(0.0, 1.0, 0.0)),
+      );
+
+      // No throw, and the edit is reflected, so the cache was invalidated.
+      expect(node.globalTransform.getTranslation(), Vector3(0.0, 1.0, 0.0));
+    });
+
+    test('mutateLocalTransform clears the authored decomposition', () {
+      final node = Node()..scale = Vector3(2.0, 2.0, 2.0);
+      expect(node.localTransformTrs, isNotNull);
+      node.mutateLocalTransform((m) => m.setTranslationRaw(1.0, 0.0, 0.0));
+
+      expect(node.localTransformTrs, isNull);
+    });
   });
 
   group('position, rotation, and scale', () {


### PR DESCRIPTION
Adds `Node.mutateLocalTransform`, a callback that edits the local matrix in place and marks the node dirty, and rewrites the `localTransform` docs to steer toward it and the component accessors.

The raw matrix getter returns the live matrix, so a bare `localTransform.translateByVector3(...)` mutates it without dirtying the cache and the node silently does not move (debug builds now throw on that). Until now there was no compiling, dirtying, in-place idiom for the matrix at all, since vector_math's mutators return void. `mutateLocalTransform((m) => ...)` is that idiom. `position`, `rotation`, and `scale` still cover most edits without a matrix.

Rides the unreleased 0.22.0.
