### PR TITLE
Standardize model-space front faces on counter-clockwise winding

### DIFF
--- a/examples/flutter_app/lib/example_nav_route.dart
+++ b/examples/flutter_app/lib/example_nav_route.dart
@@ -441,8 +441,8 @@ MeshGeometry _buildNavLine(
   for (var i = 0; i < samples - 1; i++) {
     final base = i * 2;
     builder
-      ..addTriangle(base, base + 1, base + 2)
-      ..addTriangle(base + 1, base + 3, base + 2);
+      ..addTriangle(base, base + 2, base + 1)
+      ..addTriangle(base + 1, base + 2, base + 3);
   }
   return builder.build();
 }

--- a/examples/flutter_app/lib/example_particles.dart
+++ b/examples/flutter_app/lib/example_particles.dart
@@ -770,7 +770,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
         final a = i * (segments + 1) + s;
         final b = (i + 1) * (segments + 1) + s;
         // Same rotational winding as the disc primitive (front face up).
-        indices.addAll([a, b, a + 1, a + 1, b, b + 1]);
+        indices.addAll([a, b + 1, a + 1, a, b, b + 1]);
       }
     }
     return MeshGeometry.fromArrays(
@@ -839,7 +839,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
       for (var s = 0; s < segments; s++) {
         final a = i * (segments + 1) + s;
         final b = (i + 1) * (segments + 1) + s;
-        indices.addAll([a, b, a + 1, a + 1, b, b + 1]);
+        indices.addAll([a, b + 1, a + 1, a, b, b + 1]);
       }
     }
     return MeshGeometry.fromArrays(
@@ -928,7 +928,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
     }
     for (var i = 0; i < segments; i++) {
       final l0 = base + i * 2;
-      indices.addAll([l0, l0 + 1, l0 + 2, l0 + 1, l0 + 3, l0 + 2]);
+      indices.addAll([l0, l0 + 2, l0 + 1, l0 + 1, l0 + 2, l0 + 3]);
     }
   }
 
@@ -1099,7 +1099,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
       final b = a + 1;
       final c = a + columns;
       final d = c + 1;
-      indices.addAll([a, b, c, b, d, c]);
+      indices.addAll([a, c, b, b, c, d]);
     }
   }
 

--- a/examples/flutter_app/lib/example_particles.dart
+++ b/examples/flutter_app/lib/example_particles.dart
@@ -770,7 +770,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
         final a = i * (segments + 1) + s;
         final b = (i + 1) * (segments + 1) + s;
         // Same rotational winding as the disc primitive (front face up).
