### PR TITLE
Improve scene loading and static render performance

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.24.0
 
 * Added `ExternalTexture`, a `TextureSource` fed by a platform texture id (video, camera preview), captured through the compositor on frames that sample it.
+* Generated scene registries and templates are cached per asset bundle.
+* Static render items and compressed `.fsceneb` payloads skip redundant work.
 * Widget-surface pointer forwarding dispatches events in the framework's global space (with the host's transform in the hit path), so widgets that convert `globalPosition` through render objects (Slider, text selection) work when the scene view is not at the window origin.
 * The standard PBR shader ships a no-shadow variant, selected automatically for draws with no shadow atlas bound, roughly halving the compiled fragment program for shadow-less scenes on mobile GPUs; it also skips its five per-texture UV-transform evaluations when every transform is identity.
 * `PhysicallyBasedMaterial` keeps a scalar `ior`, `specular`, and `specularColor` on the standard shader by folding them into its dielectric reflectance (the `KHR_materials_ior` / `KHR_materials_specular` formula the physical shader uses), so only specular textures and the layered features select the heavier physical variant.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## 0.24.0
 
 * Added `ExternalTexture`, a `TextureSource` fed by a platform texture id (video, camera preview), captured through the compositor on frames that sample it.
-* Generated scene registries and templates are cached per asset bundle.
-* Static render items and compressed `.fsceneb` payloads skip redundant work.
+* Generated scene registries are cached per asset bundle.
+* `.fsceneb` payload chunks compress with gzip, cutting file sizes by ~73% in exchange for higher load-time decompression CPU.
+* Static render items skip per-frame property re-assignment when their transform and bounds are unchanged.
+* Instanced mesh static shadow updates track component visibility changes correctly.
 * Widget-surface pointer forwarding dispatches events in the framework's global space (with the host's transform in the hit path), so widgets that convert `globalPosition` through render objects (Slider, text selection) work when the scene view is not at the window origin.
 * The standard PBR shader ships a no-shadow variant, selected automatically for draws with no shadow atlas bound, roughly halving the compiled fragment program for shadow-less scenes on mobile GPUs; it also skips its five per-texture UV-transform evaluations when every transform is identity.
 * `PhysicallyBasedMaterial` keeps a scalar `ior`, `specular`, and `specularColor` on the standard shader by folding them into its dielectric reflectance (the `KHR_materials_ior` / `KHR_materials_specular` formula the physical shader uses), so only specular textures and the layered features select the heavier physical variant.

