### PR TITLE
Add the verification-loop, looks, procedural, and performance agent skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,22 +47,29 @@ They do not exist here, or they break the build.
 
 Cold assumptions undersell the engine. Before hand-rolling any of these, know they exist: **directional, point, spot, and area lights, shadows (PCSS and contact shadows), GTAO ambient occlusion, screen-space reflections, SSGI, depth of field, god rays, fog, auto exposure, LUT color grading, bloom, anti-aliasing, tone mapping, instancing, and LOD**, plus ten built-in primitive geometries and `GeometryBuilder` for custom meshes. Custom `ShaderMaterial` output is linear HDR premultiplied by alpha; the engine applies exposure, tone mapping, and the display transform afterward.
 
-## The agent skill
+## The agent skills
 
-This repo ships an on-demand skill with the full correct-usage guidance, at `packages/flutter_scene/skills/flutter_scene-idioms/`. Install it into a project so a coding assistant loads it when relevant:
+This repo ships a set of on-demand skills under `packages/flutter_scene/skills/`, each loaded by a coding assistant when its topic comes up:
+
+- `flutter_scene-idioms` correct usage and the traps that fail silently (the depth behind this file).
+- `flutter_scene-verification-loop` the closed run-settle-capture-correct loop for seeing your own output.
+- `flutter_scene-looks` copy-paste presets that make a scene look deliberate (lighting plus post).
+- `flutter_scene-procedural` building content from code (terrain, noise, instancing) instead of asset files.
+
+Install them into a project:
 
 ```sh
-dart run flutter_scene:skills          # install or update
-dart run flutter_scene:skills --check  # report whether a newer skill ships
+dart run flutter_scene:skills          # install or update every bundled skill
+dart run flutter_scene:skills --check  # report whether newer skills ship
 ```
 
-`dart run flutter_scene:init` also offers to install it. The skill also installs through the standard Dart skills tool, which discovers it from your dependency tree along with any other package's skills:
+`dart run flutter_scene:init` also offers to install them. They also install through the standard Dart skills tool, which discovers them from your dependency tree along with any other package's skills:
 
 ```sh
 dart run skills@ get   # install skills shipped by your dependencies
 ```
 
-Either path installs the same skill. The skill carries the false-absence inventory and the full trap list that this file only summarizes.
+Either path installs the same skills.
 
 ## Running things in this repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ This repo ships a set of on-demand skills under `packages/flutter_scene/skills/`
 - `flutter_scene-verification-loop` the closed run-settle-capture-correct loop for seeing your own output.
 - `flutter_scene-looks` copy-paste presets that make a scene look deliberate (lighting plus post).
 - `flutter_scene-procedural` building content from code (terrain, noise, instancing) instead of asset files.
+- `flutter_scene-performance` hitting frame budget (measure which thread is over, then a fixed remediation order).
 
 Install them into a project:
 

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.22.2
+
+* Three new agent skills alongside `flutter_scene-idioms`: `flutter_scene-verification-loop` (the run-settle-capture-correct visual loop and the blind-pairwise judgment rule), `flutter_scene-looks` (copy-paste `EnvironmentSettings` presets for a deliberate look), and `flutter_scene-procedural` (terrain, noise, and instancing from code). `dart run flutter_scene:init` and `dart run flutter_scene:skills` now install every bundled skill.
+
 ## 0.22.1
 
 * Camera controllers `OrbitCameraController`, `FlyCameraController`, and `FollowCameraController` drive a camera node from drag, scroll, and keyboard input with frame-rate-independent smoothing and clamped pitch. The `CameraControls` widget wires Flutter input to a controller; controllers also expose intent methods (`orbitBy`, `dollyBy`, `look`, ...) for driving them from any source.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.22.2
 
-* Three new agent skills alongside `flutter_scene-idioms`: `flutter_scene-verification-loop` (the run-settle-capture-correct visual loop and the blind-pairwise judgment rule), `flutter_scene-looks` (copy-paste `EnvironmentSettings` presets for a deliberate look), and `flutter_scene-procedural` (terrain, noise, and instancing from code). `dart run flutter_scene:init` and `dart run flutter_scene:skills` now install every bundled skill.
+* Four new agent skills alongside `flutter_scene-idioms`: `flutter_scene-verification-loop` (the run-settle-capture-correct visual loop and the blind-pairwise judgment rule), `flutter_scene-looks` (copy-paste `EnvironmentSettings` presets for a deliberate look), `flutter_scene-procedural` (terrain, noise, and instancing from code), and `flutter_scene-performance` (frame-budget measurement and a fixed remediation order). `dart run flutter_scene:init` and `dart run flutter_scene:skills` now install every bundled skill.
 
 ## 0.22.1
 

--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -103,7 +103,8 @@ platform as of 3.47, so there is nothing to do for it.
 
 This package ships a set of agent skills so a coding assistant writes idiomatic
 Scene instead of guessing: correct usage and traps, the run-settle-capture
-verification loop, copy-paste look presets, and procedural content. `dart run
+verification loop, copy-paste look presets, procedural content, and
+performance. `dart run
 flutter_scene:init` offers to install them, and `dart run flutter_scene:skills`
 installs, updates, or checks them on their own without touching your build hook.
 Upgrading Scene can carry newer revisions; `dart run flutter_scene:skills

--- a/packages/flutter_scene/README.md
+++ b/packages/flutter_scene/README.md
@@ -101,12 +101,13 @@ platform as of 3.47, so there is nothing to do for it.
 
 ### Coding agents
 
-This package ships an agent skill, correct-usage guidance so a coding assistant
-writes idiomatic Scene instead of guessing from other 3D engines. `dart run
-flutter_scene:init` offers to install it, and `dart run flutter_scene:skills`
-installs, updates, or checks it on its own without touching your build hook.
-Upgrading Scene can carry a newer revision of the skill; `dart run
-flutter_scene:skills --check` reports whether one is available.
+This package ships a set of agent skills so a coding assistant writes idiomatic
+Scene instead of guessing: correct usage and traps, the run-settle-capture
+verification loop, copy-paste look presets, and procedural content. `dart run
+flutter_scene:init` offers to install them, and `dart run flutter_scene:skills`
+installs, updates, or checks them on their own without touching your build hook.
+Upgrading Scene can carry newer revisions; `dart run flutter_scene:skills
+--check` reports whether any are available.
 
 ### Enable Flutter GPU
 

