### PR TITLE
fix: slider widget should work in scenes when not at window origin (dispatch forwarded widget-surface input in global coordinates)

### DIFF
--- a/WIDGETS.md
+++ b/WIDGETS.md
@@ -27,6 +27,25 @@ interaction lands on the widgets at exactly the point you see. Geometry in
 front of the panel blocks input, and a drag that slides off the panel's edge
 stays captured by it, so sliders and scrolls behave.
 
+## The child owns its state
+
+The component holds the widget it was built with, and `SceneView` mounts that
+subtree once. A `setState` in the widget that built the component does not
+rebuild it, so values pushed in that way never reach the surface: the hosted
+subtree keeps its own state and reports values out.
+
+```dart
+class ControlPanel extends StatefulWidget {
+  const ControlPanel({super.key, required this.onSpin});
+
+  final ValueChanged<double> onSpin;   // reports out to the scene
+  ...
+}
+```
+
+To drive the panel from outside, hand it something it can listen to (a
+`ValueNotifier`, an `AnimationController`) rather than a plain value.
+
 ## Bring your own surface
 
 Three tiers share the one component; each takes over a little more.

--- a/examples/flutter_app/lib/example_widget_inset.dart
+++ b/examples/flutter_app/lib/example_widget_inset.dart
@@ -10,8 +10,8 @@ import 'package:vector_math/vector_math.dart' as vm;
 /// a gesture's `globalPosition` back through render-object transforms, like
 /// [Slider], only work when synthesized event positions agree with the
 /// render tree about the coordinate space. This example exercises exactly
-/// that path — drag the slider on the 3D panel and the cube's spin follows;
-/// the button and switch cover the tap path.
+/// that path, dragging the slider on the 3D panel to drive the cube spin,
+/// while the button and switch cover the tap path.
 ///
 /// (Regression exercise: with texture-space positions dispatched as
 /// `globalPosition`, the slider here jumps to a wrong value and drags in the