--- a/packages/flutter_scene/lib/src/components/instanced_mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/instanced_mesh_component.dart
@@ -55,28 +55,41 @@ class InstancedMeshComponent extends Component {
     if (item == null) return;
     // A material can declare itself draw-less for the frame (the shadow
     // catcher at zero intensity); its item then joins no pass at all.
-    item.visible = !item.material.drawsNothing;
+    final visible = !item.material.drawsNothing;
     final frustumCulled = node.frustumCulled;
-    final frustumCulledChanged = item.frustumCulled != frustumCulled;
-    item.frustumCulled = frustumCulled;
-    item.layers = node.layers;
     final lightChannelMask = node.lightChannelMask;
-    final worldTransform = node.globalTransform;
     final worldTransformVersion = node.worldTransformVersion;
     final instanceRevision = instancedMesh.revision;
     final geometryBoundsVersion = instancedMesh.geometry.localBoundsVersion;
+    if (node.shadowStatic &&
+        worldTransformVersion == _worldTransformVersion &&
+        instanceRevision == _instanceRevision &&
+        geometryBoundsVersion == _geometryBoundsVersion &&
+        item.visible == visible &&
+        item.frustumCulled == frustumCulled &&
+        item.layers == node.layers &&
+        item.shadowStatic == node.shadowStatic &&
+        item.castsShadows == node.castsShadows &&
+        item.lightChannelMask == lightChannelMask) {
+      return;
+    }
+    final frustumCulledChanged = item.frustumCulled != frustumCulled;
+    item.frustumCulled = frustumCulled;
+    item.layers = node.layers;
+    final worldTransform = node.globalTransform;
     final boundsChangedByInput =
         worldTransformVersion != _worldTransformVersion ||
         instanceRevision != _instanceRevision ||
         geometryBoundsVersion != _geometryBoundsVersion;
     final staticShadowChanged =
-        (item.visible != true ||
+        (item.visible != visible ||
             item.shadowStatic != node.shadowStatic ||
             item.castsShadows != node.castsShadows ||
             item.lightChannelMask != lightChannelMask ||
             boundsChangedByInput) &&
         (item.shadowStatic || node.shadowStatic) &&
         (item.castsShadows || node.castsShadows);
+    item.visible = visible;
     if (worldTransformVersion != _worldTransformVersion) {
       item.worldTransform.setFrom(worldTransform);
     }

--- a/packages/flutter_scene/lib/src/components/mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/mesh_component.dart
@@ -159,7 +159,6 @@ class MeshComponent extends Component {
     if (_renderItems.isEmpty) return;
     final worldTransformVersion = node.worldTransformVersion;
     var staticStateUnchanged =
-        node.shadowStatic &&
         node.skin == null &&
         node.internalMorphWeights == null &&
         worldTransformVersion == _worldTransformVersion;
@@ -171,6 +170,8 @@ class MeshComponent extends Component {
       final item = _renderItems[index];
       final primitive = _mesh.primitives[index];
       staticStateUnchanged =
+          item.jointsTexture == null &&
+          item.morphWeights == null &&
           item.visible == !item.material.drawsNothing &&
           item.primitiveVisible == primitive.visible &&
           item.frustumCulled == node.frustumCulled &&

--- a/packages/flutter_scene/lib/src/components/mesh_component.dart
+++ b/packages/flutter_scene/lib/src/components/mesh_component.dart
@@ -157,8 +157,34 @@ class MeshComponent extends Component {
   @internal
   void refreshRenderItems() {
     if (_renderItems.isEmpty) return;
-    final worldTransform = node.globalTransform;
     final worldTransformVersion = node.worldTransformVersion;
+    var staticStateUnchanged =
+        node.shadowStatic &&
+        node.skin == null &&
+        node.internalMorphWeights == null &&
+        worldTransformVersion == _worldTransformVersion;
+    for (
+      var index = 0;
+      staticStateUnchanged && index < _renderItems.length;
+      index++
+    ) {
+      final item = _renderItems[index];
+      final primitive = _mesh.primitives[index];
+      staticStateUnchanged =
+          item.visible == !item.material.drawsNothing &&
+          item.primitiveVisible == primitive.visible &&
+          item.frustumCulled == node.frustumCulled &&
+          item.layers == node.layers &&
+          item.lightChannelMask == node.lightChannelMask &&
+          item.shadowStatic == node.shadowStatic &&
+          item.castsShadows == (primitive.castsShadow && node.castsShadows) &&
+          item.highlightColor == node.highlightColor &&
+          _boundsVersions[index] == item.geometry.localBoundsVersion;
+    }
+    if (staticStateUnchanged) {
+      return;
+    }
+    final worldTransform = node.globalTransform;
     final transformChanged = worldTransformVersion != _worldTransformVersion;
     final windingFlipped = node.windingFlipped;
 

--- a/packages/flutter_scene/lib/src/hot_reload/hot_reload_coordinator.dart
+++ b/packages/flutter_scene/lib/src/hot_reload/hot_reload_coordinator.dart
@@ -13,6 +13,8 @@ import 'package:flutter_scene/src/generated_assets/generated_asset_lookup.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/hot_reload/fingerprinted_bundle.dart';
 import 'package:flutter_scene/src/hot_reload/hot_reloadable_fmat.dart';
+import 'package:flutter_scene/src/importer/scene_registry.dart'
+    show clearSceneRegistryCache;
 import 'package:flutter_scene/src/node.dart';
 import 'package:flutter_scene/src/scene_encoder.dart';
 
@@ -281,6 +283,7 @@ class HotReloadCoordinator {
     // A regenerated source can repoint the manifest, so the cached index must
     // not outlive a reload.
     clearGeneratedAssetIndexCache();
+    clearSceneRegistryCache();
     _materials.removeWhere((r) => r.material.target == null);
     _scenes.removeWhere((r) => r.root.target == null);
     _textures.removeWhere((r) => r.source.target == null);

--- a/packages/flutter_scene/lib/src/importer/build_cache.dart
+++ b/packages/flutter_scene/lib/src/importer/build_cache.dart
@@ -15,7 +15,7 @@ import 'package:hooks/hooks.dart';
 /// Bump when the hooks' generated output changes for the same inputs (the
 /// importer, the scene emitter, or the material pipeline), so outputs cached
 /// by an older flutter_scene revision are rebuilt.
-const int buildCacheRevision = 7;
+const int buildCacheRevision = 8;
 
 /// Disables the per-input build cache, so every source is reconverted. Only
 /// reaches a builder driven directly; see [HookOptions] for the pubspec form a

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -716,9 +716,10 @@ Future<bool> releaseScene(
 Future<SceneRegistry> _sharedSceneRegistry(AssetBundle? bundle) {
   final assetBundle = bundle ?? rootBundle;
   return _sceneRegistries[assetBundle] ??=
-      SceneRegistry.load(
-        bundle: assetBundle,
-      ).onError((Object error, StackTrace stackTrace) {
+      SceneRegistry.load(bundle: assetBundle).onError((
+        Object error,
+        StackTrace stackTrace,
+      ) {
         _sceneRegistries[assetBundle] = null;
         Error.throwWithStackTrace(error, stackTrace);
       });

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -42,9 +42,16 @@ final Map<String, int> _sceneTemplateHolders = {};
 /// One manifest-backed registry per asset bundle for the top-level helpers.
 /// Bundle identity is the cache boundary, and [Expando] lets a discarded
 /// test or application bundle release its registry with it.
-final Expando<Future<SceneRegistry>> _sceneRegistries = Expando(
+Expando<Future<SceneRegistry>> _sceneRegistries = Expando(
   'flutter_scene scene registries',
 );
+
+/// Evicts every cached manifest-backed scene registry so a subsequent load
+/// re-reads the bundle manifest.
+@internal
+void clearSceneRegistryCache() {
+  _sceneRegistries = Expando('flutter_scene scene registries');
+}
 
 /// Tracked dependency sets of streamed lazy subtrees, keyed by placeholder
 /// node, so repeated loads refresh the registration instead of duplicating it.
@@ -709,9 +716,11 @@ Future<bool> releaseScene(
 Future<SceneRegistry> _sharedSceneRegistry(AssetBundle? bundle) {
   final assetBundle = bundle ?? rootBundle;
   return _sceneRegistries[assetBundle] ??=
-      SceneRegistry.load(bundle: assetBundle).onError((error, stackTrace) {
+      SceneRegistry.load(
+        bundle: assetBundle,
+      ).onError((Object error, StackTrace stackTrace) {
         _sceneRegistries[assetBundle] = null;
-        throw error!;
+        Error.throwWithStackTrace(error, stackTrace);
       });
 }
 
@@ -723,6 +732,7 @@ Future<SceneRegistry> _sharedSceneRegistry(AssetBundle? bundle) {
 void clearSceneTemplateCache() {
   _sceneTemplates.clear();
   _sceneTemplateHolders.clear();
+  clearSceneRegistryCache();
 }
 
 /// The number of scene templates the shared cache is holding.

--- a/packages/flutter_scene/lib/src/importer/scene_registry.dart
+++ b/packages/flutter_scene/lib/src/importer/scene_registry.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart' show internal;
 import 'package:flutter/services.dart';
 
 import 'package:scene/scene.dart';
+
 import '../fscene/realize/component_codec.dart';
 import '../generated_assets/generated_asset_lookup.dart';
 import '../generated_assets/generated_assets.dart';
@@ -37,6 +38,13 @@ final Map<String, Future<_SceneTemplate>> _sceneTemplates = {};
 /// claim cannot drop a template another caller is still loading instances
 /// from.
 final Map<String, int> _sceneTemplateHolders = {};
+
+/// One manifest-backed registry per asset bundle for the top-level helpers.
+/// Bundle identity is the cache boundary, and [Expando] lets a discarded
+/// test or application bundle release its registry with it.
+final Expando<Future<SceneRegistry>> _sceneRegistries = Expando(
+  'flutter_scene scene registries',
+);
 
 /// Tracked dependency sets of streamed lazy subtrees, keyed by placeholder
 /// node, so repeated loads refresh the registration instead of duplicating it.
@@ -626,7 +634,7 @@ Future<Node> loadScene(
   SceneReloadCallback? onReload,
   Scene? applyStageTo,
 }) async {
-  final sceneRegistry = await SceneRegistry.load(bundle: bundle);
+  final sceneRegistry = await _sharedSceneRegistry(bundle);
   return sceneRegistry.loadScene(
     sourcePath,
     package: package,
@@ -650,7 +658,7 @@ Future<void> loadSceneSubtree(
   AssetBundle? bundle,
   FsceneComponentRegistry? registry,
 }) async {
-  final sceneRegistry = await SceneRegistry.load(bundle: bundle);
+  final sceneRegistry = await _sharedSceneRegistry(bundle);
   return sceneRegistry.loadSubtree(
     node,
     package: package,
@@ -693,9 +701,18 @@ Future<bool> releaseScene(
       ? activeSceneSourceLoader()?.resolveScene(sourcePath)
       : null;
   if (sourceKey != null) return _releaseSceneTemplateClaim(sourceKey);
-  final registry = await SceneRegistry.load(bundle: bundle);
+  final registry = await _sharedSceneRegistry(bundle);
   final key = registry.resolveKey(sourcePath, package: package);
   return _releaseSceneTemplateClaim(key);
+}
+
+Future<SceneRegistry> _sharedSceneRegistry(AssetBundle? bundle) {
+  final assetBundle = bundle ?? rootBundle;
+  return _sceneRegistries[assetBundle] ??=
+      SceneRegistry.load(bundle: assetBundle).onError((error, stackTrace) {
+        _sceneRegistries[assetBundle] = null;
+        throw error!;
+      });
 }
 
 /// Drops every cached scene template, whatever their outstanding claims.

--- a/packages/flutter_scene/test/fscene/fsceneb_test.dart
+++ b/packages/flutter_scene/test/fscene/fsceneb_test.dart
@@ -10,6 +10,23 @@ import 'package:flutter_test/flutter_test.dart';
 Uint8List _ramp(int length) =>
     Uint8List.fromList(List.generate(length, (i) => i & 0xFF));
 
+List<String> _chunkTypes(Uint8List container) {
+  final types = <String>[];
+  var offset = 16;
+  final view = ByteData.sublistView(container);
+  while (offset + 8 <= container.length) {
+    final length = view.getUint32(offset, Endian.little);
+    final type = String.fromCharCodes(
+      container.sublist(offset + 4, offset + 8),
+    );
+    types.add(type);
+    offset += 8 + length;
+    final remainder = length % 8;
+    if (remainder != 0) offset += 8 - remainder;
+  }
+  return types;
+}
+
 // A document with a couple of nodes and payload chunks of deliberately
 // awkward (non-8-multiple) lengths to exercise chunk padding.
 SceneDocument _sample() {
@@ -92,7 +109,7 @@ void main() {
 
       final encoded = writeFsceneb(doc);
       expect(encoded.length, lessThan(2048));
-      expect(String.fromCharCodes(encoded), contains('GZBL'));
+      expect(_chunkTypes(encoded), contains('GZBL'));
       expect(
         readFsceneb(encoded).payload(id)!.bytes,
         equals(Uint8List(64 * 1024)),
@@ -101,7 +118,7 @@ void main() {
 
     test('reads a version 1 container with plain payload chunks', () {
       final encoded = writeFsceneb(_sample());
-      expect(String.fromCharCodes(encoded), isNot(contains('GZBL')));
+      expect(_chunkTypes(encoded), isNot(contains('GZBL')));
       ByteData.sublistView(encoded).setUint32(4, 1, Endian.little);
 
       final restored = readFsceneb(encoded);

--- a/packages/flutter_scene/test/fscene/fsceneb_test.dart
+++ b/packages/flutter_scene/test/fscene/fsceneb_test.dart
@@ -78,6 +78,36 @@ void main() {
       expect(view.getUint32(8, Endian.little), bytes.length);
       expect(bytes.length % 8, 0);
     });
+
+    test('compresses repetitive payloads without changing their bytes', () {
+      final doc = SceneDocument();
+      final id = doc.newId();
+      doc.addPayload(
+        PayloadSpec(
+          id,
+          encoding: PayloadEncoding.vertexBuffer,
+          bytes: Uint8List(64 * 1024),
+        ),
+      );
+
+      final encoded = writeFsceneb(doc);
+      expect(encoded.length, lessThan(2048));
+      expect(String.fromCharCodes(encoded), contains('GZBL'));
+      expect(
+        readFsceneb(encoded).payload(id)!.bytes,
+        equals(Uint8List(64 * 1024)),
+      );
+    });
+
+    test('reads a version 1 container with plain payload chunks', () {
+      final encoded = writeFsceneb(_sample());
+      expect(String.fromCharCodes(encoded), isNot(contains('GZBL')));
+      ByteData.sublistView(encoded).setUint32(4, 1, Endian.little);
+
+      final restored = readFsceneb(encoded);
+      expect(restored.rootNodes.single.name, 'world');
+      expect(restored.payloads.length, 3);
+    });
   });
 
   group('malformed input', () {

--- a/packages/flutter_scene/test/fscene/scene_registry_test.dart
+++ b/packages/flutter_scene/test/fscene/scene_registry_test.dart
@@ -83,6 +83,36 @@ void main() {
     });
 
     test(
+      'hot reload and clearSceneTemplateCache re-scan the asset manifest',
+      () async {
+        clearSceneTemplateCache();
+        const keyA = 'packages/app/flutter_scene/scene/assets/a.fsceneb';
+        const keyB = 'packages/app/flutter_scene/scene/assets/b.fsceneb';
+        final docA = SceneDocument()
+          ..addNode(NodeSpec(id: const LocalId(1, 1), name: 'a'), root: true);
+        final docB = SceneDocument()
+          ..addNode(NodeSpec(id: const LocalId(2, 1), name: 'b'), root: true);
+        final bundle = _BytesAssetBundle({keyA: writeFsceneb(docA)});
+
+        try {
+          final nodeA = await loadScene('assets/a', bundle: bundle);
+          expect(nodeA.getChildByName('a'), isNotNull);
+          expect(bundle.manifestLoads, 1);
+
+          bundle.assets[keyB] = writeFsceneb(docB);
+          bundle.clear();
+          clearSceneTemplateCache();
+
+          final nodeB = await loadScene('assets/b', bundle: bundle);
+          expect(nodeB.getChildByName('b'), isNotNull);
+          expect(bundle.manifestLoads, 2);
+        } finally {
+          clearSceneTemplateCache();
+        }
+      },
+    );
+
+    test(
       'requires package disambiguation for duplicate source paths',
       () async {
         final registry = await SceneRegistry.load(

--- a/packages/flutter_scene/test/fscene/scene_registry_test.dart
+++ b/packages/flutter_scene/test/fscene/scene_registry_test.dart
@@ -65,6 +65,23 @@ void main() {
       );
     });
 
+    test('top-level loads scan each asset bundle once', () async {
+      clearSceneTemplateCache();
+      const key = 'packages/app/flutter_scene/scene/assets/shared.fsceneb';
+      final document = SceneDocument()
+        ..addNode(NodeSpec(id: const LocalId(9, 1), name: 'root'), root: true);
+      final bundle = _BytesAssetBundle({key: writeFsceneb(document)});
+
+      try {
+        await loadScene('assets/shared', bundle: bundle);
+        await loadScene('assets/shared', bundle: bundle);
+
+        expect(bundle.manifestLoads, 1);
+      } finally {
+        clearSceneTemplateCache();
+      }
+    });
+
     test(
       'requires package disambiguation for duplicate source paths',
       () async {
@@ -484,6 +501,7 @@ final class _BytesAssetBundle extends CachingAssetBundle {
 
   /// Successful [load] calls per key.
   final Map<String, int> loadCounts = {};
+  int manifestLoads = 0;
 
   /// Fails every scene read while set, standing in for a transient asset
   /// read error.
@@ -492,6 +510,7 @@ final class _BytesAssetBundle extends CachingAssetBundle {
   @override
   Future<ByteData> load(String key) async {
     if (key == 'AssetManifest.bin') {
+      manifestLoads++;
       final manifest = <String, Object>{
         for (final asset in assets.keys) asset: <Object>[],
       };

--- a/packages/flutter_scene/test/node_shadow_casting_test.dart
+++ b/packages/flutter_scene/test/node_shadow_casting_test.dart
@@ -84,4 +84,26 @@ void main() {
     root.scenePrePass(0);
     expect(renderScene.staticShadowRevision, greaterThan(moved));
   });
+
+  test('static render items still refresh changed node settings', () {
+    final renderScene = RenderScene();
+    final root = Node()..debugMountInto(renderScene);
+    final caster = Node(mesh: Mesh(_StubGeometry(), _StubMaterial()))
+      ..shadowStatic = true;
+    root.add(caster);
+    root.scenePrePass(0);
+
+    caster
+      ..castsShadows = false
+      ..frustumCulled = false
+      ..layers = 4
+      ..highlightColor = Vector4(1, 0, 1, 1);
+    root.scenePrePass(0);
+
+    final item = renderScene.items.single;
+    expect(item.castsShadows, isFalse);
+    expect(item.frustumCulled, isFalse);
+    expect(item.layers, 4);
+    expect(item.highlightColor, Vector4(1, 0, 1, 1));
+  });
 }

--- a/packages/scene/CHANGELOG.md
+++ b/packages/scene/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0
 
+- `.fsceneb` format version 2 compresses payload chunks with gzip.
 - `MorphTargetsSpec` and `GeometryResource.morphTargets` carry baked morph target deltas, names, and default weights.
 - `AnimationProperty.weights` animates morph weights.
 - `.fscene` version 4; a version-3 reader refuses a morph-bearing document instead of silently dropping the deltas. Version 3 documents read as-is.

--- a/packages/scene/CHANGELOG.md
+++ b/packages/scene/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.3.0
 
-- `.fsceneb` format version 2 compresses payload chunks with gzip.
+- `.fsceneb` format version 2 compresses payload chunks with gzip; older readers reject version 2.
 - `MorphTargetsSpec` and `GeometryResource.morphTargets` carry baked morph target deltas, names, and default weights.
 - `AnimationProperty.weights` animates morph weights.
 - `.fscene` version 4; a version-3 reader refuses a morph-bearing document instead of silently dropping the deltas. Version 3 documents read as-is.

--- a/packages/scene/lib/src/binary/fsceneb.dart
+++ b/packages/scene/lib/src/binary/fsceneb.dart
@@ -5,8 +5,8 @@
 /// The manifest chunk is the exact canonical JSON a bare `.fscene` text file
 /// would carry (so the two forms share one codec); the payload chunks hold the
 /// heavy binary the JSON references by id (vertex/index buffers, images,
-/// matrices). Chunks are uncompressed and chunk-aligned so the container stays
-/// cheap to read.
+/// matrices). Payload chunks use gzip when it reduces their size and every
+/// chunk stays aligned for cheap reads.
 ///
 /// Layout (all integers little-endian):
 ///
@@ -18,31 +18,34 @@
 ///   [12..16) reserved        uint32 (0)
 /// Chunks (repeat until totalByteLength), each 8-byte aligned:
 ///   [0..4)   dataByteLength  uint32 (unpadded)
-///   [4..8)   chunkType       4 ASCII bytes ("JSON" or "BLOB")
+///   [4..8)   chunkType       4 ASCII bytes ("JSON", "BLOB", or "GZBL")
 ///   [8..)    data            dataByteLength bytes
 ///   padding  zero bytes to the next 8-byte boundary
 /// ```
 ///
 /// The first chunk is the sole "JSON" chunk (UTF-8 document text). Each "BLOB"
 /// chunk carries one payload, its data being `[uint32 idByteLength][id token
-/// UTF-8][payload bytes]`. An unrecognized chunk type is skipped, so the format
-/// can grow new chunk kinds without breaking older readers.
+/// UTF-8][payload bytes]`. A "GZBL" chunk is the same data compressed with
+/// gzip. An unrecognized chunk type is skipped, so the format can grow new
+/// chunk kinds without breaking older readers.
 library;
 
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:archive/archive.dart';
 import 'package:scene/src/id.dart';
 import 'package:scene/src/json/fscene_json.dart';
 import 'package:scene/src/scene_document.dart';
 
 /// The current `.fsceneb` container version this build reads and writes.
 /// {@category Serialization}
-const int kFscenebVersion = 1;
+const int kFscenebVersion = 2;
 
 const List<int> _magic = [0x46, 0x53, 0x43, 0x42]; // "FSCB"
 const String _chunkJson = 'JSON';
 const String _chunkBlob = 'BLOB';
+const String _chunkGzipBlob = 'GZBL';
 const int _headerByteLength = 16;
 const int _alignment = 8;
 
@@ -95,7 +98,13 @@ Uint8List writeFsceneb(SceneDocument document) {
         'Payload ${entry.key.toToken()} has no bytes to embed',
       );
     }
-    addChunk(_chunkBlob, _encodeBlob(entry.key, bytes));
+    final blob = _encodeBlob(entry.key, bytes);
+    final compressed = const GZipEncoder().encodeBytes(blob, level: 6);
+    if (compressed.length < blob.length) {
+      addChunk(_chunkGzipBlob, compressed);
+    } else {
+      addChunk(_chunkBlob, blob);
+    }
   }
 
   final bodyBytes = body.toBytes();
@@ -162,6 +171,14 @@ SceneDocument readFsceneb(Uint8List bytes) {
       case _chunkBlob:
         final (id, payload) = _decodeBlob(data);
         blobs[id] = payload;
+      case _chunkGzipBlob:
+        try {
+          final decompressed = const GZipDecoder().decodeBytes(data);
+          final (id, payload) = _decodeBlob(decompressed);
+          blobs[id] = payload;
+        } catch (error) {
+          throw FscenebFormatException('Invalid gzip payload chunk ($error)');
+        }
       default:
         break; // Skip unrecognized chunk types.
     }

--- a/packages/scene/lib/src/binary/fsceneb.dart
+++ b/packages/scene/lib/src/binary/fsceneb.dart
@@ -37,6 +37,7 @@ import 'package:archive/archive.dart';
 import 'package:scene/src/id.dart';
 import 'package:scene/src/json/fscene_json.dart';
 import 'package:scene/src/scene_document.dart';
+import 'package:scene/src/specs.dart';
 
 /// The current `.fsceneb` container version this build reads and writes.
 /// {@category Serialization}
@@ -48,6 +49,17 @@ const String _chunkBlob = 'BLOB';
 const String _chunkGzipBlob = 'GZBL';
 const int _headerByteLength = 16;
 const int _alignment = 8;
+
+bool _isPrecompressedImage(PayloadSpec spec) {
+  if (spec.encoding != PayloadEncoding.image) return false;
+  final format = spec.format?.toLowerCase();
+  return format == 'png' ||
+      format == 'basis' ||
+      format == 'ktx2' ||
+      format == 'jpeg' ||
+      format == 'jpg' ||
+      format == 'webp';
+}
 
 /// Thrown when a `.fsceneb` container is malformed.
 /// {@category Serialization}
@@ -92,19 +104,32 @@ Uint8List writeFsceneb(SceneDocument document) {
   final payloads = document.payloads.entries.toList()
     ..sort((a, b) => a.key.toToken().compareTo(b.key.toToken()));
   for (final entry in payloads) {
-    final bytes = entry.value.bytes;
+    final spec = entry.value;
+    final bytes = spec.bytes;
     if (bytes == null) {
       throw FscenebFormatException(
         'Payload ${entry.key.toToken()} has no bytes to embed',
       );
     }
     final blob = _encodeBlob(entry.key, bytes);
-    final compressed = const GZipEncoder().encodeBytes(blob, level: 6);
-    if (compressed.length < blob.length) {
-      addChunk(_chunkGzipBlob, compressed);
-    } else {
-      addChunk(_chunkBlob, blob);
+    if (!_isPrecompressedImage(spec)) {
+      final compressed = const GZipEncoder().encodeBytes(blob, level: 6);
+      // Zero out the 32-bit timestamp at bytes 4..7 in the gzip header (RFC 1952)
+      // so encoding is deterministic on platforms where the encoder stamps DateTime.now().
+      if (compressed.length >= 10 &&
+          compressed[0] == 0x1f &&
+          compressed[1] == 0x8b) {
+        compressed[4] = 0;
+        compressed[5] = 0;
+        compressed[6] = 0;
+        compressed[7] = 0;
+      }
+      if (compressed.length < blob.length) {
+        addChunk(_chunkGzipBlob, compressed);
+        continue;
+      }
     }
+    addChunk(_chunkBlob, blob);
   }
 
   final bodyBytes = body.toBytes();

--- a/packages/scene/pubspec.yaml
+++ b/packages/scene/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: ^3.10.0
 resolution: workspace
 dependencies:
+  archive: ^4.0.7
   vector_math: ^2.1.4
 dev_dependencies:
   test: ^1.26.0


### PR DESCRIPTION
Cache generated scene registries per asset bundle, compress fsceneb payload chunks when smaller, and skip unchanged refresh work for static mesh nodes. Version 1 fsceneb files remain readable.