### PR TITLE
Let a raw ShaderMaterial declare engine scene inputs

### DIFF
--- a/MATERIALS.md
+++ b/MATERIALS.md
@@ -815,6 +815,52 @@ See `examples/flutter_app/lib/example_raw_shader.dart` with
 
 ---
 
+# Engine inputs on a raw `ShaderMaterial`
+
+A `ShaderMaterial` can declare the same per-frame engine textures a `.fmat`
+material asks for with `engine_inputs:`, which is what a translucent surface
+needs to refract and to measure its own thickness.
+
+```dart
+final water = ShaderMaterial(
+  vertexShader: library['WaterVertex']!,
+  fragmentShader: library['WaterFragment']!,
+  isOpaqueOverride: false,
+  sceneInputs: const {RenderInput.opaqueSceneColor, RenderInput.depth},
+);
+```
+
+`RenderInput.depth` binds `scene_depth`, the opaque geometry's linear
+view-space depth in world units, and forces the depth prepass.
+`RenderInput.opaqueSceneColor` binds `scene_opaque_color`, the scene behind
+this draw, and `RenderInput.filteredSceneColor` adds its roughness-filtered
+atlas as `scene_filtered_color` for rough refraction.
+
+Nothing is generated for you here, unlike the `.fmat` path. Declare the
+samplers yourself under those names and derive the screen UV from
+`gl_FragCoord`:
+
+```glsl
+uniform sampler2D scene_opaque_color;
+uniform highp sampler2D scene_depth;
+uniform PostFrameInfo { vec4 resolution; } frame;
+
+vec2 uv = gl_FragCoord.xy * frame.resolution.zw;
+float behind = texture(scene_depth, uv).r;   // linear view depth, world units
+vec3 refracted = texture(scene_opaque_color, uv + offset).rgb;
+```
+
+`sceneInputs` is settable after construction; assigning a different set
+invalidates the frame's cached input summary, and assigning an equal one
+does not. The engine produces an input only while a visible material asks for
+it, so declaring none costs nothing.
+
+Unlike the `.fmat` path this is available on `unlit` shading, and a raw
+material pays none of the lit framework's eight engine samplers, so the
+sampler budget has room for the two inputs.
+
+---
+
 # Render state
 
 A `.fmat` material declares render state in its `material` block: `culling`

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
-import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+import 'package:flutter/foundation.dart'
+    show debugPrint, setEquals, visibleForTesting;
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 
@@ -8,6 +9,8 @@ import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/engine_lighting.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/material/shader_stage.dart';
+import 'package:flutter_scene/src/render/custom_render_pass.dart'
+    show RenderInput;
 import 'package:flutter_scene/src/texture/texture2d.dart';
 import 'package:flutter_scene/src/render/frame_transients.dart';
 