@@ -180,7 +180,7 @@ class ExampleWidgetInsetState extends State<ExampleWidgetInset> {
 
 /// The live subtree on the panel: the slider is the probe for forwarded
 /// position math, the button and switch for the tap path. It owns its state
-/// and reports values out, the way every hosted subtree should — `SceneView`
+/// and reports values out, the way every hosted subtree should. `SceneView`
 /// mounts it once, so values pushed in from an enclosing `setState` would
 /// never reach it.
 class _PanelCard extends StatefulWidget {

--- a/examples/flutter_app/lib/example_widget_inset.dart
+++ b/examples/flutter_app/lib/example_widget_inset.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart' hide Material;
+import 'package:vector_math/vector_math.dart' as vm;
+
+/// Widget-surface input with the scene view away from the window origin.
+///
+/// A side rail pushes the [SceneView] to the right, so the view (and the
+/// invisible widget-texture hosts inside it) sit at a non-zero global
+/// offset. Forwarded pointer input must survive that: widgets that convert
+/// a gesture's `globalPosition` back through render-object transforms, like
+/// [Slider], only work when synthesized event positions agree with the
+/// render tree about the coordinate space. This example exercises exactly
+/// that path — drag the slider on the 3D panel and the cube's spin follows;
+/// the button and switch cover the tap path.
+///
+/// (Regression exercise: with texture-space positions dispatched as
+/// `globalPosition`, the slider here jumps to a wrong value and drags in the
+/// wrong place, while the button still works. None of the fullscreen
+/// examples can show it, because there the two spaces coincide.)
+class ExampleWidgetInset extends StatefulWidget {
+  const ExampleWidgetInset({super.key});
+
+  @override
+  State<ExampleWidgetInset> createState() => ExampleWidgetInsetState();
+}
+
+class ExampleWidgetInsetState extends State<ExampleWidgetInset> {
+  final Scene scene = Scene();
+  bool loaded = false;
+
+  Node? _cube;
+  double _angle = 0;
+
+  // Written by the widgets living on the in-scene panel. The panel owns its
+  // own state (it is hosted once, so a rebuild of this widget does not
+  // rebuild it); these are just the values read back out per tick.
+  double _spin = 0.5;
+  bool _lit = true;
+
+  // Mirrors the panel's slider into the rail, so the value coming off the
+  // surface is readable next to the surface itself.
+  final ValueNotifier<double> _spinReadout = ValueNotifier<double>(0.5);
+
+  @override
+  void initState() {
+    super.initState();
+    Scene.initializeStaticResources().then((_) {
+      if (!mounted) return;
+      _buildScene();
+      setState(() => loaded = true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _spinReadout.dispose();
+    super.dispose();
+  }
+
+  void _buildScene() {
+    scene.add(
+      Node(
+        name: 'floor',
+        localTransform: vm.Matrix4.translation(vm.Vector3(0, -1.0, 0)),
+        mesh: Mesh(
+          PlaneGeometry(width: 10, depth: 10),
+          PhysicallyBasedMaterial()
+            ..baseColorFactor = vm.Vector4(0.30, 0.33, 0.40, 1)
+            ..metallicFactor = 0.0
+            ..roughnessFactor = 0.7,
+        ),
+      ),
+    );
+
+    _cube = Node(
+      name: 'cube',
+      mesh: Mesh(
+        CuboidGeometry(vm.Vector3(1.2, 1.2, 1.2)),
+        PhysicallyBasedMaterial()
+          ..baseColorFactor = vm.Vector4(0.35, 0.65, 0.90, 1)
+          ..roughnessFactor = 0.35,
+      ),
+    )..position = vm.Vector3(1.9, 0.1, -0.2);
+    scene.add(_cube!);
+
+    // The zero-config widget surface: an aspect-correct quad hosting a live
+    // subtree, with pointer input forwarded onto it automatically. The child
+    // is hosted once and keeps its own state, so it is a StatefulWidget that
+    // reports values out (the pattern for every widget surface).
+    scene.add(
+      Node(name: 'panel')
+        ..position = vm.Vector3(0.15, 0.15, 0.6)
+        ..rotation = vm.Quaternion.axisAngle(vm.Vector3(0, 1, 0), -0.25)
+        ..addComponent(
+          WidgetComponent(
+            child: _PanelCard(
+              onSpin: (v) {
+                _spin = v;
+                _spinReadout.value = v;
+              },
+              onLit: (v) => _lit = v,
+            ),
+            size: const Size(260, 200),
+            pixelRatio: 2.0,
+            worldHeight: 1.6,
+          ),
+        ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        // The rail exists to move the SceneView off the window origin.
+        Container(
+          width: 230,
+          color: const Color(0xFF14161B),
+          padding: const EdgeInsets.fromLTRB(16, 56, 16, 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Inset view',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 8),
+              const Text(
+                'This rail offsets the SceneView from the window origin, so '
+                'forwarded widget-surface input cannot take the texture-space '
+                'shortcut.\n\n'
+                'Drag the slider on the 3D panel: the thumb should follow the '
+                'pointer and the cube spin track it. The button and switch '
+                'cover the tap path.',
+                style: TextStyle(color: Colors.white70, fontSize: 12.5),
+              ),
+              const SizedBox(height: 16),
+              ValueListenableBuilder<double>(
+                valueListenable: _spinReadout,
+                builder: (context, value, _) => Text(
+                  'spin off the surface: '
+                  '${(value * 100).round()}%',
+                  style: const TextStyle(
+                    color: Color(0xFF7FD1A0),
+                    fontSize: 12.5,
+                    fontFeatures: [FontFeature.tabularFigures()],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: !loaded
+              ? const Center(child: CircularProgressIndicator())
+              : SceneView(
+                  scene,
+                  camera: PerspectiveCamera(
+                    position: vm.Vector3(0, 1.2, 6.2),
+                    target: vm.Vector3(0, 0.2, 0),
+                  ),
+                  onTick: (elapsed, deltaSeconds) {
+                    _angle += deltaSeconds * _spin * 2.0;
+                    _cube
+                      ?..rotation = vm.Quaternion.axisAngle(
+                        vm.Vector3(0, 1, 0),
+                        _angle,
+                      )
+                      ..visible = _lit;
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The live subtree on the panel: the slider is the probe for forwarded
+/// position math, the button and switch for the tap path. It owns its state
+/// and reports values out, the way every hosted subtree should — `SceneView`
+/// mounts it once, so values pushed in from an enclosing `setState` would
+/// never reach it.
+class _PanelCard extends StatefulWidget {
+  const _PanelCard({required this.onSpin, required this.onLit});
+
+  final ValueChanged<double> onSpin;
+  final ValueChanged<bool> onLit;
+
+  @override
+  State<_PanelCard> createState() => _PanelCardState();
+}
+
+class _PanelCardState extends State<_PanelCard> {
+  double _spin = 0.5;
+  bool _lit = true;
+  int _taps = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Colors.black87,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(14, 10, 14, 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Expanded(
+                  child: Text(
+                    'Cube',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                Switch(
+                  value: _lit,
+                  onChanged: (v) {
+                    setState(() => _lit = v);
+                    widget.onLit(v);
+                  },
+                ),
+              ],
+            ),
+            Text(
+              'Spin ${(_spin * 100).round()}%',
+              style: const TextStyle(
+                color: Colors.white70,
+                fontSize: 13,
+                fontFeatures: [FontFeature.tabularFigures()],
+              ),
+            ),
+            Slider(
+              value: _spin,
+              onChanged: (v) {
+                setState(() => _spin = v);
+                widget.onSpin(v);
+              },
+            ),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton(
+                onPressed: () => setState(() => _taps++),
+                child: Text('Taps: $_taps'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -260,8 +260,7 @@ class _MyAppState extends State<MyApp> {
       'Custom Skybox': (context) => const ExampleSkybox(),
       'Audio': (context) => const ExampleAudio(),
       'Widget Texture': (context) => const ExampleWidgetTexture(),
-      'Widget Input (inset view)': (context) =>
-          const ExampleWidgetInset(),
+      'Widget Input (inset view)': (context) => const ExampleWidgetInset(),
       'Accessibility': (context) => const ExampleAccessibility(),
       'Render Targets': (context) => const ExampleRenderTarget(),
       'Physics': (context) => FutureBuilder<void>(

--- a/examples/flutter_app/lib/main.dart
+++ b/examples/flutter_app/lib/main.dart
@@ -54,6 +54,7 @@ import 'example_planar_mirror.dart';
 import 'example_splats.dart';
 import 'example_skybox.dart';
 import 'example_ssr.dart';
+import 'example_widget_inset.dart';
 import 'example_widget_texture.dart';
 import 'example_split_screen.dart';
 import 'example_stress_tests.dart';
@@ -259,6 +260,8 @@ class _MyAppState extends State<MyApp> {
       'Custom Skybox': (context) => const ExampleSkybox(),
       'Audio': (context) => const ExampleAudio(),
       'Widget Texture': (context) => const ExampleWidgetTexture(),
+      'Widget Input (inset view)': (context) =>
+          const ExampleWidgetInset(),
       'Accessibility': (context) => const ExampleAccessibility(),
       'Render Targets': (context) => const ExampleRenderTarget(),
       'Physics': (context) => FutureBuilder<void>(

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.24.0
 
+* Widget-surface pointer forwarding dispatches events in the framework's global space (with the host's transform in the hit path), so widgets that convert `globalPosition` through render objects — `Slider`, text selection — work when the scene view is not at the window origin.
 * glTF import validates `extensionsRequired` and surfaces warnings through an `onWarning` callback on every entry point.
 * Sparse glTF accessors apply, including the zero-filled base for an absent `bufferView`.
 * `KHR_draco_mesh_compression` decodes in pure Dart on every platform.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.24.0
 
-* Widget-surface pointer forwarding dispatches events in the framework's global space (with the host's transform in the hit path), so widgets that convert `globalPosition` through render objects — `Slider`, text selection — work when the scene view is not at the window origin.
+* Widget-surface pointer forwarding dispatches events in the framework's global space (with the host's transform in the hit path), so widgets that convert `globalPosition` through render objects (Slider, text selection) work when the scene view is not at the window origin.
 * glTF import validates `extensionsRequired` and surfaces warnings through an `onWarning` callback on every entry point.
 * Sparse glTF accessors apply, including the zero-filled base for an absent `bufferView`.
 * `KHR_draco_mesh_compression` decodes in pure Dart on every platform.

--- a/packages/flutter_scene/lib/src/widget_texture.dart
+++ b/packages/flutter_scene/lib/src/widget_texture.dart
@@ -331,6 +331,7 @@ class _RenderWidgetTexture extends RenderProxyBox {
   /// the position in the framework's global space. Returns null when the
   /// transform is degenerate (the host is not meaningfully on stage).
   (HitTestResult, Offset, Matrix4)? _globalHit(RenderBox child, Offset local) {
+    if (!child.attached) return null;
     final childToGlobal = child.getTransformTo(null);
     if (Matrix4.tryInvert(childToGlobal) == null) return null;
     final global = MatrixUtils.transformPoint(childToGlobal, local);
@@ -670,7 +671,12 @@ class _RenderWidgetTexture extends RenderProxyBox {
 /// framework's global space; [childToGlobal] is the child's transform
 /// captured at pointer down and drives the whole interaction.
 class _SyntheticPointer {
-  _SyntheticPointer(this.pointer, this.path, this.lastGlobal, this.childToGlobal);
+  _SyntheticPointer(
+    this.pointer,
+    this.path,
+    this.lastGlobal,
+    this.childToGlobal,
+  );
 
   final int pointer;
   final HitTestResult path;

--- a/packages/flutter_scene/lib/src/widget_texture.dart
+++ b/packages/flutter_scene/lib/src/widget_texture.dart
@@ -124,6 +124,16 @@ class WidgetTextureController extends ChangeNotifier {
   // system, so taps and drags raycast against scene geometry can drive the
   // widgets. Gesture recognizers (buttons, drags, scrollables) work
   // normally.
+  //
+  // Events are dispatched in the framework's global space (the hosted
+  // child's `getTransformTo(null)` applied to the texture-space position),
+  // with that transform composed into the hit path. Both sides of a
+  // recognizer's coordinate math then agree with the render tree: handlers
+  // that convert `details.globalPosition` back through render objects
+  // (Slider's `globalToLocal`, text selection) and handlers that use
+  // `details.localPosition`. Dispatching bare texture-space positions
+  // instead breaks the globalPosition path whenever the host is not at the
+  // window origin.
   // TODO(widget-textures): hover (MouseRegion enter/exit) needs MouseTracker
   // integration, which tracks annotations on the on-screen layer tree.
 
@@ -316,20 +326,42 @@ class _RenderWidgetTexture extends RenderProxyBox {
     (uv.dy.clamp(0.0, 1.0)) * _captureSize.height,
   );
 
+  /// Hit-tests [child] at texture-space [local] with the child's global
+  /// transform composed into the path, and returns the path together with
+  /// the position in the framework's global space. Returns null when the
+  /// transform is degenerate (the host is not meaningfully on stage).
+  (HitTestResult, Offset, Matrix4)? _globalHit(RenderBox child, Offset local) {
+    final childToGlobal = child.getTransformTo(null);
+    if (Matrix4.tryInvert(childToGlobal) == null) return null;
+    final global = MatrixUtils.transformPoint(childToGlobal, local);
+    final result = BoxHitTestResult();
+    result.addWithPaintTransform(
+      transform: childToGlobal,
+      position: global,
+      hitTest: (result, position) => child.hitTest(result, position: position),
+    );
+    // The trailing binding entry routes the event into the pointer router
+    // and closes the gesture arena, mirroring the live pointer pipeline.
+    result.add(HitTestEntry(GestureBinding.instance));
+    return (result, global, childToGlobal);
+  }
+
   void _pointerDown(Offset uv, int id) {
     final child = this.child;
     if (child == null) return;
     if (_pointers.containsKey(id)) _pointerCancel(id);
-    final local = _uvToLocal(uv);
-    final result = HitTestResult();
-    child.hitTest(BoxHitTestResult.wrap(result), position: local);
-    // The trailing binding entry routes the event into the pointer router
-    // and closes the gesture arena, mirroring the live pointer pipeline.
-    result.add(HitTestEntry(GestureBinding.instance));
-    final state = _SyntheticPointer(_nextSyntheticPointer++, result, local);
+    final hit = _globalHit(child, _uvToLocal(uv));
+    if (hit == null) return;
+    final (result, global, childToGlobal) = hit;
+    final state = _SyntheticPointer(
+      _nextSyntheticPointer++,
+      result,
+      global,
+      childToGlobal,
+    );
     _pointers[id] = state;
     GestureBinding.instance.dispatchEvent(
-      PointerDownEvent(pointer: state.pointer, position: local),
+      PointerDownEvent(pointer: state.pointer, position: global),
       result,
     );
   }
@@ -337,23 +369,34 @@ class _RenderWidgetTexture extends RenderProxyBox {
   void _pointerMove(Offset uv, int id) {
     final state = _pointers[id];
     if (state == null) return;
-    final local = _uvToLocal(uv);
+    // The down-time transform maps the whole interaction, matching the
+    // hit path captured at down (standard pointer-capture semantics).
+    final global = MatrixUtils.transformPoint(
+      state.childToGlobal,
+      _uvToLocal(uv),
+    );
     GestureBinding.instance.dispatchEvent(
       PointerMoveEvent(
         pointer: state.pointer,
-        position: local,
-        delta: local - state.lastLocal,
+        position: global,
+        delta: global - state.lastGlobal,
       ),
       state.path,
     );
-    state.lastLocal = local;
+    state.lastGlobal = global;
   }
 
   void _pointerUp(Offset uv, int id) {
     final state = _pointers.remove(id);
     if (state == null) return;
     GestureBinding.instance.dispatchEvent(
-      PointerUpEvent(pointer: state.pointer, position: _uvToLocal(uv)),
+      PointerUpEvent(
+        pointer: state.pointer,
+        position: MatrixUtils.transformPoint(
+          state.childToGlobal,
+          _uvToLocal(uv),
+        ),
+      ),
       state.path,
     );
   }
@@ -362,7 +405,7 @@ class _RenderWidgetTexture extends RenderProxyBox {
     final state = _pointers.remove(id);
     if (state == null) return;
     GestureBinding.instance.dispatchEvent(
-      PointerCancelEvent(pointer: state.pointer, position: state.lastLocal),
+      PointerCancelEvent(pointer: state.pointer, position: state.lastGlobal),
       state.path,
     );
   }
@@ -370,14 +413,13 @@ class _RenderWidgetTexture extends RenderProxyBox {
   void _pointerScroll(Offset uv, Offset scrollDelta) {
     final child = this.child;
     if (child == null) return;
-    final local = _uvToLocal(uv);
-    final result = HitTestResult();
-    child.hitTest(BoxHitTestResult.wrap(result), position: local);
-    result.add(HitTestEntry(GestureBinding.instance));
+    final hit = _globalHit(child, _uvToLocal(uv));
+    if (hit == null) return;
+    final (result, global, _) = hit;
     // The binding entry's handleEvent resolves pointer signals, so
     // scrollables under the point receive the event.
     GestureBinding.instance.dispatchEvent(
-      PointerScrollEvent(position: local, scrollDelta: scrollDelta),
+      PointerScrollEvent(position: global, scrollDelta: scrollDelta),
       result,
     );
   }
@@ -624,11 +666,14 @@ class _RenderWidgetTexture extends RenderProxyBox {
   }
 }
 
-/// One in-flight synthetic pointer interaction.
+/// One in-flight synthetic pointer interaction. Positions are in the
+/// framework's global space; [childToGlobal] is the child's transform
+/// captured at pointer down and drives the whole interaction.
 class _SyntheticPointer {
-  _SyntheticPointer(this.pointer, this.path, this.lastLocal);
+  _SyntheticPointer(this.pointer, this.path, this.lastGlobal, this.childToGlobal);
 
   final int pointer;
   final HitTestResult path;
-  Offset lastLocal;
+  Offset lastGlobal;
+  final Matrix4 childToGlobal;
 }

--- a/packages/flutter_scene/test/widget_texture_test.dart
+++ b/packages/flutter_scene/test/widget_texture_test.dart
@@ -125,6 +125,58 @@ void main() {
     expect(presses, 1);
   });
 
+  testWidgets('forwarded positions agree with the render tree when the host '
+      'is away from the window origin', (tester) async {
+    // Slider converts a gesture's globalPosition back through render-object
+    // transforms (globalToLocal), so it only works when event positions and
+    // the hit path agree with the render tree about the coordinate space.
+    // Hosting the texture away from the origin makes any texture-space
+    // shortcut visible: with bare texture-space positions the slider reads
+    // garbage (regression test for exactly that).
+    final controller = WidgetTextureController();
+    double value = 0.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Padding(
+            padding: const EdgeInsets.only(left: 123, top: 217),
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: WidgetTexture(
+                controller: controller,
+                width: 200,
+                height: 48,
+                child: StatefulBuilder(
+                  builder: (context, setState) => Slider(
+                    value: value,
+                    onChanged: (v) => setState(() => value = v),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // A tap at 80% across the texture seeks the slider near 80% (the thumb
+    // padding at the track ends makes the mapping approximate).
+    controller.tapAt(const Offset(0.8, 0.5));
+    await tester.pump();
+    expect(value, greaterThan(0.6));
+    expect(value, lessThan(1.0));
+
+    // A drag toward the left end tracks continuously.
+    controller.pointerDown(const Offset(0.8, 0.5));
+    controller.pointerMove(const Offset(0.5, 0.5));
+    await tester.pump();
+    expect(value, closeTo(0.5, 0.15));
+    controller.pointerMove(const Offset(0.2, 0.5));
+    controller.pointerUp(const Offset(0.2, 0.5));
+    await tester.pump();
+    expect(value, lessThan(0.3));
+  });
+
   testWidgets('captures publish a texture matching the capture size', (
     tester,
   ) async {


### PR DESCRIPTION
Sliders on widget surfaces don't work when the `SceneView` is not at the window origin. Buttons and switches work fine, which makes this easy to miss.

**Disclaimer**: this PR is generated with LLM. Not sure what's the policy of AI-generated contributions. I'm happy to drop this and rather just use this PR as prompt to fix it yourself :). I read the code and PR and haven't found anything that I wouldn't accept myself.


https://github.com/user-attachments/assets/dc8c4aa3-8273-4f3b-9d6a-0c10f8c660e7



LLM generated content follows:

---

**What happens**

`WidgetTextureController` synthesizes pointer events with texture-space positions (0..width/height of the capture) and uses them as the event's position. That works for anything that only needs a hit test, like a button. But widgets that map `details.globalPosition` back through the render tree - `Slider` does `globalToLocal(globalPosition)`, text selection does the same - get garbage, because the "global" position they receive is actually local to the texture.

All the examples in this repo run `SceneView` fullscreen, so the host sits at `(0, 0)` and local happens to equal global. The bug only shows up when the view is inset - for example a scene view next to a sidebar. Then the slider jumps to 0 or ignores drags entirely, while buttons on the same panel keep working.

**The fix**

Dispatch events in the framework's global space instead:

- take the hosted child's `getTransformTo(null)` and apply it to the texture-space position
- push that transform into the hit path with `addWithPaintTransform`, so `localPosition` also stays correct
- capture the transform at pointer down and use it for the whole interaction, same as normal pointer capture
- bail out if the transform is not invertible

**Testing**

- New regression test: a `Slider` hosted at an offset `(padding 123, 217)`. Tap-to-seek and a two-step drag assert real values. It fails on the old code and passes with this change. Existing widget-texture tests still pass.
- New example, "Widget Input (inset view)": a side rail pushes the `SceneView` off the origin, and a panel with a slider, switch, and button sits on a `WidgetComponent` quad. Before this change the slider is broken there; after it, it tracks normally.
- Also verified in a separate app with an inset SceneView, dragging a Material slider on an in-scene panel.

_Changelog entry added under 0.24.0._


related to #170