### PR TITLE
Give a raw ShaderMaterial the whole scene-input contract

### DIFF
--- a/MATERIALS.md
+++ b/MATERIALS.md
@@ -920,30 +920,61 @@ final water = ShaderMaterial(
 );
 ```
 
-`RenderInput.depth` binds `scene_depth`, the opaque geometry's linear
-view-space depth in world units, and forces the depth prepass.
-`RenderInput.opaqueSceneColor` binds `scene_opaque_color`, the scene behind
-this draw, and `RenderInput.filteredSceneColor` adds its roughness-filtered
-atlas as `scene_filtered_color` for rough refraction.
+`RenderInput.opaqueSceneColor` binds `scene_opaque_color`, the scene composed
+behind this draw. `RenderInput.depth` binds `scene_depth`, the opaque
+geometry's linear view-space depth in world units.
+`RenderInput.filteredSceneColor` adds the roughness-filtered atlas as
+`scene_filtered_color` for rough refraction, and implies the snapshot it is
+built from. Those three are the whole set a material may declare; the rest of
+`RenderInput` belongs to `CustomRenderPass.inputs` and is rejected here.
 
-Nothing is generated for you here, unlike the `.fmat` path. Declare the
-samplers yourself under those names and derive the screen UV from
-`gl_FragCoord`:
+In the shader, `#include <scene_inputs.glsl>` and declare which inputs you took
+so only those samplers exist:
 
 ```glsl
-uniform sampler2D scene_opaque_color;
-uniform highp sampler2D scene_depth;
-uniform PostFrameInfo { vec4 resolution; } frame;
+#define FLUTTER_SCENE_SCENE_COLOR
+#define FLUTTER_SCENE_SCENE_DEPTH
+#include <scene_inputs.glsl>
 
-vec2 uv = gl_FragCoord.xy * frame.resolution.zw;
-float behind = texture(scene_depth, uv).r;   // linear view depth, world units
-vec3 refracted = texture(scene_opaque_color, uv + offset).rgb;
+// v_viewvector is the engine vertex shaders' output; a material with its own
+// vertex stage passes whatever it computed.
+float thickness = GetSceneDepth(vec2(0.0)) - GetFragmentViewDepth(v_viewvector);
+vec3 refracted = GetSceneColor(normal_offset * refraction_strength);
 ```
 
-`sceneInputs` is settable after construction; assigning a different set
-invalidates the frame's cached input summary, and assigning an equal one
-does not. The engine produces an input only while a visible material asks for
-it, so declaring none costs nothing.
+The header is the same contract the `.fmat` accessors give you, and it exists
+for a reason worth stating. An input is produced only on the frames a visible
+material asks for it, and it can go missing anyway (a non-perspective camera
+produces no depth), so every read is gated: `GetSceneColor` returns black and
+`GetSceneDepth` returns a huge depth when the input is absent, which fades an
+effect out. Sampling the sampler directly instead reads an opaque-white
+placeholder on those frames, which is a blown-out image rather than an inert
+one. The header also derives the screen UV from a `SceneInputInfo` block the
+engine binds, since a raw shader has no other way to learn the render-target
+size (it is the widget size times the device pixel ratio times
+`Scene.renderScale`, and the material draws into the scene color target rather
+than into the widget).
+
+`buildTargetShaderBundleJson` puts flutter_scene's `shaders/` on the include
+path, so the `#include` resolves with no setup. It also reaches `noise.glsl`
+and the rest of the engine's GLSL.
+
+**Keep the defines and the Dart set in step.** They are two declarations of one
+thing, and disagreeing is not a no-op. A sampler the shader declares but never
+samples is eliminated by the compiler while the runtime reflection still lists
+it, and the bind then writes into a slot that does not exist, which fails at
+draw time. Check what a bundle really compiled with:
+
+```sh
+strings my.shaderbundle | grep -oE "[a-z_0-9]+ \[\[texture\([0-9]+\)\]\]" | sort -u
+```
+
+`sceneInputs` is settable after construction, and assigning an equal set is not
+a change. Treat it as a declaration rather than a per-frame knob, though.
+Producing an input is not free: `RenderInput.depth` forces the depth prepass,
+and the scene-color inputs split the scene pass around every screen-reading
+layer. Any non-empty set also moves the frame off its cached whole-scene
+summary onto a per-view collection, and each change re-summarizes the scene.
 
 Unlike the `.fmat` path this is available on `unlit` shading, and a raw
 material pays none of the lit framework's eight engine samplers, so the

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ## 0.23.0
 