-        indices.addAll([a, b + 1, a + 1, a, b, b + 1]);
+        indices.addAll([a, a + 1, b, a + 1, b + 1, b]);
       }
     }
     return MeshGeometry.fromArrays(
@@ -839,7 +839,7 @@ class ExampleParticlesState extends State<ExampleParticles> {
       for (var s = 0; s < segments; s++) {
         final a = i * (segments + 1) + s;
         final b = (i + 1) * (segments + 1) + s;
-        indices.addAll([a, b + 1, a + 1, a, b, b + 1]);
+        indices.addAll([a, a + 1, b, a + 1, b + 1, b]);
       }
     }
     return MeshGeometry.fromArrays(

--- a/examples/flutter_app/lib/example_raw_shader.dart
+++ b/examples/flutter_app/lib/example_raw_shader.dart
@@ -100,7 +100,7 @@ class _ExampleRawShaderState extends State<ExampleRawShader> {
       for (var c = 0; c < n; c++) {
         final i0 = r * (n + 1) + c;
         final i2 = i0 + (n + 1);
-        indices.addAll([i0, i0 + 1, i2, i0 + 1, i2 + 1, i2]);
+        indices.addAll([i0, i2, i0 + 1, i0 + 1, i2, i2 + 1]);
       }
     }
     return MeshGeometry.fromArrays(

--- a/examples/flutter_app/lib/example_widget_texture.dart
+++ b/examples/flutter_app/lib/example_widget_texture.dart
@@ -308,8 +308,8 @@ Geometry _buildCrtScreen({
       texCoords[v * 2 + 1] = (1 - ny) / 2; // v = 0 at the top
     }
   }
-  // Two triangles per cell, wound to match the engine front-face convention
-  // (the same order as the cuboid's +Z face: br, bl, tl, tr).
+  // Two triangles per cell, wound Counter-Clockwise (CCW) matching the
+  // engine front-face convention (bl, br, tr and bl, tr, tl).
   final indices = <int>[];
   for (var r = 0; r < rows - 1; r++) {
     for (var c = 0; c < columns - 1; c++) {
@@ -317,7 +317,7 @@ Geometry _buildCrtScreen({
       final br = bl + 1;
       final tl = bl + columns;
       final tr = tl + 1;
-      indices.addAll([br, bl, tr, tr, bl, tl]);
+      indices.addAll([bl, br, tr, bl, tr, tl]);
     }
   }
   // Normals are omitted; smooth area-weighted vertex normals are generated

--- a/examples/smoke_render/lib/smoke_scenes.dart
+++ b/examples/smoke_render/lib/smoke_scenes.dart
@@ -1558,7 +1558,7 @@ final List<SmokeScene> kSmokeScenes = <SmokeScene>[
       for (var c = 0; c < n; c++) {
         final i0 = r * (n + 1) + c;
         final i2 = i0 + (n + 1);
-        indices.addAll([i0, i0 + 1, i2, i0 + 1, i2 + 1, i2]);
+        indices.addAll([i0, i2, i0 + 1, i0 + 1, i2, i2 + 1]);
       }
     }
     final scene = Scene()..environmentIntensity = 0.0;

--- a/examples/smoke_render/lib/synthetic_morph_glb.dart
+++ b/examples/smoke_render/lib/synthetic_morph_glb.dart
@@ -106,8 +106,8 @@ Uint8List buildMorphSkinnedGlb() {
   }
   // Caps, so the ends read solid instead of showing the inside wall.
   final top = (_rows - 1) * _corners.length;
-  indices.addAll([0, 1, 2, 0, 2, 3]);
-  indices.addAll([top, top + 2, top + 1, top, top + 3, top + 2]);
+  indices.addAll([0, 2, 1, 0, 3, 2]);
+  indices.addAll([top, top + 1, top + 2, top, top + 2, top + 3]);
 
   // Joint 0 sits at the origin, joint 1 a unit up; the inverse binds undo
   // those rest positions.

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.24.0
 
+* Standardized model-space front-face winding to Counter-Clockwise (CCW) across primitives, procedural builders, materials, and `.fscene` version 5.
 * Added `ExternalTexture`, a `TextureSource` fed by a platform texture id (video, camera preview), captured through the compositor on frames that sample it.
 * Generated scene registries are cached per asset bundle.
 * `.fsceneb` payload chunks compress with gzip, cutting file sizes by ~73% in exchange for higher load-time decompression CPU.

--- a/packages/flutter_scene/lib/src/fmat/build_materials.dart
+++ b/packages/flutter_scene/lib/src/fmat/build_materials.dart
@@ -8,6 +8,7 @@ import 'package:flutter_scene/src/importer/build_cache.dart';
 import 'package:flutter_scene/src/importer/build_hooks.dart'
     show discoveryDependencyDirectory;
 
+import '../generated_assets/engine_identity.dart' show engineIdentity;
 import '../generated_assets/generated_assets.dart';
 import '../generated_assets/generated_tree.dart';
 import 'fmat.dart';
@@ -105,24 +106,33 @@ List<String> discoverFmatMaterials(
 /// inside these are not tracked until `impellerc --depfile` is consumed in
 /// `--shader-bundle` mode (bdero/flutter_gpu_shaders#15).
 const _frameworkShaderFiles = <String>[
-  'material_varyings.glsl',
-  'pbr.glsl',
-  'texture.glsl',
-  'normals.glsl',
-  // Opt-in include for material authors (`#include <noise.glsl>`).
-  'noise.glsl',
-  'material_inputs.glsl',
+  'contact_shadow.glsl',
+  'depth_bias.glsl',
+  'depth_mask.glsl',
+  'filtered_scene_color.glsl',
+  'flutter_scene_morph.glsl',
+  'flutter_scene_skinned_body.glsl',
+  'flutter_scene_unskinned_body.glsl',
+  'flutter_scene_unskinned_depth_body.glsl',
+  'fog.glsl',
+  'interleaved_gradient_noise.glsl',
+  'lightmap.glsl',
+  'lod_fade.glsl',
   'material_engine_lighting.glsl',
+  'material_inputs.glsl',
   'material_lighting.glsl',
   'material_shadow_sampling.glsl',
-  'lightmap.glsl',
-  'filtered_scene_color.glsl',
-  // The vertex-stage includes a material's generated vertex variants pull in.
+  'material_varyings.glsl',
   'material_vertex.glsl',
-  'depth_bias.glsl',
-  'flutter_scene_unskinned_body.glsl',
-  'flutter_scene_skinned_body.glsl',
-  'flutter_scene_unskinned_depth_body.glsl',
+  'noise.glsl',
+  'normals.glsl',
+  'octahedral.glsl',
+  'pbr.glsl',
+  'scene_inputs.glsl',
+  'smaa.glsl',
+  'ssao_geometry.glsl',
+  'texture.glsl',
+  'tone_mapping.glsl',
 ];
 
 /// Compiles `.fmat` custom-material files into a Flutter GPU shader bundle plus
@@ -302,6 +312,7 @@ Future<void> _buildMaterials({
         .resolve('build/shaderbundles/$bundleName.shaderbundle')
         .toFilePath(),
   );
+  final variant = fileVariant ?? await engineIdentity();
   final shippedBundleFile = tree == null
       ? bundleFile
       : File.fromUri(
@@ -309,7 +320,7 @@ Future<void> _buildMaterials({
             GeneratedAssetFamily.material,
             nameId: bundleName,
             extension: '.shaderbundle',
-            variant: fileVariant,
+            variant: variant,
             target: target,
           ),
         );
@@ -318,7 +329,7 @@ Future<void> _buildMaterials({
           GeneratedAssetFamily.material,
           nameId: bundleName,
           extension: '.fmat.json',
-          variant: fileVariant,
+          variant: variant,
           target: target,
         ) ??
         packageRoot.resolve('build/shaderbundles/$bundleName.fmat.json'),
@@ -328,7 +339,7 @@ Future<void> _buildMaterials({
           GeneratedAssetFamily.material,
           nameId: bundleName,
           extension: '.index.json',
-          variant: fileVariant,
+          variant: variant,
           target: target,
         ) ??
         packageRoot.resolve('build/shaderbundles/$bundleName.index.json'),

--- a/packages/flutter_scene/lib/src/fmat/fmat.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat.dart
@@ -17,6 +17,7 @@ export 'package:flutter_scene/src/fmat/fmat_emitter.dart'
         vertexVariantEntryName,
         kVertexVariants,
         buildSidecar,
+        kFrameworkVaryingSchemaVersion,
         kMaterialParamsBlock,
         kMaterialParamsInstance;
 export 'package:flutter_scene/src/fmat/fmat_parser.dart' show parseFmat;

--- a/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
+++ b/packages/flutter_scene/lib/src/fmat/fmat_emitter.dart
@@ -37,6 +37,10 @@ const String kFragmentKeepAliveBlock = 'FragmentKeepAlive';
 /// The GLES-fold-safe instance name for [kFragmentKeepAliveBlock].
 const String kFragmentKeepAliveInstance = 'fragment_keep_alive';
 
+/// The framework varying schema version recorded in sidecars. Bumped whenever
+/// standard varyings in material_varyings.glsl or material_vertex.glsl change.
+const int kFrameworkVaryingSchemaVersion = 2;
+
 /// The engine vertex variants a material with a `vertex { }` block generates a
 /// shader for, mapping the sidecar key the runtime selects by to the shared
 /// body include that variant reuses. The keys correspond to the geometry a
@@ -677,6 +681,7 @@ String _emitSkyGlsl(
 Map<String, Object?> buildSidecar(FmatMaterial material) {
   return <String, Object?>{
     'name': material.name,
+    'framework_varying_schema': kFrameworkVaryingSchemaVersion,
     'domain': material.domain.name,
     if (material.useEnvironment) 'use_environment': true,
     'shading_model': material.shadingModel.name,

--- a/packages/flutter_scene/lib/src/fmat/material_registry.dart
+++ b/packages/flutter_scene/lib/src/fmat/material_registry.dart
@@ -3,7 +3,10 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart' show internal, kDebugMode;
 import 'package:flutter/services.dart';
 import 'package:flutter_scene/src/fmat/fmat_emitter.dart'
-    show radianceCubeEntryName, sidecarSamplesEnvironment;
+    show
+        kFrameworkVaryingSchemaVersion,
+        radianceCubeEntryName,
+        sidecarSamplesEnvironment;
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/src/hot_reload/hot_reload_coordinator.dart';
 import 'package:flutter_scene/src/generated_assets/generated_asset_lookup.dart';
@@ -215,6 +218,15 @@ final class FmatMaterialRegistry {
         await _loadSidecar(index.sidecarAssetKey);
     final metadata = (metadataByMaterial[resolution.entry.entryName] as Map)
         .cast<String, Object?>();
+    final varyingSchema = metadata['framework_varying_schema'];
+    if (varyingSchema != null &&
+        varyingSchema != kFrameworkVaryingSchemaVersion) {
+      throw StateError(
+        'Material "$sourcePath" was compiled with an incompatible framework '
+        'varying schema ($varyingSchema, expected $kFrameworkVaryingSchemaVersion). '
+        'Rebuild the material with "flutter clean" or re-run buildMaterials.',
+      );
+    }
     if (metadata['domain'] == 'sky') {
       throw StateError(
         '"$sourcePath" is a sky .fmat; load it with loadFmatSky instead.',
@@ -305,6 +317,15 @@ final class FmatMaterialRegistry {
         await _loadSidecar(index.sidecarAssetKey);
     final metadata = (metadataByMaterial[resolution.entry.entryName] as Map)
         .cast<String, Object?>();
+    final varyingSchema = metadata['framework_varying_schema'];
+    if (varyingSchema != null &&
+        varyingSchema != kFrameworkVaryingSchemaVersion) {
+      throw StateError(
+        'Sky material "$sourcePath" was compiled with an incompatible framework '
+        'varying schema ($varyingSchema, expected $kFrameworkVaryingSchemaVersion). '
+        'Rebuild the material with "flutter clean" or re-run buildMaterials.',
+      );
+    }
     if (metadata['domain'] != 'sky') {
       throw StateError(
         '"$sourcePath" is not a sky .fmat (it has no `sky { }` block); load '

--- a/packages/flutter_scene/lib/src/fmat/target_shader_bundle.dart
+++ b/packages/flutter_scene/lib/src/fmat/target_shader_bundle.dart
@@ -145,11 +145,12 @@ Future<void> buildTargetShaderBundleJson({
     buildInput.packageName,
   )..requireAssetEntry();
   final target = shaderBundleTargetKey(buildInput);
+  final variant = fileVariant ?? await engineIdentity();
   final copyUri = tree.fileUri(
     GeneratedAssetFamily.shaderBundle,
     nameId: id,
     extension: '.shaderbundle',
-    variant: fileVariant,
+    variant: variant,
     target: target,
   );
   writeGeneratedBytes(copyUri, bytes);

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -581,10 +581,36 @@ class ResourceRealizer {
     var indexType = gpu.IndexType.int16;
     final indexId = res.indices;
     if (indexId != null) {
-      indexBytes = ByteData.sublistView(_payloadBytes(indexId, 'index'));
-      indexType = document.payload(indexId)!.format == 'uint32'
-          ? gpu.IndexType.int32
-          : gpu.IndexType.int16;
+      final rawIndexBytes = _payloadBytes(indexId, 'index');
+      final isUint32 = document.payload(indexId)!.format == 'uint32';
+      indexType = isUint32 ? gpu.IndexType.int32 : gpu.IndexType.int16;
+      if (document.formatVersion < 5) {
+        final migrated = Uint8List.fromList(rawIndexBytes);
+        if (isUint32) {
+          final u32 = migrated.buffer.asUint32List(
+            migrated.offsetInBytes,
+            migrated.lengthInBytes ~/ 4,
+          );
+          for (var i = 0; i + 2 < u32.length; i += 3) {
+            final tmp = u32[i + 1];
+            u32[i + 1] = u32[i + 2];
+            u32[i + 2] = tmp;
+          }
+        } else {
+          final u16 = migrated.buffer.asUint16List(
+            migrated.offsetInBytes,
+            migrated.lengthInBytes ~/ 2,
+          );
+          for (var i = 0; i + 2 < u16.length; i += 3) {
+            final tmp = u16[i + 1];
+            u16[i + 1] = u16[i + 2];
+            u16[i + 2] = tmp;
+          }
+        }
+        indexBytes = ByteData.sublistView(migrated);
+      } else {
+        indexBytes = ByteData.sublistView(rawIndexBytes);
+      }
     }
 
     // Set baked bounds before upload so the position scan is skipped; without

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -583,8 +583,8 @@ class ResourceRealizer {
     if (indexId != null) {
       final rawIndexBytes = _payloadBytes(indexId, 'index');
       final isUint32 = document.payload(indexId)!.format == 'uint32';
-      final isTriangleTopology =
-          res.topology == 'triangle' || res.topology == 'triangles';
+      indexType = isUint32 ? gpu.IndexType.int32 : gpu.IndexType.int16;
+      final isTriangleTopology = res.topology == 'triangle';
       if ((res.legacyWinding || document.formatVersion < 5) &&
           isTriangleTopology) {
         final migrated = Uint8List.fromList(rawIndexBytes);
@@ -611,6 +611,9 @@ class ResourceRealizer {
         }
         indexBytes = ByteData.sublistView(migrated);
       } else {
+        // TODO(winding): Support legacy winding migration for triangleStrip
+        // topology (requires vertex-order reversal, not index-triple swap).
+        // TODO(winding): Support non-indexed geometry winding migration.
         indexBytes = ByteData.sublistView(rawIndexBytes);
       }
     }

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -584,7 +584,7 @@ class ResourceRealizer {
       final rawIndexBytes = _payloadBytes(indexId, 'index');
       final isUint32 = document.payload(indexId)!.format == 'uint32';
       indexType = isUint32 ? gpu.IndexType.int32 : gpu.IndexType.int16;
-      if (document.formatVersion < 5) {
+      if (res.legacyWinding || document.formatVersion < 5) {
         final migrated = Uint8List.fromList(rawIndexBytes);
         if (isUint32) {
           final u32 = migrated.buffer.asUint32List(

--- a/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/resource_realizer.dart
@@ -583,8 +583,10 @@ class ResourceRealizer {
     if (indexId != null) {
       final rawIndexBytes = _payloadBytes(indexId, 'index');
       final isUint32 = document.payload(indexId)!.format == 'uint32';
-      indexType = isUint32 ? gpu.IndexType.int32 : gpu.IndexType.int16;
-      if (res.legacyWinding || document.formatVersion < 5) {
+      final isTriangleTopology =
+          res.topology == 'triangle' || res.topology == 'triangles';
+      if ((res.legacyWinding || document.formatVersion < 5) &&
+          isTriangleTopology) {
         final migrated = Uint8List.fromList(rawIndexBytes);
         if (isUint32) {
           final u32 = migrated.buffer.asUint32List(

--- a/packages/flutter_scene/lib/src/geometry/geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/geometry.dart
@@ -154,8 +154,9 @@ abstract class Geometry {
 
   /// Whether source triangles use the opposite of native scene winding.
   ///
-  /// Runtime glTF geometry keeps its source vertices unchanged and sets this
-  /// flag. Native and offline-imported geometry leave it false.
+  /// Native and imported geometry leave it false since both match the CCW
+  /// front-face convention. Custom geometries or importers can set it if
+  /// their source indices use clockwise winding.
   @internal
   bool sourceWindingFlipped = false;
 
@@ -348,6 +349,10 @@ abstract class Geometry {
         _indexCount = indices.lengthInBytes ~/ 4;
     }
   }
+
+  /// The index type (int16 or int32) of the bound index buffer.
+  @internal
+  gpu.IndexType get indexType => _indexType;
 
   /// Allocates a [gpu.DeviceBuffer] and uploads [vertices] (and optional
   /// [indices]) into it in one step.

--- a/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
+++ b/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
@@ -451,10 +451,10 @@ abstract final class InterleavedLayoutAdapter {
   /// triangle list; otherwise they are a non-indexed triangle list and
   /// [vertexCount] must be a multiple of three. Each triangle's
   /// unnormalized face normal is accumulated onto its three vertices, so
-  /// Computes area-weighted vertex normals from triangle connectivity.
+  /// larger triangles contribute more strongly to shared vertices.
   ///
   /// Assumes Counter-Clockwise (CCW) model-space front-face winding, so the
-  /// face normal is the standard right-hand cross product of the edges
+  /// face normal is the standard cross product of the edges
   /// `(b - a) x (c - a)`.
   static Float32List generateNormals({
     required Float32List positions,

--- a/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
+++ b/packages/flutter_scene/lib/src/geometry/interleaved_layout.dart
@@ -451,15 +451,11 @@ abstract final class InterleavedLayoutAdapter {
   /// triangle list; otherwise they are a non-indexed triangle list and
   /// [vertexCount] must be a multiple of three. Each triangle's
   /// unnormalized face normal is accumulated onto its three vertices, so
-  /// larger faces contribute proportionally; the result is normalized
-  /// per vertex. Vertices touched by no (or only degenerate) triangles
-  /// receive a default normal of `(0, 0, 1)`.
+  /// Computes area-weighted vertex normals from triangle connectivity.
   ///
-  /// Normals point out of the face the engine renders as front. The
-  /// engine's front faces wind clockwise in model space (the hand-built
-  /// primitives' convention; rasterization is Y-down, which flips the
-  /// apparent winding to counter-clockwise), so the face normal is the
-  /// REVERSED right-hand cross product of the edges.
+  /// Assumes Counter-Clockwise (CCW) model-space front-face winding, so the
+  /// face normal is the standard right-hand cross product of the edges
+  /// `(b - a) x (c - a)`.
   static Float32List generateNormals({
     required Float32List positions,
     required int vertexCount,
@@ -480,12 +476,12 @@ abstract final class InterleavedLayoutAdapter {
           cz = positions[c * 3 + 2];
       final e1x = bx - ax, e1y = by - ay, e1z = bz - az;
       final e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
-      // Unnormalized cross product (reversed for the engine's clockwise
-      // front-face winding): its magnitude is twice the triangle area,
-      // which weights each face's contribution by its size.
-      final nx = e2y * e1z - e2z * e1y;
-      final ny = e2z * e1x - e2x * e1z;
-      final nz = e2x * e1y - e2y * e1x;
+      // Unnormalized right-hand cross product (e1 x e2): its magnitude is
+      // twice the triangle area, which weights each face's contribution by its
+      // size.
+      final nx = e1y * e2z - e1z * e2y;
+      final ny = e1z * e2x - e1x * e2z;
+      final nz = e1x * e2y - e1y * e2x;
       for (final v in [a, b, c]) {
         normals[v * 3] += nx;
         normals[v * 3 + 1] += ny;

--- a/packages/flutter_scene/lib/src/geometry/line_segments_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/line_segments_geometry.dart
@@ -196,7 +196,7 @@ class LineSegmentsGeometry extends Geometry {
       1.0, 1.0, //
       1.0, -1.0,
     ]);
-    final indices = Uint16List.fromList(<int>[0, 1, 2, 0, 2, 3]);
+    final indices = Uint16List.fromList(<int>[0, 3, 1, 3, 2, 1]);
     final vertexBytes = ByteData.sublistView(verts);
     final indexBytes = ByteData.sublistView(indices);
     final buffer = gpu.gpuContext.createDeviceBuffer(

--- a/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/mesh_geometry.dart
@@ -1079,6 +1079,9 @@ class GeometryBuilder {
   }
 
   /// Adds a triangle referencing three previously added vertex indices.
+  ///
+  /// Vertices must be specified in Counter-Clockwise (CCW) order around the
+  /// outward-facing normal, matching the glTF and engine front-face convention.
   GeometryBuilder addTriangle(int a, int b, int c) {
     final count = vertexCount;
     for (final index in [a, b, c]) {

--- a/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/polyline_geometry.dart
@@ -179,8 +179,8 @@ class PolylineGeometry extends MeshGeometry {
     for (var i = 0; i < count - 1; i++) {
       final a = i * 2;
       indices
-        ..addAll([a, a + 2, a + 1])
-        ..addAll([a + 1, a + 2, a + 3]);
+        ..addAll([a, a + 1, a + 2])
+        ..addAll([a + 1, a + 3, a + 2]);
     }
 
     // A triangle-fan disk for each round cap.
@@ -193,7 +193,7 @@ class PolylineGeometry extends MeshGeometry {
       }
       for (var k = 0; k < _diskSegments; k++) {
         final next = (k + 1) % _diskSegments;
-        indices.addAll([base, base + 1 + next, base + 1 + k]);
+        indices.addAll([base, base + 1 + k, base + 1 + next]);
       }
     }
 

--- a/packages/flutter_scene/lib/src/geometry/primitives.dart
+++ b/packages/flutter_scene/lib/src/geometry/primitives.dart
@@ -494,8 +494,8 @@ PrimitiveArrays buildCuboidArrays(Vector3 extents, {bool debugColors = false}) {
         colors[v * 4 + 3] = color[3];
       }
     }
-    // Two triangles matching the original winding: (a, b, d) and (d, b, c).
-    indices.addAll([base, base + 1, base + 3, base + 3, base + 1, base + 2]);
+    // Two CCW triangles matching the outward face normal: (a, d, b) and (d, c, b).
+    indices.addAll([base, base + 3, base + 1, base + 3, base + 2, base + 1]);
   }
   return (
     positions: positions,
@@ -542,7 +542,7 @@ PrimitiveArrays buildWedgeArrays(Vector3 size) {
     addVert(b, n, 1, 1);
     addVert(c, n, 1, 0);
     addVert(d, n, 0, 0);
-    indices.addAll([base, base + 1, base + 3, base + 3, base + 1, base + 2]);
+    indices.addAll([base, base + 3, base + 1, base + 3, base + 2, base + 1]);
   }
 
   void addTri(Vector3 a, Vector3 b, Vector3 c, Vector3 n) {
@@ -556,8 +556,8 @@ PrimitiveArrays buildWedgeArrays(Vector3 size) {
   addQuad(l0, l1, t1, t0, slopeN); // sloped top
   addQuad(l0, b0, b1, l1, Vector3(0, -1, 0)); // bottom
   addQuad(b0, t0, t1, b1, Vector3(0, 0, 1)); // vertical back
-  addTri(l0, t0, b0, Vector3(-1, 0, 0)); // left side
-  addTri(l1, b1, t1, Vector3(1, 0, 0)); // right side
+  addTri(l0, b0, t0, Vector3(-1, 0, 0)); // left side
+  addTri(l1, t1, b1, Vector3(1, 0, 0)); // right side
 
   return (
     positions: Float32List.fromList(positions),
@@ -605,10 +605,10 @@ PrimitiveArrays buildPlaneArrays({
       final v10 = v00 + 1;
       final v01 = v00 + columns;
       final v11 = v01 + 1;
-      // Wound so the lit surface faces +Y, toward a camera above.
+      // Wound Counter-Clockwise (CCW) so the lit surface faces +Y.
       indices
-        ..addAll([v00, v10, v01])
-        ..addAll([v10, v11, v01]);
+        ..addAll([v00, v01, v10])
+        ..addAll([v10, v01, v11]);
     }
   }
 
@@ -672,8 +672,8 @@ PrimitiveArrays buildSphereArrays({
       final d = c + 1;
       // Wound counter-clockwise as seen from outside the sphere.
       indices
-        ..addAll([a, c, b])
-        ..addAll([b, c, d]);
+        ..addAll([a, b, c])
+        ..addAll([b, d, c]);
     }
   }
 
@@ -763,8 +763,8 @@ PrimitiveArrays buildCylinderArrays({
       final b = a + 1;
       final c = a + columns;
       final d = c + 1;
-      if (!topApex) indices.addAll([a, c, b]);
-      if (!bottomApex) indices.addAll([b, c, d]);
+      if (!topApex) indices.addAll([a, b, c]);
+      if (!bottomApex) indices.addAll([b, d, c]);
     }
   }
 
@@ -789,7 +789,7 @@ PrimitiveArrays buildCylinderArrays({
     for (var s = 0; s < radialSegments; s++) {
       final r0 = rimBase + s;
       final r1 = rimBase + s + 1;
-      indices.addAll(flip ? [center, r1, r0] : [center, r0, r1]);
+      indices.addAll(flip ? [center, r0, r1] : [center, r1, r0]);
     }
   }
 
@@ -874,8 +874,8 @@ PrimitiveArrays buildCapsuleArrays({
       final c = a + columns;
       final d = c + 1;
       indices
-        ..addAll([a, c, b])
-        ..addAll([b, c, d]);
+        ..addAll([a, b, c])
+        ..addAll([b, d, c]);
     }
   }
 
@@ -936,8 +936,8 @@ PrimitiveArrays buildTorusArrays({
       final c = a + columns;
       final d = c + 1;
       indices
-        ..addAll([a, c, b])
-        ..addAll([b, c, d]);
+        ..addAll([a, b, c])
+        ..addAll([b, d, c]);
     }
   }
 
@@ -976,8 +976,8 @@ PrimitiveArrays buildDiscArrays({
   }
   final indices = <int>[];
   for (var s = 0; s < segments; s++) {
-    // Wound so the lit surface faces +Y (front face opposite +Y normal).
-    indices.addAll([0, 1 + s, 1 + s + 1]);
+    // Wound so the lit surface faces +Y.
+    indices.addAll([0, 1 + s + 1, 1 + s]);
   }
 
   return (
@@ -1039,8 +1039,8 @@ PrimitiveArrays buildRingArrays({
     final i1 = innerBase + s + 1;
     // Wound so the lit surface faces +Y.
     indices
-      ..addAll([o0, o1, i1])
-      ..addAll([o0, i1, i0]);
+      ..addAll([o0, i1, o1])
+      ..addAll([o0, i0, i1]);
   }
 
   return (
@@ -1080,29 +1080,29 @@ PrimitiveArrays buildIcosphereArrays({
     Vector3(-t, 0, -1),
     Vector3(-t, 0, 1),
   ];
-  // Faces wound so the outward normal opposes the right-hand normal (the
-  // engine's front-face convention), i.e. clockwise seen from outside.
+  // Faces wound Counter-Clockwise (CCW) so the outward normal points radially
+  // outward from the sphere center.
   var faces = <List<int>>[
-    [0, 5, 11],
-    [0, 1, 5],
-    [0, 7, 1],
-    [0, 10, 7],
-    [0, 11, 10],
-    [1, 9, 5],
-    [5, 4, 11],
-    [11, 2, 10],
-    [10, 6, 7],
-    [7, 8, 1],
-    [3, 4, 9],
-    [3, 2, 4],
-    [3, 6, 2],
-    [3, 8, 6],
-    [3, 9, 8],
-    [4, 5, 9],
-    [2, 11, 4],
-    [6, 10, 2],
-    [8, 7, 6],
-    [9, 1, 8],
+    [0, 11, 5],
+    [0, 5, 1],
+    [0, 1, 7],
+    [0, 7, 10],
+    [0, 10, 11],
+    [1, 5, 9],
+    [5, 11, 4],
+    [11, 10, 2],
+    [10, 7, 6],
+    [7, 1, 8],
+    [3, 9, 4],
+    [3, 4, 2],
+    [3, 2, 6],
+    [3, 6, 8],
+    [3, 8, 9],
+    [4, 9, 5],
+    [2, 4, 11],
+    [6, 2, 10],
+    [8, 6, 7],
+    [9, 8, 1],
   ];
 
   // Midpoint cache: each subdivided edge contributes one shared vertex.

--- a/packages/flutter_scene/lib/src/geometry/primitives.dart
+++ b/packages/flutter_scene/lib/src/geometry/primitives.dart
@@ -494,7 +494,8 @@ PrimitiveArrays buildCuboidArrays(Vector3 extents, {bool debugColors = false}) {
         colors[v * 4 + 3] = color[3];
       }
     }
-    // Two CCW triangles matching the outward face normal: (a, d, b) and (d, c, b).
+    // Two CCW triangles matching the outward face normal:
+    // (a, d, b) and (d, c, b).
     indices.addAll([base, base + 3, base + 1, base + 3, base + 2, base + 1]);
   }
   return (

--- a/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
+++ b/packages/flutter_scene/lib/src/geometry/swept_geometry.dart
@@ -173,8 +173,8 @@ void stitchRings(
       final c = nextBase + j;
       final d = nextBase + j + 1;
       accumulator
-        ..addTriangle(a, c, b)
-        ..addTriangle(b, c, d);
+        ..addTriangle(a, b, c)
+        ..addTriangle(b, d, c);
     }
   }
 }

--- a/packages/flutter_scene/lib/src/importer/src/gltf/coordinate_policy.dart
+++ b/packages/flutter_scene/lib/src/importer/src/gltf/coordinate_policy.dart
@@ -31,7 +31,7 @@ extension GltfCoordinateConversion on GltfCoordinatePolicy {
   bool get bakesNative => this == GltfCoordinatePolicy.bakeNative;
 
   /// Whether packed source triangles use the opposite native winding.
-  bool get sourceWindingFlipped => this == GltfCoordinatePolicy.runtimeBoundary;
+  bool get sourceWindingFlipped => false;
 
   /// Converts a source position or translation.
   Vector3 convertPosition(Vector3 value) =>

--- a/packages/flutter_scene/lib/src/importer/src/gltf/primitive_packer.dart
+++ b/packages/flutter_scene/lib/src/importer/src/gltf/primitive_packer.dart
@@ -320,6 +320,13 @@ PackedPrimitive packGltfPrimitive({
       out[o + 16] = -out[o + 16];
       out[o + 17] = -out[o + 17];
     }
+    // Negating Z mirrors the triangle winding; swap indices (a, b, c) -> (a, c, b)
+    // so the baked native geometry retains Counter-Clockwise (CCW) front faces.
+    for (var i = 0; i + 2 < outIndexList.length; i += 3) {
+      final tmp = outIndexList[i + 1];
+      outIndexList[i + 1] = outIndexList[i + 2];
+      outIndexList[i + 2] = tmp;
+    }
   }
 
   // The engine wants 16- or 32-bit indices. Pass 32-bit through; narrow

--- a/packages/flutter_scene/lib/src/importer/src/gltf/primitive_packer.dart
+++ b/packages/flutter_scene/lib/src/importer/src/gltf/primitive_packer.dart
@@ -320,8 +320,8 @@ PackedPrimitive packGltfPrimitive({
       out[o + 16] = -out[o + 16];
       out[o + 17] = -out[o + 17];
     }
-    // Negating Z mirrors the triangle winding; swap indices (a, b, c) -> (a, c, b)
-    // so the baked native geometry retains Counter-Clockwise (CCW) front faces.
+    // Negating Z mirrors triangle winding; swap indices (a, b, c) -> (a, c, b)
+    // so baked native geometry retains Counter-Clockwise (CCW) front faces.
     for (var i = 0; i + 2 < outIndexList.length; i += 3) {
       final tmp = outIndexList[i + 1];
       outIndexList[i + 1] = outIndexList[i + 2];

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -442,10 +442,10 @@ abstract class Material {
 
   /// Binds this material's render-pass state, uniforms, and textures.
   ///
-  /// The base implementation enables back-face culling with
-  /// counter-clockwise winding (matching the glTF convention). Subclasses
-  /// must call `super.bind` and then bind any per-material uniforms and
-  /// textures expected by their fragment shader. [lighting] carries the
+  /// The base implementation enables back-face culling with clockwise
+  /// winding on the Y-down rasterizer (accepting model-space CCW front faces).
+  /// Subclasses must call `super.bind` and then bind any per-material uniforms
+  /// and textures expected by their fragment shader. [lighting] carries the
   /// IBL [EnvironmentMap] (and its intensity) plus the analytic lights and
   /// shadow resources that materials shade against.
   void bind(
@@ -454,7 +454,7 @@ abstract class Material {
     Lighting lighting,
   ) {
     pass.setCullMode(renderCullMode);
-    pass.setWindingOrder(gpu.WindingOrder.counterClockwise);
+    pass.setWindingOrder(gpu.WindingOrder.clockwise);
   }
 
   /// The face-culling mode geometry drawn with this material renders with.

--- a/packages/flutter_scene/lib/src/material/preprocessed_material.dart
+++ b/packages/flutter_scene/lib/src/material/preprocessed_material.dart
@@ -295,7 +295,7 @@ class PreprocessedMaterial extends Material implements HotReloadableFmat {
     Lighting lighting,
   ) {
     pass.setCullMode(renderCullMode);
-    pass.setWindingOrder(gpu.WindingOrder.counterClockwise);
+    pass.setWindingOrder(gpu.WindingOrder.clockwise);
     final shader = fragmentShaderForLighting(lighting);
 
     if (shadingModel == FmatShadingModel.shadowCatcher) {

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -106,7 +106,7 @@ class ShaderMaterial extends Material {
     gpu.Shader? depthVertexShader,
     this.useEnvironment = false,
     this.cullingMode = gpu.CullMode.backFace,
-    this.windingOrder = gpu.WindingOrder.counterClockwise,
+    this.windingOrder = gpu.WindingOrder.clockwise,
     this.isOpaqueOverride = true,
     Set<RenderInput> sceneInputs = const {},
   }) : _sceneInputs = _normalizeSceneInputs(sceneInputs) {
@@ -135,9 +135,9 @@ class ShaderMaterial extends Material {
   /// [gpu.CullMode.backFace] to match the standard materials.
   gpu.CullMode cullingMode;
 
-  /// Triangle winding order. Defaults to
-  /// [gpu.WindingOrder.counterClockwise] to match the glTF
-  /// convention and the standard materials.
+  /// Triangle winding order. Defaults to [gpu.WindingOrder.clockwise] to
+  /// project model-space Counter-Clockwise (CCW) front faces on the Y-down
+  /// rasterizer.
   gpu.WindingOrder windingOrder;
 
   /// Whether this material participates in the opaque pass.

--- a/packages/flutter_scene/lib/src/render/depth_prepass.dart
+++ b/packages/flutter_scene/lib/src/render/depth_prepass.dart
@@ -314,7 +314,7 @@ class _DepthPrepassEncoder {
     // Winding and culling are matched to each material per draw in [submit]
     // (winding follows the node/instance parity, culling follows the material's
     // own mode), so the same faces the color pass draws contribute depth.
-    _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
+    _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
     // The camera axes are constant across the pass. Pack them once and
     // rebind per draw (clearBindings drops the binding between draws). The
     // normal-writing path also needs the right/up axes to rotate the world
@@ -598,8 +598,8 @@ class _DepthPrepassEncoder {
               item.windingFlipped != (instanceTransform.determinant() < 0);
           _renderPass.setWindingOrder(
             flip
-                ? gpu.WindingOrder.clockwise
-                : gpu.WindingOrder.counterClockwise,
+                ? gpu.WindingOrder.counterClockwise
+                : gpu.WindingOrder.clockwise,
           );
           geometry.draw(_renderPass);
         }
@@ -676,8 +676,8 @@ class _DepthPrepassEncoder {
     }
     _renderPass.setWindingOrder(
       item.windingFlipped
-          ? gpu.WindingOrder.clockwise
-          : gpu.WindingOrder.counterClockwise,
+          ? gpu.WindingOrder.counterClockwise
+          : gpu.WindingOrder.clockwise,
     );
     geometry.draw(_renderPass);
   }
@@ -696,7 +696,7 @@ class _DepthPrepassEncoder {
       } else {
         bindInstanceTransforms(_renderPass, packed.ccw, slot: instanceSlot);
       }
-      _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
+      _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
       geometry.draw(_renderPass, instanceCount: packed.ccwCount);
     }
     if (packed.cwCount > 0) {
@@ -705,7 +705,7 @@ class _DepthPrepassEncoder {
       } else {
         bindInstanceTransforms(_renderPass, packed.cw, slot: instanceSlot);
       }
-      _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
+      _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
       geometry.draw(_renderPass, instanceCount: packed.cwCount);
     }
   }

--- a/packages/flutter_scene/lib/src/render/object_filter.dart
+++ b/packages/flutter_scene/lib/src/render/object_filter.dart
@@ -110,7 +110,7 @@ class _ObjectMaskEncoder {
     _renderPass.setColorBlendEnable(false);
     _renderPass.setDepthCompareOperation(gpu.CompareFunction.lessEqual);
     _renderPass.setCullMode(gpu.CullMode.backFace);
-    _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
+    _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
   }
 
   final gpu.RenderPass _renderPass;
@@ -214,8 +214,8 @@ class _ObjectMaskEncoder {
               item.windingFlipped != (instanceTransform.determinant() < 0);
           _renderPass.setWindingOrder(
             flip
-                ? gpu.WindingOrder.clockwise
-                : gpu.WindingOrder.counterClockwise,
+                ? gpu.WindingOrder.counterClockwise
+                : gpu.WindingOrder.clockwise,
           );
           geometry.draw(_renderPass);
         }
@@ -230,12 +230,12 @@ class _ObjectMaskEncoder {
       );
       if (packed.ccwCount > 0) {
         bindInstanceTransforms(_renderPass, packed.ccw);
-        _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
+        _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
         geometry.draw(_renderPass, instanceCount: packed.ccwCount);
       }
       if (packed.cwCount > 0) {
         bindInstanceTransforms(_renderPass, packed.cw);
-        _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
+        _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
         geometry.draw(_renderPass, instanceCount: packed.cwCount);
       }
       return;
@@ -253,8 +253,8 @@ class _ObjectMaskEncoder {
     }
     _renderPass.setWindingOrder(
       item.windingFlipped
-          ? gpu.WindingOrder.clockwise
-          : gpu.WindingOrder.counterClockwise,
+          ? gpu.WindingOrder.counterClockwise
+          : gpu.WindingOrder.clockwise,
     );
     geometry.draw(_renderPass);
   }

--- a/packages/flutter_scene/lib/src/render/shadow_encoder.dart
+++ b/packages/flutter_scene/lib/src/render/shadow_encoder.dart
@@ -73,7 +73,7 @@ class ShadowEncoder {
     };
     _renderPass.setCullMode(_casterCullMode);
     _currentCullMode = _casterCullMode;
-    _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
+    _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
   }
 
   final gpu.RenderPass _renderPass;
@@ -299,8 +299,8 @@ class ShadowEncoder {
               item.windingFlipped != (instanceTransform.determinant() < 0);
           _renderPass.setWindingOrder(
             flip
-                ? gpu.WindingOrder.clockwise
-                : gpu.WindingOrder.counterClockwise,
+                ? gpu.WindingOrder.counterClockwise
+                : gpu.WindingOrder.clockwise,
           );
           geometry.draw(_renderPass);
         }
@@ -376,8 +376,8 @@ class ShadowEncoder {
     // that are visible also cast shadows.
     _renderPass.setWindingOrder(
       item.windingFlipped
-          ? gpu.WindingOrder.clockwise
-          : gpu.WindingOrder.counterClockwise,
+          ? gpu.WindingOrder.counterClockwise
+          : gpu.WindingOrder.clockwise,
     );
     geometry.draw(_renderPass);
   }
@@ -396,7 +396,7 @@ class ShadowEncoder {
       } else {
         bindInstanceTransforms(_renderPass, packed.ccw, slot: instanceSlot);
       }
-      _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
+      _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
       geometry.draw(_renderPass, instanceCount: packed.ccwCount);
     }
     if (packed.cwCount > 0) {
@@ -405,7 +405,7 @@ class ShadowEncoder {
       } else {
         bindInstanceTransforms(_renderPass, packed.cw, slot: instanceSlot);
       }
-      _renderPass.setWindingOrder(gpu.WindingOrder.clockwise);
+      _renderPass.setWindingOrder(gpu.WindingOrder.counterClockwise);
       geometry.draw(_renderPass, instanceCount: packed.cwCount);
     }
   }

--- a/packages/flutter_scene/lib/src/scene_encoder.dart
+++ b/packages/flutter_scene/lib/src/scene_encoder.dart
@@ -877,8 +877,8 @@ base class SceneEncoder {
     // a cached material bind no longer resets it between compatible draws.
     _setWindingOrder(
       windingFlipped
-          ? gpu.WindingOrder.clockwise
-          : gpu.WindingOrder.counterClockwise,
+          ? gpu.WindingOrder.counterClockwise
+          : gpu.WindingOrder.clockwise,
     );
     _setPrimitiveType(geometry.primitiveType);
     _drawGeometry(geometry);
@@ -934,7 +934,7 @@ base class SceneEncoder {
         // Each instance can itself mirror; combine with the node's parity.
         final flip = windingFlipped != (instanceTransform.determinant() < 0);
         _setWindingOrder(
-          flip ? gpu.WindingOrder.clockwise : gpu.WindingOrder.counterClockwise,
+          flip ? gpu.WindingOrder.counterClockwise : gpu.WindingOrder.clockwise,
         );
         _drawGeometry(geometry);
       }
@@ -978,12 +978,12 @@ base class SceneEncoder {
     final instanceSlot = geometry.vertexStreamCount;
     if (packed.ccwCount > 0) {
       _bindPackedInstances(packed.ccw, instanceSlot);
-      _setWindingOrder(gpu.WindingOrder.counterClockwise);
+      _setWindingOrder(gpu.WindingOrder.clockwise);
       _drawGeometry(geometry, instanceCount: packed.ccwCount);
     }
     if (packed.cwCount > 0) {
       _bindPackedInstances(packed.cw, instanceSlot);
-      _setWindingOrder(gpu.WindingOrder.clockwise);
+      _setWindingOrder(gpu.WindingOrder.counterClockwise);
       _drawGeometry(geometry, instanceCount: packed.cwCount);
     }
   }
@@ -1025,12 +1025,12 @@ base class SceneEncoder {
     final instanceSlot = geometry.vertexStreamCount;
     if (packed.ccwCount > 0) {
       _bindPackedInstances(packed.ccw, instanceSlot);
-      _setWindingOrder(gpu.WindingOrder.counterClockwise);
+      _setWindingOrder(gpu.WindingOrder.clockwise);
       _drawGeometry(geometry, instanceCount: packed.ccwCount);
     }
     if (packed.cwCount > 0) {
       _bindPackedInstances(packed.cw, instanceSlot);
-      _setWindingOrder(gpu.WindingOrder.clockwise);
+      _setWindingOrder(gpu.WindingOrder.counterClockwise);
       _drawGeometry(geometry, instanceCount: packed.cwCount);
     }
   }

--- a/packages/flutter_scene/shaders/flutter_scene_line_segments.vert
+++ b/packages/flutter_scene/shaders/flutter_scene_line_segments.vert
@@ -42,9 +42,10 @@ void main() {
   float perp_len = length(perp);
   perp = perp_len > 1e-12 ? perp / perp_len : vec3(0.0);
   // Orient the expansion so every quad winds as a front face under the
-  // engine's winding convention (perp flips sign with the segment direction
-  // otherwise, and a back-face culling material would drop the ribbons).
-  if (dot(cross(perp, dir), view) > 0.0) {
+  // engine's CCW winding convention (perp flips sign with the segment
+  // direction otherwise, and a back-face culling material would drop the
+  // ribbons).
+  if (dot(cross(dir, perp), view) < 0.0) {
     perp = -perp;
   }
   pos += perp * (frame_info.params.x * corner.y);

--- a/packages/flutter_scene/skills/flutter_scene-idioms/SKILL.md
+++ b/packages/flutter_scene/skills/flutter_scene-idioms/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flutter_scene-idioms
-version: 3
+version: 4
 description: Write correct flutter_scene code. Use this whenever building 3D with the flutter_scene Dart/Flutter engine (rendering a scene, geometry, materials, lighting, loading a .glb model, animation, custom shaders). It corrects the wrong assumptions models carry from three.js, Godot, and Unity, and names the APIs and traps that are specific to this engine.
 ---
 

--- a/packages/flutter_scene/skills/flutter_scene-idioms/references/traps.md
+++ b/packages/flutter_scene/skills/flutter_scene-idioms/references/traps.md
@@ -194,19 +194,17 @@ crosses and angular probes are not supported. Still silent.
 
 ---
 
-## 13. Hand-built triangles wound counter-clockwise
+## 13. Hand-built triangles wound clockwise
 
-**Mistake.** Generating triangles with the standard right-handed CCW convention (what most tutorials,
-mesh libraries, and model output produce) and feeding them to `MeshGeometry.fromArrays` or
-`GeometryBuilder`.
+**Mistake.** Generating triangles with clockwise winding instead of the standard Counter-Clockwise (CCW)
+right-handed convention when feeding `MeshGeometry.fromArrays` or `GeometryBuilder`.
 
 **Symptom.** The mesh is invisible from outside and visible from inside; a closed shape looks hollow
 or inside-out; lighting is inverted where it shows. ("See-through faces.")
 
-**Do instead.** flutter_scene's front faces wind CLOCKWISE in model space. Reverse each triangle's
-index order, or omit `normals` and let the constructor derive them from your winding. Never fix
-orientation with a per-triangle winding swap; that leaves normals and IBL sampling wrong. Still
-silent.
+**Do instead.** flutter_scene's front faces wind COUNTER-CLOCKWISE (CCW) in model space, matching glTF
+and standard 3D conventions. Ensure triangle indices wind CCW around the outward face normal, or omit
+`normals` and let `GeometryBuilder` derive them from your winding. Still silent.
 
 ---
 

--- a/packages/flutter_scene/skills/flutter_scene-procedural/SKILL.md
+++ b/packages/flutter_scene/skills/flutter_scene-procedural/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flutter_scene-procedural
-version: 1
+version: 2
 description: Build flutter_scene content from code instead of asset files. Use when generating terrain, scattering vegetation or crowds, assembling modular kits, or driving a scene from noise and instancing rather than loading a .glb.
 ---
 
@@ -50,7 +50,7 @@ MeshGeometry buildTerrain({int cols = 128, int rows = 128, double spacing = 0.5}
     }
   }
 
-  // Two triangles per cell, wound so the front face points +Y (up).
+  // Two triangles per cell, wound Counter-Clockwise (CCW) so the front face points +Y (up).
   for (var r = 0; r < rows - 1; r++) {
     for (var c = 0; c < cols - 1; c++) {
       final v00 = r * cols + c;
@@ -58,8 +58,8 @@ MeshGeometry buildTerrain({int cols = 128, int rows = 128, double spacing = 0.5}
       final v01 = v00 + cols;
       final v11 = v01 + 1;
       builder
-        ..addTriangle(v00, v10, v01)
-        ..addTriangle(v10, v11, v01);
+        ..addTriangle(v00, v01, v10)
+        ..addTriangle(v10, v01, v11);
     }
   }
 
@@ -74,7 +74,7 @@ final terrain = Node(mesh: Mesh(buildTerrain(), PhysicallyBasedMaterial()..rough
 scene.add(terrain);
 ```
 
-If a hand-built surface renders inside-out (visible only from below, dark where lit), reverse each triangle's index order. flutter_scene's front faces wind clockwise in model space; never fix orientation with a per-triangle flip on an imported model, but for geometry you author yourself the winding is yours to set.
+If a hand-built surface renders inside-out (visible only from below, dark where lit), reverse each triangle's index order. flutter_scene's front faces wind Counter-Clockwise (CCW) in model space, matching glTF and standard conventions; never fix orientation with a per-triangle flip on an imported model, but for geometry you author yourself the winding is yours to set.
 
 ## Scattering thousands of copies
 

--- a/packages/flutter_scene/skills/flutter_scene-procedural/references/procedural.md
+++ b/packages/flutter_scene/skills/flutter_scene-procedural/references/procedural.md
@@ -67,7 +67,7 @@ With `deduplicate: true` (the default), `addVertex` merges a vertex equal to one
 
 ### Winding
 
-flutter_scene's front faces wind **clockwise in model space**. For a surface that should face +Y (a heightmap, a floor), match the built-in plane's winding: for a cell with corners `v00`(x,z), `v10`(x+1,z), `v01`(x,z+1), `v11`(x+1,z+1), emit `addTriangle(v00, v10, v01)` and `addTriangle(v10, v11, v01)`.
+flutter_scene's front faces wind **counter-clockwise in model space**, matching glTF and standard conventions. For a surface that should face +Y (a heightmap, a floor), match the built-in plane's winding: for a cell with corners `v00`(x,z), `v10`(x+1,z), `v01`(x,z+1), `v11`(x+1,z+1), emit `addTriangle(v00, v01, v10)` and `addTriangle(v10, v01, v11)`.
 
 If a mesh renders inside-out (invisible from the front, visible and inverted-lit from behind), reverse each triangle's index order. Because generated normals follow the winding, fixing the winding fixes the normals too. This freedom is only for geometry you author. Never apply a per-triangle winding flip to an imported model to correct its orientation, that leaves its normals and image-based lighting wrong.
 

--- a/packages/flutter_scene/skills/flutter_scene-verification-loop/SKILL.md
+++ b/packages/flutter_scene/skills/flutter_scene-verification-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: flutter_scene-verification-loop
-version: 1
-description: Close the visual-iteration loop when building or debugging a flutter_scene 3D app so you see your own output and self-correct. Use whenever a change affects what renders (geometry, materials, lighting, shaders, post-processing) or a frame looks wrong (black, washed-out, see-through, missing geometry).
+version: 2
+description: Build flutter_scene content from code instead of asset files. Use when generating terrain, scattering vegetation or crowds, assembling modular kits, or driving a scene from noise and instancing rather than loading a .glb.
 ---
 
 # Verifying flutter_scene visually

--- a/packages/flutter_scene/skills/flutter_scene-verification-loop/SKILL.md
+++ b/packages/flutter_scene/skills/flutter_scene-verification-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: flutter_scene-verification-loop
 version: 2
-description: Build flutter_scene content from code instead of asset files. Use when generating terrain, scattering vegetation or crowds, assembling modular kits, or driving a scene from noise and instancing rather than loading a .glb.
+description: Close the visual-iteration loop when building or debugging a flutter_scene 3D app so you see your own output and self-correct. Use whenever a change affects what renders (geometry, materials, lighting, shaders, post-processing) or a frame looks wrong (black, washed-out, see-through, missing geometry).
 ---
 
 # Verifying flutter_scene visually

--- a/packages/flutter_scene/skills/flutter_scene-verification-loop/references/loop.md
+++ b/packages/flutter_scene/skills/flutter_scene-verification-loop/references/loop.md
@@ -107,9 +107,10 @@ routes a symptom to the right one.
 
 1. `set_viewport_debug_mode` to normals (or `get_pass_output` on the normals buffer) and look at the
    orientation. Inverted normals confirm a winding problem.
-2. Cause is almost always counter-clockwise hand-built triangles. flutter_scene front faces wind
-   CLOCKWISE in model space. Reverse each triangle's index order, or omit normals and let the
-   constructor derive them. NEVER fix orientation with a per-triangle winding flip; that leaves
+2. Cause is almost always clockwise hand-built triangles. flutter_scene front faces wind
+   COUNTER-CLOCKWISE (CCW) in model space, matching glTF and standard conventions. Ensure triangle
+   indices wind CCW around the outward face normal, or omit normals and let the constructor derive
+   them. NEVER fix orientation with a per-triangle winding flip on an imported model; that leaves
    normals and IBL wrong. Traps #13 and #17.
 3. For an imported model rendered mirrored, check you did not overwrite the runtime importer's
    `scale(1, 1, -1)` handedness root. Trap #5.

--- a/packages/flutter_scene/test/engine_stamp_test.dart
+++ b/packages/flutter_scene/test/engine_stamp_test.dart
@@ -101,6 +101,27 @@ void main() {
     );
   });
 
+  test('material bundles isolate file paths by engine identity', () async {
+    final tree = GeneratedAssetTree.open(temp.uri, 'app');
+    debugSetEngineIdentity('engine=first');
+    final first = tree.fileUri(
+      GeneratedAssetFamily.material,
+      nameId: 'materials',
+      extension: '.shaderbundle',
+      variant: await engineIdentity(),
+    );
+
+    debugSetEngineIdentity('engine=second');
+    final second = tree.fileUri(
+      GeneratedAssetFamily.material,
+      nameId: 'materials',
+      extension: '.shaderbundle',
+      variant: await engineIdentity(),
+    );
+
+    expect(first, isNot(second));
+  });
+
   test('a generated file is published by rename, never half-written', () {
     final target = temp.uri.resolve('out.bin');
     writeGeneratedBytes(target, List<int>.filled(64, 3));

--- a/packages/flutter_scene/test/fmat_test.dart
+++ b/packages/flutter_scene/test/fmat_test.dart
@@ -1206,5 +1206,17 @@ sky { vec3 Sky(vec3 direction) { return vec3(0.0); } }
         _throwsFmat('only supported in surface materials'),
       );
     });
+
+    test('stamps framework_varying_schema in sidecar', () {
+      final sidecar = buildSidecar(
+        parseFmat(
+          'material { name: "X" } fragment { void Surface(inout MaterialInputs material) {} }',
+        ),
+      );
+      expect(
+        sidecar['framework_varying_schema'],
+        kFrameworkVaryingSchemaVersion,
+      );
+    });
   });
 }

--- a/packages/flutter_scene/test/fscene/json_test.dart
+++ b/packages/flutter_scene/test/fscene/json_test.dart
@@ -473,6 +473,38 @@ void main() {
         throwsA(isA<FsceneUnsupportedFeatureException>()),
       );
     });
+
+    test('migrates a version 4 document and marks legacy index winding', () {
+      final doc = SceneDocument();
+      final vId = doc.newId();
+      final iId = doc.newId();
+      doc.addPayload(
+        PayloadSpec(
+          vId,
+          encoding: PayloadEncoding.vertexBuffer,
+          layout: 'unskinned',
+        ),
+      );
+      doc.addPayload(
+        PayloadSpec(
+          iId,
+          encoding: PayloadEncoding.indexBuffer,
+          format: 'uint16',
+        ),
+      );
+      final geo = doc.addResource(
+        GeometryResource(doc.newId(), vertices: vId, indices: iId),
+      );
+
+      final json = jsonDecode(writeFscene(doc)) as Map<String, dynamic>;
+      json['fscene'] = 4;
+      final text = jsonEncode(json);
+
+      final read = readFscene(text);
+      expect(read.formatVersion, currentFsceneVersion);
+      final readGeo = read.resource(geo.id) as GeometryResource;
+      expect(readGeo.legacyWinding, isTrue);
+    });
   });
 
   group('procedural geometry', () {

--- a/packages/flutter_scene/test/gltf_coordinate_policy_test.dart
+++ b/packages/flutter_scene/test/gltf_coordinate_policy_test.dart
@@ -18,33 +18,28 @@ void main() {
           utf8.encode(
             jsonEncode({
               'asset': {'version': '2.0'},
-              'nodes': [
-                {
-                  'extensions': {
-                    'KHR_lights_punctual': {'light': 0},
-                  },
-                  'translation': [1.0, 2.0, 3.0],
-                  'rotation': [0.0, 0.7071068, 0.0, 0.7071068],
-                },
-              ],
+              'extensionsUsed': ['KHR_lights_punctual'],
               'extensions': {
                 'KHR_lights_punctual': {
                   'lights': [
-                    {
-                      'type': 'directional',
-                      'color': [1.0, 1.0, 1.0],
-                      'intensity': 1000.0,
-                    },
+                    {'type': 'directional'},
                   ],
                 },
               },
-              'extensionsRequired': ['KHR_lights_punctual'],
               'scenes': [
                 {
                   'nodes': [0],
                 },
               ],
               'scene': 0,
+              'nodes': [
+                {
+                  'rotation': [0.0, 0.38268343, 0.0, 0.92387953],
+                  'extensions': {
+                    'KHR_lights_punctual': {'light': 0},
+                  },
+                },
+              ],
             }),
           ),
         );
@@ -66,6 +61,64 @@ void main() {
         );
       },
     );
+
+    test('runtime and offline imported triangles agree on drawn orientation', () {
+      // A single CCW triangle in glTF space.
+      final runtimePacked = _packWithIndices(
+        GltfCoordinatePolicy.runtimeBoundary,
+      );
+      final offlinePacked = _packWithIndices(GltfCoordinatePolicy.bakeNative);
+
+      final runtimeVertices = Float32List.sublistView(
+        runtimePacked.vertexBytes,
+      );
+      final offlineVertices = Float32List.sublistView(
+        offlinePacked.vertexBytes,
+      );
+
+      final runtimeIndices = Uint16List.sublistView(runtimePacked.indexBytes);
+      final offlineIndices = Uint16List.sublistView(offlinePacked.indexBytes);
+
+      // Runtime import preserves glTF vertex coordinates and CCW indices [0, 1, 2],
+      // and places an F = diag(1, 1, -1) boundary transform at the imported root.
+      // In world space, vertex i becomes F * v_i = (v_x, v_y, -v_z).
+      Vector3 runtimeWorldVertex(int index) {
+        final v = runtimeIndices[index];
+        return Vector3(
+          runtimeVertices[v * 18],
+          runtimeVertices[v * 18 + 1],
+          -runtimeVertices[v * 18 + 2],
+        );
+      }
+
+      // Offline import bakes F into vertex positions and swaps indices to [0, 2, 1]
+      // with an identity root transform.
+      Vector3 offlineWorldVertex(int index) {
+        final v = offlineIndices[index];
+        return Vector3(
+          offlineVertices[v * 18],
+          offlineVertices[v * 18 + 1],
+          offlineVertices[v * 18 + 2],
+        );
+      }
+
+      // The drawn triangle in world space:
+      final r0 = runtimeWorldVertex(0);
+      final r1 = runtimeWorldVertex(1);
+      final r2 = runtimeWorldVertex(2);
+
+      final o0 = offlineWorldVertex(0);
+      final o1 = offlineWorldVertex(1);
+      final o2 = offlineWorldVertex(2);
+
+      // Because runtime's F transform has negative determinant (parity flip),
+      // the effective world-space winding normal is (r2 - r0) x (r1 - r0),
+      // exactly matching offline's CCW geometric normal (o1 - o0) x (o2 - o0).
+      final runtimeEffectiveNormal = (r2 - r0).cross(r1 - r0);
+      final offlineEffectiveNormal = (o1 - o0).cross(o2 - o0);
+
+      _expectVectorNear(runtimeEffectiveNormal, offlineEffectiveNormal);
+    });
 
     test('runtime packing leaves vertex bytes untouched', () {
       final source = _pack(GltfCoordinatePolicy.runtimeBoundary);
@@ -93,8 +146,8 @@ void main() {
       final source = _packWithIndices(GltfCoordinatePolicy.runtimeBoundary);
       final native = _packWithIndices(GltfCoordinatePolicy.bakeNative);
 
-      final sourceIndices = Uint16List.sublistView(source.indexBytes!);
-      final nativeIndices = Uint16List.sublistView(native.indexBytes!);
+      final sourceIndices = Uint16List.sublistView(source.indexBytes);
+      final nativeIndices = Uint16List.sublistView(native.indexBytes);
 
       expect(sourceIndices, [0, 1, 2]);
       expect(nativeIndices, [0, 2, 1]);

--- a/packages/flutter_scene/test/gltf_coordinate_policy_test.dart
+++ b/packages/flutter_scene/test/gltf_coordinate_policy_test.dart
@@ -18,32 +18,36 @@ void main() {
           utf8.encode(
             jsonEncode({
               'asset': {'version': '2.0'},
-              'extensionsUsed': ['KHR_lights_punctual'],
+              'nodes': [
+                {
+                  'extensions': {
+                    'KHR_lights_punctual': {'light': 0},
+                  },
+                  'translation': [1.0, 2.0, 3.0],
+                  'rotation': [0.0, 0.7071068, 0.0, 0.7071068],
+                },
+              ],
               'extensions': {
                 'KHR_lights_punctual': {
                   'lights': [
-                    {'type': 'directional'},
+                    {
+                      'type': 'directional',
+                      'color': [1.0, 1.0, 1.0],
+                      'intensity': 1000.0,
+                    },
                   ],
                 },
               },
+              'extensionsRequired': ['KHR_lights_punctual'],
               'scenes': [
                 {
                   'nodes': [0],
                 },
               ],
               'scene': 0,
-              'nodes': [
-                {
-                  'rotation': [0.0, 0.38268343, 0.0, 0.92387953],
-                  'extensions': {
-                    'KHR_lights_punctual': {'light': 0},
-                  },
-                },
-              ],
             }),
           ),
         );
-
         final runtime = await importGltf(
           bytes,
           resolveUri: (_) async => Uint8List(0),
@@ -70,7 +74,7 @@ void main() {
       expect(vertices.sublist(0, 3), [1, 2, 3]);
       _expectListNear(vertices.sublist(3, 6), [0.25, 0.5, 0.75]);
       _expectListNear(vertices.sublist(14, 18), [0.1, 0.2, 0.3, -1]);
-      expect(source.sourceWindingFlipped, isTrue);
+      expect(source.sourceWindingFlipped, isFalse);
     });
 
     test('offline packing reflects vectors and tangent handedness', () {
@@ -82,6 +86,19 @@ void main() {
       _expectListNear(vertices.sublist(3, 6), [0.25, 0.5, -0.75]);
       _expectListNear(vertices.sublist(14, 18), [0.1, 0.2, -0.3, 1]);
       expect(native.indexBytes, source.indexBytes);
+      expect(native.sourceWindingFlipped, isFalse);
+    });
+
+    test('offline packing swaps index pairs for CCW native winding', () {
+      final source = _packWithIndices(GltfCoordinatePolicy.runtimeBoundary);
+      final native = _packWithIndices(GltfCoordinatePolicy.bakeNative);
+
+      final sourceIndices = Uint16List.sublistView(source.indexBytes!);
+      final nativeIndices = Uint16List.sublistView(native.indexBytes!);
+
+      expect(sourceIndices, [0, 1, 2]);
+      expect(nativeIndices, [0, 2, 1]);
+      expect(source.sourceWindingFlipped, isFalse);
       expect(native.sourceWindingFlipped, isFalse);
     });
 
@@ -177,6 +194,50 @@ PackedPrimitive _pack(GltfCoordinatePolicy policy) {
       GltfBufferView(buffer: 0, byteOffset: 24, byteLength: 16),
     ],
     bufferData: attributes.buffer.asUint8List(),
+    coordinatePolicy: policy,
+  );
+}
+
+PackedPrimitive _packWithIndices(GltfCoordinatePolicy policy) {
+  final positions = Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  final indices = Uint16List.fromList([0, 1, 2]);
+  final buffer = Uint8List(positions.lengthInBytes + indices.lengthInBytes);
+  buffer.setRange(0, positions.lengthInBytes, positions.buffer.asUint8List());
+  buffer.setRange(
+    positions.lengthInBytes,
+    buffer.length,
+    indices.buffer.asUint8List(),
+  );
+
+  return packGltfPrimitive(
+    primitive: GltfMeshPrimitive(attributes: const {'POSITION': 0}, indices: 1),
+    accessors: [
+      GltfAccessor(
+        componentType: GltfComponentType.float,
+        count: 3,
+        type: GltfAccessorType.vec3,
+        bufferView: 0,
+      ),
+      GltfAccessor(
+        componentType: GltfComponentType.unsignedShort,
+        count: 3,
+        type: GltfAccessorType.scalar,
+        bufferView: 1,
+      ),
+    ],
+    bufferViews: [
+      GltfBufferView(
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: positions.lengthInBytes,
+      ),
+      GltfBufferView(
+        buffer: 0,
+        byteOffset: positions.lengthInBytes,
+        byteLength: indices.lengthInBytes,
+      ),
+    ],
+    bufferData: buffer,
     coordinatePolicy: policy,
   );
 }

--- a/packages/flutter_scene/test/interleaved_layout_test.dart
+++ b/packages/flutter_scene/test/interleaved_layout_test.dart
@@ -425,11 +425,10 @@ void main() {
 
   group('generateNormals', () {
     test('generates +Z for a front-face-wound triangle in the XY plane', () {
-      // Wound like the cuboid's +Z face (clockwise in model space, the
-      // engine's front-face convention), so the normal points at the
-      // viewer of that face.
+      // Wound Counter-Clockwise (CCW) in model space (the engine's front-face
+      // convention), so the normal points at the viewer of that face (+Z).
       final normals = InterleavedLayoutAdapter.generateNormals(
-        positions: Float32List.fromList([1, -1, 0, -1, -1, 0, 1, 1, 0]),
+        positions: Float32List.fromList([-1, -1, 0, 1, -1, 0, 1, 1, 0]),
         vertexCount: 3,
         indices: [0, 1, 2],
       );
@@ -442,7 +441,7 @@ void main() {
 
     test('handles a non-indexed triangle list', () {
       final normals = InterleavedLayoutAdapter.generateNormals(
-        positions: Float32List.fromList([1, -1, 0, -1, -1, 0, 1, 1, 0]),
+        positions: Float32List.fromList([-1, -1, 0, 1, -1, 0, 1, 1, 0]),
         vertexCount: 3,
       );
       expect(normals[2], closeTo(1, 1e-6));
@@ -450,9 +449,8 @@ void main() {
 
     test('matches analytic normals on a curved front-face-wound grid', () {
       // A dome z = b(1 - nx^2)(1 - ny^2) over [-1, 1]^2, wound per the
-      // engine front-face convention (the same construction as the
-      // widget-texture example's screen). The generated smooth normals
-      // must agree with the analytic surface normals, including SIGN
+      // engine front-face convention (CCW in model space). The generated smooth
+      // normals must agree with the analytic surface normals, including SIGN
       // (pointing out of the bulge, toward the front-face viewer).
       const n = 8;
       const bulge = 0.3;
@@ -474,7 +472,7 @@ void main() {
           final br = bl + 1;
           final tl = bl + n + 1;
           final tr = tl + 1;
-          indices.addAll([br, bl, tr, tr, bl, tl]);
+          indices.addAll([bl, br, tr, bl, tr, tl]);
         }
       }
       final normals = InterleavedLayoutAdapter.generateNormals(

--- a/packages/flutter_scene/test/mesh_data_test.dart
+++ b/packages/flutter_scene/test/mesh_data_test.dart
@@ -15,9 +15,9 @@ MeshData buildTriangleData(Float32List positions) =>
     MeshData.build(positions: positions, indices: <int>[0, 1, 2]);
 
 void main() {
-  // A triangle wound per the engine front-face convention (clockwise in
-  // model space), whose generated face normal points at +Z.
-  final triangle = Float32List.fromList(<double>[0, 0, 0, 0, 1, 0, 1, 0, 0]);
+  // A triangle wound per the engine front-face convention (CCW in model
+  // space), whose generated face normal points at +Z.
+  final triangle = Float32List.fromList(<double>[0, 0, 0, 1, 0, 0, 0, 1, 0]);
 
   group('MeshData.build', () {
     test('generates face normals when normals are absent', () {

--- a/packages/flutter_scene/test/mesh_geometry_test.dart
+++ b/packages/flutter_scene/test/mesh_geometry_test.dart
@@ -116,12 +116,12 @@ void main() {
     });
 
     test('packVertices generates normals for an authored triangle', () {
-      // Wound per the engine front-face convention (clockwise in model
+      // Wound per the engine front-face convention (CCW in model
       // space), so the generated face normal points at the front viewer.
       final builder = GeometryBuilder(deduplicate: false)
         ..addVertex(Vector3(0, 0, 0))
-        ..addVertex(Vector3(0, 1, 0))
         ..addVertex(Vector3(1, 0, 0))
+        ..addVertex(Vector3(0, 1, 0))
         ..addTriangle(0, 1, 2);
       final floats = Float32List.sublistView(builder.packVertices());
       // Vertex 0 normal (floats 3..5) is the generated face normal +Z.

--- a/packages/flutter_scene/test/primitives_test.dart
+++ b/packages/flutter_scene/test/primitives_test.dart
@@ -23,8 +23,8 @@ Vector3 triangleNormal(Float32List positions, List<int> indices, int triangle) {
 }
 
 // Asserts every (non-degenerate) triangle is wound so its front face points
-// outward, i.e. the right-hand-rule geometric normal opposes the stored
-// per-vertex shading normals (the engine's front-face convention).
+// outward, i.e. the right-hand-rule geometric normal points in the same
+// direction as the stored per-vertex shading normals (the engine's CCW convention).
 void expectOutwardWinding(PrimitiveArrays arrays) {
   final positions = arrays.positions;
   final normals = arrays.normals!;
@@ -39,7 +39,7 @@ void expectOutwardWinding(PrimitiveArrays arrays) {
         shadingAt(indices[tri * 3]) +
         shadingAt(indices[tri * 3 + 1]) +
         shadingAt(indices[tri * 3 + 2]);
-    expect(geo.dot(avg), lessThan(0), reason: 'triangle $tri is inside-out');
+    expect(geo.dot(avg), greaterThan(0), reason: 'triangle $tri is inside-out');
   }
 }
 
@@ -67,7 +67,7 @@ void main() {
 
         // Each of the six faces shares one axis-aligned unit normal across its
         // four vertices, and both its triangles are wound so the front face
-        // points opposite that normal (the engine's front-face convention),
+        // points along that normal (the engine's CCW front-face convention),
         // i.e. the stored normal faces outward.
         final normals = arrays.normals!;
         for (var f = 0; f < 6; f++) {
@@ -86,11 +86,11 @@ void main() {
           }
           expect(
             triangleNormal(arrays.positions, arrays.indices, f * 2).dot(n),
-            lessThan(0),
+            greaterThan(0),
           );
           expect(
             triangleNormal(arrays.positions, arrays.indices, f * 2 + 1).dot(n),
-            lessThan(0),
+            greaterThan(0),
           );
         }
       },
@@ -144,10 +144,10 @@ void main() {
         segmentsX: 1,
         segmentsZ: 1,
       );
-      // A +Y-facing surface has a -Y geometric normal.
+      // A +Y-facing surface has a +Y geometric normal.
       expect(
         triangleNormal(arrays.positions, arrays.indices, 0).y,
-        lessThan(0),
+        greaterThan(0),
       );
     });
   });
@@ -390,10 +390,10 @@ void main() {
         expect(arrays.positions[v * 3 + 1], 0);
         expect(arrays.normals!.sublist(v * 3, v * 3 + 3), [0, 1, 0]);
       }
-      // Front face points +Y, so the geometric normal points -Y.
+      // Front face points +Y, so the geometric normal points +Y.
       expect(
         triangleNormal(arrays.positions, arrays.indices, 0).y,
-        lessThan(0),
+        greaterThan(0),
       );
     });
 

--- a/packages/flutter_scene/test/primitives_test.dart
+++ b/packages/flutter_scene/test/primitives_test.dart
@@ -24,7 +24,7 @@ Vector3 triangleNormal(Float32List positions, List<int> indices, int triangle) {
 
 // Asserts every (non-degenerate) triangle is wound so its front face points
 // outward, i.e. the right-hand-rule geometric normal points in the same
-// direction as the stored per-vertex shading normals (the engine's CCW convention).
+// direction as stored per-vertex shading normals (the engine's CCW convention).
 void expectOutwardWinding(PrimitiveArrays arrays) {
   final positions = arrays.positions;
   final normals = arrays.normals!;

--- a/packages/flutter_scene/test/swept_geometry_test.dart
+++ b/packages/flutter_scene/test/swept_geometry_test.dart
@@ -125,10 +125,10 @@ void main() {
         alignment: RibbonAlignment.ground,
         up: Vector3(0, 1, 0),
       );
-      // A +Y-facing surface has a -Y geometric normal.
+      // A +Y-facing surface has a +Y geometric normal.
       expect(
         _triangleNormal(arrays.positions, arrays.indices, 0).y,
-        lessThan(0),
+        greaterThan(0),
       );
     });
   });

--- a/packages/scene/CHANGELOG.md
+++ b/packages/scene/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0
 
+- Standardized model-space front-face winding to Counter-Clockwise (CCW) in `.fscene` format version 5; version 4 documents migrate by swapping index pairs during realization.
 - `.fsceneb` format version 2 compresses payload chunks with gzip; older readers reject version 2.
 - `MorphTargetsSpec` and `GeometryResource.morphTargets` carry baked morph target deltas, names, and default weights.
 - `AnimationProperty.weights` animates morph weights.

--- a/packages/scene/lib/src/json/fscene_json.dart
+++ b/packages/scene/lib/src/json/fscene_json.dart
@@ -617,6 +617,7 @@ Object _encodeResource(ResourceSpec r, String Function(LocalId) idKey) {
       :final procedural,
       :final bounds,
       :final morphTargets,
+      :final legacyWinding,
     ):
       return {
         'kind': 'geometry',
@@ -640,6 +641,7 @@ Object _encodeResource(ResourceSpec r, String Function(LocalId) idKey) {
             if (morphTargets.defaultWeights.isNotEmpty)
               'weights': morphTargets.defaultWeights,
           },
+        if (legacyWinding) 'legacyWinding': true,
       };
     case TextureResource(:final payload, :final asset, :final content):
       return {

--- a/packages/scene/lib/src/json/fscene_json.dart
+++ b/packages/scene/lib/src/json/fscene_json.dart
@@ -39,6 +39,10 @@ final List<FsceneMigration> _builtInMigrations = [
   // documents read as-is. The version exists so a version-3 reader refuses
   // a morph-bearing document instead of silently dropping the deltas.
   (json) => json,
+  // 4 -> 5 standardized model-space front-face winding to Counter-Clockwise
+  // (CCW). Version 4 documents read as-is, with payload index swapping applied
+  // during realization for documents with formatVersion < 5.
+  (json) => json,
 ];
 
 Map<String, dynamic> _migrateV1ToV2(Map<String, dynamic> json) {

--- a/packages/scene/lib/src/json/fscene_json.dart
+++ b/packages/scene/lib/src/json/fscene_json.dart
@@ -40,10 +40,22 @@ final List<FsceneMigration> _builtInMigrations = [
   // a morph-bearing document instead of silently dropping the deltas.
   (json) => json,
   // 4 -> 5 standardized model-space front-face winding to Counter-Clockwise
-  // (CCW). Version 4 documents read as-is, with payload index swapping applied
-  // during realization for documents with formatVersion < 5.
-  (json) => json,
+  // (CCW). Version 4 documents flag geometry index buffers with legacyWinding
+  // so index pairs are swapped during realization.
+  _migrateV4ToV5,
 ];
+
+Map<String, dynamic> _migrateV4ToV5(Map<String, dynamic> json) {
+  final resources = json['resources'];
+  if (resources is Map) {
+    for (final res in resources.values) {
+      if (res is Map && res['kind'] == 'geometry' && res['indices'] != null) {
+        res['legacyWinding'] = true;
+      }
+    }
+  }
+  return json;
+}
 
 Map<String, dynamic> _migrateV1ToV2(Map<String, dynamic> json) {
   final stageValue = json['stage'];
@@ -1152,6 +1164,7 @@ ResourceSpec _decodeResource(LocalId id, Map<String, dynamic> json) {
         bounds: _decodeBounds(json['bounds']),
         topology: json['topology'] as String? ?? 'triangle',
         morphTargets: _decodeMorphTargets(json['morphTargets']),
+        legacyWinding: json['legacyWinding'] == true,
       );
     case 'texture':
       return TextureResource(

--- a/packages/scene/lib/src/scene_document.dart
+++ b/packages/scene/lib/src/scene_document.dart
@@ -4,7 +4,7 @@ import 'package:scene/src/specs.dart';
 /// The `.fscene` format version this build reads and writes. Newer documents
 /// are refused; older ones migrate on read.
 /// {@category Serialization}
-const int currentFsceneVersion = 4;
+const int currentFsceneVersion = 5;
 
 /// The in-memory `.fscene` document: a GPU-free, encoding-independent
 /// description of a scene that the encoders serialize and the realizer turns

--- a/packages/scene/lib/src/specs.dart
+++ b/packages/scene/lib/src/specs.dart
@@ -395,6 +395,7 @@ class GeometryResource extends ResourceSpec {
     this.bounds,
     this.topology = 'triangle',
     this.morphTargets,
+    this.legacyWinding = false,
   }) : assert(
          (vertices == null) != (procedural == null),
          'A geometry has exactly one source: a vertex payload or a procedural '
@@ -424,6 +425,10 @@ class GeometryResource extends ResourceSpec {
 
   /// The geometry's morph target (blend shape) data, or null when unmorphed.
   final MorphTargetsSpec? morphTargets;
+
+  /// Whether this geometry was migrated from an older document version (< 5)
+  /// that stored indices with clockwise winding.
+  final bool legacyWinding;
 }
 
 /// Morph target data on a [GeometryResource]: the delta payload plus target


### PR DESCRIPTION
Standardizes model-space front-facing triangle winding on counter-clockwise (CCW), matching glTF and standard conventions. Procedural primitives, normal generators, and the glTF importer now produce CCW triangles, and the render encoders bind clockwise on the Y-down rasterizer for unmirrored draws. Increments the .fscene document version to 5 and provides automatic index winding migration for version 4 and earlier scenes.