--- a/packages/flutter_scene/bin/init.dart
+++ b/packages/flutter_scene/bin/init.dart
@@ -12,7 +12,7 @@ Future<void> main(List<String> args) async {
     );
     stdout.writeln('');
     stdout.writeln(
-      'By default it also offers to install the flutter_scene agent skill '
+      'By default it also offers to install the flutter_scene agent skills '
       '(correct-usage guidance for coding agents) into this project. It asks '
       'first at a terminal. Pass --skills to install or update without asking '
       '(for CI), or --no-skills to skip it. To manage the skill on its own '
@@ -56,13 +56,13 @@ Future<void> _handleSkill(List<String> args) async {
     case SkillInstallAction.sourceMissing:
       if (forced) {
         stdout.writeln(
-          'Could not locate the bundled flutter_scene skill to install.',
+          'Could not locate the bundled flutter_scene skills to install.',
         );
       }
       return;
     case SkillInstallAction.upToDate:
       if (forced) {
-        stdout.writeln('The flutter_scene agent skill is up to date.');
+        stdout.writeln('The flutter_scene agent skills are up to date.');
       }
       return;
     case SkillInstallAction.install:
@@ -74,8 +74,8 @@ Future<void> _handleSkill(List<String> args) async {
   var go = forced;
   if (!go) {
     void skip() => stdout.writeln(
-      'Skipping the flutter_scene agent skill. Run with --skills to install '
-      'or update it, or --no-skills to silence this.',
+      'Skipping the flutter_scene agent skills. Run with --skills to install '
+      'or update them, or --no-skills to silence this.',
     );
     if (!stdin.hasTerminal) {
       skip();
@@ -84,9 +84,8 @@ Future<void> _handleSkill(List<String> args) async {
     final where = plan.homes.join(', ');
     stdout.write(
       update
-          ? 'Update the flutter_scene agent skill (v${plan.installedVersion} '
-                'to v${plan.bundledVersion}) in $where? [Y/n] '
-          : 'Install the flutter_scene agent skill (correct-usage guidance '
+          ? 'Update the flutter_scene agent skills in $where? [Y/n] '
+          : 'Install the flutter_scene agent skills (correct-usage guidance '
                 'for coding agents) into $where? [y/N] ',
     );
     // Closed stdin (a misdetected terminal, or piped input in CI) reads as

--- a/packages/flutter_scene/bin/skills.dart
+++ b/packages/flutter_scene/bin/skills.dart
@@ -10,7 +10,7 @@ Future<void> main(List<String> args) async {
     stdout.writeln('Usage: dart run flutter_scene:skills [--check]');
     stdout.writeln('');
     stdout.writeln(
-      'Installs or updates the flutter_scene agent skill (correct-usage '
+      'Installs or updates the flutter_scene agent skills (correct-usage '
       'guidance for coding agents) into this project. Unlike '
       'flutter_scene:init it does not modify hook/build.dart or pubspec.yaml, '
       'so it is safe to run after customizing those.',

--- a/packages/flutter_scene/lib/src/fmat/init_command.dart
+++ b/packages/flutter_scene/lib/src/fmat/init_command.dart
@@ -81,15 +81,13 @@ Future<InitHookResult> installFlutterSceneBuildHook({
   );
 }
 
-/// The bundled agent skill teaching correct flutter_scene usage.
-///
-/// When you change the skill content under `skills/flutter_scene-idioms/`,
-/// bump the `version:` field in its SKILL.md, or an already-installed copy is
-/// not detected as stale and never offered an update.
-const String flutterSceneSkillName = 'flutter_scene-idioms';
-
-// Agent skill homes. The skill installs under `<parent>/skills/` for every
-// parent already present in the project, defaulting to `.claude` when none is.
+// The bundled agent skills teaching correct flutter_scene usage each live at
+// `skills/<name>/` with a SKILL.md. When you change a skill's content, bump the
+// `version:` field in its SKILL.md, or an already-installed copy is not detected
+// as stale and never offered an update.
+//
+// Each skill installs under `<parent>/skills/<name>/` for every agent parent
+// already present in the project, defaulting to `.claude` when none is.
 const List<String> _agentSkillParents = <String>[
   '.claude',
   '.cursor',
@@ -121,21 +119,25 @@ enum SkillInstallAction {
 final class SkillInstallPlan {
   const SkillInstallPlan(
     this.action, {
-    this.bundledVersion,
-    this.installedVersion,
+    this.skillNames = const [],
     this.homes = const [],
+    this.installCount = 0,
+    this.updateCount = 0,
   });
 
   final SkillInstallAction action;
 
-  /// The version shipped with this package.
-  final int? bundledVersion;
+  /// The bundled skill names, sorted.
+  final List<String> skillNames;
 
-  /// The lowest version found across target homes, or null when absent.
-  final int? installedVersion;
-
-  /// The agent-home skill paths that a write would create or refresh.
+  /// The agent skill-home dirs a write touches (e.g. `.claude/skills`).
   final List<String> homes;
+
+  /// Bundled skills missing from at least one home.
+  final int installCount;
+
+  /// Bundled skills with an older copy in at least one home.
+  final int updateCount;
 }
 
 /// Inspects the skill state without writing. Callers use [SkillInstallPlan.action]
@@ -143,37 +145,54 @@ final class SkillInstallPlan {
 /// [installFlutterSceneSkills].
 Future<SkillInstallPlan> planFlutterSceneSkillInstall({
   Directory? projectRoot,
-  Uri? skillSource,
+  Uri? skillsRoot,
 }) async {
   final root = projectRoot ?? Directory.current;
-  final source = skillSource ?? await _resolveBundledSkill();
-  if (source == null || !Directory.fromUri(source).existsSync()) {
+  final rootUri = skillsRoot ?? await _resolveBundledSkillsRoot();
+  final bundled = rootUri == null
+      ? const <({String name, Uri dir})>[]
+      : _bundledSkills(rootUri);
+  if (bundled.isEmpty) {
     return const SkillInstallPlan(SkillInstallAction.sourceMissing);
   }
 
-  final bundled = _skillVersion(File.fromUri(source.resolve('SKILL.md')));
-  final homes = _skillHomes(root);
-
-  int? installed;
-  for (final home in homes) {
-    final file = File.fromUri(root.uri.resolve('$home/SKILL.md'));
-    if (!file.existsSync()) continue;
-    final version = _skillVersion(file);
-    installed = installed == null
-        ? version
-        : (version < installed ? version : installed);
+  final homes = _presentSkillHomes(root);
+  var installCount = 0;
+  var updateCount = 0;
+  for (final skill in bundled) {
+    final bundledVersion = _skillVersion(
+      File.fromUri(skill.dir.resolve('SKILL.md')),
+    );
+    var missingSomewhere = false;
+    var staleSomewhere = false;
+    for (final home in homes) {
+      final file = File.fromUri(
+        root.uri.resolve('$home/${skill.name}/SKILL.md'),
+      );
+      if (!file.existsSync()) {
+        missingSomewhere = true;
+      } else if (_skillVersion(file) < bundledVersion) {
+        staleSomewhere = true;
+      }
+    }
+    if (missingSomewhere) {
+      installCount++;
+    } else if (staleSomewhere) {
+      updateCount++;
+    }
   }
 
-  final action = installed == null
+  final action = installCount > 0
       ? SkillInstallAction.install
-      : (bundled > installed
+      : (updateCount > 0
             ? SkillInstallAction.update
             : SkillInstallAction.upToDate);
   return SkillInstallPlan(
     action,
-    bundledVersion: bundled,
-    installedVersion: installed,
+    skillNames: [for (final s in bundled) s.name],
     homes: homes,
+    installCount: installCount,
+    updateCount: updateCount,
   );
 }
 
@@ -182,20 +201,19 @@ Future<SkillInstallPlan> planFlutterSceneSkillInstall({
 String describeSkillPlan(SkillInstallPlan plan) {
   switch (plan.action) {
     case SkillInstallAction.sourceMissing:
-      return 'Could not locate the bundled flutter_scene skill. This package '
-          'version may predate it, or it is a git dependency published '
-          'without it.';
+      return 'Could not locate the bundled flutter_scene skills. This package '
+          'version may predate them, or it is a git dependency published '
+          'without them.';
     case SkillInstallAction.upToDate:
-      return 'The flutter_scene agent skill is up to date '
-          '(v${plan.bundledVersion}).';
+      return 'The flutter_scene agent skills are up to date '
+          '(${plan.skillNames.length} installed).';
     case SkillInstallAction.install:
-      return 'The flutter_scene agent skill (v${plan.bundledVersion}) is not '
-          'installed. Install it with: dart run flutter_scene:skills';
+      return '${plan.installCount} of the flutter_scene agent skills '
+          '(${plan.skillNames.length} total) are not installed. Install them '
+          'with: dart run flutter_scene:skills';
     case SkillInstallAction.update:
-      return 'A newer flutter_scene agent skill is available (installed '
-          'v${plan.installedVersion}, this package ships '
-          'v${plan.bundledVersion}). Update it with: '
-          'dart run flutter_scene:skills';
+      return '${plan.updateCount} flutter_scene agent skill(s) have a newer '
+          'version available. Update with: dart run flutter_scene:skills';
   }
 }
 
@@ -208,41 +226,68 @@ final class InitSkillResult {
   final String message;
 }
 
-/// Copies the bundled `flutter_scene-idioms` skill into the project's agent
-/// skill homes. Writes into every known agent home already present, or `.claude`
-/// by default, and overwrites so an upgrade refreshes the skill. Never called
-/// without the caller having established consent (a prompt or a flag).
+/// Copies every bundled skill into the project's agent skill homes. Writes
+/// `<home>/skills/<skill>/` into every known agent home already present, or
+/// `.claude` by default, and overwrites so an upgrade refreshes each skill.
+/// Never called without the caller having established consent (a prompt or a
+/// flag).
 Future<InitSkillResult> installFlutterSceneSkills({
   Directory? projectRoot,
-  Uri? skillSource,
+  Uri? skillsRoot,
 }) async {
   final root = projectRoot ?? Directory.current;
-  final source = skillSource ?? await _resolveBundledSkill();
-  if (source == null || !Directory.fromUri(source).existsSync()) {
+  final rootUri = skillsRoot ?? await _resolveBundledSkillsRoot();
+  final bundled = rootUri == null
+      ? const <({String name, Uri dir})>[]
+      : _bundledSkills(rootUri);
+  if (bundled.isEmpty) {
     return const InitSkillResult(
       InitSkillStatus.sourceMissing,
-      'Could not locate the bundled flutter_scene skill; skipped skill install.',
+      'Could not locate the bundled flutter_scene skills; skipped skill '
+      'install.',
     );
   }
 
-  final homes = _skillHomes(root);
+  final homes = _presentSkillHomes(root);
   for (final home in homes) {
-    _copyDirectory(source, root.uri.resolve('$home/'));
+    for (final skill in bundled) {
+      _copyDirectory(skill.dir, root.uri.resolve('$home/${skill.name}/'));
+    }
   }
+  final count = bundled.length;
   return InitSkillResult(
     InitSkillStatus.installed,
-    'Installed the flutter_scene agent skill into ${homes.join(', ')}.',
+    'Installed $count flutter_scene agent skill${count == 1 ? '' : 's'} into '
+    '${homes.join(', ')}.',
   );
 }
 
-// The agent-home skill paths to write to: `<parent>/skills/<skill>` for every
-// known parent already present, or `.claude` when none is.
-List<String> _skillHomes(Directory root) {
+// The agent skill-home dirs to write into: `<parent>/skills` for every known
+// parent already present, or `.claude/skills` when none is. Each bundled skill
+// lands in a `<name>/` subdirectory under one of these.
+List<String> _presentSkillHomes(Directory root) {
   final present = _agentSkillParents
       .where((p) => Directory.fromUri(root.uri.resolve('$p/')).existsSync())
       .toList();
   if (present.isEmpty) present.add('.claude');
-  return [for (final p in present) '$p/skills/$flutterSceneSkillName'];
+  return [for (final p in present) '$p/skills'];
+}
+
+// The bundled skills: every `skills/<name>/` directory holding a SKILL.md,
+// sorted by name.
+List<({String name, Uri dir})> _bundledSkills(Uri skillsRoot) {
+  final dir = Directory.fromUri(skillsRoot);
+  if (!dir.existsSync()) return const [];
+  final skills = <({String name, Uri dir})>[];
+  for (final entity in dir.listSync()) {
+    if (entity is! Directory) continue;
+    final skillDir = Uri.directory(entity.path);
+    if (!File.fromUri(skillDir.resolve('SKILL.md')).existsSync()) continue;
+    final segments = skillDir.pathSegments;
+    skills.add((name: segments[segments.length - 2], dir: skillDir));
+  }
+  skills.sort((a, b) => a.name.compareTo(b.name));
+  return skills;
 }
 
 // Reads the `version:` field from a SKILL.md frontmatter. A skill installed
@@ -264,13 +309,13 @@ int _skillVersion(File skill) {
   return 0;
 }
 
-// The bundled skill lives at the package root next to lib/, so resolve a
+// The bundled skills live at the package root next to lib/, so resolve a
 // library file and step up out of lib/.
-Future<Uri?> _resolveBundledSkill() async {
+Future<Uri?> _resolveBundledSkillsRoot() async {
   final lib = await Isolate.resolvePackageUri(
     Uri.parse('package:flutter_scene/scene.dart'),
   );
-  return lib?.resolve('../skills/$flutterSceneSkillName/');
+  return lib?.resolve('../skills/');
 }
 
 void _copyDirectory(Uri from, Uri to) {

--- a/packages/flutter_scene/pubspec.yaml
+++ b/packages/flutter_scene/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_scene
 description: A flexible realtime 3D engine for Flutter games and apps, with glTF models, physics, skeletal animation, and PBR lighting.
-version: 0.22.1
+version: 0.22.2
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
 topics:

--- a/packages/flutter_scene/skills/flutter_scene-looks/SKILL.md
+++ b/packages/flutter_scene/skills/flutter_scene-looks/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: flutter_scene-looks
+version: 1
+description: Give a flutter_scene render a deliberate, polished look. Use this whenever a scene looks flat, dull, or washed out, or whenever the ask is to make it look good, because a good look is lighting plus post-processing, not geometry. Ships copy-paste EnvironmentSettings presets that configure the whole stack coherently.
+---
+
+# Making flutter_scene look good
+
+The single most common reason a flutter_scene render looks amateur is that the post-processing stack was left at defaults. flutter_scene has a deep lit-and-post pipeline (image-based lighting, tone mapping, bloom, ambient occlusion, screen-space reflections, fog, god rays, depth of field, color grading, vignette, film grain). Out of the box almost all of it is off, so a bare scene is technically correct and visually flat.
+
+**The insight: a polished look is lighting and post-processing, not geometry.** Better meshes will not fix a flat render. Do not spend effort on modeling detail when the scene reads dull; spend it on the look. And a look is a *coherent* set of choices, not twelve knobs turned independently. Turning bloom, AO, SSR, fog, grain, and grading up one at a time, each by feel, lands in muddy incoherent territory. Pick one deliberate preset and paste it whole.
+
+## Apply a look in one line
+
+Every scene-wide look field lives on one aggregate value, `EnvironmentSettings`, assigned through a single setter:
+
+```dart
+scene.environmentSettings = EnvironmentSettings(/* fields below */);
+```
+
+That one assignment configures tone mapping, exposure, image-based-lighting intensity, and the entire post stack, **including** fog, god rays, depth of field, and auto exposure. You do not need to touch `scene.fog`, `scene.godRays`, `scene.depthOfField`, or `scene.autoExposure` separately; those are the live per-effect objects, but `EnvironmentSettings` carries all of their fields and applies them for you. Every effect is off by default, so a preset only names the fields it turns on.
+
+`EnvironmentSettings` is also a blendable snapshot. Read the current look with `scene.environmentSettings`, and cross-fade two looks with `EnvironmentSettings.lerp(a, b, t)` driven from an animation. That is how you transition day to night or ramp an effect in.
+
+## Lights are separate, and still matter
+
+`EnvironmentSettings` covers image-based lighting (the `environment` map) and the whole post stack, but **direct lights are not part of it.** Shadows, god rays, and any strong key light come from the scene's lights, set separately:
+
+```dart
+scene.directionalLight = DirectionalLight(
+  direction: vm.Vector3(-0.4, -1.0, -0.3),
+  intensity: 4.0,
+  castsShadow: true,        // shadows are off until you ask
+);
+```
+
+An unset `scene.environment` still resolves to a default studio IBL, so a `PhysicallyBasedMaterial` is always lit. But a scene with no direct light is soft and shadowless. God rays require a shadow-casting `DirectionalLight`; shadows require `castsShadow: true` on the light.
+
+## The four looks
+
+Paste one whole. Each is a real `EnvironmentSettings` literal; import `package:vector_math/vector_math.dart as vm` for the `Vector3` color fields. AO, SSR, god rays, and depth of field require a `PerspectiveCamera` (the only built-in camera).
+
+### showcase
+
+Clean, bright product-viz beauty. Punchy tone mapping, soft bloom on highlights, grounded contact occlusion, and real reflections. The default reach-for-it look.
+
+```dart
+scene.environmentSettings = EnvironmentSettings(
+  toneMapping: ToneMappingMode.aces,
+  exposure: 1.0,
+  bloomEnabled: true,
+  bloomThreshold: 1.1,
+  bloomIntensity: 0.2,
+  bloomScatter: 0.7,
+  ambientOcclusionEnabled: true,
+  ambientOcclusionMethod: AmbientOcclusionMethod.groundTruth,
+  ambientOcclusionBentNormals: true,
+  ambientOcclusionSpecularMode: SpecularAmbientOcclusionMode.bentCone,
+  ambientOcclusionIntensity: 1.0,
+  screenSpaceReflectionsEnabled: true,
+  screenSpaceReflectionsIntensity: 1.0,
+  vignetteEnabled: true,
+  vignetteIntensity: 0.25,
+);
+```
+
+### stylized
+
+Vivid and graphic. Saturated, slightly warm, glowing, flatter shading (no heavy occlusion or reflections). For playful or illustrative scenes.
+
+```dart
+scene.environmentSettings = EnvironmentSettings(
+  toneMapping: ToneMappingMode.aces,
+  colorGradingEnabled: true,
+  saturation: 1.25,
+  contrast: 1.1,
+  brightness: 1.05,
+  temperature: 0.1,
+  bloomEnabled: true,
+  bloomThreshold: 0.9,
+  bloomIntensity: 0.28,
+  bloomScatter: 0.8,
+  vignetteEnabled: true,
+  vignetteIntensity: 0.2,
+);
+```
+
+### moody
+
+Dark, cinematic, atmospheric. Lower exposure, cool graded, foggy, heavy vignette, subtle grain and aberration, deep occlusion. God rays if the scene has a shadow-casting sun. Use a cool horizon-colored fog.
+
+```dart
+scene.environmentSettings = EnvironmentSettings(
+  toneMapping: ToneMappingMode.aces,
+  exposure: 0.8,
+  colorGradingEnabled: true,
+  contrast: 1.15,
+  saturation: 0.9,
+  temperature: -0.1,
+  fogEnabled: true,
+  fogMode: FogMode.exponential,
+  fogColor: vm.Vector3(0.05, 0.06, 0.09),
+  fogDensity: 0.03,
+  ambientOcclusionEnabled: true,
+  ambientOcclusionMethod: AmbientOcclusionMethod.groundTruth,
+  ambientOcclusionIntensity: 1.2,
+  ambientOcclusionPower: 1.8,
+  vignetteEnabled: true,
+  vignetteIntensity: 0.6,
+  vignetteRadius: 0.6,
+  filmGrainEnabled: true,
+  filmGrainIntensity: 0.25,
+  chromaticAberrationEnabled: true,
+  chromaticAberrationIntensity: 0.15,
+  godRaysEnabled: true,          // needs scene.directionalLight with castsShadow: true
+  godRaysIntensity: 1.0,
+  godRaysDensity: 0.6,
+  godRaysColor: vm.Vector3(1.0, 0.95, 0.85),
+);
+```
+
+### clean
+
+Neutral and honest. Minimal post, no grading, no bloom, no vignette, just correct tone mapping and gentle grounding occlusion. The right look for an editor, an inspector, a UI-embedded viewer, or anywhere you want an accurate read of the actual material.
+
+```dart
+scene.environmentSettings = EnvironmentSettings(
+  toneMapping: ToneMappingMode.pbrNeutral,   // the engine default
+  exposure: 1.0,
+  ambientOcclusionEnabled: true,
+  ambientOcclusionIntensity: 0.8,
+  ambientOcclusionHalfResolution: true,
+);
+```
+
+## Tuning from a preset
+
+Start from the nearest look, then move one field at a time.
+
+- **Too dim or too bright overall.** Change `exposure` (default 1.0), not per-light intensity. Or turn on `autoExposureEnabled: true` to let the scene meter itself.
+- **Highlights not glowing.** Lower `bloomThreshold` toward 1.0 or below, or raise `bloomIntensity`. `bloomScatter` widens the glow.
+- **Reads flat and ungrounded.** `ambientOcclusionEnabled: true`. Use `AmbientOcclusionMethod.groundTruth` for quality, keep `ambientOcclusionHalfResolution: true` for cost.
+- **Colors feel wrong.** Turn on `colorGradingEnabled` and reach for `saturation`, `contrast`, `temperature`, `tint` before anything else.
+- **Wrong tone-map feel.** `ToneMappingMode.aces` is contrasty and filmic, `pbrNeutral` (default) preserves hue and saturation, `agx` is the most neutral highlight rolloff. Do not reintroduce an `exposure: 2.0` hack; that was an artifact of an older renderer.
+
+## Cost
+
+The post stack is not free. AO, SSR, depth of field, and god rays each add screen-space passes, and mobile and web are the budget. Keep `ambientOcclusionHalfResolution: true`, prefer `DepthOfFieldQuality.low` on mobile, and do not stack SSR plus god rays plus depth of field on a low-end target without profiling. The `clean` look is nearly free; `moody` is the heaviest. See `references/looks.md` for the full per-effect knob reference, defaults, and cost notes.

--- a/packages/flutter_scene/skills/flutter_scene-looks/references/looks.md
+++ b/packages/flutter_scene/skills/flutter_scene-looks/references/looks.md
@@ -1,0 +1,206 @@
+# The look stack, knob by knob
+
+Every field here is a constructor argument on `EnvironmentSettings` (`lib/src/environment_settings.dart`). Assigning `scene.environmentSettings = EnvironmentSettings(...)` applies all of them at once. Defaults are the constructor defaults; a preset only names what it changes. Direct lights (`scene.directionalLight` and friends) are separate and not covered by `EnvironmentSettings`.
+
+Color fields are `vm.Vector3` (import `package:vector_math/vector_math.dart as vm`).
+
+---
+
+## Base look
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `toneMapping` | `ToneMappingMode.pbrNeutral` | HDR to display operator. `pbrNeutral` preserves hue/saturation, `aces` is contrasty and filmic, `agx` has the gentlest highlight rolloff, `reinhard`/`linear` are simpler references. |
+| `exposure` | `1.0` | Linear scene exposure multiplier. The one knob for overall brightness. Do not use `2.0`; that was an old-renderer hack. |
+| `environmentIntensity` | `1.0` | Scales image-based lighting (the environment map) contribution. |
+| `agxWhite` | `16.29` | AgX white point, only meaningful with `ToneMappingMode.agx`. |
+| `agxContrast` | `1.25` | AgX contrast, only with `agx`. |
+
+`environment` (an `EnvironmentMap?`) and the sky fields are also on `EnvironmentSettings`, but building environment maps is the domain of the idioms skill; a null environment resolves to a default studio IBL.
+
+## Auto exposure (`autoExposure*`)
+
+Meters the frame and multiplies on top of `exposure`. Off by default.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `autoExposureEnabled` | `false` | Turn metering on. |
+| `autoExposureStrength` | `0.55` | How fully it drives toward the metered target (0 = none, 1 = full). |
+| `autoExposureCompensation` | `0.0` | EV bias applied after metering. |
+| `autoExposureMinEv` / `autoExposureMaxEv` | `-4.0` / `4.0` | Clamp range for the adaptation. |
+| `autoExposureSpeedUp` / `autoExposureSpeedDown` | `3.0` / `1.0` | Adaptation rate brightening vs darkening. |
+
+## Bloom (`bloom*`)
+
+Blooms bright pixels. Off by default. The cheapest way to make a scene feel lit rather than rendered.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `bloomEnabled` | `false` | Turn bloom on. |
+| `bloomThreshold` | `1.0` | Brightness above which a pixel blooms. Lower for more glow. |
+| `bloomIntensity` | `0.15` | Strength of the added glow. |
+| `bloomScatter` | `0.7` | Spread of the glow, wider values feel dreamier. |
+
+## Color grading (`colorGrading*`)
+
+Post-tone-map color shaping. Off by default. Reach here to change the *mood* of the color rather than the exposure.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `colorGradingEnabled` | `false` | Turn grading on. |
+| `brightness` | `1.0` | Multiplicative brightness. |
+| `contrast` | `1.0` | Contrast around mid-gray. |
+| `saturation` | `1.0` | Color saturation. Above 1 is vivid, below 1 desaturates toward gray. |
+| `temperature` | `0.0` | Warm (positive) to cool (negative) white balance. |
+| `tint` | `0.0` | Green to magenta balance. |
+| `lift` / `gamma` / `gain` | `Vector3(0)` / `Vector3(1)` / `Vector3(1)` | Per-channel shadow/mid/highlight color control (lift-gamma-gain). |
+| `colorGradingLut` | `null` | A `ColorLut` (from a `.cube` file) applied after tone mapping. Independent of `colorGradingEnabled`. |
+| `colorGradingLutBlend` | `1.0` | LUT mix amount. |
+
+## Vignette (`vignette*`)
+
+Darkens the frame edges. Off by default. Small amounts read as cinematic; large amounts as a peephole.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `vignetteEnabled` | `false` | Turn vignette on. |
+| `vignetteIntensity` | `0.5` | Darkening strength at the edge. |
+| `vignetteRadius` | `0.75` | How far in the darkening starts (smaller = tighter, more closed-in). |
+| `vignetteSmoothness` | `0.5` | Falloff softness of the edge. |
+
+## Chromatic aberration (`chromaticAberration*`)
+
+Splits color channels toward the edges. Off by default. A touch adds a lens feel; too much looks broken.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `chromaticAberrationEnabled` | `false` | Turn it on. |
+| `chromaticAberrationIntensity` | `0.2` | Channel-separation strength. |
+
+## Film grain (`filmGrain*`)
+
+Adds animated grain. Off by default. Sells a moody or analog look and hides banding in dark gradients.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `filmGrainEnabled` | `false` | Turn it on. |
+| `filmGrainIntensity` | `0.3` | Grain strength. |
+
+## Ambient occlusion (`ambientOcclusion*`)
+
+Screen-space contact darkening. Off by default. Requires a `PerspectiveCamera`. The single biggest upgrade for "grounded" vs "floating". Half-resolution by default to stay affordable.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `ambientOcclusionEnabled` | `false` | Turn AO on. |
+| `ambientOcclusionMethod` | `AmbientOcclusionMethod.obscurance` | `obscurance` is the cheap default; `groundTruth` (GTAO) is higher quality and needed for bent normals. |
+| `ambientOcclusionIntensity` | `1.0` | Darkening strength. |
+| `ambientOcclusionRadius` | `0.33` | World-space sampling radius. |
+| `ambientOcclusionPower` | `1.5` | Contrast of the occlusion curve. |
+| `ambientOcclusionBias` | `0.07` | Self-occlusion rejection. |
+| `ambientOcclusionBentNormals` | `false` | Compute bent normals (needs `groundTruth`); improves indirect lighting direction and enables `bentCone` specular AO. |
+| `ambientOcclusionSpecularMode` | `SpecularAmbientOcclusionMode.none` | `simple` occludes reflections cheaply; `bentCone` is directional and needs bent normals. |
+| `ambientOcclusionHalfResolution` | `true` | Compute at half res. Keep on unless AO edges look too coarse. |
+| `ambientOcclusionIndirectLight` | `0.0` | Above 0 turns on screen-space global illumination (SSGI) bounce; expensive. |
+| `ambientOcclusionMultiBounce` | `0.0` | Approximate multi-bounce darkening recovery. |
+| `ambientOcclusionSampleCount` | `16` | Samples for the `obscurance` method. |
+| `ambientOcclusionSliceCount` / `ambientOcclusionStepsPerSlice` | `3` / `3` | GTAO slice sampling. |
+| `ambientOcclusionDetail` | `0.5` | Fine-detail term weight (obscurance). |
+| `ambientOcclusionHorizonAngle` | `0.06` | Horizon rejection angle. |
+| `ambientOcclusionThickness` / `ambientOcclusionThicknessHeuristic` | `0.5` / `0.004` | Depth thickness assumptions for occlusion. |
+| `ambientOcclusionDirectLightAffect` | `0.0` | How much AO also dims direct light. |
+| `ambientOcclusionVisibilityBitmask` | `false` | Bitmask visibility estimator. |
+| `ambientOcclusionDepthMipChain` | `false` | Build a depth mip chain for wide-radius sampling. |
+
+## Screen-space reflections (`screenSpaceReflections*`)
+
+Reflects on-screen geometry. Off by default. Requires a `PerspectiveCamera`. Adds realism to floors, water, and glossy surfaces, but only reflects what is on screen.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `screenSpaceReflectionsEnabled` | `false` | Turn SSR on. |
+| `screenSpaceReflectionsIntensity` | `1.0` | Reflection strength. |
+| `screenSpaceReflectionsMaxDistance` | `24.4` | Max world-space ray distance. |
+| `screenSpaceReflectionsThickness` | `0.46` | Assumed surface thickness for hit tests. |
+| `screenSpaceReflectionsStride` | `9.0` | March step size (larger = faster, coarser). |
+| `screenSpaceReflectionsMaxSteps` | `90` | Ray-march step budget. |
+| `screenSpaceReflectionsBlur` | `0.3` | Roughness-based blur of the reflection. |
+| `screenSpaceReflectionsDistanceFadeStart` | `0.0` | Where reflections start fading with distance. |
+| `screenSpaceReflectionsResolutionScale` | `1.0` | Compute resolution scale; drop below 1 to save cost. |
+
+## Fog (`fog*`)
+
+Distance and height fog, evaluated in linear HDR before tone mapping. Off by default. Needs both `fogEnabled` and a non-`none` `fogMode`. Applies to lit and unlit materials; the skybox is left unfogged, so set `fogColor` to your horizon color for distant blending.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `fogEnabled` | `false` | Turn fog on. |
+| `fogMode` | `FogMode.exponential` | `none`, `linear`, `exponential`, `exponentialSquared`. Must be non-`none` to render. |
+| `fogColor` | `Vector3(0.6, 0.7, 0.8)` | Fog tint. Match your sky/horizon. |
+| `fogDensity` | `0.02` | Density for the exponential modes. |
+| `fogStart` / `fogEnd` | `0.0` / `200.0` | Near/far bounds for `linear` mode. |
+| `fogSkyColorInfluence` | `0.0` | Blend fog color toward the sky color. |
+| `fogMaxOpacity` | `1.0` | Cap on how opaque fog gets. |
+| `fogHeight` / `fogHeightFalloff` | `0.0` / `0.0` | Height-fog band and falloff. |
+| `fogSunInScatter` / `fogSunInScatterExponent` | `0.0` / `8.0` | Sun in-scatter glow through the fog. |
+| `fogCutoffDistance` | `0.0` | Distance beyond which fog stops accumulating. |
+
+## God rays (`godRays*`)
+
+Volumetric light shafts. Off by default. Requires a shadow-casting `DirectionalLight` and a `PerspectiveCamera`; without a shadow-casting sun there is nothing to shaft.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `godRaysEnabled` | `false` | Turn shafts on. |
+| `godRaysIntensity` | `1.0` | Shaft strength. |
+| `godRaysDensity` | `0.5` | Medium density the light scatters through. |
+| `godRaysAnisotropy` | `0.7` | Forward-scatter bias (higher = tighter shafts toward the sun). |
+| `godRaysStepCount` | `24` | March steps; higher is smoother and costlier. |
+| `godRaysMaxDistance` | `200.0` | Max shaft distance. |
+| `godRaysJitter` | `1.0` | Dither to hide banding. |
+| `godRaysColor` | `Vector3(1)` | Shaft tint. |
+
+## Depth of field (`depthOfField*`)
+
+Physically parameterized lens blur. Off by default. Requires a `PerspectiveCamera`. Great for a hero shot, wasteful for a full interactive scene.
+
+| Field | Default | What it does |
+| --- | --- | --- |
+| `depthOfFieldEnabled` | `false` | Turn DoF on. |
+| `depthOfFieldFocusDistance` | `10.0` | World distance in sharp focus. |
+| `depthOfFieldFStop` | `2.8` | Aperture; lower = shallower focus, more blur. |
+| `depthOfFieldFocalLength` | `0.0` | Lens focal length (0 derives from FOV). |
+| `depthOfFieldSensorHeight` | `0.024` | Sensor height in meters (35mm-ish). |
+| `depthOfFieldBlurScale` | `1.0` | Overall blur multiplier. |
+| `depthOfFieldMaxForegroundBlur` / `depthOfFieldMaxBackgroundBlur` | `24.0` / `32.0` | Blur radius caps. |
+| `depthOfFieldBladeCount` | `0` | Aperture blades for bokeh shape (0 = round). |
+| `depthOfFieldBladeRotation` / `depthOfFieldBladeCurvature` | `0.0` / `0.0` | Bokeh blade shaping. |
+| `depthOfFieldQuality` | `DepthOfFieldQuality.medium` | `low` (16 taps, mobile/web), `medium` (32 taps + postfilter), `high` (48 taps). |
+
+---
+
+## Cost and budget
+
+Post effects are screen-space passes; they cost per output pixel, not per triangle. Rough order, cheapest first:
+
+- **Nearly free.** Tone mapping, exposure, color grading, vignette, chromatic aberration, film grain, bloom. The `clean` and `stylized` looks live here.
+- **Moderate.** Ambient occlusion (keep `ambientOcclusionHalfResolution: true`), fog.
+- **Expensive.** SSR, god rays, depth of field, and especially SSGI (`ambientOcclusionIndirectLight > 0`). Each adds ray-marching or gather passes.
+
+Budget guidance:
+
+- **Mobile and web are the ceiling.** A look that is smooth on desktop can tank a phone. Profile the target, do not assume.
+- **Keep AO at half resolution** unless the coarse edges actually show. Full-res AO rarely earns its cost.
+- **Do not stack the expensive effects blindly.** SSR plus god rays plus depth of field together on a low-end device needs profiling; drop one or lower its resolution/step budget (`screenSpaceReflectionsResolutionScale`, `godRaysStepCount`, `DepthOfFieldQuality.low`).
+- **Depth of field is a hero-shot tool.** It reads as intentional on a framed still and as a smear on a free-moving interactive camera. Prefer it where the camera is controlled.
+- **Bloom and grading buy the most look per cost.** When you need "flashier" cheaply, reach for these before the screen-space passes.
+
+## Why each look is built the way it is
+
+**showcase** aims for a clean, believable, flattering render, the default for showing a model off. `aces` tone mapping gives contrast and pop; soft bloom (threshold just above 1.0) lights the highlights without haze; GTAO with bent normals and `bentCone` specular AO grounds the object and tightens reflections in its cavities; SSR adds real floor and surface reflections; a light vignette focuses the eye. Every choice supports "look at this object", nothing calls attention to itself.
+
+**stylized** trades realism for graphic punch. It leans on color (saturation up, a warm push, contrast up) and glow (a lower bloom threshold so more of the frame blooms) and deliberately *omits* AO and SSR, because heavy occlusion and reflection read as realism and fight the flatter, poppier intent. Cheap to run, since it is all near-free passes.
+
+**moody** is the atmospheric, cinematic end. Lower exposure and cool grading set a somber base; exponential fog with a dark horizon color adds depth and hides the far plane; strong AO deepens the shadows; a tight heavy vignette closes the frame; film grain and a touch of chromatic aberration add texture and a lens feel; god rays (given a shadow-casting sun) add drama. It is the most expensive look; on a tight budget, drop god rays first, then SSR if present.
+
+**clean** is the honest look, for when the render must show the *actual* material and lighting without editorializing: an editor viewport, an inspector, a UI-embedded preview. Default `pbrNeutral` tone mapping preserves hue and saturation, and the only effect on is gentle half-res AO for grounding. No bloom, grading, or vignette, because each of those changes what the color and brightness actually are, which is exactly what an accurate preview must not do. Also the cheapest look by far.

--- a/packages/flutter_scene/skills/flutter_scene-performance/SKILL.md
+++ b/packages/flutter_scene/skills/flutter_scene-performance/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: flutter_scene-performance
+version: 1
+description: Make a flutter_scene app hit frame budget. Use whenever a scene janks, stutters, or drops frames, or when the ask is to make it faster or run on mobile or web, because code-driven scenes are reliably slow and the fix depends on which thread is over budget, not on a guessed poly count.
+---
+
+# Making flutter_scene fast
+
+A code-driven flutter_scene scene is reliably slow, and the usual reason is that nothing told you the budget or what to fix first, so optimization starts as guesswork. Guessing wastes iterations and often makes the wrong thread slower. This skill replaces the guessing with a budget, a way to measure it, and a fixed order to apply fixes in.
+
+**The one thing to internalize: measure the actual frame, find which of the two threads is over budget, then fix that thread. Do not target a triangle or draw-call number from memory.** There is no built-in poly budget, and the same scene can be fast on desktop and jank on a phone. The number that matters is milliseconds per frame on the real target.
+
+## The budget
+
+A frame has a fixed wall-clock budget set by the refresh rate.
+
+- **60 fps is 16.6 ms per frame. 120 fps is 8.3 ms.** Miss it and the frame janks.
+- That budget is split across **two threads**, and either one blowing it drops the frame:
+  - **UI thread** runs your Dart. flutter_scene walks the scene graph, culls, updates components, and builds the render here.
+  - **Raster thread** is where Impeller draws the built frame on the GPU. The whole post-processing stack (ambient occlusion, reflections, depth of field, god rays, bloom) lands here.
+- **Mobile and web are the real constraint.** Desktop GPUs hide a lot; a scene that runs smooth on a laptop can miss budget badly on a phone or in a browser. Profile on the lowest target you must support.
+
+## Measure first (do not skip this)
+
+flutter_scene has **no built-in stats API**. There is no `scene.frameTime`, no draw-call counter. The editor MCP `get_app_state` reports only lifecycle (launching/running), not frame timing. So measurement is Flutter's own tooling.
+
+1. **Run in profile mode.** `flutter run --profile --enable-flutter-gpu`. Debug-mode timings are meaningless for performance (assertions, no JIT-to-AOT optimization, extra checks), so never judge speed in debug.
+2. **Read the frame chart.** Open DevTools, go to the Performance view, and read **per-frame UI time vs raster time**. The jank frames are flagged. This single view tells you which thread is over budget, which decides everything below.
+3. **Or use the performance overlay** for a quick in-app read of the two thread graphs without DevTools.
+4. **Stopwatch as a coarse fallback.** A `Stopwatch` around the per-frame work gives a rough UI-thread number when you cannot open DevTools. It sees nothing on the raster thread.
+
+Which thread is over budget names the fix. UI over budget means too much graph/CPU work (steps a, b, c below). Raster over budget means too much GPU work (steps d, e). See `references/performance.md` for the symptom to thread diagnosis.
+
+## The fixed remediation order
+
+Apply top-down. Each step lists the real API. Do the measured-over-budget thread's steps first, but the order within is deliberate, the earlier fixes are the bigger wins.
+
+1. **Instancing** (UI thread). Many copies of one mesh collapse into one draw and one cull test. Build an `InstancedMesh(geometry:, material:)`, add a transform per copy with `addInstance(matrix, {color})`, and mount it with `InstancedMeshComponent`. The single biggest win for repeated geometry (foliage, crowds, tiles, debris). Per-instance frustum culling is off by default (`cullInstances: false`), so the batch is one cull test as a unit. See the `flutter_scene-procedural` skill for the full scatter pattern.
+
+2. **Level of detail** (both threads). `LodComponent(List<LodLevel>)` swaps cheaper meshes as an object shrinks on screen. Each `LodLevel(geometry:, material:, screenSize:)` gives a threshold (projected size as a fraction of viewport height, highest detail first, last is the cull floor). Fewer triangles for distant objects on the GPU, and nothing drawn below the floor. Note the shadow and depth passes always draw the highest-detail level, so LOD does not lighten shadow cost.
+
+3. **Culling** (UI thread). `Node.frustumCulled` (default true) skips off-screen subtrees; leave it on. Set it `false` only where the cached bound is known-stale or unbounded (procedural terrain you regenerate). For whole sets, `RenderView.cullingPlanes` adds extra clip planes, and `node.layers` (default `kRenderLayerDefault`) against `RenderView.layerMask` (default `kRenderLayerAll`) skips entire layers a view should not draw.
+
+4. **Shrink the post stack** (raster thread). This is usually where raster time goes. Turn off effects you do not need via the `EnvironmentSettings` `*Enabled` flags, keep `ambientOcclusionHalfResolution: true`, lower `depthOfFieldQuality` toward `DepthOfFieldQuality.low`, drop `RenderView.renderScale` (or `Scene.renderScale`) below `1.0` to render fewer pixels, and step `Scene.antiAliasingMode` down (`msaa` to `fxaa` to `none`). See the `flutter_scene-looks` skill for what each knob does to the look.
+
+5. **Texture and material consolidation** (raster thread). Fewer distinct textures and materials means fewer state changes and binds per frame. `TextureAtlas` (with `generateSolidColorAtlasPixels` for placeholders) packs many tiles into one texture so one material covers them all; share a single `Material` instance across many nodes instead of constructing one per node; use `MaterialsVariantsComponent` to switch a model between named material sets rather than duplicating materials.
+
+6. **Static shadows** (raster thread). `Node.shadowStatic = true` promises a caster's geometry, material coverage, and world transform will not change while mounted, so the engine renders it into cached shadow-map tiles reused across frames instead of re-encoding every caster every frame. A large static world becomes dramatically cheaper to shadow. Flag only genuinely static content; a static node that moves shows stale shadows until its render item re-registers.
+
+## More depth
+
+`references/performance.md` expands each step with the full API and when it helps, the UI-vs-raster symptom map (what a wrong frame time points to), and the honest note on what measurement tooling actually exists.

--- a/packages/flutter_scene/skills/flutter_scene-performance/references/performance.md
+++ b/packages/flutter_scene/skills/flutter_scene-performance/references/performance.md
@@ -1,0 +1,127 @@
+# flutter_scene performance reference
+
+Companion to the `flutter_scene-performance` skill. The skill states the budget, the measure-first rule, and the fixed remediation order. This file expands each step with the real API, when it helps and when it does not, the diagnosis that maps a wrong frame time to a thread, and an honest account of the measurement tooling.
+
+Verify any symbol here against `lib/src` before relying on it; the inventory in the `flutter_scene-idioms` skill (`references/what-exists.md`) is the fuller API map.
+
+## The two threads, concretely
+
+A frame is built on the UI thread and drawn on the raster thread, and they overlap across frames (frame N rasters while frame N+1 builds). Either thread over budget drops the frame.
+
+- **UI thread work** is Dart. flutter_scene walks the scene graph, computes world transforms, runs frustum culling, ticks every component's `update`, and encodes the draw list. Cost scales with node count, component count, and how much per-frame Dart you run in `onTick` or component `update`.
+- **Raster thread work** is the GPU. Impeller executes the encoded passes, the shadow pass, the main color pass, and every enabled screen-space post-processing pass. Cost scales with pixels drawn, overdraw, shadow-map resolution, and how many post passes are on.
+
+## Diagnosis, symptom to thread
+
+Read the two thread graphs in DevTools (or the performance overlay) and match the over-budget one to a cause.
+
+| Observation | Over-budget thread | Likely cause | Go to step |
+| --- | --- | --- | --- |
+| UI time high, raster fine | UI | Too many nodes/draws or heavy per-frame Dart | 1 instancing, 3 culling |
+| UI time scales with object count | UI | Thousands of separate nodes for one repeated mesh | 1 instancing |
+| UI time high with a huge static world | UI | No culling; whole graph walked every frame | 3 culling |
+| Raster time high, UI fine | Raster | Too many pixels or post passes | 4 post stack, 5 consolidation |
+| Raster time high, and it tracks resolution | Raster | Fill-bound; too many pixels | 4 `renderScale`, AA |
+| Raster spikes only when shadows are on | Raster | Every caster re-encoded per frame | 6 static shadows |
+| Raster time tracks the number of distinct materials | Raster | State-change churn from per-node materials/textures | 5 consolidation |
+| Jank only on phone or web, smooth on desktop | Whichever is over budget there | Desktop GPU was hiding it | measure on the real target |
+
+If both threads are near budget, fix the UI thread first (steps 1 to 3); a lighter draw list also lightens the raster thread.
+
+## Measurement tooling, honestly
+
+There is **no built-in frame-stats API in flutter_scene**. No `scene.frameTime`, no draw-call count, no visible-triangle count. Do not invent one or claim one exists.
+
+- **Profile mode is mandatory.** `flutter run --profile --enable-flutter-gpu`. Debug builds carry assertions and skip AOT optimization, so their timings do not reflect a release build. A number taken in debug mode is not a performance number.
+- **DevTools Performance view** is the primary tool. It shows per-frame UI time and raster time as two tracks, flags janky frames, and lets you expand a frame's timeline. This is what tells you which thread is over budget.
+- **The performance overlay** gives the same two thread graphs in-app for a quick read without attaching DevTools.
+- **A `Stopwatch`** around the per-frame work (the `onTick` body, or a component `update`) is a coarse UI-thread fallback. It cannot see the raster thread at all, so a good stopwatch number does not clear a raster-bound jank.
+- **Editor MCP.** `get_app_state` reports lifecycle only (launching/running), not timing. The one place per-pass GPU timings surface is a render-graph capture (`Scene.captureRenderGraph`, or the editor MCP capture tool), whose result carries per-pass timing and lets you see which post pass is expensive. That is per-pass GPU detail, not a whole-frame counter, and the editor MCP is not connected in every project. When it is not, the DevTools loop above is fully sufficient.
+
+## Step 1, instancing
+
+`InstancedMesh` holds one `geometry`/`material` pair and one transform per copy. The whole set encodes as a single draw and, by default, a single frustum cull test.
+
+```dart
+final mesh = InstancedMesh(
+  geometry: someGeometry,
+  material: sharedMaterial,   // one material for the whole batch
+);
+for (final placement in placements) {
+  mesh.addInstance(placement.transform, color: placement.tint); // matrix is cloned
+}
+scene.add(Node()..addComponent(InstancedMeshComponent(mesh)));
+```
+
+- `addInstance(Matrix4, {Vector4? color})` returns an index; the matrix is cloned, so mutating your copy afterward is safe. Per-instance `color` is a linear RGBA multiplier.
+- Edit later with `setInstanceTransform(i, m)`, `setInstanceColor(i, color)`, `removeInstanceAt(i)`, `clearInstances()`, or move the whole batch in one pass with `updateInstanceTransforms((list) { ... })`.
+- **Culling default.** `cullInstances` defaults to `false`, so the batch is culled as one unit against its combined bounds, not per instance. Turn `cullInstances: true` on only for a batch spread across a large area where many instances are off-screen, since per-instance culling adds CPU work.
+- **When it helps.** Repeated geometry, foliage, crowds, tiles, debris, particles-as-meshes. It is the largest UI-thread win available, because N separate nodes become one. It does nothing for a scene of distinct meshes.
+- **Winding trap.** A mirrored (negative-determinant) instance edited with `updateInstanceTransforms(recomputeWinding: false)` renders inside-out. Keep instance edits orientation-preserving, or let winding recompute.
+
+See the `flutter_scene-procedural` skill for the full scatter-on-terrain pattern.
+
+## Step 2, level of detail
+
+`LodComponent(List<LodLevel>)` draws one of several mesh variants per frame, chosen from how large the object appears on screen.
+
+```dart
+node.addComponent(LodComponent([
+  LodLevel(geometry: high, material: mat, screenSize: 0.4),
+  LodLevel(geometry: mid,  material: mat, screenSize: 0.15),
+  LodLevel(geometry: low,  material: mat, screenSize: 0.04), // set 0.0 to never cull
+]));
+```
+
+- `screenSize` is the projected bounding-sphere diameter as a fraction of viewport height. Levels are highest detail first, strictly descending. The engine draws the highest-detail level whose threshold the object still meets, and draws nothing below the last threshold (the cull floor).
+- Selection is screen-size based, so it is field-of-view aware and resolution independent, and it is per view (a split-screen frame can pick different levels per view).
+- `LodComponent(levels, {lodBias = 1.0, hysteresis = 0.1, blendRange = 0.0})`. `lodBias` above `1` keeps detail farther away; `hysteresis` is a dead-band so an object on a boundary does not flip-flop; `blendRange` above `0` dither-cross-fades adjacent levels to remove the pop (honored by the built-in lit and unlit materials).
+- **Limitation that matters for shadows.** The shadow and depth-prepass passes always draw the highest-detail level and ignore the LOD cull. So LOD lightens the color pass, not shadow or depth cost. A shadow-heavy scene needs step 6, not LOD.
+- **Not for instanced draws.** A `LodComponent` draws a single mesh and picks one level for the whole node; it does not combine with hardware instancing.
+
+## Step 3, culling
+
+Skip work for things the camera cannot see.
+
+- **`Node.frustumCulled`** (default `true`) skips a subtree whose `combinedLocalBounds` do not intersect the camera frustum. Leave it on. Set it `false` only where the cached bound is known-stale or misleading (procedural geometry you regenerate, large terrain pieces). A subtree that reports no bound (skinned content, geometry without a computable bound) is treated as always visible regardless of the flag.
+- **`RenderView.cullingPlanes`** (`List<Plane>`, default empty) adds extra clip planes beyond the frustum, for portal or region culling.
+- **Layers.** `node.layers` (a 32-bit mask, default `kRenderLayerDefault` which is layer 0, not inherited by children) against `RenderView.layerMask` (default `kRenderLayerAll`) decides whether a view draws a node at all, when `node.layers & view.layerMask != 0`. Put editor gizmos, an inset viewport's contents, or a minimap's set on their own layer and give each view the mask it needs, so a view skips whole sets cheaply.
+- **When it helps.** Large worlds where much of the graph is off-screen each frame. Culling is a UI-thread win (fewer nodes encoded) that also lightens the raster thread (fewer draws).
+
+## Step 4, shrink the post stack
+
+Every screen-space effect is a raster-thread pass. Turning off what you do not need is the most direct raster win. All the scene-wide look fields live on `EnvironmentSettings` (see the `flutter_scene-looks` skill); each effect has an `*Enabled` flag, off by default.
+
+- **Turn effects off.** `ambientOcclusionEnabled`, `screenSpaceReflectionsEnabled`, `godRaysEnabled`, `depthOfFieldEnabled`, `bloomEnabled`, and the rest default `false`. A preset the app copied may have turned several on; drop the ones the scene does not visibly need. Ambient occlusion, screen-space reflections, god rays, and depth of field are the heavy ones.
+- **Half-resolution AO.** `ambientOcclusionHalfResolution` defaults `true`; keep it. Full-resolution AO roughly doubles that pass's cost for little visible gain on most content.
+- **Cheaper depth of field.** `depthOfFieldQuality` (`DepthOfFieldQuality.low`/`medium`/`high`, default `medium`) trades gather taps and cleanup passes for time. Step it down to `low` on mobile.
+- **Render fewer pixels.** `Scene.renderScale` (default `1.0`), or per-view `RenderView.renderScale`, renders the scene at a fraction of resolution and upscales. Dropping to `0.75` cuts fill cost by nearly half and is often barely visible after anti-aliasing. This is the biggest lever for a fill-bound (resolution-tracking) raster time.
+- **Step anti-aliasing down.** `Scene.antiAliasingMode`. `AntiAliasingMode.auto` picks `msaa` where supported else `fxaa`. `msaa` is cheap on mobile tilers and highest quality; `fxaa` is a single post pass on every backend; `none` is free. Read what actually runs with `Scene.effectiveAntiAliasingMode`.
+- **When it helps.** Any raster-bound scene. The `clean` look in the looks skill is nearly free; a full `moody` stack (AO plus SSR plus god rays plus DoF plus grain) is the heaviest. Do not stack all of those on a low-end target without profiling.
+
+## Step 5, texture and material consolidation
+
+Every distinct material and texture is a potential state change and bind on the raster thread. Fewer of them means a shorter, cheaper draw list.
+
+- **`TextureAtlas`** packs many equally sized tiles (voxel faces, sprite sheets, terrain tiles) into one texture, so a single material and draw call cover every tile. Resolve a tile's UV box with `tileBounds(index)` or map a within-tile coordinate with `tileUv(index, u, v)`, write those into the mesh's texture coordinates, and build the bound material with `toMaterial()`. `generateSolidColorAtlasPixels(tileColors:, columns:, tileSize:, padding:)` builds placeholder pixels to bring the atlas path up before real art exists.
+- **Share one `Material` instance** across many nodes rather than constructing a new one per node. Identical materials that are separate objects still churn binds; the same object does not. Build the material once and reuse the reference.
+- **`MaterialsVariantsComponent`** switches an imported model between its named `KHR_materials_variants` sets in place (`MaterialsVariantsComponent.of(model)?.select('name')`), instead of duplicating a model per look. Read `variants` for the declared names; `select(null)` restores defaults.
+- **When it helps.** Scenes whose raster time tracks the count of distinct materials or textures, tile-based worlds, and models shown in several finishes.
+
+## Step 6, static shadows
+
+Shadow casting re-encodes every caster into the shadow map each frame by default. `Node.shadowStatic = true` promises a caster will not change and lets the engine cache its shadow-map tiles across frames.
+
+```dart
+staticWorldNode.shadowStatic = true;  // set per mesh-bearing node; not inherited
+```
+
+- **The contract.** The node's geometry, material coverage, and world transform must not change while mounted. In return, the engine renders it into cached shadow-map tiles reused across frames instead of re-encoding it every frame. Dynamic nodes (the default) still cast per-frame shadows on top of the cache, so a moving character over a static world works.
+- **Not inherited.** Set it on each mesh-bearing node, not once on a root.
+- **Stale-shadow caveat.** A static node that does change (moves, remeshes, edits material coverage) shows stale shadows until its render item re-registers. Flag only genuinely static content.
+- **Displacement caveat.** A material with a `vertex { }` displacement stage should stay dynamic, since its cached shadow would not follow a camera-dependent displacement.
+- **When it helps.** Large static worlds with a shadow-casting `DirectionalLight`. The win scales with how many static casters you have; a mostly static level with a few moving actors is the ideal case.
+
+## Order and stopping
+
+Fix the measured over-budget thread first, top-down within it, and re-measure after each change so cause and effect stay legible. Stop when the frame chart clears budget on the real target; there is no reason to keep optimizing a thread that is already under budget while the other one janks. The whole point of measuring first is to avoid spending a step's effort on the thread that was never the problem.

--- a/packages/flutter_scene/skills/flutter_scene-procedural/SKILL.md
+++ b/packages/flutter_scene/skills/flutter_scene-procedural/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: flutter_scene-procedural
+version: 1
+description: Build flutter_scene content from code instead of asset files. Use when generating terrain, scattering vegetation or crowds, assembling modular kits, or driving a scene from noise and instancing rather than loading a .glb.
+---
+
+# Procedural content in flutter_scene
+
+A lot of 3D work does not need an artist's `.glb` at all. Terrain, scattered foliage, debris fields, crowds, and modular buildings are cheaper and more flexible built from code, and flutter_scene has the whole path in the box. Reach for it before wiring up an asset pipeline.
+
+**The insight: for a code-driven scene, generate geometry and draw it instanced. That path is more reliable than loading external assets, because it has no import step, no coordinate-conversion traps, no missing-file failure modes, and one draw call for thousands of copies.** Three pieces cover almost everything:
+
+- **`GeometryBuilder`** (and the ten built-in primitives) build custom meshes without a model file.
+- **`FastNoiseLite`** drives heightmaps, placement, and displacement deterministically.
+- **`InstancedMesh`** draws thousands of copies of one mesh as a single render item.
+
+Do not hand-pack a `ByteData` vertex buffer. The vertex layout is fixed (72 bytes unskinned, a specific attribute order) and a wrong stride fails silently with washed-out or see-through geometry. `GeometryBuilder` and `MeshGeometry.fromArrays` interleave the layout for you.
+
+## Imports
+
+Geometry and instancing live in the main barrel. **Noise is a separate barrel** and is easy to forget:
+
+```dart
+import 'package:flutter_scene/scene.dart';   // GeometryBuilder, MeshGeometry, InstancedMesh, ...
+import 'package:flutter_scene/noise.dart';   // FastNoiseLite, bakeNoiseTexture, noiseCurl3
+import 'package:vector_math/vector_math.dart' as vm;   // NOT vector_math_64
+```
+
+## Terrain from a noise heightmap
+
+Sample `FastNoiseLite` on a grid, add each vertex, and wind the two triangles per cell so the lit surface faces up. Omitting normals lets the builder derive them from the actual face slopes, which is what you want for terrain.
+
+```dart
+MeshGeometry buildTerrain({int cols = 128, int rows = 128, double spacing = 0.5}) {
+  final noise = FastNoiseLite(seed: 1337)
+    ..noiseType = NoiseType.openSimplex2
+    ..fractalType = FractalType.fbm   // stack octaves for natural detail
+    ..octaves = 5
+    ..frequency = 0.02;               // world units are multiplied by this
+
+  final builder = GeometryBuilder();
+
+  // One vertex per grid point. getNoise2 returns roughly -1..1.
+  for (var r = 0; r < rows; r++) {
+    for (var c = 0; c < cols; c++) {
+      final x = c * spacing;
+      final z = r * spacing;
+      final height = noise.getNoise2(x, z) * 6.0;
+      builder.addVertex(vm.Vector3(x, height, z));
+    }
+  }
+
+  // Two triangles per cell, wound so the front face points +Y (up).
+  for (var r = 0; r < rows - 1; r++) {
+    for (var c = 0; c < cols - 1; c++) {
+      final v00 = r * cols + c;
+      final v10 = v00 + 1;
+      final v01 = v00 + cols;
+      final v11 = v01 + 1;
+      builder
+        ..addTriangle(v00, v10, v01)
+        ..addTriangle(v10, v11, v01);
+    }
+  }
+
+  return builder.build();
+}
+```
+
+Attach it like any mesh:
+
+```dart
+final terrain = Node(mesh: Mesh(buildTerrain(), PhysicallyBasedMaterial()..roughnessFactor = 1.0));
+scene.add(terrain);
+```
+
+If a hand-built surface renders inside-out (visible only from below, dark where lit), reverse each triangle's index order. flutter_scene's front faces wind clockwise in model space; never fix orientation with a per-triangle flip on an imported model, but for geometry you author yourself the winding is yours to set.
+
+## Scattering thousands of copies
+
+`InstancedMesh` holds one geometry/material pair and a transform per copy. The whole set is one pipeline and one cull test. Place instances by sampling the same terrain height so they sit on the ground.
+
+```dart
+final rng = math.Random(7);
+final scatter = InstancedMesh(
+  geometry: CylinderGeometry(bottomRadius: 0.0, topRadius: 0.15, height: 1.2), // a cone
+  material: PhysicallyBasedMaterial()..baseColorFactor = vm.Vector4(0.2, 0.5, 0.15, 1),
+);
+
+for (var i = 0; i < 4000; i++) {
+  final x = rng.nextDouble() * 64;
+  final z = rng.nextDouble() * 64;
+  final y = noise.getNoise2(x, z) * 6.0; // same field as the terrain
+  final transform = vm.Matrix4.translation(vm.Vector3(x, y, z))
+    ..rotateY(rng.nextDouble() * math.pi * 2);
+  scatter.addInstance(transform); // the matrix is cloned; mutating it later is safe
+}
+
+// InstancedMesh rides on a component, not Node(mesh:).
+final node = Node()..addComponent(InstancedMeshComponent(scatter));
+scene.add(node);
+```
+
+`addInstance(matrix, {color})` returns an index; edit later with `setInstanceTransform(i, m)` or move the whole batch at once through `updateInstanceTransforms((list) { ... })`. Per-instance `color` is a linear RGBA multiplier. Keep instance edits orientation-preserving, a mirrored (negative-determinant) instance edited with `updateInstanceTransforms(recomputeWinding: false)` renders inside-out.
+
+## The web noise trap
+
+The Dart `FastNoiseLite` relies on 32-bit integer math. On the web (dart2js) a Dart `int` is a JavaScript double, exact only to 53 bits, so the hash loses its low bits and 3D noise can overflow, producing wrong values. This is silent, you get a plausible-looking but incorrect field, and only on web.
+
+For web targets:
+
+- Prefer the **GLSL side** (`#include <noise.glsl>` in a `.fmat` block), which is correct on every backend including WebGL2 and matches the Dart algorithms table-for-table.
+- Or **bake** the field once with `bakeNoiseTexture(noise, width: ..., height: ...)` at build time or in a native isolate, then sample the texture. `bakeNoisePixels` is pure CPU with no engine imports, so it runs in a build hook or background isolate.
+
+Native platforms are unaffected. `noiseHash2`/`noiseHash3` are the bit-exact CPU/GPU-agreeing integer path for decisions that must never disagree (world generation, placement), but they carry the same web-overflow caveat, so make the decision once and share it rather than re-deriving it on both sides.
+
+## More depth
+
+`references/procedural.md` has the full `GeometryBuilder` and `MeshData` API (including off-isolate meshing), the complete `FastNoiseLite` config reference, the instancing API in full, modular-kit assembly from the built-in primitives, and the web-noise caveat expanded.

--- a/packages/flutter_scene/skills/flutter_scene-procedural/references/procedural.md
+++ b/packages/flutter_scene/skills/flutter_scene-procedural/references/procedural.md
@@ -1,0 +1,344 @@
+# Procedural content, the full API
+
+Everything for building flutter_scene content from code, custom meshes, noise, instancing, and modular kits. All symbols verified against the package source. Import geometry and instancing from the main barrel, noise from its own barrel:
+
+```dart
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene/noise.dart';
+import 'package:vector_math/vector_math.dart' as vm;   // NOT vector_math_64
+```
+
+---
+
+## GeometryBuilder
+
+The incremental way to build a custom triangle mesh. You add vertices one at a time, each carrying whatever attributes are currently set, then reference them by returned index to form triangles.
+
+```dart
+class GeometryBuilder {
+  GeometryBuilder({bool deduplicate = true});
+
+  // Sticky attribute setters (return `this`, so cascade or chain them).
+  GeometryBuilder normal(vm.Vector3 value);
+  GeometryBuilder texCoord(vm.Vector2 value);
+  GeometryBuilder texCoord1(vm.Vector2 value);   // secondary UV set
+  GeometryBuilder color(vm.Vector4 value);        // linear RGBA
+  GeometryBuilder tangent(vm.Vector4 value);      // xyz + handedness in w
+
+  int addVertex(vm.Vector3 position);             // returns the vertex index
+  GeometryBuilder addTriangle(int a, int b, int c); // throws RangeError on a bad index
+
+  int get vertexCount;
+  int get triangleCount;
+
+  Uint8List packVertices();                       // pure, no GPU context needed
+  MeshGeometry build({
+    GeometryStorage storage = GeometryStorage.fixed,
+    GeometryBufferArena? bufferArena,
+    bool retainCpuData = true,
+  });
+}
+```
+
+### The sticky-attribute model
+
+The attribute setters do not apply to one vertex, they set state that every following `addVertex` inherits until you change it. This makes flat-shaded faces and per-region colors natural:
+
+```dart
+final geometry = (GeometryBuilder()
+      ..color(vm.Vector4(1, 0, 0, 1))   // every vertex below is red...
+      ..addVertex(vm.Vector3(0, 0, 0))
+      ..addVertex(vm.Vector3(1, 0, 0))
+      ..color(vm.Vector4(0, 1, 0, 1))   // ...until this changes it to green
+      ..addVertex(vm.Vector3(0, 1, 0))
+      ..addTriangle(0, 1, 2))
+    .build();
+```
+
+### Normals, generated or authored
+
+If you never call `normal()`, the builder generates area-weighted vertex normals from the faces you wound. That is the right default for most procedural geometry, terrain, extrusions, anything where the surface shape defines the normal.
+
+**Calling `normal()` even once opts the whole mesh out of generated normals.** After that, any vertex you add without an explicit normal keeps the default `(0, 0, 1)`, which is almost never what you want. So either author a normal for every vertex, or author none and let generation run. Do not mix.
+
+### Deduplication
+
+With `deduplicate: true` (the default), `addVertex` merges a vertex equal to one already added and returns the existing index, so a shared grid corner is stored once. Pass `deduplicate: false` when you want every call to produce a distinct vertex (flat shading with per-face normals, or per-vertex data that must not collapse).
+
+### Winding
+
+flutter_scene's front faces wind **clockwise in model space**. For a surface that should face +Y (a heightmap, a floor), match the built-in plane's winding: for a cell with corners `v00`(x,z), `v10`(x+1,z), `v01`(x,z+1), `v11`(x+1,z+1), emit `addTriangle(v00, v10, v01)` and `addTriangle(v10, v11, v01)`.
+
+If a mesh renders inside-out (invisible from the front, visible and inverted-lit from behind), reverse each triangle's index order. Because generated normals follow the winding, fixing the winding fixes the normals too. This freedom is only for geometry you author. Never apply a per-triangle winding flip to an imported model to correct its orientation, that leaves its normals and image-based lighting wrong.
+
+### From builder to scene
+
+`build()` returns a `MeshGeometry`, which is a `Geometry`. Wrap it in a `Mesh` with a material, hang the mesh on a `Node`, add the node:
+
+```dart
+final node = Node(mesh: Mesh(geometry, PhysicallyBasedMaterial()));
+scene.add(node);
+```
+
+---
+
+## MeshGeometry.fromArrays, the bulk path
+
+When you already have attributes as flat arrays (a generator that fills typed lists), skip the per-vertex calls and hand `MeshGeometry.fromArrays` structure-of-arrays data directly. Same result, less overhead for large meshes.
+
+```dart
+MeshGeometry.fromArrays({
+  required Float32List positions,   // 3 floats/vertex, required
+  Float32List? normals,             // 3/vertex; omitted -> generated for triangle lists
+  Float32List? texCoords,           // 2/vertex; omitted -> (0, 0)
+  Float32List? texCoords1,          // 2/vertex
+  Float32List? colors,              // 4/vertex; omitted -> opaque white
+  Float32List? tangents,            // 4/vertex
+  List<int>? indices,               // omitted -> vertex count must be a multiple of 3
+  gpu.PrimitiveType primitiveType = gpu.PrimitiveType.triangle,
+  Aabb3? bounds,                    // skips the position scan; MUST cover every vertex
+  GeometryStorage storage = GeometryStorage.fixed,
+  GeometryBufferArena? bufferArena,
+  bool retainCpuData = true,
+});
+```
+
+Notes that bite:
+
+- Every supplied optional array must match the vertex count implied by `positions`.
+- Out-of-range `indices` are **not** validated here (unlike `GeometryBuilder.addTriangle`), and produce stray triangles or holes silently. Keep every index in `0..vertexCount-1`.
+- A `bounds` you pass that does not enclose every vertex makes the mesh over-cull and pop out of view at some angles. Omit it (the constructor scans positions) unless you computed it correctly off-thread.
+- `retainCpuData: false` drops the CPU copy after upload, saving memory, but then the mesh cannot be raycast or read back with `extractMeshData`.
+
+### Updatable geometry (animated meshes)
+
+Pass `storage: GeometryStorage.updatable` to get a mesh you can mutate in place each frame without reallocating. The in-place updaters replace one attribute when the vertex count is unchanged:
+
+```dart
+final water = MeshGeometry.fromArrays(positions: p, storage: GeometryStorage.updatable);
+// later, per frame:
+water.updatePositions(newPositions);         // also updateNormals/TexCoords/Colors/Tangents
+// or replace everything (may change the count):
+water.rebuild(positions: p2, indices: i2);
+```
+
+An updatable mesh fixes its indexed-or-not state at construction, if you built it with `indices`, `rebuild` requires them thereafter, and vice versa. To start empty and fill later, pass a zero-length `positions` with `updatable`. Updatable geometry must retain CPU data and cannot use a buffer arena.
+
+`GeometryBufferArena({int blockSizeInBytes = 16 * 1024 * 1024})` lets many fixed meshes share immutable GPU buffer blocks, worth it when you build a large number of small static meshes.
+
+---
+
+## MeshData, meshing off the render isolate
+
+Heavy generation (remeshing a voxel chunk, a large marching-cubes surface) should not block the render isolate. `MeshData` is a pure, isolate-transferable snapshot, build it on a background isolate with `compute`, send it back, upload it there.
+
+```dart
+factory MeshData.build({
+  required Float32List positions,
+  Float32List? normals,          // omitted -> generated for triangle lists (the win here)
+  Float32List? texCoords,
+  Float32List? texCoords1,
+  Float32List? colors,
+  Float32List? tangents,
+  List<int>? indices,
+  gpu.PrimitiveType primitiveType = gpu.PrimitiveType.triangle,
+  Map<String, MeshAttributeData> customAttributes = const {},
+});
+```
+
+Recipe:
+
+```dart
+// Top-level or static, runs on the background isolate.
+MeshData buildChunk(ChunkInput input) {
+  final positions = /* your generator */;
+  final indices = /* ... */;
+  return MeshData.build(positions: positions, indices: indices);
+}
+
+// On the render isolate:
+final data = await compute(buildChunk, input);
+final geometry = MeshGeometry.fromMeshData(data);
+// or, to feed an existing updatable mesh in place:
+existing.applyMeshData(data);
+```
+
+The normal generation is the expensive part, and running it inside `MeshData.build` is exactly the work you moved off the render isolate.
+
+Pure derivations on a `MeshData` (all off-isolate safe): `transformed(Matrix4)` (moves positions, carries normals by the inverse transpose so a non-uniform scale stays correct, reverses winding on a mirror), `unweld({attributes})`, `extractEdges({creaseAngleDegrees})`, static `MeshData.merge(parts)`, plus `triangleCount`/`triangles`. `Geometry.extractMeshData()` reads a loaded mesh back into one.
+
+---
+
+## FastNoiseLite
+
+One configurable object evaluating several noise algorithms, sampled with `getNoise2`/`getNoise3`. Output is roughly in `[-1, 1]`.
+
+```dart
+final noise = FastNoiseLite(seed: 1337)
+  ..frequency = 0.01                        // coords are multiplied by this before eval
+  ..noiseType = NoiseType.openSimplex2
+  ..fractalType = FractalType.fbm
+  ..octaves = 5;
+
+final h = noise.getNoise2(x, z);            // 2D
+final d = noise.getNoise3(x, y, z);         // 3D
+```
+
+### Config reference
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `seed` | 1337 | Seed for every noise type. |
+| `frequency` | 0.01 | Input coordinates are scaled by this. Bigger = finer features. |
+| `noiseType` | `openSimplex2` | Base algorithm (see below). |
+| `fractalType` | `none` | How octaves layer (see below). |
+| `octaves` | 3 | Number of fractal layers. More detail, more cost. |
+| `lacunarity` | 2.0 | Frequency multiplier between octaves. |
+| `gain` | 0.5 | Amplitude multiplier between octaves. |
+| `weightedStrength` | 0.0 | Biases octave amplitude toward stronger detail. |
+| `pingPongStrength` | 2.0 | Warp strength for `FractalType.pingPong`. |
+| `cellularDistanceFunction` | `euclideanSq` | Distance metric for `NoiseType.cellular`. |
+| `cellularReturnType` | `distance` | What cellular returns. |
+| `cellularJitterModifier` | 1.0 | Cell-point jitter; above 1 causes artifacts. |
+| `domainWarpType` | `openSimplex2` | Warp algorithm for `domainWarp2`/`domainWarp3`. |
+| `domainWarpAmp` | 1.0 | Max warp distance. |
+| `domainWarpFractalType` | `none` | Octave layering for domain warp. |
+
+Enums:
+
+- `NoiseType` = `openSimplex2` | `openSimplex2S` | `cellular` | `perlin` | `value`.
+- `FractalType` = `none` | `fbm` (classic layered fractal, the usual terrain choice) | `ridged` (sharp ridges, mountains) | `pingPong`.
+- `CellularDistanceFunction` = `euclidean` | `euclideanSq` | `manhattan` | `hybrid`.
+- `CellularReturnType` = `cellValue` | `distance` | `distance2` | `distance2Add` | `distance2Sub` | `distance2Mul` | `distance2Div`.
+- `DomainWarpType` = `openSimplex2` | `openSimplex2Reduced` | `basicGrid`.
+- `DomainWarpFractalType` = `none` | `progressive` | `independent`.
+
+### Domain warp
+
+`domainWarp2`/`domainWarp3` distort the input coordinates before sampling, breaking up the regular look of raw fractal noise. The reference version mutates in place, this port returns the warped position for you to feed back in:
+
+```dart
+final w = noise.domainWarp2(x, z);   // ({double x, double y})
+final v = noise.getNoise2(w.x, w.y);
+```
+
+### Curl noise
+
+`noiseCurl3(x, y, z, {int seed = 1337, double epsilon = 0.25})` returns a divergence-free 3D vector `({x, y, z})` from a seeded potential field, for advecting particles so they swirl without clumping. Coordinates are taken pre-scaled (no frequency parameter), matching the GLSL `NoiseCurl3`. Advect by adding `curl * speed * dt`. A smaller `epsilon` sharpens the field and amplifies CPU/GPU divergence.
+
+### Baking noise to a texture
+
+Sampling many octaves per fragment is expensive. When the field is static, bake it once and sample the texture instead:
+
+```dart
+Texture2D bakeNoiseTexture(
+  FastNoiseLite noise, {
+  required int width,
+  required int height,
+  double originX = 0.0,
+  double originY = 0.0,
+  double cellSize = 1.0,
+  TextureSampling sampling = const TextureSampling(),
+});
+```
+
+It bakes `getNoise2` over a `width` x `height` grid into a grayscale `Texture2D` (content is linear `data`, so mipmaps average cleanly) ready to bind as a material sampler. It must run where GPU resources are created (the raster thread). The CPU half, `bakeNoisePixels(noise, {width, height, originX, originY, cellSize})`, returns `Uint8List` RGBA and has no engine imports, so it runs in a build hook or a background isolate, then `Texture2D.fromPixels` uploads the result.
+
+---
+
+## The web noise caveat, expanded
+
+The Dart `FastNoiseLite` port relies on 32-bit integer arithmetic. On native platforms this is exact. On the web (dart2js), a Dart `int` is a JavaScript double, exact only to 53 bits, so the integer hash loses its low bits and 3D noise can overflow. The result is a plausible-looking but wrong field, silent, and web-only. A web-safe integer multiply for the Dart side is a planned follow-up.
+
+The GLSL half of the module is unaffected, it is correct on every backend including WebGL2, and implements the same algorithms with the same tables and seeds, so a field sampled on the CPU (native) and evaluated in a shader agree. The agreement has two tiers:
+
+- **Bit-exact**: `noiseHash2`/`noiseHash3` (and GLSL `NoiseHash2`/`NoiseHash3`) are pure integer math and match bit for bit across backends. Use them for decisions that must never disagree between machines (world generation, deterministic placement).
+- **Float-close**: the float noise functions match within a small tolerance (float32 rounding differs per GPU), imperceptible visually. Do not re-derive a hard threshold from float noise on both the CPU and GPU sides, make the decision once and share the result.
+
+Both tiers carry the web-overflow caveat on the Dart side. Strategy by target:
+
+- **Native only**: use the Dart `FastNoiseLite` freely, on the render isolate or a background one.
+- **Web, per-fragment noise**: move it to the GLSL side (`#include <noise.glsl>` in a `.fmat` block).
+- **Web, a static field**: bake it with `bakeNoiseTexture` (or `bakeNoisePixels` in a build hook / native isolate) and sample the texture. This sidesteps the overflow because the baking happens where `int` is 64-bit.
+
+---
+
+## InstancedMesh, thousands of copies for one draw
+
+One geometry/material pair drawn many times, each placed by its own model transform. The whole set is one render item, one pipeline, one cull test. This is how you scatter foliage, crowds, debris, or a grid of the same prop without a node per copy.
+
+```dart
+class InstancedMesh {
+  InstancedMesh({
+    required Geometry geometry,
+    required Material material,
+    bool cullInstances = false,          // per-instance cull after the aggregate pass
+    bool sortTransparentInstances = true,
+  });
+
+  int get instanceCount;
+
+  int addInstance(vm.Matrix4 transform, {vm.Vector4? color}); // matrix is CLONED; returns index
+  void setInstanceTransform(int index, vm.Matrix4 transform);
+  void updateInstanceTransforms(
+    void Function(List<vm.Matrix4> transforms) update, {
+    bool recomputeWinding = true,
+  });
+  void setInstanceColor(int index, vm.Vector4 color);         // linear RGBA multiplier
+  void removeInstanceAt(int index);                            // shifts later indices down
+  void clearInstances();
+}
+```
+
+Attach it to a node with an `InstancedMeshComponent` (it does not go on `Node(mesh:)`):
+
+```dart
+final mesh = InstancedMesh(geometry: geo, material: mat);
+for (final placement in placements) {
+  mesh.addInstance(placement); // a Matrix4 in the instanced mesh's local space
+}
+final node = Node()..addComponent(InstancedMeshComponent(mesh));
+scene.add(node);
+```
+
+Practical notes:
+
+- `addInstance` clones the matrix, so reusing one scratch `Matrix4` across the loop is fine.
+- The node the component is on transforms the entire batch. Instance transforms compose under it.
+- To animate all instances cheaply, use `updateInstanceTransforms`, which invalidates the batch once instead of per call. Mutate the matrices in the callback list; do not add, remove, or replace entries.
+- `updateInstanceTransforms(recomputeWinding: false)` skips the parity refresh. Only pass it when no edit changes a transform's winding. A mirrored (negative-determinant) edit under it renders those instances inside-out.
+- `cullInstances: true` pays for per-instance culling, worth it for a large spatial spread whose instances enter view at different times; leave it off for a small compact clump that the single aggregate cull already handles.
+- Set `cullInstances` per instanced mesh based on that trade; it is not a global.
+
+---
+
+## Modular kits from the built-in primitives
+
+Before authoring a mesh, remember the ten primitives assemble a surprising amount by composition, no builder needed. Each is a `Geometry`, so each goes on its own `Node`, and a parent node groups a kit piece you can clone and place.
+
+| Class | Constructor | Notes |
+| --- | --- | --- |
+| `CuboidGeometry` | `CuboidGeometry(vm.Vector3 extents)` | Box from `-extents/2` to `+extents/2`. Positional. |
+| `SphereGeometry` | `SphereGeometry({radius = 0.5, segments = 32, rings = 16})` | UV sphere. |
+| `IcosphereGeometry` | `IcosphereGeometry({radius = 0.5, subdivisions = 2})` | Even triangle distribution. |
+| `CylinderGeometry` | `CylinderGeometry({bottomRadius = 0.5, topRadius = 0.5, height = 1.0, ...})` | `topRadius: 0` makes a cone; different radii make a frustum. |
+| `CapsuleGeometry` | `CapsuleGeometry({radius = 0.5, height = 1.0, ...})` | `height` is the mid-section; total Y is `height + 2*radius`. |
+| `TorusGeometry` | `TorusGeometry({radius = 0.5, tubeRadius = 0.2, ...})` | Lies in XZ. |
+| `PlaneGeometry` | `PlaneGeometry({width = 1.0, depth = 1.0, segmentsX = 1, segmentsZ = 1})` | XZ plane, faces +Y. |
+| `DiscGeometry` | `DiscGeometry({radius = 0.5, segments = 32})` | Filled circle, XZ, faces +Y. |
+| `RingGeometry` | `RingGeometry({innerRadius = 0.25, outerRadius = 0.5, segments = 32})` | Annulus, XZ, +Y. |
+| `WedgeGeometry` | `WedgeGeometry(vm.Vector3 size)` | Triangular prism; base on `y = 0` (not Y-centered). |
+
+Because a cone is just `CylinderGeometry(topRadius: 0)`, a tree is a green cone on a brown cylinder, a fence is repeated thin cuboids, a table is a plane on four cylinders. Assemble each piece as a parented `Node` subtree, then `clone()` and place it, or feed the placements to an `InstancedMesh` when the same piece repeats many times.
+
+Every primitive except `PlaneGeometry` exposes a `Shape get collisionShape` for the physics package, so a code-built kit gets colliders for free.
+
+### Swept geometry for shapes primitives cannot make
+
+For paths, tubes, and profiles, sweep a `ScenePath` (`BezierPath`, `CatmullRomPath`, `PolylinePath`):
+
+- `TubeGeometry(path, {radius = 0.5, radialSegments = 12, stations = 64, caps = true})` for pipes, cables, vines.
+- `ExtrudeGeometry(path, {required List<vm.Vector2> profile, stations = 64, caps = true})` sweeps a 2D profile along the path (railings, moldings, extruded logos).
+- `RibbonGeometry(path, {width = 1.0, stations = 64, alignment = RibbonAlignment.ground})` for flat strips (roads, trails).
+
+These build detailed shapes from a curve and a few parameters, often replacing an imported model outright.

--- a/packages/flutter_scene/skills/flutter_scene-verification-loop/SKILL.md
+++ b/packages/flutter_scene/skills/flutter_scene-verification-loop/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: flutter_scene-verification-loop
+version: 1
+description: Close the visual-iteration loop when building or debugging a flutter_scene 3D app so you see your own output and self-correct. Use whenever a change affects what renders (geometry, materials, lighting, shaders, post-processing) or a frame looks wrong (black, washed-out, see-through, missing geometry).
+---
+
+# Verifying flutter_scene visually
+
+flutter_scene renders 3D. A rendering change you cannot see is a guess, and guessing at pixels is the single biggest waste of iterations. The highest-value habit is a closed visual loop plus judgment that does not drift. This skill is that loop.
+
+**The one thing to internalize: run it, let it settle, look at the frame AND the console, localize before you edit, repeat.** Do not change code off a hypothesis you did not confirm from the actual output.
+
+## The loop
+
+1. **Run.** Launch the app with `flutter run --enable-flutter-gpu` (native; the flag is mandatory and it is the only run flag, see the idioms skill). Where the editor MCP is connected, `run_project` launches the managed session instead.
+2. **Settle.** A live frame is a moving target. Auto-exposure is still ramping, particles have a random phase, an animation is mid-clip, IBL re-bakes after the first present. Let the scene reach steady state (a few frames, or until the image stops changing) before you trust a capture. Do not screenshot the first frame and reason from it.
+3. **Capture the frame AND read the console.** A screenshot alone hides errors that print; the console alone hides wrong pixels. Take both every time. Baseline path is a screenshot plus the run log; with the editor MCP it is `screenshot_viewport` plus `get_console`.
+4. **Localize before editing.** When something is wrong, find where it goes wrong before you touch code. Read an intermediate buffer, read a single pixel's exact value, or scan for non-finite values. A NaN or Inf propagates silently into black or garbage downstream, so the first pass that produced it is the culprit, not the pass where you see the black. `references/loop.md` has the tool table and a symptom to action map.
+5. **Correct, repeat.** Make one change, run the loop again. One change per iteration keeps cause and effect legible.
+
+## The readiness gate (do not debug through it)
+
+Rendering is gated on `Scene.initializeStaticResources()`. Until that Future completes, every frame is skipped and the engine prints exactly:
+
+```
+Flutter Scene is not ready to render. Skipping frame.
+```
+
+If you see that line, the scene is not broken, it is not ready. Wait for readiness (build geometry and materials inside `initializeStaticResources().then(...)`, gate the widget on `Scene.isReadyToRender`) before you diagnose anything else. A black frame while that line prints is the gate, not your code.
+
+## Judge blind, never self-score (the load-bearing rule)
+
+When deciding whether a change improved the look, **do not assign the frame a quality score.** Self-assigned scores drift upward, because the model is grading its own trajectory and wants to have made progress. That drift is how a session convinces itself a regression is an improvement.
+
+Instead, **compare two frames and return a binary pick.** Put the new frame next to a reference (a known-good target) or the previous frame, and answer only "which of these two is better", A or B. No number, no "8/10", no "looks pretty good now". A blind pairwise pick does not inflate the way a solo score does. This applies to every visual review, including the ones that feel obvious.
+
+If you have no reference at all, say so and describe the concrete difference between the two frames (this one is brighter here, that one has an artifact there) rather than inventing a score.
+
+## Be honest about tooling
+
+The richest observation tooling lives behind the editor MCP (`flutter_scene_mcp`): screenshots, console, NaN scans, render-graph capture, per-pass and per-pixel readback, viewport debug modes. A general-purpose observation server for an arbitrary running game is still being built, so do not assume those tools exist for every project. When the MCP is not connected, the baseline loop is still fully usable: `flutter run --enable-flutter-gpu`, read the console, take a screenshot. Do not claim a capability you cannot reach in the current project.
+
+## More depth
+
+- `references/loop.md` for the full editor-MCP tool table, the symptom to action map (black frame, washed-out, see-through, missing geometry), and the settle details.
+- The `flutter_scene-idioms` skill (`references/traps.md`) for the underlying mistakes each symptom points back to (wrong vertex layout, hand-rolled winding flip, transform-in-place, the blank-frame causes).

--- a/packages/flutter_scene/skills/flutter_scene-verification-loop/references/loop.md
+++ b/packages/flutter_scene/skills/flutter_scene-verification-loop/references/loop.md
@@ -1,0 +1,144 @@
+# The verification loop in detail
+
+The core loop, the readiness gate, and the blind-judgment rule are in `SKILL.md`. This file has the
+tool table (what exists where), the settle details, and the symptom to action map.
+
+---
+
+## Two tooling tiers
+
+### Baseline (any project, no MCP)
+
+This always works and needs nothing installed beyond the package setup.
+
+- Launch: `flutter run --enable-flutter-gpu` (native; add `-d chrome` for web). The flag is mandatory.
+- Console: read the run log. The readiness line, `debugPrint` output, asserts, and the 0.22.0
+  blank-frame diagnostic all land here.
+- Frame: take a screenshot of the running app after it settles.
+
+That is the whole loop when there is no editor. Run, settle, screenshot, read the log, correct.
+
+### Editor MCP (`flutter_scene_mcp`, when connected)
+
+The editor exposes richer observation. Tool names below are exact. Do not assume they exist unless
+the MCP is actually connected for the current project.
+
+| Tool | What it does | Reach for it when |
+| --- | --- | --- |
+| `run_project` | Launch the editor-managed Play session (a managed `flutter run`). | Starting a session under the editor. |
+| `build_project` | Start the selected build config; output streams to the console. | You want a build without launching. |
+| `stop_project` | Stop the running session. | Ending or restarting cleanly. |
+| `hot_reload` | Hot reload the running debug session. | A Dart-only change, fastest turnaround. |
+| `hot_restart` | Hot restart the session. | State or startup changed, or reload did not take. |
+| `get_console` | The build/run console tail plus building/running flags. | EVERY iteration, paired with a screenshot. |
+| `screenshot_viewport` | The viewport as a PNG, what the user sees. | EVERY iteration, paired with the console. |
+| `describe_scene` | The scene-graph tree (ids, paths, names, component types). | Confirming a node/mesh is actually in the scene. |
+| `scan_for_nans` | Capture a frame and scan every float render target for NaN/Inf in pass order. | A black or garbage frame with no error. Find where non-finite values start. |
+| `capture_render_graph` | Capture the next frame's graph with thumbnails. | You need to see intermediate buffers. |
+| `list_render_passes` | The executed passes in order with CPU timings and the buffer keys each read/wrote, plus target formats and sizes. No images. | Learning which pass owns which buffer, and the key names to read. |
+| `get_pass_output` | Render one captured buffer (a key like `scene_color`, `linear_depth`) as a PNG. NaN paints magenta, Inf yellow, negative blue. | Eyeballing an intermediate buffer to see which stage broke. |
+| `read_pass_pixel` | One pixel's exact float RGBA from a captured buffer, with NaN/Inf flags. | Confirming an exact value (is this really 0, or NaN, or negative). |
+| `list_viewport_debug_modes` | The available debug outputs (final, HDR color, linear depth, normals, AO, shadow atlas, ...) and which is active. | Seeing what debug views exist. |
+| `set_viewport_debug_mode` | Render one debug output full-viewport. Set `final` to restore. | Inspecting depth/normals/AO live, paired with `screenshot_viewport`. |
+
+Render-graph capture (`capture_render_graph`, `list_render_passes`, `get_pass_output`,
+`read_pass_pixel`, `scan_for_nans`) is gated on `Scene.debugAllowRenderGraphCapture`. It is a debug
+opt-in, so a release build or a scene that never armed it returns nothing. The editor arms it for you;
+outside the editor, set `Scene.debugAllowRenderGraphCapture = true` and call
+`Scene.captureRenderGraph(...)` directly.
+
+---
+
+## Settle, do not seed
+
+Frames differ from run to run for benign reasons. That is normal, not a bug to eliminate.
+
+- **Auto-exposure** (`Scene.autoExposure`) ramps toward the target over `speedUp`/`speedDown` seconds,
+  so the first second is darker or brighter than the settled image.
+- **Particles and trails** carry a random phase, so a `ParticleSystem` looks different every launch.
+- **Animations** are mid-clip unless you seek them, so a screenshot lands on an arbitrary frame.
+- **Image-based lighting** re-bakes after the first present on some paths, so reflections dim in for
+  a frame before they are correct.
+
+So let the scene settle before you trust a capture. Watch until the image stops changing, or advance
+a fixed few frames, then screenshot. Judge the settled frame, not the first one.
+
+**Seeding is a different job.** Strict determinism (a fixed random seed, a pinned animation time, a
+frozen exposure) is what you set up for pixel-exact regression comparison, where two runs must be
+byte-identical. You do not need it for ordinary observation. For "does this change look right", settle
+and look. Reserve the seeding work for when you are building a golden or diffing two runs at the pixel
+level.
+
+---
+
+## Symptom to action map
+
+Localize before editing. Each row says what to capture first and the mistakes it usually points back
+to. The mistakes are detailed in the `flutter_scene-idioms` skill's `references/traps.md`; this map
+routes a symptom to the right one.
+
+### Entirely black frame
+
+1. Read the console FIRST. If `Flutter Scene is not ready to render. Skipping frame.` is printing, it
+   is the readiness gate, not your scene. Wait for `Scene.initializeStaticResources()`. Stop here.
+2. In 0.22.0 a frame that issues zero draws prints once in debug naming the likely cause (not ready,
+   empty region, no views, no visible meshes, or a layer mask matching nothing). Read that line.
+3. If draws are happening but the image is black, `scan_for_nans`. A NaN or Inf anywhere upstream
+   collapses the final image to black, and the scan names the first offending pass. Then
+   `get_pass_output` on that pass's buffer (NaN shows magenta) to confirm.
+4. Common non-NaN causes: a degenerate camera (target equals position, `up` parallel to the view
+   direction on a top-down camera, FOV passed in degrees not radians), `layerMask: 0`, an oversized
+   environment texture that failed to allocate on the device. See traps #23 and #16.
+
+### Washed-out, low-contrast, or too-bright color
+
+1. `screenshot_viewport` after settling, and check whether auto-exposure has finished ramping (a
+   too-bright first second is just the ramp).
+2. If it persists, suspect a shader-output contract break. A custom `ShaderMaterial`/`PostEffect`/sky
+   shader must output linear HDR premultiplied by alpha. Tone-mapping or gamma-encoding in the shader
+   gets applied a second time by the resolve pass, giving exactly this washed-out look. See traps #37
+   and the root `MATERIALS.md`.
+3. Also check for a non-color texture bound as color (a normal or metallic-roughness map without the
+   right `TextureContent`), which reads wrong and distance-dependent. Trap #2.
+4. Hand-packed vertex data at the wrong stride also washes out color (the color attribute lands at the
+   wrong offset). `describe_scene` plus trap #17.
+
+### See-through or inside-out faces
+
+1. `set_viewport_debug_mode` to normals (or `get_pass_output` on the normals buffer) and look at the
+   orientation. Inverted normals confirm a winding problem.
+2. Cause is almost always counter-clockwise hand-built triangles. flutter_scene front faces wind
+   CLOCKWISE in model space. Reverse each triangle's index order, or omit normals and let the
+   constructor derive them. NEVER fix orientation with a per-triangle winding flip; that leaves
+   normals and IBL wrong. Traps #13 and #17.
+3. For an imported model rendered mirrored, check you did not overwrite the runtime importer's
+   `scale(1, 1, -1)` handedness root. Trap #5.
+
+### Missing or popping geometry
+
+1. `describe_scene` to confirm the node is actually in the graph. If it is absent, it is a scene-build
+   bug, not a render bug.
+2. If it is present but invisible, check the layer mask (`Node.layers` is a bitmask, NOT inherited,
+   and must match the view's `layerMask`; `layers = 2` means `1 << 1`, not "layer 2"). Trap #10.
+3. If it appears and disappears with camera angle, the bounds do not cover the geometry (a
+   caller-supplied `bounds` or `setLocalBounds` that is too small, or a swapped primitive geometry on
+   an older version). Widen or omit the bounds. Traps #8 and #24.
+4. A moved skinned mesh that will not move is the skinned-node transform being ignored by design; move
+   the skeleton root instead. Trap #4.
+
+### A value looks numerically wrong (not visually)
+
+Use `read_pass_pixel` on the relevant buffer to read the exact float RGBA at a coordinate, with NaN/Inf
+flags. This settles "is this pixel actually 0.5, or is it NaN, or negative" without eyeballing a PNG
+that the display remap has already clamped.
+
+---
+
+## Judgment, restated
+
+The blind-pairwise rule from `SKILL.md` is the part most likely to be skipped, so it bears repeating
+here. When you have a before and an after, put them side by side and pick the better one as a binary
+A-or-B choice against a reference or the previous frame. Do not narrate a score. A solo score climbs
+on its own because you are grading your own progress; a blind pick between two concrete frames does
+not. Every visual review runs through a pairwise pick, including the ones that feel too obvious to
+bother with.

--- a/packages/flutter_scene/test/init_command_test.dart
+++ b/packages/flutter_scene/test/init_command_test.dart
@@ -167,41 +167,43 @@ $hookEndMarker
   });
 
   group('skill install', () {
-    late Uri skillSource;
+    late Uri skillsRoot;
 
-    // Writes a fake bundled skill (versioned frontmatter plus a reference) to
-    // [dir] and returns its uri.
-    Uri writeSkill(String dir, int version) {
-      final src = Directory.fromUri(temp.uri.resolve('$dir/'))
+    // Writes a fake bundled skill (versioned frontmatter plus a reference)
+    // named [name] under [root], and returns [root].
+    Uri writeSkill(Uri root, String name, int version) {
+      final src = Directory.fromUri(root.resolve('$name/'))
         ..createSync(recursive: true);
       File.fromUri(src.uri.resolve('SKILL.md')).writeAsStringSync(
-        '---\nname: $flutterSceneSkillName\nversion: $version\n---\n# skill\n',
+        '---\nname: $name\nversion: $version\n---\n# skill\n',
       );
       Directory.fromUri(src.uri.resolve('references/')).createSync();
       File.fromUri(
         src.uri.resolve('references/what-exists.md'),
       ).writeAsStringSync('x\n');
-      return src.uri;
+      return root;
     }
 
-    setUp(() => skillSource = writeSkill('_src/$flutterSceneSkillName', 1));
+    setUp(() {
+      skillsRoot = temp.uri.resolve('_src/');
+      writeSkill(skillsRoot, 'flutter_scene-idioms', 1);
+    });
 
-    File installed(String parent) => File.fromUri(
-      temp.uri.resolve('$parent/skills/$flutterSceneSkillName/SKILL.md'),
-    );
+    File installed(String parent, [String name = 'flutter_scene-idioms']) =>
+        File.fromUri(temp.uri.resolve('$parent/skills/$name/SKILL.md'));
 
     test('defaults to .claude when no agent home is present', () async {
       final plan = await planFlutterSceneSkillInstall(
         projectRoot: temp,
-        skillSource: skillSource,
+        skillsRoot: skillsRoot,
       );
       expect(plan.action, SkillInstallAction.install);
-      expect(plan.bundledVersion, 1);
-      expect(plan.installedVersion, isNull);
+      expect(plan.installCount, 1);
+      expect(plan.skillNames, ['flutter_scene-idioms']);
 
       final result = await installFlutterSceneSkills(
         projectRoot: temp,
-        skillSource: skillSource,
+        skillsRoot: skillsRoot,
       );
 
       expect(result.status, InitSkillStatus.installed);
@@ -210,7 +212,7 @@ $hookEndMarker
       expect(
         File.fromUri(
           temp.uri.resolve(
-            '.claude/skills/$flutterSceneSkillName/references/what-exists.md',
+            '.claude/skills/flutter_scene-idioms/references/what-exists.md',
           ),
         ).existsSync(),
         isTrue,
@@ -223,7 +225,7 @@ $hookEndMarker
 
       await installFlutterSceneSkills(
         projectRoot: temp,
-        skillSource: skillSource,
+        skillsRoot: skillsRoot,
       );
 
       expect(installed('.cursor').existsSync(), isTrue);
@@ -232,39 +234,58 @@ $hookEndMarker
       expect(installed('.claude').existsSync(), isFalse);
     });
 
+    test('discovers and installs every bundled skill', () async {
+      writeSkill(skillsRoot, 'flutter_scene-looks', 1);
+
+      final plan = await planFlutterSceneSkillInstall(
+        projectRoot: temp,
+        skillsRoot: skillsRoot,
+      );
+      expect(plan.skillNames, ['flutter_scene-idioms', 'flutter_scene-looks']);
+      expect(plan.installCount, 2);
+
+      await installFlutterSceneSkills(
+        projectRoot: temp,
+        skillsRoot: skillsRoot,
+      );
+      expect(installed('.claude', 'flutter_scene-idioms').existsSync(), isTrue);
+      expect(installed('.claude', 'flutter_scene-looks').existsSync(), isTrue);
+    });
+
     test('an installed matching version reports up to date', () async {
       await installFlutterSceneSkills(
         projectRoot: temp,
-        skillSource: skillSource,
+        skillsRoot: skillsRoot,
       );
 
       final plan = await planFlutterSceneSkillInstall(
         projectRoot: temp,
-        skillSource: skillSource,
+        skillsRoot: skillsRoot,
       );
       expect(plan.action, SkillInstallAction.upToDate);
-      expect(plan.installedVersion, 1);
+      expect(plan.installCount, 0);
+      expect(plan.updateCount, 0);
     });
 
     test('a newer bundled version reports an update', () async {
-      // Install v1, then point at a v2 source.
       await installFlutterSceneSkills(
         projectRoot: temp,
-        skillSource: skillSource,
+        skillsRoot: skillsRoot,
       );
-      final v2 = writeSkill('_src2/$flutterSceneSkillName', 2);
+      // Bump the bundled skill to v2 in a fresh source root.
+      final v2 = temp.uri.resolve('_src2/');
+      writeSkill(v2, 'flutter_scene-idioms', 2);
 
       final plan = await planFlutterSceneSkillInstall(
         projectRoot: temp,
-        skillSource: v2,
+        skillsRoot: v2,
       );
       expect(plan.action, SkillInstallAction.update);
-      expect(plan.installedVersion, 1);
-      expect(plan.bundledVersion, 2);
+      expect(plan.updateCount, 1);
 
-      await installFlutterSceneSkills(projectRoot: temp, skillSource: v2);
+      await installFlutterSceneSkills(projectRoot: temp, skillsRoot: v2);
       expect(
-        await planFlutterSceneSkillInstall(projectRoot: temp, skillSource: v2),
+        await planFlutterSceneSkillInstall(projectRoot: temp, skillsRoot: v2),
         isA<SkillInstallPlan>().having(
           (p) => p.action,
           'action',
@@ -276,28 +297,28 @@ $hookEndMarker
     test('a pre-versioning install reads as stale', () async {
       // A skill with no version frontmatter counts as 0, below any bundle.
       final home = Directory.fromUri(
-        temp.uri.resolve('.claude/skills/$flutterSceneSkillName/'),
+        temp.uri.resolve('.claude/skills/flutter_scene-idioms/'),
       )..createSync(recursive: true);
       File.fromUri(home.uri.resolve('SKILL.md')).writeAsStringSync('# old\n');
 
       final plan = await planFlutterSceneSkillInstall(
         projectRoot: temp,
-        skillSource: skillSource,
+        skillsRoot: skillsRoot,
       );
       expect(plan.action, SkillInstallAction.update);
-      expect(plan.installedVersion, 0);
+      expect(plan.updateCount, 1);
     });
 
     test('reports a missing source instead of throwing', () async {
       final plan = await planFlutterSceneSkillInstall(
         projectRoot: temp,
-        skillSource: temp.uri.resolve('_nope/'),
+        skillsRoot: temp.uri.resolve('_nope/'),
       );
       expect(plan.action, SkillInstallAction.sourceMissing);
 
       final result = await installFlutterSceneSkills(
         projectRoot: temp,
-        skillSource: temp.uri.resolve('_nope/'),
+        skillsRoot: temp.uri.resolve('_nope/'),
       );
       expect(result.status, InitSkillStatus.sourceMissing);
     });
@@ -307,15 +328,19 @@ $hookEndMarker
         describeSkillPlan(
           const SkillInstallPlan(
             SkillInstallAction.update,
-            installedVersion: 1,
-            bundledVersion: 3,
+            updateCount: 2,
+            skillNames: ['a', 'b'],
           ),
         ),
-        allOf(contains('v1'), contains('v3'), contains('flutter_scene:skills')),
+        allOf(contains('2'), contains('flutter_scene:skills')),
       );
       expect(
         describeSkillPlan(
-          const SkillInstallPlan(SkillInstallAction.install, bundledVersion: 3),
+          const SkillInstallPlan(
+            SkillInstallAction.install,
+            installCount: 3,
+            skillNames: ['a', 'b', 'c'],
+          ),
         ),
         contains('not installed'),
       );
@@ -323,7 +348,7 @@ $hookEndMarker
         describeSkillPlan(
           const SkillInstallPlan(
             SkillInstallAction.upToDate,
-            bundledVersion: 3,
+            skillNames: ['a', 'b', 'c'],
           ),
         ),
         contains('up to date'),


### PR DESCRIPTION
Four new agent skills alongside `flutter_scene-idioms`, cut as 0.22.2: `flutter_scene-verification-loop` (the run-settle-capture-correct visual loop plus the blind-pairwise judgment rule), `flutter_scene-looks` (copy-paste `EnvironmentSettings` presets for a deliberate look), `flutter_scene-procedural` (terrain, noise, and instancing from code), and `flutter_scene-performance` (frame-budget measurement and a fixed remediation order).

The install path (`init_command.dart`, `flutter_scene:init`, `flutter_scene:skills`) is generalized to enumerate and install every bundled `skills/*/` dir instead of only idioms. Every cited API is verified against source and the code examples compile against the published package.