### PR TITLE
Support watchOS and tvOS shader targets

### DIFF
--- a/packages/flutter_scene/lib/src/fmat/target_shader_bundle.dart
+++ b/packages/flutter_scene/lib/src/fmat/target_shader_bundle.dart
@@ -186,11 +186,25 @@ Future<void> buildTargetShaderBundleJson({
 /// inputs, or flutter_tools not making the redundant native data pass. Revisit
 /// if a Flutter release adds such a field.
 Set<ShaderBundleBackend> shaderBundleBackendsForBuild(BuildInput buildInput) =>
-    shaderBundleBackendsForOS(
-      buildInput.config.buildCodeAssets
-          ? buildInput.config.code.targetOS.name
-          : null,
-    );
+    shaderBundleBackendsForOS(_targetOSName(buildInput));
+
+/// The target OS named on [buildInput], or null when it names none.
+///
+/// Read off the config JSON rather than through `config.code.targetOS`, which
+/// parses the name into an `OS`. That set was closed until
+/// `package:code_assets` 2.0.0, and the older versions this package still
+/// supports throw on a name they do not know instead of minting one, so the
+/// typed accessor turns an embedder for a platform `dart:ffi` cannot name into
+/// a crashed build hook. Apple's watchOS and tvOS are two of those.
+///
+/// The name is a plain string in the protocol syntax on both sides, and a
+/// string is all backend selection needs.
+String? _targetOSName(BuildInput buildInput) {
+  if (!buildInput.config.buildCodeAssets) return null;
+  final extensions = buildInput.config.json['extensions'];
+  final code = extensions is Map ? extensions['code_assets'] : null;
+  return code is Map ? code['target_os'] as String? : null;
+}
 
 /// The leading part of a compiled bundle's build stamp, before its shader
 /// sources: the format revision, the backends this target needs, and the

--- a/packages/flutter_scene/lib/src/generated_assets/generated_assets.dart
+++ b/packages/flutter_scene/lib/src/generated_assets/generated_assets.dart
@@ -53,9 +53,14 @@ enum ShaderBundleBackend { metalIos, metalDesktop, openglEs, vulkan }
 /// The build and the runtime both resolve through here, so what an output is
 /// recorded as and what the app looks for cannot drift apart. Drift is silent,
 /// it renders a black frame.
+///
+/// Apple's embedded platforms share the iOS arm because `metalIos` names a
+/// shader family rather than a product: watchOS and tvOS run Metal and take the
+/// same variant. Left out, they fall to the default and ask for a bundle no
+/// build produces.
 Set<ShaderBundleBackend> shaderBundleBackendsForOS(String? os) => switch (os) {
   null => const {ShaderBundleBackend.openglEs},
-  'ios' => const {ShaderBundleBackend.metalIos},
+  'ios' || 'watchos' || 'tvos' => const {ShaderBundleBackend.metalIos},
   'macos' => const {ShaderBundleBackend.metalDesktop},
   'fuchsia' => const {ShaderBundleBackend.vulkan},
   _ => const {ShaderBundleBackend.openglEs, ShaderBundleBackend.vulkan},

--- a/packages/flutter_scene/test/generated_target_isolation_test.dart
+++ b/packages/flutter_scene/test/generated_target_isolation_test.dart
@@ -21,8 +21,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks/hooks.dart';
 
 /// A hook input like the one `flutter run` makes for [targetOS], or like the
-/// one it also makes with no asset types at all when [targetOS] is null.
-BuildInput _input(Uri packageRoot, {OS? targetOS}) {
+/// one it also makes with no asset types at all when both are null.
+///
+/// [rawTargetOS] writes that name over the one [targetOS] produced, standing in
+/// for an embedder whose platform the protocol cannot name.
+BuildInput _input(Uri packageRoot, {OS? targetOS, String? rawTargetOS}) {
   final builder = BuildInputBuilder()
     ..setupShared(
       packageRoot: packageRoot,
@@ -32,6 +35,7 @@ BuildInput _input(Uri packageRoot, {OS? targetOS}) {
     )
     ..setupBuildInput();
   builder.config.setupBuild(linkingEnabled: false);
+  if (rawTargetOS != null) targetOS ??= OS.iOS;
   if (targetOS != null) {
     CodeAssetExtension(
       targetArchitecture: Architecture.arm64,
@@ -45,6 +49,12 @@ BuildInput _input(Uri packageRoot, {OS? targetOS}) {
           ? AndroidCodeConfig(targetNdkApi: 21)
           : null,
     ).setupBuildInput(builder);
+    if (rawTargetOS != null) {
+      // `target_os` is a plain string in the syntax, so an embedder can write
+      // a name the API has no `OS` for and still produce a valid config.
+      final extensions = builder.config.json['extensions']! as Map;
+      (extensions['code_assets']! as Map)['target_os'] = rawTargetOS;
+    }
   }
   return builder.build();
 }
@@ -330,6 +340,33 @@ void main() {
         ),
       ),
       currentShaderTarget,
+    );
+  });
+
+  test('an Apple embedded build and runtime agree on a key', () {
+    // Both sides spell these the same way, so they meet without either having
+    // to know about the other.
+    for (final os in ['watchos', 'tvos']) {
+      expect(
+        shaderBundleTargetKey(_input(temp.uri, rawTargetOS: os)),
+        shaderTargetKey(shaderBundleBackendsForOS(os)),
+        reason: 'a mismatch here is a black frame on $os',
+      );
+    }
+  });
+
+  test('a target OS the protocol cannot name is still read', () {
+    // Fails if the name is ever read back through `config.code.targetOS`,
+    // which throws on an OS this version of code_assets does not know.
+    expect(
+      shaderBundleBackendsForBuild(_input(temp.uri, rawTargetOS: 'watchos')),
+      {ShaderBundleBackend.metalIos},
+    );
+    // A name nothing recognises falls to the portable set rather than
+    // throwing, so adding cases above does not disturb the default.
+    expect(
+      shaderBundleBackendsForBuild(_input(temp.uri, rawTargetOS: 'nope')),
+      {ShaderBundleBackend.openglEs, ShaderBundleBackend.vulkan},
     );
   });
 


### PR DESCRIPTION
Fixes #361.

Two changes, both in the package.

**The `metalIos` arm now covers all three Apple platforms.** watchOS and tvOS run Metal with the same shader variant iOS uses, so they join that arm instead of falling through to `{openglEs, vulkan}`, which no build produces.

**The target OS is read off the config JSON rather than through `config.code.targetOS`.** That getter parses the name into an `OS` and throws on one code_assets doesn't know, which kills the hook outright. 2.0.0 accepts unknown names, but `^1.2.1` can't resolve it, and widening the constraint would only move the crash to whichever apps resolve 1.x. The name is a plain string in the protocol on both sides and a string is all backend selection needs.

I tried raising the floor to `^2.0.0` first. It doesn't work in practice: `box3d 0.1.1` still pins `^1.2.1` and holds a whole workspace on 1.x.

### Tests

Three in `generated_target_isolation_test.dart`, next to the existing OS agreement test. The helper takes a `rawTargetOS` that writes the name directly, standing in for an embedder whose platform the protocol can't name.

The second one fails if the typed accessor is ever put back, which is the regression I'd worry about here since the symptom is a black frame rather than an error.

### Verified

`smoke_render` on the watchOS and tvOS simulators and on a physical Apple TV 4K (tvOS 26.6), Impeller Metal, no pipeline failures. Shipped manifests carry 8 `metalIos` entries on both. Full suite green.

Nothing changes for existing platforms. A macOS build produces a byte-identical manifest and hook input before and after, same cache key, so no rebuild is forced.
