### PR TITLE
Standard shader performance mega branch

### DIFF
--- a/MATERIALS.md
+++ b/MATERIALS.md
@@ -513,9 +513,14 @@ in vec3 v_viewvector;      // camera_position - vertex_position
 in vec2 v_texture_coords;
 in vec2 v_texture_coords_1;
 in vec4 v_color;           // per-vertex color, white when the model has none
-in vec3 v_model_scale;
 in vec4 v_tangent;         // world-space tangent and bitangent sign
 ```
+
+The model scale is no longer one of the interpolated outputs (lit materials
+read it from `FragInfo.model_scale`, which the `.fmat` `GetModelScale()`
+accessor wraps). A raw shader pair that needs it computes it from the model
+transform its vertex stage already receives and passes it through its own
+varying.
 
 The fragment output is `out vec4 frag_color;` at location 0.
 
@@ -836,7 +841,7 @@ a raw `ShaderMaterial` has no such declaration and always sees the fixed record.
 
 Your shader writes `gl_Position` and the standard outputs the fragment stage reads
 (`v_position`, `v_normal`, `v_viewvector`, `v_texture_coords`,
-`v_texture_coords_1`, `v_color`, `v_model_scale`, `v_tangent`), plus any of
+`v_texture_coords_1`, `v_color`, `v_tangent`), plus any of
 your own varyings. A skinned mesh
 instead takes its model transform,
 `enable_skinning`, and `joint_texture_size` in `FrameInfo`, and adds the

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -1047,6 +1047,33 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
     scene.add(_cuboid(vm.Vector4(0.95, 0.95, 0.95, 1.0), 1.0, 0.15));
     return (scene: scene, camera: _camera());
   }),
+  // Scalar ior / specular factor / specular color on the standard shader
+  // (folded into its dielectric F0, no physical variant): an ior 1.0 sphere
+  // with no dielectric reflection, a high-ior sphere, and a tinted,
+  // half-weight specular sphere. Sensitive to the fold drifting from the
+  // physical shader's formula.
+  SmokeScene('dielectric_specular', () {
+    final scene = Scene();
+    Node sphere(double x, PhysicallyBasedMaterial material) =>
+        Node(mesh: Mesh(SphereGeometry(radius: 0.42), material))
+          ..localTransform = vm.Matrix4.translation(vm.Vector3(x, 0, 0));
+    PhysicallyBasedMaterial dielectric() => PhysicallyBasedMaterial()
+      ..baseColorFactor = vm.Vector4(0.75, 0.12, 0.1, 1.0)
+      ..metallicFactor = 0.0
+      ..roughnessFactor = 0.2
+      ..vertexColorWeight = 0.0;
+    scene.add(sphere(-0.95, dielectric()..ior = 1.0));
+    scene.add(sphere(0.0, dielectric()..ior = 2.4));
+    scene.add(
+      sphere(
+        0.95,
+        dielectric()
+          ..specular = 0.5
+          ..specularColor = vm.Vector4(0.2, 0.6, 1.0, 1.0),
+      ),
+    );
+    return (scene: scene, camera: _camera());
+  }),
   // Layered physical shader with several factor-only lobes enabled.
   SmokeScene('physical_layered', () {
     final scene = Scene();

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.24.0
 
 * Widget-surface pointer forwarding dispatches events in the framework's global space (with the host's transform in the hit path), so widgets that convert `globalPosition` through render objects (Slider, text selection) work when the scene view is not at the window origin.
-* The standard PBR shader ships a no-shadow variant, selected automatically for draws with no shadow atlas bound, roughly halving the compiled fragment program for shadow-less scenes on mobile GPUs.
+* The standard PBR shader ships a no-shadow variant, selected automatically for draws with no shadow atlas bound, roughly halving the compiled fragment program for shadow-less scenes on mobile GPUs; it also skips its five per-texture UV-transform evaluations when every transform is identity.
 * glTF import validates `extensionsRequired` and surfaces warnings through an `onWarning` callback on every entry point.
 * Sparse glTF accessors apply, including the zero-filled base for an absent `bufferView`.
 * `KHR_draco_mesh_compression` decodes in pure Dart on every platform.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Widget-surface pointer forwarding dispatches events in the framework's global space (with the host's transform in the hit path), so widgets that convert `globalPosition` through render objects (Slider, text selection) work when the scene view is not at the window origin.
 * The standard PBR shader ships a no-shadow variant, selected automatically for draws with no shadow atlas bound, roughly halving the compiled fragment program for shadow-less scenes on mobile GPUs; it also skips its five per-texture UV-transform evaluations when every transform is identity.
+* `PhysicallyBasedMaterial` keeps a scalar `ior`, `specular`, and `specularColor` on the standard shader by folding them into its dielectric reflectance (the `KHR_materials_ior` / `KHR_materials_specular` formula the physical shader uses), so only specular textures and the layered features select the heavier physical variant.
 * The model scale is no longer interpolated per fragment (`v_model_scale` left the vertex output interface, cutting varying bandwidth on tiler GPUs); lit materials read it from `FragInfo.model_scale` through the unchanged `GetModelScale()` accessor, now carrying the node's scale rather than per-instance or per-joint scale, and a raw `ShaderMaterial` pair that needs it passes its own varying computed from the model transform.
 * glTF import validates `extensionsRequired` and surfaces warnings through an `onWarning` callback on every entry point.
 * Sparse glTF accessors apply, including the zero-filled base for an absent `bufferView`.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Widget-surface pointer forwarding dispatches events in the framework's global space (with the host's transform in the hit path), so widgets that convert `globalPosition` through render objects (Slider, text selection) work when the scene view is not at the window origin.
 * The standard PBR shader ships a no-shadow variant, selected automatically for draws with no shadow atlas bound, roughly halving the compiled fragment program for shadow-less scenes on mobile GPUs; it also skips its five per-texture UV-transform evaluations when every transform is identity.
+* The model scale is no longer interpolated per fragment (`v_model_scale` left the vertex output interface, cutting varying bandwidth on tiler GPUs); lit materials read it from `FragInfo.model_scale` through the unchanged `GetModelScale()` accessor, now carrying the node's scale rather than per-instance or per-joint scale, and a raw `ShaderMaterial` pair that needs it passes its own varying computed from the model transform.
 * glTF import validates `extensionsRequired` and surfaces warnings through an `onWarning` callback on every entry point.
 * Sparse glTF accessors apply, including the zero-filled base for an absent `bufferView`.
 * `KHR_draco_mesh_compression` decodes in pure Dart on every platform.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.24.0
 
 * Widget-surface pointer forwarding dispatches events in the framework's global space (with the host's transform in the hit path), so widgets that convert `globalPosition` through render objects (Slider, text selection) work when the scene view is not at the window origin.
+* The standard PBR shader ships a no-shadow variant, selected automatically for draws with no shadow atlas bound, roughly halving the compiled fragment program for shadow-less scenes on mobile GPUs.
 * glTF import validates `extensionsRequired` and surfaces warnings through an `onWarning` callback on every entry point.
 * Sparse glTF accessors apply, including the zero-filled base for an absent `bufferView`.
 * `KHR_draco_mesh_compression` decodes in pure Dart on every platform.

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -24,12 +24,21 @@ import 'package:flutter_scene/src/render/frame_transients.dart';
 /// [PhysicallyBasedMaterial] and `PreprocessedMaterial` use it so the lighting
 /// packing lives in one place.
 class EngineLightingUniforms {
-  /// The float count of the full `FragInfo` block (688 bytes / 172 floats:
+  /// The float count of the full `FragInfo` block (704 bytes / 176 floats:
   /// the mat4 `environment_transform` ends at float 155, the `ssao_params`
   /// vec4 at floats 156..159, then the `radiance_blend` vec4 at floats
-  /// 160..163, `ssao_lighting` at 164..167, and `model_scale` at 168..171).
-  /// See the layout map in the implementation.
-  static const fragInfoFloatCount = 172;
+  /// 160..163, `ssao_lighting` at 164..167, `model_scale` at 168..171, and
+  /// `dielectric_f0` at 172..175). See the layout map in the implementation.
+  static const fragInfoFloatCount = 176;
+
+  /// Index of the `dielectric_f0` vec4 in `FragInfo`. [packInto] writes the
+  /// standard 0.04 dielectric reflectance; a material with a non-default
+  /// ior, specular factor, or specular color overwrites it afterward.
+  static const dielectricF0Index = 172;
+
+  /// The dielectric F0 of a default material (ior 1.5, specular 1, white
+  /// specular color), the value the standard shader used to hard-code.
+  static const defaultDielectricF0 = 0.04;
 
   /// Index of the LOD cross-fade `fade` field in `FragInfo`, occupying std140
   /// padding before `environment_transform` (so the block size is unchanged).
@@ -184,6 +193,11 @@ class EngineLightingUniforms {
     fragInfo[168] = modelScaleX;
     fragInfo[169] = modelScaleY;
     fragInfo[170] = modelScaleZ;
+    // dielectric_f0 at [172..174]: the standard shader path's dielectric
+    // reflectance, the plain 0.04 unless the material overwrites it.
+    fragInfo[dielectricF0Index] = defaultDielectricF0;
+    fragInfo[dielectricF0Index + 1] = defaultDielectricF0;
+    fragInfo[dielectricF0Index + 2] = defaultDielectricF0;
     // punctual_dims [8..10] (the first unused diffuse-SH vec4 slot): the
     // dimensions the shader needs to normalize its punctual-light fetches.
     // x: parameters-texture row count (all scene lights). y/z: the light-index

--- a/packages/flutter_scene/lib/src/material/engine_lighting.dart
+++ b/packages/flutter_scene/lib/src/material/engine_lighting.dart
@@ -24,12 +24,12 @@ import 'package:flutter_scene/src/render/frame_transients.dart';
 /// [PhysicallyBasedMaterial] and `PreprocessedMaterial` use it so the lighting
 /// packing lives in one place.
 class EngineLightingUniforms {
-  /// The float count of the full `FragInfo` block (672 bytes / 168 floats:
+  /// The float count of the full `FragInfo` block (688 bytes / 172 floats:
   /// the mat4 `environment_transform` ends at float 155, the `ssao_params`
   /// vec4 at floats 156..159, then the `radiance_blend` vec4 at floats
-  /// 160..163, then `ssao_lighting` at 164..167). See the layout map in the
-  /// implementation.
-  static const fragInfoFloatCount = 168;
+  /// 160..163, `ssao_lighting` at 164..167, and `model_scale` at 168..171).
+  /// See the layout map in the implementation.
+  static const fragInfoFloatCount = 172;
 
   /// Index of the LOD cross-fade `fade` field in `FragInfo`, occupying std140
   /// padding before `environment_transform` (so the block size is unchanged).
@@ -55,6 +55,9 @@ class EngineLightingUniforms {
     Lighting lighting,
     EnvironmentMap env, {
     int nodeChannelMask = 0xFF,
+    double modelScaleX = 1.0,
+    double modelScaleY = 1.0,
+    double modelScaleZ = 1.0,
   }) {
     // Default to fully drawn; a material with an active LOD cross-fade
     // overwrites this. Without it the zero-initialized slot would discard
@@ -176,6 +179,11 @@ class EngineLightingUniforms {
     fragInfo[165] = lighting.ssaoMultiBounce.clamp(0.0, 1.0);
     fragInfo[166] = lighting.ssaoBentNormals ? 1.0 : 0.0;
     fragInfo[167] = lighting.ssaoContactShadows ? 1.0 : 0.0;
+    // model_scale at [168..170]: the draw's model scale, set by the encoder
+    // on the material before bind (replaces the old v_model_scale varying).
+    fragInfo[168] = modelScaleX;
+    fragInfo[169] = modelScaleY;
+    fragInfo[170] = modelScaleZ;
     // punctual_dims [8..10] (the first unused diffuse-SH vec4 slot): the
     // dimensions the shader needs to normalize its punctual-light fetches.
     // x: parameters-texture row count (all scene lights). y/z: the light-index

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
+import 'dart:math' as math;
 import 'dart:typed_data';
+
+import 'package:vector_math/vector_math.dart' show Matrix4;
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/light.dart';
@@ -231,6 +234,28 @@ abstract class Material {
   /// uniform path. Defaults to `0xFF` (every channel).
   @internal
   int lightChannelMask = 0xFF;
+
+  /// The draw's model scale (world-space lengths of the model transform's
+  /// basis vectors), set by the encoder right before [bind] and packed into
+  /// `FragInfo.model_scale`. Scales local-space lengths like the transmission
+  /// volume thickness into world units. An instanced draw carries its node's
+  /// scale (not per-instance), and a skinned draw its node's (not per-joint).
+  @internal
+  double modelScaleX = 1.0;
+  @internal
+  double modelScaleY = 1.0;
+  @internal
+  double modelScaleZ = 1.0;
+
+  /// Sets [modelScaleX]/[modelScaleY]/[modelScaleZ] from [transform]'s basis
+  /// vector lengths. Called by the encoder with the drawn world transform.
+  @internal
+  void setModelScaleFromTransform(Matrix4 transform) {
+    final s = transform.storage;
+    modelScaleX = math.sqrt(s[0] * s[0] + s[1] * s[1] + s[2] * s[2]);
+    modelScaleY = math.sqrt(s[4] * s[4] + s[5] * s[5] + s[6] * s[6]);
+    modelScaleZ = math.sqrt(s[8] * s[8] + s[9] * s[9] + s[10] * s[10]);
+  }
 
   gpu.Shader? _fragmentShader;
   String? _fragmentShaderName;

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
+
 import 'dart:typed_data';
 
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
@@ -256,6 +257,10 @@ abstract class Material {
   void setFragmentShader(gpu.Shader shader) {
     _fragmentShader = shader;
     _fragmentShaderName = null;
+    _noShadowFragmentShader = null;
+    _noShadowFragmentShaderName = null;
+    _noShadowRadianceCubeFragmentShader = null;
+    _noShadowRadianceCubeFragmentShaderName = null;
   }
 
   /// Assigns the fragment shader by [name] from [baseShaderLibrary].
@@ -267,15 +272,33 @@ abstract class Material {
   ///
   /// [cubeName] is the twin built for the cubemap radiance layout, needed by
   /// any shader that samples the environment (see [radianceCubeFragmentShader]).
-  void setFragmentShaderName(String name, {String? cubeName}) {
+  ///
+  /// [noShadowName] and [noShadowCubeName] are the twins built with
+  /// `FLUTTER_SCENE_SKIP_SHADOWS`, selected for a draw with no shadow atlas
+  /// bound (see [fragmentShaderForLighting]). A material without them always
+  /// draws with the full shaders.
+  void setFragmentShaderName(
+    String name, {
+    String? cubeName,
+    String? noShadowName,
+    String? noShadowCubeName,
+  }) {
     _fragmentShaderName = name;
     _fragmentShader = null;
     _radianceCubeFragmentShaderName = cubeName;
     _radianceCubeFragmentShader = null;
+    _noShadowFragmentShaderName = noShadowName;
+    _noShadowFragmentShader = null;
+    _noShadowRadianceCubeFragmentShaderName = noShadowCubeName;
+    _noShadowRadianceCubeFragmentShader = null;
   }
 
   gpu.Shader? _radianceCubeFragmentShader;
   String? _radianceCubeFragmentShaderName;
+  gpu.Shader? _noShadowFragmentShader;
+  String? _noShadowFragmentShaderName;
+  gpu.Shader? _noShadowRadianceCubeFragmentShader;
+  String? _noShadowRadianceCubeFragmentShaderName;
 
   /// Assigns the already-loaded variant built with
   /// `FLUTTER_SCENE_RADIANCE_CUBE`, the counterpart of [setFragmentShader]
@@ -315,12 +338,50 @@ abstract class Material {
       lighting.environmentMap.usesCubeRadianceLayout &&
       radianceCubeFragmentShader != null;
 
-  /// Selects this material's fragment shader for the frame lighting state.
+  /// The `FLUTTER_SCENE_SKIP_SHADOWS` twin of [fragmentShader], or null when
+  /// this material carries none and always draws with the full shader.
   @internal
-  gpu.Shader fragmentShaderForLighting(Lighting lighting) =>
-      usesRadianceCubeVariant(lighting)
-      ? radianceCubeFragmentShader!
-      : fragmentShader;
+  gpu.Shader? get noShadowFragmentShader =>
+      _noShadowFragmentShader ??= _noShadowFragmentShaderName == null
+      ? null
+      : baseShaderLibrary[_noShadowFragmentShaderName!];
+
+  /// The `FLUTTER_SCENE_SKIP_SHADOWS` twin of [radianceCubeFragmentShader],
+  /// or null when this material carries none.
+  @internal
+  gpu.Shader? get noShadowRadianceCubeFragmentShader =>
+      _noShadowRadianceCubeFragmentShader ??=
+          _noShadowRadianceCubeFragmentShaderName == null
+          ? null
+          : baseShaderLibrary[_noShadowRadianceCubeFragmentShaderName!];
+
+  /// Whether [fragmentShaderForLighting] picks a no-shadow twin for
+  /// [lighting], which is also what decides whether the `shadow_map` sampler
+  /// (which that twin does not declare) gets bound. Both decisions must come
+  /// from here, like [usesRadianceCubeVariant].
+  @internal
+  bool usesNoShadowVariant(Lighting lighting) =>
+      lighting.shadowMap == null &&
+      (usesRadianceCubeVariant(lighting)
+              ? noShadowRadianceCubeFragmentShader
+              : noShadowFragmentShader) !=
+          null;
+
+  /// Selects this material's fragment shader for the frame lighting state.
+  ///
+  /// The radiance-layout variant wins over the shadow one: a shadow variant
+  /// in the wrong layout would be handed a texture its sampler cannot read,
+  /// while dropping the no-shadow variant only costs dead shadow code.
+  @internal
+  gpu.Shader fragmentShaderForLighting(Lighting lighting) {
+    final noShadow = usesNoShadowVariant(lighting);
+    if (usesRadianceCubeVariant(lighting)) {
+      return noShadow
+          ? noShadowRadianceCubeFragmentShader!
+          : radianceCubeFragmentShader!;
+    }
+    return noShadow ? noShadowFragmentShader! : fragmentShader;
+  }
 
   /// The vertex shader this material supplies for a geometry's [variant]
   /// (`'unskinned'` / `'skinned'` for the color pass, `'depth'` for the

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -1507,6 +1507,9 @@ class PhysicallyBasedMaterial extends Material {
         ..lightListOffset = lightListOffset
         ..lightListCount = lightListCount
         ..lightChannelMask = lightChannelMask
+        ..modelScaleX = modelScaleX
+        ..modelScaleY = modelScaleY
+        ..modelScaleZ = modelScaleZ
         ..environment = environment;
       prepared.bind(pass, transientsBuffer, lighting);
       return;
@@ -1544,6 +1547,9 @@ class PhysicallyBasedMaterial extends Material {
       lighting,
       env,
       nodeChannelMask: lightChannelMask,
+      modelScaleX: modelScaleX,
+      modelScaleY: modelScaleY,
+      modelScaleZ: modelScaleZ,
     );
     fragInfo[0] = baseColorFactor.r;
     fragInfo[1] = baseColorFactor.g;

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -60,9 +60,11 @@ class TextureTransform {
 /// transmissive features.
 ///
 /// The material selects and caches an internal shader variant from its active
-/// features. Basic opaque configurations use the standard shader, while
-/// clearcoat, sheen, transmission, anisotropy, iridescence, and related
-/// properties activate physical variants without changing the public type.
+/// features. Basic opaque configurations use the standard shader, including
+/// a scalar [ior], [specular], and [specularColor] (folded into its dielectric
+/// reflectance), while specular textures, clearcoat, sheen, transmission,
+/// anisotropy, iridescence, and related properties activate physical variants
+/// without changing the public type.
 /// Importers normalize format-specific extensions into these scene-native
 /// properties.
 ///
@@ -993,15 +995,41 @@ class PhysicallyBasedMaterial extends Material {
     }
   }
 
+  /// Whether the scalar specular inputs differ from the glTF defaults, in
+  /// which case the standard shader's dielectric F0 carries their product.
+  bool get _hasScalarSpecularConfiguration =>
+      ior != 1.5 ||
+      specular != 1.0 ||
+      specularColor.x != 1.0 ||
+      specularColor.y != 1.0 ||
+      specularColor.z != 1.0;
+
+  /// The dielectric specular reflectance at normal incidence the standard
+  /// shader path uses for these inputs, `clamp(((ior - 1) / (ior + 1))^2 *
+  /// specularColor * specular, 0, 1)` per `KHR_materials_ior` and
+  /// `KHR_materials_specular`, which is the same product the physical shader
+  /// forms from its material inputs. Returns 0.04 for the defaults.
+  @visibleForTesting
+  static Vector3 dielectricSpecularF0({
+    required double ior,
+    required double specular,
+    required Vector4 specularColor,
+  }) {
+    final clampedIor = math.max(ior, 1.0);
+    final iorF0 = math.pow((clampedIor - 1.0) / (clampedIor + 1.0), 2.0);
+    return Vector3(
+      (iorF0 * specularColor.x * specular).clamp(0.0, 1.0).toDouble(),
+      (iorF0 * specularColor.y * specular).clamp(0.0, 1.0).toDouble(),
+      (iorF0 * specularColor.z * specular).clamp(0.0, 1.0).toDouble(),
+    );
+  }
+
   int _computeVariantKey() {
     var key = 0;
-    if (specular != 1.0 ||
-        specularTexture != null ||
-        specularColorTexture != null ||
-        specularColor.x != 1.0 ||
-        specularColor.y != 1.0 ||
-        specularColor.z != 1.0 ||
-        ior != 1.5) {
+    // Scalar ior, specular factor, and specular color fold into the
+    // standard shader's dielectric F0 (see dielectricSpecularF0), so only a
+    // specular texture needs the physical variant.
+    if (specularTexture != null || specularColorTexture != null) {
       key |= _specularFeature;
     }
     if (clearcoat > 0.0) key |= _clearcoatFeature;
@@ -1059,6 +1087,7 @@ class PhysicallyBasedMaterial extends Material {
   @internal
   bool get hasPhysicalConfiguration =>
       (_computeVariantKey() & ~_lightmapFeature) != 0 ||
+      _hasScalarSpecularConfiguration ||
       clearcoatRoughness != 0.0 ||
       clearcoatNormalScale != Vector2.all(1.0) ||
       sheenRoughness != 0.0 ||
@@ -1569,6 +1598,19 @@ class PhysicallyBasedMaterial extends Material {
     fragInfo[133] = alphaCutoff;
     fragInfo[138] = specularAntiAliasingVariance;
     fragInfo[139] = specularAntiAliasingThreshold;
+    // dielectric_f0 [172..174]: packInto wrote the plain 0.04; a scalar ior,
+    // specular factor, or specular color replaces it with their product so
+    // the draw stays on the standard shader.
+    if (_hasScalarSpecularConfiguration) {
+      final f0 = dielectricSpecularF0(
+        ior: ior,
+        specular: specular,
+        specularColor: specularColor,
+      );
+      fragInfo[EngineLightingUniforms.dielectricF0Index] = f0.x;
+      fragInfo[EngineLightingUniforms.dielectricF0Index + 1] = f0.y;
+      fragInfo[EngineLightingUniforms.dielectricF0Index + 2] = f0.z;
+    }
     fragInfo[EngineLightingUniforms.fadeIndex] = lodFade;
     // radiance_blend.zw [162]/[163]: this item's punctual-light slice
     // (count, offset) into the per-frame light-index buffer.

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -1604,6 +1604,22 @@ class PhysicallyBasedMaterial extends Material {
       occlusionTextureTransform,
       occlusionTextureTexCoord,
     );
+    // The base record's padding float carries one flag the shader branches on
+    // to skip the five UV-transform evaluations, set when any record
+    // transforms its UVs or selects UV set 1. The identity transform
+    // reproduces the raw UV bit-exactly, so the flag only gates work.
+    final transformedUvs =
+        !baseColorTextureTransform.isIdentity ||
+        !metallicRoughnessTextureTransform.isIdentity ||
+        !normalTextureTransform.isIdentity ||
+        !emissiveTextureTransform.isIdentity ||
+        !occlusionTextureTransform.isIdentity ||
+        baseColorTextureTexCoord != 0 ||
+        metallicRoughnessTextureTexCoord != 0 ||
+        normalTextureTexCoord != 0 ||
+        emissiveTextureTexCoord != 0 ||
+        occlusionTextureTexCoord != 0;
+    textureTransforms[7] = transformedUvs ? 1.0 : 0.0;
     pass.bindUniform(
       shader.getUniformSlot('TextureTransforms'),
       transientsBuffer.emplace(ByteData.sublistView(textureTransforms)),

--- a/packages/flutter_scene/lib/src/material/physically_based_material.dart
+++ b/packages/flutter_scene/lib/src/material/physically_based_material.dart
@@ -98,7 +98,12 @@ class PhysicallyBasedMaterial extends Material {
        _normalTexture = normalTexture,
        _emissiveTexture = emissiveTexture,
        _occlusionTexture = occlusionTexture {
-    setFragmentShaderName('StandardFragment', cubeName: 'StandardCubeFragment');
+    setFragmentShaderName(
+      'StandardFragment',
+      cubeName: 'StandardCubeFragment',
+      noShadowName: 'StandardNoShadowFragment',
+      noShadowCubeName: 'StandardNoShadowCubeFragment',
+    );
   }
 
   /// Creates a material from normalized imported properties.
@@ -1082,6 +1087,12 @@ class PhysicallyBasedMaterial extends Material {
       cubeName: lightmapped
           ? 'StandardLightmapCubeFragment'
           : 'StandardCubeFragment',
+      noShadowName: lightmapped
+          ? 'StandardLightmapNoShadowFragment'
+          : 'StandardNoShadowFragment',
+      noShadowCubeName: lightmapped
+          ? 'StandardLightmapNoShadowCubeFragment'
+          : 'StandardNoShadowCubeFragment',
     );
   }
 
@@ -1617,6 +1628,9 @@ class PhysicallyBasedMaterial extends Material {
       shader,
       lighting,
       env,
+      // The no-shadow twin declares no shadow_map sampler; the same call
+      // that picked `shader` above decides whether the slot exists.
+      bindShadows: !usesNoShadowVariant(lighting),
       bindDiffuseSh: !_usesLightmapVariant,
       cubeShader: usesRadianceCubeVariant(lighting),
     );

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -147,6 +147,9 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
       lighting,
       env,
       nodeChannelMask: lightChannelMask,
+      modelScaleX: modelScaleX,
+      modelScaleY: modelScaleY,
+      modelScaleZ: modelScaleZ,
     );
     // radiance_blend.zw [162]/[163]: this item's punctual-light slice
     // (count, offset) into the per-frame light-index buffer.

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -51,7 +51,6 @@ import 'package:flutter_scene/src/render/frame_transients.dart';
 /// in vec2 v_texture_coords;
 /// in vec2 v_texture_coords_1;
 /// in vec4 v_color;           // per-vertex color, white when absent
-/// in vec3 v_model_scale;     // rotation-independent world scale
 /// in vec4 v_tangent;         // world tangent + bitangent sign, zero when absent
 /// ```
 ///

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -1086,6 +1086,7 @@ base class SceneEncoder {
       record.material.lightListOffset = item.lightListOffset;
       record.material.lightListCount = item.lightListCount;
       record.material.lightChannelMask = item.lightChannelMask;
+      record.material.setModelScaleFromTransform(item.worldTransform);
       item.applyJointsTexture(record.geometry);
       item.applyMorphWeights(record.geometry);
 
@@ -1448,6 +1449,7 @@ base class SceneEncoder {
       record.material.lightListOffset = record.lightListOffset;
       record.material.lightListCount = record.lightListCount;
       record.material.lightChannelMask = record.item.lightChannelMask;
+      record.material.setModelScaleFromTransform(record.item.worldTransform);
       final joints = record.jointsTexture;
       if (joints != null) {
         record.geometry.setJointsTexture(joints, record.jointsTextureWidth);

--- a/packages/flutter_scene/shaders/base.shaderbundle.json
+++ b/packages/flutter_scene/shaders/base.shaderbundle.json
@@ -51,6 +51,22 @@
     "type": "fragment",
     "file": "shaders/flutter_scene_standard_lightmap_cube.frag"
   },
+  "StandardNoShadowFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_standard_no_shadow.frag"
+  },
+  "StandardNoShadowCubeFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_standard_no_shadow_cube.frag"
+  },
+  "StandardLightmapNoShadowFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_standard_lightmap_no_shadow.frag"
+  },
+  "StandardLightmapNoShadowCubeFragment": {
+    "type": "fragment",
+    "file": "shaders/flutter_scene_standard_lightmap_no_shadow_cube.frag"
+  },
   "DepthOnlyFragment": {
     "type": "fragment",
     "file": "shaders/flutter_scene_depth_only.frag"

--- a/packages/flutter_scene/shaders/flutter_scene_line_segments.vert
+++ b/packages/flutter_scene/shaders/flutter_scene_line_segments.vert
@@ -26,7 +26,6 @@ out vec3 v_viewvector;
 out vec2 v_texture_coords;
 out vec2 v_texture_coords_1;
 out vec4 v_color;
-out vec3 v_model_scale;
 out vec4 v_tangent;
 
 void main() {
@@ -63,8 +62,5 @@ void main() {
   v_texture_coords = vec2(corner.x, corner.y * 0.5 + 0.5);
   v_texture_coords_1 = v_texture_coords;
   v_color = vec4(1.0);
-  v_model_scale = vec3(length(frame_info.model_transform[0].xyz),
-                       length(frame_info.model_transform[1].xyz),
-                       length(frame_info.model_transform[2].xyz));
   v_tangent = vec4(0.0);
 }

--- a/packages/flutter_scene/shaders/flutter_scene_skinned_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_skinned_body.glsl
@@ -120,9 +120,6 @@ void main() {
   v_texture_coords = vertex.uv;
   v_texture_coords_1 = vertex.uv1;
   v_color = vertex.color;
-  v_model_scale = vec3(length(combined_transform[0].xyz),
-                       length(combined_transform[1].xyz),
-                       length(combined_transform[2].xyz));
   v_tangent = vertex.world_tangent;
 
 #ifdef MATERIAL_INSTANCE_VARYINGS

--- a/packages/flutter_scene/shaders/flutter_scene_standard.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard.frag
@@ -32,9 +32,17 @@ texture_transforms;
 // lighting framework (material_lighting.glsl) consumes it.
 void Surface(inout MaterialInputs material) {
   vec4 vertex_color = mix(vec4(1), v_color, frag_info.vertex_color_weight);
-  vec2 base_color_uv = MaterialTextureUv(
-      texture_transforms.base_color_transform,
-      texture_transforms.base_color_rotation);
+  // base_color_rotation.w (padding in each record) carries a single flag set
+  // when any of the five records transforms its UVs or selects UV set 1.
+  // Every record is identity for a default glTF material, and the identity
+  // transform reproduces the raw UV bit-exactly, so the uniform branch only
+  // skips work.
+  bool transformed_uvs = texture_transforms.base_color_rotation.w > 0.5;
+  vec2 base_color_uv = transformed_uvs
+      ? MaterialTextureUv(
+            texture_transforms.base_color_transform,
+            texture_transforms.base_color_rotation)
+      : GetUV0();
   vec4 base_color_srgb = texture(base_color_texture, base_color_uv);
   vec3 albedo = SRGBToLinear(base_color_srgb.rgb) * vertex_color.rgb *
                 frag_info.color.rgb;
@@ -55,17 +63,21 @@ void Surface(inout MaterialInputs material) {
   //       (camera_position - vertex_position).
   vec3 normal = GetWorldNormal();
   if (frag_info.has_normal_map > 0.5) {
-    vec2 normal_uv = MaterialTextureUv(
-        texture_transforms.normal_transform,
-        texture_transforms.normal_rotation);
+    vec2 normal_uv = transformed_uvs
+        ? MaterialTextureUv(
+              texture_transforms.normal_transform,
+              texture_transforms.normal_rotation)
+        : GetUV0();
     normal = PerturbNormal(normal_texture, normal, v_viewvector,
                            normal_uv, frag_info.normal_scale);
   }
   material.normal = normal;
 
-  vec2 metallic_roughness_uv = MaterialTextureUv(
-      texture_transforms.metallic_roughness_transform,
-      texture_transforms.metallic_roughness_rotation);
+  vec2 metallic_roughness_uv = transformed_uvs
+      ? MaterialTextureUv(
+            texture_transforms.metallic_roughness_transform,
+            texture_transforms.metallic_roughness_rotation)
+      : GetUV0();
   vec4 metallic_roughness =
       texture(metallic_roughness_texture, metallic_roughness_uv);
   material.metallic = clamp(metallic_roughness.b * frag_info.metallic_factor,
@@ -74,15 +86,19 @@ void Surface(inout MaterialInputs material) {
       clamp(metallic_roughness.g * frag_info.roughness_factor, kMinRoughness,
             1.0);
 
-  vec2 occlusion_uv = MaterialTextureUv(
-      texture_transforms.occlusion_transform,
-      texture_transforms.occlusion_rotation);
+  vec2 occlusion_uv = transformed_uvs
+      ? MaterialTextureUv(
+            texture_transforms.occlusion_transform,
+            texture_transforms.occlusion_rotation)
+      : GetUV0();
   float occlusion = texture(occlusion_texture, occlusion_uv).r;
   material.occlusion = 1.0 - (1.0 - occlusion) * frag_info.occlusion_strength;
 
-  vec2 emissive_uv = MaterialTextureUv(
-      texture_transforms.emissive_transform,
-      texture_transforms.emissive_rotation);
+  vec2 emissive_uv = transformed_uvs
+      ? MaterialTextureUv(
+            texture_transforms.emissive_transform,
+            texture_transforms.emissive_rotation)
+      : GetUV0();
   material.emissive = SRGBToLinear(texture(emissive_texture, emissive_uv).rgb) *
                       frag_info.emissive_factor.rgb *
                       frag_info.emissive_factor.a;

--- a/packages/flutter_scene/shaders/flutter_scene_standard_lightmap_no_shadow.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard_lightmap_no_shadow.frag
@@ -1,0 +1,5 @@
+// The baked-lightmap standard shader for a draw with no shadow atlas bound.
+// Both defines, one body.
+#define FLUTTER_SCENE_LIGHTMAP
+#define FLUTTER_SCENE_SKIP_SHADOWS
+#include <flutter_scene_standard.frag>

--- a/packages/flutter_scene/shaders/flutter_scene_standard_lightmap_no_shadow_cube.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard_lightmap_no_shadow_cube.frag
@@ -1,0 +1,6 @@
+// The baked-lightmap no-shadow standard shader for the cubemap radiance
+// layout. All three defines, one body.
+#define FLUTTER_SCENE_LIGHTMAP
+#define FLUTTER_SCENE_SKIP_SHADOWS
+#define FLUTTER_SCENE_RADIANCE_CUBE
+#include <flutter_scene_standard.frag>

--- a/packages/flutter_scene/shaders/flutter_scene_standard_no_shadow.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard_no_shadow.frag
@@ -1,0 +1,7 @@
+// The standard lit fragment shader for a draw with no shadow atlas bound.
+// Same body as flutter_scene_standard.frag; the define compiles the cascade
+// and spot shadow sampling out, dropping the shadow_map sampler and roughly
+// halving the program, which matters most for register pressure on mobile
+// GPUs. Selected exactly when Lighting.shadowMap is null.
+#define FLUTTER_SCENE_SKIP_SHADOWS
+#include <flutter_scene_standard.frag>

--- a/packages/flutter_scene/shaders/flutter_scene_standard_no_shadow_cube.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_standard_no_shadow_cube.frag
@@ -1,0 +1,5 @@
+// The no-shadow standard shader for backends whose prefiltered radiance is
+// a roughness-mip cubemap. Both defines, one body.
+#define FLUTTER_SCENE_SKIP_SHADOWS
+#define FLUTTER_SCENE_RADIANCE_CUBE
+#include <flutter_scene_standard.frag>

--- a/packages/flutter_scene/shaders/flutter_scene_unskinned_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_unskinned_body.glsl
@@ -82,9 +82,6 @@ void main() {
   v_texture_coords = vertex.uv;
   v_texture_coords_1 = vertex.uv1;
   v_color = vertex.color;
-  v_model_scale = vec3(length(model_transform[0].xyz),
-                       length(model_transform[1].xyz),
-                       length(model_transform[2].xyz));
   v_tangent = vertex.world_tangent;
 
 #ifdef MATERIAL_INSTANCE_VARYINGS

--- a/packages/flutter_scene/shaders/flutter_scene_unskinned_depth_body.glsl
+++ b/packages/flutter_scene/shaders/flutter_scene_unskinned_depth_body.glsl
@@ -62,9 +62,6 @@ void main() {
   v_texture_coords = vec2(0.0);
   v_texture_coords_1 = vec2(0.0);
   v_color = vec4(0.0);
-  v_model_scale = vec3(length(model_transform[0].xyz),
-                       length(model_transform[1].xyz),
-                       length(model_transform[2].xyz));
   v_tangent = vec4(0.0);
 
 #ifdef MATERIAL_INSTANCE_VARYINGS

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -136,8 +136,17 @@ uniform FragInfo {
   // when the occlusion texture's gba channels carry a packed view-space bent
   // normal. w is reserved.
   vec4 ssao_lighting;
+  // xyz: the draw's model scale (world-space lengths of the model transform's
+  // basis vectors), for scaling local-space lengths like the transmission
+  // thickness into world units. Replaces the old v_model_scale varying; an
+  // instanced draw carries its node's scale (not per-instance), and a skinned
+  // draw its node's (not per-joint). w unused.
+  vec4 model_scale;
 }
 frag_info;
+
+// The per-draw model scale (see FragInfo.model_scale).
+vec3 GetModelScale() { return frag_info.model_scale.xyz; }
 
 // FLUTTER_SCENE_SHADOW_CATCHER compiles out the image-based-lighting
 // samplers: a shadow catcher never evaluates the lighting, and a declared

--- a/packages/flutter_scene/shaders/material_engine_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_engine_lighting.glsl
@@ -142,6 +142,11 @@ uniform FragInfo {
   // instanced draw carries its node's scale (not per-instance), and a skinned
   // draw its node's (not per-joint). w unused.
   vec4 model_scale;
+  // xyz: the dielectric specular reflectance at normal incidence for the
+  // standard (non-physical) shader path, clamp(((ior - 1) / (ior + 1))^2 *
+  // specular_color * specular_factor, 0, 1), 0.04 for a default material.
+  // The physical path derives its own from material inputs. w unused.
+  vec4 dielectric_f0;
 }
 frag_info;
 

--- a/packages/flutter_scene/shaders/material_lighting.glsl
+++ b/packages/flutter_scene/shaders/material_lighting.glsl
@@ -385,14 +385,19 @@ vec4 EvaluateLighting(MaterialInputs material) {
       normalize(cross(geometric_normal, anisotropic_tangent));
 #endif
 
-  vec3 dielectric_reflectance = vec3(0.04);
 #ifdef FLUTTER_SCENE_PHYSICAL_MATERIAL
   float ior_f0 = pow((max(material.ior, 1.0) - 1.0) /
                          (max(material.ior, 1.0) + 1.0),
                      2.0);
-  dielectric_reflectance = clamp(
+  vec3 dielectric_reflectance = clamp(
       vec3(ior_f0) * material.specular_color * material.specular_weight,
       vec3(0.0), vec3(1.0));
+#else
+  // The standard path takes its dielectric F0 from the draw's FragInfo, the
+  // same ior * specular_color * specular_weight product the physical path
+  // forms above, precomputed on the CPU. A default material packs 0.04, so
+  // a scalar ior or specular tweak no longer needs the physical shader.
+  vec3 dielectric_reflectance = frag_info.dielectric_f0.xyz;
 #endif
   vec3 reflectance = mix(dielectric_reflectance, albedo, metallic);
 

--- a/packages/flutter_scene/shaders/material_varyings.glsl
+++ b/packages/flutter_scene/shaders/material_varyings.glsl
@@ -9,7 +9,6 @@ in vec3 v_viewvector; // camera_position - vertex_position (world space)
 in vec2 v_texture_coords;
 in vec2 v_texture_coords_1;
 in vec4 v_color;
-in vec3 v_model_scale;
 in vec4 v_tangent;
 
 out vec4 frag_color;
@@ -37,10 +36,6 @@ vec2 GetUV(int channel) { return channel == 1 ? GetUV1() : GetUV0(); }
 
 // Interpolated per-vertex color (white if the mesh has none).
 vec4 GetVertexColor() { return v_color; }
-
-// Rotation-independent world scale of the model transform. Volume thickness
-// is authored in local units and uses this to form a world-space ray.
-vec3 GetModelScale() { return v_model_scale; }
 
 // World-space tangent and bitangent sign. A zero vector means the mesh did
 // not provide tangents and the fragment shader derives its tangent frame.

--- a/packages/flutter_scene/shaders/material_vertex.glsl
+++ b/packages/flutter_scene/shaders/material_vertex.glsl
@@ -45,7 +45,6 @@ out vec3 v_viewvector; // camera_position - vertex_position (world space)
 out vec2 v_texture_coords;
 out vec2 v_texture_coords_1;
 out vec4 v_color;
-out vec3 v_model_scale;
 out vec4 v_tangent;
 
 #ifndef HAS_MATERIAL_VERTEX

--- a/packages/flutter_scene/test/physical_material_sources_test.dart
+++ b/packages/flutter_scene/test/physical_material_sources_test.dart
@@ -524,6 +524,26 @@ void main() {
     expect(lighting, isNot(contains('prefiltered_radiance_cube')));
   });
 
+  test('the standard path takes its dielectric F0 from FragInfo', () {
+    final lighting = File('shaders/material_lighting.glsl').readAsStringSync();
+    final uniforms = File(
+      'shaders/material_engine_lighting.glsl',
+    ).readAsStringSync();
+    // The physical path still derives its own from the material inputs; the
+    // standard path reads the CPU-packed product, so scalar ior and specular
+    // no longer force the physical variant.
+    expect(uniforms, contains('vec4 dielectric_f0;'));
+    expect(lighting, contains('frag_info.dielectric_f0.xyz'));
+    expect(
+      lighting,
+      contains('material.specular_color * material.specular_weight'),
+    );
+    expect(
+      lighting,
+      isNot(contains('vec3 dielectric_reflectance = vec3(0.04);')),
+    );
+  });
+
   test('lit materials reverse normals on back-facing fragments', () {
     final varyings = File('shaders/material_varyings.glsl').readAsStringSync();
     final standard = File(

--- a/packages/flutter_scene/test/physical_material_sources_test.dart
+++ b/packages/flutter_scene/test/physical_material_sources_test.dart
@@ -263,6 +263,10 @@ void main() {
         'flutter_scene_standard_cube',
         'flutter_scene_standard_lightmap',
         'flutter_scene_standard_lightmap_cube',
+        'flutter_scene_standard_no_shadow',
+        'flutter_scene_standard_no_shadow_cube',
+        'flutter_scene_standard_lightmap_no_shadow',
+        'flutter_scene_standard_lightmap_no_shadow_cube',
       ]) {
         final reflection =
             await _compileReflection(
@@ -438,6 +442,60 @@ void main() {
       final source = File('shaders/$entry.frag').readAsStringSync();
       expect(source, contains('#define FLUTTER_SCENE_LIGHTMAP'));
       expect(source, contains('#include <flutter_scene_standard.frag>'));
+    }
+  });
+
+  test('the base bundle ships the no-shadow standard entries', () async {
+    final manifest =
+        jsonDecode(File('shaders/base.shaderbundle.json').readAsStringSync())
+            as Map<String, dynamic>;
+
+    const entries = {
+      'StandardNoShadowFragment': 'flutter_scene_standard_no_shadow',
+      'StandardNoShadowCubeFragment': 'flutter_scene_standard_no_shadow_cube',
+      'StandardLightmapNoShadowFragment':
+          'flutter_scene_standard_lightmap_no_shadow',
+      'StandardLightmapNoShadowCubeFragment':
+          'flutter_scene_standard_lightmap_no_shadow_cube',
+    };
+    entries.forEach((entry, file) {
+      expect(manifest[entry]['file'], 'shaders/$file.frag');
+      final source = File('shaders/$file.frag').readAsStringSync();
+      expect(source, contains('#define FLUTTER_SCENE_SKIP_SHADOWS'));
+      expect(source, contains('#include <flutter_scene_standard.frag>'));
+    });
+
+    // The twin exists to drop the shadow sampling; the full entry keeps it.
+    final temp = Directory.systemTemp.createTempSync('standard_no_shadow');
+    try {
+      final impellerc = await findImpellerC();
+      final full =
+          await _compileReflection(
+                impellerc,
+                temp,
+                'StandardFragment',
+                File('shaders/flutter_scene_standard.frag').readAsStringSync(),
+              )
+              as Map<String, Object?>;
+      final slim =
+          await _compileReflection(
+                impellerc,
+                temp,
+                'StandardNoShadowFragment',
+                File(
+                  'shaders/flutter_scene_standard_no_shadow.frag',
+                ).readAsStringSync(),
+              )
+              as Map<String, Object?>;
+      expect(_hasNamedResource(full, 'shadow_map'), isTrue);
+      expect(_hasNamedResource(slim, 'shadow_map'), isFalse);
+      // The twins must stay bind-compatible outside the shadow atlas: the
+      // punctual light textures survive the define, so a shadow-less scene
+      // still shades its point and spot lights.
+      expect(_hasNamedResource(slim, 'punctual_lights'), isTrue);
+      expect(_hasNamedResource(slim, 'punctual_index'), isTrue);
+    } finally {
+      temp.deleteSync(recursive: true);
     }
   });
 

--- a/packages/flutter_scene/test/physical_material_sources_test.dart
+++ b/packages/flutter_scene/test/physical_material_sources_test.dart
@@ -645,6 +645,13 @@ void main() {
     expect(unlit, contains('MaterialTextureUv('));
     expect(depthNormal, contains('MaterialTextureUv('));
     expect(standard, isNot(contains('vec2 TransformUv(')));
+    // The standard shader skips all five UV-transform evaluations behind one
+    // uniform flag carried in the base record's padding float, set by the
+    // material when any record transforms its UVs or selects UV set 1.
+    expect(
+      standard,
+      contains('texture_transforms.base_color_rotation.w > 0.5'),
+    );
   });
 
   test('filtered scene color lives in a reviewable shader include', () {

--- a/packages/flutter_scene/test/physically_based_material_test.dart
+++ b/packages/flutter_scene/test/physically_based_material_test.dart
@@ -148,4 +148,77 @@ void main() {
     expect(info[6], 0.0);
     expect(info[7], 0.0);
   });
+
+  test('scalar ior and specular stay on the standard shader', () {
+    final material = PhysicallyBasedMaterial()
+      ..ior = 2.0
+      ..specular = 0.5
+      ..specularColor = Vector4(0.9, 0.8, 0.7, 1.0);
+
+    // No physical feature bit, so the draw keeps the standard shader.
+    expect(material.variantKey & 0x7f, 0);
+    // Serialization still has to preserve them.
+    expect(material.hasPhysicalConfiguration, isTrue);
+
+    // A specular texture is what needs the physical variant.
+    material.specularTexture = _FakeTextureSource();
+    expect(material.variantKey & 0x7f, isNot(0));
+    material.specularTexture = null;
+    expect(material.variantKey & 0x7f, 0);
+    material.specularColorTexture = _FakeTextureSource();
+    expect(material.variantKey & 0x7f, isNot(0));
+  });
+
+  test('the folded dielectric F0 matches the physical formula', () {
+    final defaults = PhysicallyBasedMaterial.dielectricSpecularF0(
+      ior: 1.5,
+      specular: 1.0,
+      specularColor: Vector4.all(1.0),
+    );
+    expect(
+      defaults.x,
+      closeTo(EngineLightingUniforms.defaultDielectricF0, 1e-7),
+    );
+    expect(
+      defaults.y,
+      closeTo(EngineLightingUniforms.defaultDielectricF0, 1e-7),
+    );
+    expect(
+      defaults.z,
+      closeTo(EngineLightingUniforms.defaultDielectricF0, 1e-7),
+    );
+
+    // ((2 - 1) / (2 + 1))^2 = 1 / 9.
+    final glass = PhysicallyBasedMaterial.dielectricSpecularF0(
+      ior: 2.0,
+      specular: 1.0,
+      specularColor: Vector4.all(1.0),
+    );
+    expect(glass.x, closeTo(1 / 9, 1e-7));
+
+    // The specular factor and color scale the F0 per channel.
+    final tinted = PhysicallyBasedMaterial.dielectricSpecularF0(
+      ior: 1.5,
+      specular: 0.5,
+      specularColor: Vector4(1.0, 0.5, 0.0, 1.0),
+    );
+    expect(tinted.x, closeTo(0.02, 1e-7));
+    expect(tinted.y, closeTo(0.01, 1e-7));
+    expect(tinted.z, 0.0);
+
+    // Vector3 stores float32, hence the tolerances above. Clamped to [0, 1]
+    // like the shader, and an ior below 1 reads as 1.
+    final clamped = PhysicallyBasedMaterial.dielectricSpecularF0(
+      ior: 100.0,
+      specular: 1.0,
+      specularColor: Vector4.all(30.0),
+    );
+    expect(clamped.x, 1.0);
+    final air = PhysicallyBasedMaterial.dielectricSpecularF0(
+      ior: 0.5,
+      specular: 1.0,
+      specularColor: Vector4.all(1.0),
+    );
+    expect(air.x, 0.0);
+  });
 }


### PR DESCRIPTION
Performance mega branch for the standard PBR shader, following the diagnosis in #351 (a ~3x frame-rate drop on a Mali-G57 phone that traces to the 0.21.0 uber-shader and vertex-layout growth, not to any one feature). Four stages, each verified bit-identical for default rendering against master with a same-worktree pixel A/B of every smoke scene.

## Stages

1. **No-shadow variants of the standard shader.** A draw with no shadow atlas bound now selects a `FLUTTER_SCENE_SKIP_SHADOWS` twin (`StandardNoShadowFragment` plus its cube and lightmap twins, 4 new base bundle entries), mirroring the fast path `.fmat` materials already had. `Material.usesNoShadowVariant` decides both the shader and the `shadow_map` bind from one place. Optimized SPIR-V for the fragment program goes from 3681 to 1929 instructions (about 48 percent), conditional branches 283 to 68, loops 10 to 1, which is the register-pressure profile that was collapsing occupancy on Mali.
2. **Identity UV-transform skip.** The five per-texture `MaterialTextureUv` evaluations sit behind one uniform flag carried in the base record's padding float, so a default glTF material gets roughly 50 ALU per fragment back. The identity transform reproduces the raw UV bit-exactly.
3. **`v_model_scale` out of the varyings.** The standard fragment shader never read it; only the transmission thickness ray does. The encoder now sets the drawn transform's basis lengths on the material and they ride a new `FragInfo.model_scale`, with `GetModelScale()` unchanged for `.fmat` code. Interpolated varyings drop from 24 to 21 floats and the vertex shader loses three `length()` calls.
4. **Fold scalar ior and specular into the standard shader's dielectric F0.** A `PhysicallyBasedMaterial` with only a scalar `ior`, `specular`, or `specularColor` no longer promotes to the full physical shader body. The standard path reads `FragInfo.dielectric_f0`, packed as 0.04 by the engine and overwritten by the material with the `KHR_materials_ior` and `KHR_materials_specular` product, which is the same formula the physical path forms from its inputs. Only specular textures and the layered features promote now. `hasPhysicalConfiguration` keeps the scalar checks explicitly so fscene serialization still preserves them.

## Verification

Each stage ran the full unit suite (1896 passed, 38 skipped at the tip), the macOS smoke integration run (34 scenes), and a pixel comparison of every capture against the previous stage and against a detached master run in the same worktree. Stages 1 to 3 are pixel-identical to master on every scene except `reflection_probe`, which also differs between two identical-code runs (run noise). Stage 4 adds a `dielectric_specular` smoke scene; rendered through the old promoted physical path and the new folded standard path it differs by at most 8/255 with 86 percent of differing pixels at exactly 1/255, and the ior 1.0 sphere (zero dielectric specular) drifts the same, so the delta is float ordering between the two shader bodies rather than a formula difference. The new scene needs an Argos baseline approval.

## Compatibility notes

- Raw `ShaderMaterial` pairs no longer receive `v_model_scale` from the engine vertex shaders (MATERIALS.md updated with the migration, compute it from the model transform and pass your own varying). No in-repo shader used it.
- An instanced draw now carries its node's scale rather than per-instance scale, and a skinned draw the node's rather than per-joint, only affecting transmission thickness.
- Assets declaring a scalar ior or specular render about 1 LSB differently (through the standard shader instead of the physical body) and much cheaper.
- `FragInfo` grows 168 to 176 floats (two appended vec4s, no index shifts).

## Not in this PR

Arm Mali Offline Compiler occupancy numbers (the harness is ready, pending the tool install), the `SKIP_SSAO` axis (gated on those numbers), and the large-scene follow-ups noted in the plan (static batching, frozen static subtrees, occlusion culling, impostors).
