### PR TITLE
Route editor dialogs through an in-window DialogRoute

### DIFF
--- a/apps/flutter_scene_editor_app/lib/main.dart
+++ b/apps/flutter_scene_editor_app/lib/main.dart
@@ -776,8 +776,8 @@ class _EditorHomeState extends State<_EditorHome> {
     );
     if (!context.mounted) return false;
     String gb(int bytes) => (bytes / (1 << 30)).toStringAsFixed(2);
-    final confirmed = await showDialog<bool>(
-      context: context,
+    final confirmed = await showEditorDialog<bool>(
+      context,
       builder: (context) => AlertDialog(
         title: const Text('Delete managed checkout?'),
         content: Text(

--- a/packages/flutter_scene_editor/lib/flutter_scene_editor.dart
+++ b/packages/flutter_scene_editor/lib/flutter_scene_editor.dart
@@ -70,6 +70,7 @@ export 'src/settings/open_in_editor.dart'
     show buildEditorInvocation, openSourceInEditor;
 export 'src/settings/settings_dialog.dart'
     show SettingsDialog, showSettingsDialog;
+export 'src/shell/editor_dialog.dart' show showEditorDialog;
 export 'src/toolchains/managed_checkout.dart'
     show
         ManagedCheckoutJob,

--- a/packages/flutter_scene_editor/lib/src/assets/environment_image_picker.dart
+++ b/packages/flutter_scene_editor/lib/src/assets/environment_image_picker.dart
@@ -4,6 +4,7 @@ import 'package:forui/forui.dart';
 import '../io/scene_io.dart';
 import 'asset_index.dart';
 import 'environment_thumbnail.dart';
+import '../shell/editor_dialog.dart';
 
 /// Picks an existing project environment image or imports one from disk.
 Future<String?> showEnvironmentImagePicker(
@@ -17,8 +18,8 @@ Future<String?> showEnvironmentImagePicker(
             .where((asset) => asset.kind == FileAssetKind.environmentImage)
             .toList();
   if (!context.mounted) return null;
-  return showDialog<String>(
-    context: context,
+  return showEditorDialog<String>(
+    context,
     builder: (context) => Dialog(
       child: _EnvironmentImagePickerDialog(
         assets: assets,

--- a/packages/flutter_scene_editor/lib/src/inspector/reference_picker.dart
+++ b/packages/flutter_scene_editor/lib/src/inspector/reference_picker.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 // ignore: implementation_imports
 import 'package:scene/scene.dart';
+import '../shell/editor_dialog.dart';
 
 typedef ReferencePickerEntry = ({LocalId id, String label});
 
@@ -28,8 +29,8 @@ class ReferencePicker extends StatelessWidget {
   }
 
   Future<void> _open(BuildContext context) async {
-    final selected = await showDialog<LocalId>(
-      context: context,
+    final selected = await showEditorDialog<LocalId>(
+      context,
       builder: (context) {
         final colors = context.theme.colors;
         return Dialog(

--- a/packages/flutter_scene_editor/lib/src/io/glb_import_options.dart
+++ b/packages/flutter_scene_editor/lib/src/io/glb_import_options.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../shell/editor_dialog.dart';
 
 /// The up axis the imported model was authored in. glTF is Y-up by spec, so
 /// [yUp] is the default and a no-op; [zUp] adds a corrective rotation.
@@ -39,8 +40,8 @@ Future<GlbImportOptions?> showGlbImportOptions(
   bool showLinkToggle = true,
   String title = 'Import glTF',
 }) {
-  return showDialog<GlbImportOptions>(
-    context: context,
+  return showEditorDialog<GlbImportOptions>(
+    context,
     builder: (context) => _GlbImportDialog(
       initial: initial ?? const GlbImportOptions(),
       showLinkToggle: showLinkToggle,

--- a/packages/flutter_scene_editor/lib/src/panels/render_graph_panel.dart
+++ b/packages/flutter_scene_editor/lib/src/panels/render_graph_panel.dart
@@ -16,6 +16,7 @@ import '../controller/editor_controller.dart';
 import '../render_graph/debug_shaders.dart';
 import '../render_graph/render_graph_inspector.dart';
 import '../shell/editor_theme.dart';
+import '../shell/editor_dialog.dart';
 
 /// The dockable Render Graph inspector.
 class RenderGraphPanel extends StatefulWidget {
@@ -331,8 +332,8 @@ class _RenderGraphPanelState extends State<RenderGraphPanel> {
   Future<void> _openViewer(InspectedResource resource) async {
     final snapshot = await _inspector.captureFullResolution(resource.key);
     if (!mounted) return;
-    await showDialog<void>(
-      context: context,
+    await showEditorDialog<void>(
+      context,
       builder: (context) => Dialog(
         child: SizedBox(
           width: 900,

--- a/packages/flutter_scene_editor/lib/src/project/build_config_dialog.dart
+++ b/packages/flutter_scene_editor/lib/src/project/build_config_dialog.dart
@@ -9,6 +9,7 @@ import 'package:forui/forui.dart' hide FTheme;
 
 import 'fproject.dart';
 import '../shell/editor_theme.dart';
+import '../shell/editor_dialog.dart';
 
 const _modes = ['debug', 'profile', 'release'];
 
@@ -23,8 +24,8 @@ Future<void> showBuildConfigDialog(
   Map<String, String> Function(BuildConfiguration configuration)?
   previewVariables,
 }) {
-  return showDialog<void>(
-    context: context,
+  return showEditorDialog<void>(
+    context,
     builder: (context) => Dialog(
       child: _BuildConfigEditor(
         project: project,

--- a/packages/flutter_scene_editor/lib/src/settings/managed_checkout_dialog.dart
+++ b/packages/flutter_scene_editor/lib/src/settings/managed_checkout_dialog.dart
@@ -7,6 +7,7 @@ import 'package:forui/forui.dart' hide FTheme;
 
 import '../toolchains/managed_checkout.dart';
 import '../shell/editor_theme.dart';
+import '../shell/editor_dialog.dart';
 
 /// Shows [job]'s progress. Resolves when the dialog closes; the job's result
 /// (or error) is on the job itself.
@@ -14,8 +15,8 @@ Future<void> showManagedCheckoutDialog(
   BuildContext context,
   ManagedCheckoutJob job,
 ) {
-  return showDialog<void>(
-    context: context,
+  return showEditorDialog<void>(
+    context,
     barrierDismissible: false,
     builder: (context) => Dialog(child: _ManagedCheckoutProgress(job: job)),
   );

--- a/packages/flutter_scene_editor/lib/src/settings/settings_dialog.dart
+++ b/packages/flutter_scene_editor/lib/src/settings/settings_dialog.dart
@@ -14,6 +14,7 @@ import '../toolchains/editor_build_info.dart';
 import '../toolchains/flutter_installation.dart';
 import 'editor_settings.dart';
 import 'open_in_editor.dart';
+import '../shell/editor_dialog.dart';
 
 /// Shows the settings window. Callbacks mutate/persist through the host.
 Future<void> showSettingsDialog(
@@ -27,8 +28,8 @@ Future<void> showSettingsDialog(
   Future<bool> Function(BuildContext context, FlutterInstallation installation)?
   onDeleteManaged,
 }) {
-  return showDialog<void>(
-    context: context,
+  return showEditorDialog<void>(
+    context,
     builder: (context) => Dialog(
       backgroundColor: editorSurfaceColor,
       child: SettingsDialog(

--- a/packages/flutter_scene_editor/lib/src/shell/editor_dialog.dart
+++ b/packages/flutter_scene_editor/lib/src/shell/editor_dialog.dart
@@ -1,0 +1,33 @@
+/// In-window modal dialogs for the editor shell.
+///
+/// With the windowing feature enabled, showDialog hosts dialogs in their own
+/// OS window. On the stable revision the editor distributions build against,
+/// that window never receives its content size (it opens 0x0) while still
+/// blocking the app modally, and its widget tree mounts outside the shell's
+/// theme scope, so forui controls throw on mount. Pushing the DialogRoute
+/// directly keeps every editor dialog a classic modal inside the main
+/// window. All shell dialogs go through this helper, never showDialog.
+library;
+
+import 'package:flutter/material.dart';
+
+/// Shows [builder]'s widget as a modal dialog inside the current window.
+///
+/// A drop-in for showDialog that never hosts the dialog in a separate OS
+/// window. Returns the value passed to `Navigator.pop`, like showDialog.
+Future<T?> showEditorDialog<T>(
+  BuildContext context, {
+  required WidgetBuilder builder,
+  bool barrierDismissible = true,
+}) {
+  final navigator = Navigator.of(context, rootNavigator: true);
+  return navigator.push(
+    DialogRoute<T>(
+      context: context,
+      builder: builder,
+      barrierColor: Colors.black54,
+      barrierDismissible: barrierDismissible,
+      themes: InheritedTheme.capture(from: context, to: navigator.context),
+    ),
+  );
+}

--- a/packages/flutter_scene_editor/lib/src/shell/editor_shell.dart
+++ b/packages/flutter_scene_editor/lib/src/shell/editor_shell.dart
@@ -24,6 +24,7 @@ import 'command_palette.dart';
 import 'dock_layout.dart';
 import 'docking_shell.dart';
 import 'editor_theme.dart';
+import 'editor_dialog.dart';
 
 /// The panels [EditorShell] registers with its [DockingShell], id to the
 /// title shown on tabs and in the View menu.
@@ -283,8 +284,8 @@ class _EditorShellState extends State<EditorShell> with WidgetsBindingObserver {
         toolchain?.describe() ??
         library.toolchainError ??
         'Not resolved yet; the toolchain resolves on the first .fmat load.';
-    showDialog<void>(
-      context: context,
+    showEditorDialog<void>(
+      context,
       builder: (context) => AlertDialog(
         title: const Text('Shader toolchain', style: TextStyle(fontSize: 14)),
         content: SelectableText(

--- a/packages/flutter_scene_editor/test/editor_dialog_test.dart
+++ b/packages/flutter_scene_editor/test/editor_dialog_test.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene_editor/src/shell/editor_dialog.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('showEditorDialog shows content and returns the popped value', (
+    tester,
+  ) async {
+    Future<String?>? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () {
+              result = showEditorDialog<String>(
+                context,
+                builder: (context) => TextButton(
+                  onPressed: () => Navigator.of(context).pop('picked'),
+                  child: const Text('inside'),
+                ),
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('inside'), findsOneWidget);
+    await tester.tap(find.text('inside'));
+    await tester.pumpAndSettle();
+    expect(await result, 'picked');
+    expect(find.text('inside'), findsNothing);
+  });
+
+  test('editor dialogs never call showDialog directly', () {
+    // showDialog hosts dialogs in their own OS window when windowing is
+    // enabled, which breaks modally on the pinned stable (a 0x0 window blocks
+    // the whole app). Everything must route through showEditorDialog.
+    final offenders = <String>[];
+    for (final root in ['lib', '../../apps/flutter_scene_editor_app/lib']) {
+      final dir = Directory(root);
+      if (!dir.existsSync()) continue;
+      for (final file in dir.listSync(recursive: true)) {
+        if (file is! File || !file.path.endsWith('.dart')) continue;
+        if (file.path.endsWith('shell/editor_dialog.dart')) continue;
+        if (file.readAsStringSync().contains('showDialog')) {
+          offenders.add(file.path);
+        }
+      }
+    }
+    expect(offenders, isEmpty, reason: 'use showEditorDialog instead');
+  });
+}


### PR DESCRIPTION
Resolves #344.

With windowing enabled, showDialog hosts each dialog in its own OS window. On the stable revision distributions build against, that window opens 0x0 while still blocking the app modally, and its widget tree mounts outside the shell's theme scope, so forui controls throw on mount. The new showEditorDialog pushes the DialogRoute directly, keeping every editor dialog a classic modal inside the main window, and a test keeps new showDialog call sites out.