+* `ShaderMaterial.sceneInputs` declares the engine's per-frame scene textures, so a raw shader can refract and measure its own thickness like a `.fmat` material. Include `<scene_inputs.glsl>` for the samplers and their accessors; `buildTargetShaderBundleJson` puts flutter_scene's `shaders/` on the include path so it resolves with no setup.
 * Parallax-corrected reflection probes via `ReflectionProbeComponent`, capturing the scene into a local environment whose reflections track the probe's box.
 * `Scene.captureEnvironment` renders the scene's lighting at a point into a new `EnvironmentMap`.
 * SMAA anti-aliasing via `AntiAliasingMode.smaa`, cleaner edges than FXAA with far less texture blurring.

--- a/packages/flutter_scene/lib/src/fmat/build_materials.dart
+++ b/packages/flutter_scene/lib/src/fmat/build_materials.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:data_assets/data_assets.dart';
 import 'package:hooks/hooks.dart';
@@ -19,6 +18,7 @@ import 'fmat_emitter.dart'
         lightmapEntryName,
         materialSamplesEnvironment,
         radianceCubeEntryName;
+import 'framework_shaders.dart';
 import 'target_shader_bundle.dart';
 
 /// Controls where [buildMaterials] puts generated `.fmat` shader assets.
@@ -285,18 +285,7 @@ Future<void> _buildMaterials({
   // output keyed to it is separated by target. Several builds share one tree.
   final target = shaderBundleTargetKey(buildInput);
 
-  // Locate flutter_scene's framework shader directory. flutter_scene has no
-  // top-level `flutter_scene.dart` library, so resolve through this package's
-  // `build_hooks.dart` (which always exists) and hop to the sibling `shaders/`.
-  final frameworkLib = await Isolate.resolvePackageUri(
-    Uri.parse('package:flutter_scene/build_hooks.dart'),
-  );
-  if (frameworkLib == null) {
-    throw Exception(
-      'buildMaterials could not resolve the flutter_scene package location.',
-    );
-  }
-  final frameworkShaders = frameworkLib.resolve('../shaders/');
+  final frameworkShaders = await frameworkShaderInclude();
 
   // Generated GLSL and the synthesized manifest live under the package's build
   // directory; they are regenerated each run.

--- a/packages/flutter_scene/lib/src/fmat/framework_shaders.dart
+++ b/packages/flutter_scene/lib/src/fmat/framework_shaders.dart
@@ -1,0 +1,21 @@
+import 'dart:isolate';
+
+/// Locates flutter_scene's framework shader directory, the one that has to be
+/// on `impellerc`'s include path for a generated or hand-written shader to
+/// `#include` the engine's GLSL.
+///
+/// flutter_scene has no top-level `flutter_scene.dart` library, so this
+/// resolves through `build_hooks.dart` (which always exists) and hops to the
+/// sibling `shaders/`.
+Future<Uri> frameworkShaderInclude() async {
+  final frameworkLib = await Isolate.resolvePackageUri(
+    Uri.parse('package:flutter_scene/build_hooks.dart'),
+  );
+  if (frameworkLib == null) {
+    throw Exception(
+      'Could not resolve the flutter_scene package location, so its shader '
+      'include directory is unavailable.',
+    );
+  }
+  return frameworkLib.resolve('../shaders/');
+}

--- a/packages/flutter_scene/lib/src/fmat/target_shader_bundle.dart
+++ b/packages/flutter_scene/lib/src/fmat/target_shader_bundle.dart
@@ -12,6 +12,7 @@ import '../generated_assets/generated_file_names.dart';
 import '../generated_assets/generated_tree.dart';
 import '../gpu/web/shader_bundle_generated.dart' as fb;
 import '../importer/build_cache.dart' show buildCacheRevision;
+import 'framework_shaders.dart';
 
 export '../generated_assets/generated_assets.dart' show ShaderBundleBackend;
 
@@ -93,7 +94,10 @@ Future<void> buildTargetShaderBundleJson({
     buildInput: buildInput,
     buildOutput: buildOutput,
     manifestFileName: manifestFileName,
-    includeDirectories: includeDirectories,
+    // flutter_scene's own shaders/ goes last, so a raw shader can
+    // `#include <scene_inputs.glsl>` (or the noise library) without the caller
+    // resolving the package, and a same-named file of the caller's still wins.
+    includeDirectories: [...includeDirectories, await frameworkShaderInclude()],
     assetMode: switch (assetMode) {
       TargetShaderBundleAssetMode.generatedTree =>
         ShaderBundleAssetMode.legacyOnly,

--- a/packages/flutter_scene/lib/src/light.dart
+++ b/packages/flutter_scene/lib/src/light.dart
@@ -941,8 +941,10 @@ class Lighting {
   /// visibility in a (instead of visibility in r).
   final bool ssaoIndirectLight;
 
-  /// The color-pass render-target size, used to map `gl_FragCoord` into the
-  /// occlusion texture's UV. Zero when occlusion is off.
+  /// The color-pass render-target size, which maps `gl_FragCoord` into the
+  /// occlusion texture's UV and into the screen UV a material samples its
+  /// scene inputs at. Always the pass dimensions, independent of whether
+  /// occlusion is on.
   final ui.Size viewportSize;
 
   /// The opaque geometry's linear (planar view-space) depth texture for

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -672,6 +672,61 @@ class EngineLightingUniforms {
     }
   }
 
+  /// Binds the standalone `SceneInputInfo` block that
+  /// `shaders/scene_inputs.glsl` declares, carrying what a `.fmat` material
+  /// reads out of `FragInfo`: which inputs exist this frame, the render-target
+  /// size the screen UV comes from, and the camera basis a refraction projects
+  /// against. A raw [gpu.Shader] has no `FragInfo`, so without this it can
+  /// neither gate on availability nor find the UV to sample with.
+  ///
+  /// Does nothing when the shader does not declare the block, which is both
+  /// the material that computes its own mapping and the one whose declaration
+  /// was optimized away. Unlike a sampler, an absent block reflects as a null
+  /// size, so this is detectable rather than a bad bind.
+  static void bindSceneInputInfo(
+    gpu.RenderPass pass,
+    gpu.Shader shader,
+    Lighting lighting,
+    TransientWriter transientsBuffer,
+  ) {
+    final slot = shader.getUniformSlot('SceneInputInfo');
+    if (slot.sizeInBytes == null) return;
+
+    final info = Float32List(20);
+    info[0] = lighting.opaqueSceneColor != null ? 1.0 : 0.0;
+    info[1] = lighting.sceneDepthLinear != null ? 1.0 : 0.0;
+    info[2] = lighting.filteredSceneColor != null ? 1.0 : 0.0;
+    final viewport = lighting.viewportSize;
+    info[4] = viewport.width;
+    info[5] = viewport.height;
+    info[6] = viewport.width > 0 ? 1.0 / viewport.width : 0.0;
+    info[7] = viewport.height > 0 ? 1.0 / viewport.height : 0.0;
+    final forward = lighting.cameraForward;
+    if (forward != null) {
+      info[8] = forward.x;
+      info[9] = forward.y;
+      info[10] = forward.z;
+    }
+    info[11] = lighting.tanHalfFovY;
+    final right = lighting.cameraRight;
+    if (right != null) {
+      info[12] = right.x;
+      info[13] = right.y;
+      info[14] = right.z;
+    }
+    info[15] = lighting.tanHalfFovX;
+    final up = lighting.cameraUp;
+    if (up != null) {
+      info[16] = up.x;
+      info[17] = up.y;
+      info[18] = up.z;
+    }
+    pass.bindUniform(
+      slot,
+      transientsBuffer.emplace(ByteData.sublistView(info)),
+    );
+  }
+
   /// Binds the secondary cross-fade environment's prefiltered radiance to the
   /// `prefiltered_radiance_b` sampler (the specular term only, no diffuse SH).
   /// Shared by the lit material and the environment skybox; both share the

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -110,7 +110,14 @@ class ShaderMaterial extends Material {
     this.windingOrder = gpu.WindingOrder.counterClockwise,
     this.isOpaqueOverride = true,
     Set<RenderInput> sceneInputs = const {},
-  }) : _sceneInputs = sceneInputs {
+  }) : _sceneInputs = _normalizeSceneInputs(sceneInputs) {
+    // A material constructed with inputs is not in the frame's cached summary
+    // yet. Attaching it to a mounted mesh invalidates through the mesh
+    // component, but constructing before the first render does not, so cover
+    // the declaration itself.
+    if (_sceneInputs.isNotEmpty) {
+      markMaterialSceneInputsChanged();
+    }
     if (fragmentShader != null) {
       setFragmentShader(fragmentShader);
     }
@@ -141,27 +148,76 @@ class ShaderMaterial extends Material {
   /// translucent pass with alpha blending.
   bool isOpaqueOverride;
 
+  /// The inputs a material may declare. The rest of [RenderInput] is for
+  /// custom render passes; a material asking for one would neither bind
+  /// anything nor make the engine produce it, while still costing the frame
+  /// its cached whole-scene summary.
+  static const _materialInputs = <RenderInput>{
+    RenderInput.opaqueSceneColor,
+    RenderInput.filteredSceneColor,
+    RenderInput.depth,
+  };
+
+  static Set<RenderInput> _normalizeSceneInputs(Set<RenderInput> value) {
+    for (final input in value) {
+      if (!_materialInputs.contains(input)) {
+        throw ArgumentError.value(
+          input,
+          'sceneInputs',
+          'a material can declare only ${_materialInputs.join(', ')}. '
+              'The rest of RenderInput is for CustomRenderPass.inputs',
+        );
+      }
+    }
+    // The filtered atlas is built from the scene-color snapshot, so asking for
+    // it asks for that too. `.fmat` normalizes the same way; doing it here
+    // keeps one meaning of the set no matter which path declared it.
+    final normalized = {...value};
+    if (normalized.contains(RenderInput.filteredSceneColor)) {
+      normalized.add(RenderInput.opaqueSceneColor);
+    }
+    // Copied and frozen so a caller mutating the set it passed in, or the set
+    // this hands back, cannot change what the material asks for behind the
+    // invalidation below.
+    return Set.unmodifiable(normalized);
+  }
+
   Set<RenderInput> _sceneInputs;
 
   /// Per-frame engine textures this material samples.
   ///
-  /// [RenderInput.depth] binds `scene_depth`, the opaque geometry's linear
-  /// view-space depth, and forces the depth prepass.
   /// [RenderInput.opaqueSceneColor] binds `scene_opaque_color`, the scene
-  /// behind this draw, and [RenderInput.filteredSceneColor] adds its
-  /// roughness-filtered atlas as `scene_filtered_color`. Together they are what
-  /// a translucent surface needs for refraction and depth-fade absorption.
+  /// composed behind this draw, [RenderInput.filteredSceneColor] adds its
+  /// roughness-filtered atlas as `scene_filtered_color` (and implies the
+  /// snapshot), and [RenderInput.depth] binds `scene_depth`, the opaque
+  /// geometry's linear view-space depth. Together they are what a translucent
+  /// surface needs for refraction and depth-fade absorption.
   ///
-  /// Nothing is generated for you, unlike a `.fmat` material: declare the
-  /// samplers yourself under those names and derive the screen UV from
-  /// `gl_FragCoord`. The engine produces an input only while a visible material
-  /// asks for it, so an unused one costs nothing.
+  /// Include `<scene_inputs.glsl>` to get the samplers and their accessors
+  /// rather than declaring them by hand. It gates each read on whether the
+  /// engine produced the input this frame, which a raw shader cannot otherwise
+  /// know, and it derives the screen UV from a `SceneInputInfo` block the
+  /// engine binds. Hand-rolling that means sampling an opaque-white placeholder
+  /// on the frames an input is missing.
+  ///
+  /// **Declaring an input the shader does not sample is a crash, not a
+  /// no-op.** A declared-but-unsampled sampler is eliminated by the compiler
+  /// while the runtime reflection still lists it, and the bind then writes into
+  /// a slot that does not exist. Keep this set and the shader's
+  /// `FLUTTER_SCENE_*` defines in step.
+  ///
+  /// This is a declaration, not a per-frame knob. Producing an input is not
+  /// free: [RenderInput.depth] forces the depth prepass, and the scene-color
+  /// inputs split the scene pass around every screen-reading layer. Any
+  /// non-empty set also moves the frame off its cached whole-scene answer onto
+  /// a per-view collection, and each change re-summarizes the whole scene.
   @override
   Set<RenderInput> get sceneInputs => _sceneInputs;
 
   set sceneInputs(Set<RenderInput> value) {
-    if (setEquals(_sceneInputs, value)) return;
-    _sceneInputs = value;
+    final normalized = _normalizeSceneInputs(value);
+    if (setEquals(_sceneInputs, normalized)) return;
+    _sceneInputs = normalized;
     // The frame's input set is summarized across materials and cached, so a
     // change has to invalidate it or the engine keeps producing (or skipping)
     // last frame's buffers.
@@ -409,6 +465,12 @@ class ShaderMaterial extends Material {
         shader,
         lighting,
         _sceneInputs,
+      );
+      EngineLightingUniforms.bindSceneInputInfo(
+        pass,
+        shader,
+        lighting,
+        transientsBuffer,
       );
     }
   }

--- a/packages/flutter_scene/shaders/scene_inputs.glsl
+++ b/packages/flutter_scene/shaders/scene_inputs.glsl
@@ -1,0 +1,113 @@
+// Engine scene inputs for a raw ShaderMaterial.
+//
+// A `.fmat` material gets these accessors generated against the lit
+// framework's FragInfo block. A ShaderMaterial owns its whole pipeline and has
+// no FragInfo, so it includes this instead. Same names, same gate semantics,
+// same screen mapping, so a shader ported between the two paths reads alike.
+//
+// Declare only what the material declared in Dart. A sampler the shader
+// declares but never samples is eliminated by the compiler while the runtime
+// reflection still lists it, which fails at bind time, so each one is behind
+// the define that asks for it:
+//
+//   #define FLUTTER_SCENE_SCENE_COLOR
+//   #define FLUTTER_SCENE_SCENE_DEPTH
+//   #include <scene_inputs.glsl>
+//
+// The defines must match the material's `sceneInputs` set exactly.
+
+// Per-frame engine state for the samplers below. Bound automatically whenever
+// the material declares any scene input and the shader references this block.
+uniform SceneInputInfo {
+  // Which inputs exist this frame. x scene color, y depth, z filtered color.
+  // An input can go missing for a frame (a non-perspective camera produces no
+  // depth), which is what the accessors gate on. w is reserved.
+  vec4 available;
+
+  // xy: the color-pass render-target size in pixels. zw: its reciprocal.
+  vec4 screen;
+
+  // xyz: the camera's world-space forward axis. w: tan(fovY / 2), zero for a
+  // non-perspective camera.
+  vec4 camera_forward;
+
+  // xyz: the camera's world-space right axis. w: tan(fovX / 2).
+  vec4 camera_right;
+
+  // xyz: the camera's world-space up axis. w is reserved.
+  vec4 camera_up;
+}
+scene_input_info;
+
+// This fragment's screen UV, for sampling the screen-space inputs below.
+vec2 GetScreenUv() { return gl_FragCoord.xy * scene_input_info.screen.zw; }
+
+// This fragment's planar view-space depth in world units, directly comparable
+// against GetSceneDepth. Pass the world-space vector from the fragment to the
+// camera. The engine vertex shaders emit it as `v_viewvector`; a material with
+// its own vertex stage passes whatever it computed.
+float GetFragmentViewDepth(vec3 view_vector) {
+  return dot(-view_vector, scene_input_info.camera_forward.xyz);
+}
+
+// Projects a world-space offset from this fragment back into screen UV, for
+// refraction that exits the volume somewhere other than where it entered.
+// Leaves the sample at this fragment when the camera is not perspective.
+vec2 ProjectWorldOffsetToScreenUv(vec3 world_offset, vec3 view_vector) {
+  vec2 result = GetScreenUv();
+  if (scene_input_info.camera_right.w > 0.0 &&
+      scene_input_info.camera_forward.w > 0.0) {
+    vec3 from_camera = -view_vector + world_offset;
+    float view_z = dot(from_camera, scene_input_info.camera_forward.xyz);
+    if (view_z > 1e-5) {
+      float view_x = dot(from_camera, scene_input_info.camera_right.xyz);
+      float view_y = dot(from_camera, scene_input_info.camera_up.xyz);
+      result = vec2(
+          0.5 + 0.5 * view_x / (view_z * scene_input_info.camera_right.w),
+          0.5 - 0.5 * view_y / (view_z * scene_input_info.camera_forward.w));
+    }
+  }
+  return result;
+}
+
+#ifdef FLUTTER_SCENE_SCENE_COLOR
+// The scene composed behind this draw, linear HDR.
+uniform sampler2D scene_opaque_color;
+
+// The scene behind this fragment, offset in screen UV (pass vec2(0.0) for no
+// distortion). Black when the snapshot is unavailable, so an effect fades out
+// instead of sampling a placeholder.
+vec3 GetSceneColor(vec2 uv_offset) {
+  vec3 result = vec3(0.0);
+  if (scene_input_info.available.x >= 0.5) {
+    vec2 uv = clamp(GetScreenUv() + uv_offset, vec2(0.001), vec2(0.999));
+    result = texture(scene_opaque_color, uv).rgb;
+  }
+  return result;
+}
+#endif
+
+#ifdef FLUTTER_SCENE_SCENE_DEPTH
+// The opaque geometry's linear (planar view-space) depth, in world units.
+// highp because fp16 quantizes depth hard enough to break the comparison.
+uniform highp sampler2D scene_depth;
+
+// The opaque depth behind this fragment, offset in screen UV. Returns a huge
+// depth when unavailable, so a depth difference reads as "nothing behind" and
+// the effect fades out instead of popping.
+float GetSceneDepth(vec2 uv_offset) {
+  float result = 1.0e8;
+  if (scene_input_info.available.y >= 0.5) {
+    vec2 uv = clamp(GetScreenUv() + uv_offset, vec2(0.001), vec2(0.999));
+    result = texture(scene_depth, uv).r;
+  }
+  return result;
+}
+#endif
+
+#ifdef FLUTTER_SCENE_FILTERED_SCENE_COLOR
+// The roughness-filtered atlas of the scene color, for rough refraction.
+// Sampling it needs the band layout, so this exposes the atlas rather than a
+// ready-made accessor.
+uniform sampler2D scene_filtered_color;
+#endif

--- a/packages/flutter_scene/test/scene_inputs_shader_test.dart
+++ b/packages/flutter_scene/test/scene_inputs_shader_test.dart
@@ -1,0 +1,78 @@
+// Locks the raw-material scene-input header against the `.fmat` accessors it
+// mirrors. The two are separate sources (a raw shader has no FragInfo to read
+// gates and the screen mapping out of), so nothing but a test keeps them
+// meaning the same thing.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+File _resolveFile(String relativePath) {
+  final direct = File(relativePath);
+  if (direct.existsSync()) return direct;
+  final inPackage = File('packages/flutter_scene/$relativePath');
+  if (inPackage.existsSync()) return inPackage;
+  throw FileSystemException('Could not find $relativePath');
+}
+
+void main() {
+  final header = _resolveFile('shaders/scene_inputs.glsl').readAsStringSync();
+  // The generated accessors the header has to agree with.
+  final emitter = _resolveFile(
+    'lib/src/fmat/fmat_emitter.dart',
+  ).readAsStringSync();
+
+  test('each sampler is behind the define that declares it', () {
+    // A declared-but-unsampled sampler is eliminated while the reflection
+    // still lists it, which fails at bind time, so a material that took only
+    // one input must compile with only that one.
+    for (final (define, sampler) in const [
+      ('FLUTTER_SCENE_SCENE_COLOR', 'uniform sampler2D scene_opaque_color;'),
+      ('FLUTTER_SCENE_SCENE_DEPTH', 'uniform highp sampler2D scene_depth;'),
+      (
+        'FLUTTER_SCENE_FILTERED_SCENE_COLOR',
+        'uniform sampler2D scene_filtered_color;',
+      ),
+    ]) {
+      final guard = header.indexOf('#ifdef $define');
+      expect(guard, isNonNegative, reason: '$define has no guard');
+      final end = header.indexOf('#endif', guard);
+      expect(header.substring(guard, end), contains(sampler));
+    }
+  });
+
+  test('reads are gated on the frame producing the input', () {
+    // Ungated, a missing input samples the opaque-white placeholder. The
+    // sentinels are the emitter's, so an effect fades out the same way on
+    // either path.
+    expect(header, contains('scene_input_info.available.x >= 0.5'));
+    expect(header, contains('scene_input_info.available.y >= 0.5'));
+    expect(emitter, contains('frag_info.scene_inputs.x < 0.5'));
+    expect(emitter, contains('frag_info.scene_inputs.y < 0.5'));
+
+    // Missing color reads black and missing depth reads far, matching
+    // `GetSceneColor` and `GetSceneDepth` in the emitter.
+    expect(header, contains('vec3 result = vec3(0.0);'));
+    expect(header, contains('float result = 1.0e8;'));
+    expect(emitter, contains('return vec3(0.0);'));
+    expect(emitter, contains('return 1.0e8;'));
+  });
+
+  test('samples at the same clamped screen UV as a .fmat material', () {
+    expect(header, contains('gl_FragCoord.xy * scene_input_info.screen.zw'));
+    expect(emitter, contains('clamp(GetScreenUv() + uv_offset, vec2(0.001)'));
+    expect(header, contains('clamp(GetScreenUv() + uv_offset, vec2(0.001)'));
+  });
+
+  test('the block matches what bindSceneInputInfo packs', () {
+    // Five vec4s in this order, which is the Float32List the engine writes.
+    final block = header.substring(
+      header.indexOf('uniform SceneInputInfo'),
+      header.indexOf('scene_input_info;'),
+    );
+    expect(
+      RegExp(r'vec4 (\w+);').allMatches(block).map((m) => m.group(1)).toList(),
+      ['available', 'screen', 'camera_forward', 'camera_right', 'camera_up'],
+    );
+  });
+}

--- a/packages/flutter_scene/test/shader_material_test.dart
+++ b/packages/flutter_scene/test/shader_material_test.dart
@@ -104,5 +104,59 @@ void main() {
       material.sceneInputs = const {RenderInput.depth};
       expect(materialSceneInputsRevision, after);
     });
+
+    test('declaring inputs at construction invalidates too', () {
+      final before = materialSceneInputsRevision;
+      ShaderMaterial(sceneInputs: const {RenderInput.depth});
+      expect(materialSceneInputsRevision, greaterThan(before));
+
+      // A material that declares nothing cannot change the frame's answer.
+      final after = materialSceneInputsRevision;
+      ShaderMaterial();
+      expect(materialSceneInputsRevision, after);
+    });
+
+    test('rejects inputs only a custom render pass can ask for', () {
+      expect(
+        () => ShaderMaterial(sceneInputs: const {RenderInput.shadowMap}),
+        throwsArgumentError,
+      );
+      expect(
+        () => ShaderMaterial(sceneInputs: const {RenderInput.normals}),
+        throwsArgumentError,
+      );
+      expect(
+        () => ShaderMaterial().sceneInputs = const {RenderInput.shadowMap},
+        throwsArgumentError,
+      );
+    });
+
+    test('the filtered atlas implies the snapshot it is built from', () {
+      final material = ShaderMaterial(
+        sceneInputs: const {RenderInput.filteredSceneColor},
+      );
+      expect(
+        material.sceneInputs,
+        containsAll(<RenderInput>[
+          RenderInput.filteredSceneColor,
+          RenderInput.opaqueSceneColor,
+        ]),
+      );
+    });
+
+    test('the declared set cannot be mutated behind the invalidation', () {
+      final declared = <RenderInput>{RenderInput.depth};
+      final material = ShaderMaterial(sceneInputs: declared);
+
+      // Mutating the caller's set must not reach the material, and the getter
+      // must not hand out something a caller can mutate. Either would change
+      // what the frame produces without bumping the revision.
+      declared.add(RenderInput.opaqueSceneColor);
+      expect(material.sceneInputs, const {RenderInput.depth});
+      expect(
+        () => material.sceneInputs.add(RenderInput.opaqueSceneColor),
+        throwsUnsupportedError,
+      );
+    });
   });
 }