@@ -106,7 +109,8 @@ class ShaderMaterial extends Material {
     this.cullingMode = gpu.CullMode.backFace,
     this.windingOrder = gpu.WindingOrder.counterClockwise,
     this.isOpaqueOverride = true,
-  }) {
+    Set<RenderInput> sceneInputs = const {},
+  }) : _sceneInputs = sceneInputs {
     if (fragmentShader != null) {
       setFragmentShader(fragmentShader);
     }
@@ -136,6 +140,33 @@ class ShaderMaterial extends Material {
   /// materials, which the encoder defers to the back-to-front
   /// translucent pass with alpha blending.
   bool isOpaqueOverride;
+
+  Set<RenderInput> _sceneInputs;
+
+  /// Per-frame engine textures this material samples.
+  ///
+  /// [RenderInput.depth] binds `scene_depth`, the opaque geometry's linear
+  /// view-space depth, and forces the depth prepass.
+  /// [RenderInput.opaqueSceneColor] binds `scene_opaque_color`, the scene
+  /// behind this draw, and [RenderInput.filteredSceneColor] adds its
+  /// roughness-filtered atlas as `scene_filtered_color`. Together they are what
+  /// a translucent surface needs for refraction and depth-fade absorption.
+  ///
+  /// Nothing is generated for you, unlike a `.fmat` material: declare the
+  /// samplers yourself under those names and derive the screen UV from
+  /// `gl_FragCoord`. The engine produces an input only while a visible material
+  /// asks for it, so an unused one costs nothing.
+  @override
+  Set<RenderInput> get sceneInputs => _sceneInputs;
+
+  set sceneInputs(Set<RenderInput> value) {
+    if (setEquals(_sceneInputs, value)) return;
+    _sceneInputs = value;
+    // The frame's input set is summarized across materials and cached, so a
+    // change has to invalidate it or the engine keeps producing (or skipping)
+    // last frame's buffers.
+    markMaterialSceneInputsChanged();
+  }
 
   final Map<String, ByteData> _uniformBlocks = {};
   final Map<String, _BoundTexture> _textures = {};
@@ -370,6 +401,15 @@ class ShaderMaterial extends Material {
 
     if (useEnvironment) {
       _bindEnvironmentTextures(pass, shader, lighting);
+    }
+
+    if (_sceneInputs.isNotEmpty) {
+      EngineLightingUniforms.bindSceneInputTextures(
+        pass,
+        shader,
+        lighting,
+        _sceneInputs,
+      );
     }
   }
 

--- a/packages/flutter_scene/test/shader_material_test.dart
+++ b/packages/flutter_scene/test/shader_material_test.dart
@@ -6,6 +6,11 @@
 import 'dart:typed_data';
 
 import 'package:flutter_scene/scene.dart';
+// The revision counter the frame's scene-input summary is cached against is
+// internal, and asserting the invalidation is the point of the last test here.
+// ignore: implementation_imports
+import 'package:flutter_scene/src/material/material.dart'
+    show materialSceneInputsRevision;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -66,6 +71,38 @@ void main() {
       expect(opaque.isOpaque(), isTrue);
       opaque.isOpaqueOverride = false;
       expect(opaque.isOpaque(), isFalse);
+    });
+  });
+
+  group('ShaderMaterial scene inputs', () {
+    test('requests nothing by default', () {
+      expect(ShaderMaterial().sceneInputs, isEmpty);
+    });
+
+    test('carries what the constructor declared', () {
+      final material = ShaderMaterial(
+        sceneInputs: const {RenderInput.opaqueSceneColor, RenderInput.depth},
+      );
+      expect(
+        material.sceneInputs,
+        containsAll(<RenderInput>[
+          RenderInput.opaqueSceneColor,
+          RenderInput.depth,
+        ]),
+      );
+    });
+
+    test('a change invalidates the cached frame summary', () {
+      final material = ShaderMaterial();
+      final before = materialSceneInputsRevision;
+      material.sceneInputs = const {RenderInput.depth};
+      expect(materialSceneInputsRevision, greaterThan(before));
+
+      // Setting an equal set is not a change and must not invalidate, or every
+      // material assignment costs the frame its input summary.
+      final after = materialSceneInputsRevision;
+      material.sceneInputs = const {RenderInput.depth};
+      expect(materialSceneInputsRevision, after);
     });
   });
 }


### PR DESCRIPTION
A translucent surface needs `scene_color` and `scene_depth` to refract and to measure its own thickness, and a surface that displaces geometry from a texture needs a vertex shader that can sample one. Today only `PreprocessedMaterial` can do the first (`.fmat`'s `engine_inputs:`) and only `ShaderMaterial` can do the second, so a refractive water surface cannot be written at all.

`sceneInputs` moves onto `ShaderMaterial` as a settable field, reusing the binding path `PreprocessedMaterial` already uses. Assigning a different set invalidates the frame's cached input summary; assigning an equal one does not. Additive, and a material that declares nothing behaves exactly as before.

Two things this reaches that the `.fmat` path does not. Engine inputs are `lit`-only there because the accessors ride the lighting framework, while a raw material writes its own and can be unlit. And a raw material pays none of the lit framework's eight engine samplers, so the budget has room for the inputs.