### PR DESCRIPTION
Related to #347. That PR bound the scene-input samplers for a raw `ShaderMaterial` and stopped there. The accessors a `.fmat` material gets, the availability gates and the screen mapping, ride `FragInfo`, which a `ShaderMaterial` never binds, so a raw shader could not tell whether an input existed this frame and had no way to compute the UV to sample it with. An input that went missing read as the opaque-white placeholder instead of fading out, and the documented recipe reached for a `PostFrameInfo` block that only full-screen passes bind.

`shaders/scene_inputs.glsl` is now the same contract for a shader that owns its pipeline, with each sampler behind the define that asks for it so a material never declares one it does not sample. The engine binds the `SceneInputInfo` block it reads whenever the material declares an input and the shader references the block; an absent block reflects as a null size, so it is skipped rather than mis-bound.

The set itself is narrowed to the three inputs a material can use (the rest of `RenderInput` bound nothing while still costing the frame its cached whole-scene summary), the filtered atlas normalizes to imply its snapshot, and the set is copied and frozen so it cannot change behind the invalidation. `buildTargetShaderBundleJson` puts flutter_scene's `shaders/` on the include path, so the include resolves with no setup.

Verified by compiling a shader against the header through `impellerc` on both Metal and GLES 3.00, with the full and partial define sets, and checking the sampler slots and block name survive to reflection.