### PR TITLE
Declare per-instance attributes on a raw ShaderMaterial

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -45,6 +45,7 @@
 * SH-9 diffuse helpers, `parseDiffuseShSidecar`/`encodeDiffuseShSidecar`, `evaluateDiffuseSphericalHarmonics`, and `describeDiffuseSphericalHarmonics` for verifying imported coefficients.
 * `PhysicallyBasedMaterial.lightmapTexture` adds a baked lightmap that replaces the SH diffuse ambient.
 * `.fmat` `instance_attributes` declare typed per-instance data, set via `InstancedMesh.setInstanceAttribute`.
+* A raw `ShaderMaterial` declares the same per-instance data through `ShaderInstanceAttribute`, so a custom vertex shader reads the `instance_<name>` inputs a `.fmat` would have generated.
 * `PlanarReflectorComponent` renders a mirrored scene capture that `.fmat` materials sample via the `planar_reflection` engine input.
 
 ## 0.23.0

--- a/packages/flutter_scene/lib/scene.dart
+++ b/packages/flutter_scene/lib/scene.dart
@@ -97,7 +97,8 @@ export 'src/material/physically_based_material.dart'
     show AlphaMode, PhysicallyBasedMaterial, TextureTransform;
 export 'src/material/preprocessed_material.dart' show PreprocessedMaterial;
 export 'src/material/preprocessed_sky.dart' show PreprocessedSky;
-export 'src/material/shader_material.dart' show ShaderMaterial;
+export 'src/material/shader_material.dart'
+    show ShaderInstanceAttribute, ShaderInstanceAttributeType, ShaderMaterial;
 export 'src/material/shader_stage.dart' show MeshVariant, ShaderStage;
 export 'src/material/shadow_catcher_material.dart'
     show ShadowCatcherMaterial, ShadowCatcherMode;

--- a/packages/flutter_scene/lib/src/material/material.dart
+++ b/packages/flutter_scene/lib/src/material/material.dart
@@ -421,8 +421,8 @@ abstract class Material {
   gpu.Shader? materialVertexShader(String variant) => null;
 
   /// The per-instance attributes this material declares, or null when it
-  /// declares none (everything but a `.fmat` with an `instance_attributes`
-  /// block).
+  /// declares none. A `.fmat` `instance_attributes` block declares them, as
+  /// does a raw `ShaderMaterial` constructed with `instanceAttributes`.
   ///
   /// The schema widens the instance-rate vertex buffer, so it is part of the
   /// pipeline's vertex layout as well as of what an instanced mesh accepts.

--- a/packages/flutter_scene/lib/src/material/shader_material.dart
+++ b/packages/flutter_scene/lib/src/material/shader_material.dart
@@ -7,12 +7,31 @@ import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 
 import 'package:flutter_scene/src/light.dart';
 import 'package:flutter_scene/src/material/engine_lighting.dart';
+import 'package:flutter_scene/src/material/instance_attributes.dart';
 import 'package:flutter_scene/src/material/material.dart';
 import 'package:flutter_scene/src/material/shader_stage.dart';
+import 'package:flutter_scene/src/fmat/fmat_ast.dart' show FmatType;
 import 'package:flutter_scene/src/render/custom_render_pass.dart'
     show RenderInput;
 import 'package:flutter_scene/src/texture/texture2d.dart';
 import 'package:flutter_scene/src/render/frame_transients.dart';
+
+/// Scalar/vector type supplied once per instance to a raw shader pair.
+/// {@category Materials}
+enum ShaderInstanceAttributeType { float, vec2, vec3, vec4 }
+
+/// A named custom value appended to an instanced mesh's instance record.
+/// {@category Materials}
+class ShaderInstanceAttribute {
+  /// Creates a raw shader instance attribute declaration.
+  const ShaderInstanceAttribute(this.name, this.type);
+
+  /// Shader input suffix. The vertex shader receives `instance_<name>`.
+  final String name;
+
+  /// Number of components supplied for each instance.
+  final ShaderInstanceAttributeType type;
+}
 
 /// A [Material] backed by a caller-supplied fragment shader.
 ///
@@ -67,6 +86,22 @@ import 'package:flutter_scene/src/render/frame_transients.dart';
 /// diffuse irradiance SH coefficients are not bound generically; declare them
 /// in your own uniform block if you need them.
 ///
+/// ## Per-instance attributes
+///
+/// [ShaderInstanceAttribute] declarations widen the instance-rate vertex
+/// buffer of every `InstancedMesh` this material draws. Declare each one in
+/// your vertex shader as an `in` input named `instance_<name>`, and set its
+/// value per instance with `InstancedMesh.setInstanceAttribute`. A `vec3`
+/// occupies four floats in the record, as it does in a `.fmat`.
+///
+/// The engine's standard vertex shader does not declare these inputs, so a
+/// material declaring attributes supplies its own `vertexShader` (and a
+/// skinned or depth variant for the meshes it draws in those passes).
+///
+/// TODO(shader-instance-attributes): fail the draw when a material declares
+/// attributes with no vertex shader to read them, the way the `.fmat` parser
+/// rejects the same pairing.
+///
 /// ## Uniform block packing
 ///
 /// Flutter GPU resolves uniform blocks by name (via
@@ -97,7 +132,8 @@ class ShaderMaterial extends Material {
   /// assigned later via [setFragmentShader]; rendering throws until a
   /// shader is set. Set [useEnvironment] to `true` to have the engine
   /// bind the scene environment's IBL textures by their standard
-  /// names.
+  /// names, and pass `instanceAttributes` to widen the instance record
+  /// this material's instanced meshes carry.
   ShaderMaterial({
     gpu.Shader? fragmentShader,
     gpu.Shader? radianceCubeFragmentShader,
@@ -109,7 +145,9 @@ class ShaderMaterial extends Material {
     this.windingOrder = gpu.WindingOrder.clockwise,
     this.isOpaqueOverride = true,
     Set<RenderInput> sceneInputs = const {},
-  }) : _sceneInputs = _normalizeSceneInputs(sceneInputs) {
+    List<ShaderInstanceAttribute> instanceAttributes = const [],
+  }) : _sceneInputs = _normalizeSceneInputs(sceneInputs),
+       _instanceAttributes = _buildInstanceAttributes(instanceAttributes) {
     // A material constructed with inputs is not in the frame's cached summary
     // yet. Attaching it to a mounted mesh invalidates through the mesh
     // component, but constructing before the first render does not, so cover
@@ -228,6 +266,45 @@ class ShaderMaterial extends Material {
   final Map<String, ByteData> _vertexUniformBlocks = {};
   final Map<String, _BoundTexture> _vertexTextures = {};
   final Map<MeshVariant, gpu.Shader> _vertexShaders = {};
+  final InstanceAttributeSchema? _instanceAttributes;
+
+  static InstanceAttributeSchema? _buildInstanceAttributes(
+    List<ShaderInstanceAttribute> declarations,
+  ) {
+    if (declarations.isEmpty) return null;
+    final names = <String>{};
+    final slots = <InstanceAttributeSlot>[];
+    var offset = 0;
+    for (final declaration in declarations) {
+      if (declaration.name.isEmpty || !names.add(declaration.name)) {
+        throw ArgumentError.value(
+          declaration.name,
+          'instanceAttributes',
+          'Names must be non-empty and unique.',
+        );
+      }
+      final type = switch (declaration.type) {
+        ShaderInstanceAttributeType.float => FmatType.float_,
+        ShaderInstanceAttributeType.vec2 => FmatType.vec2,
+        ShaderInstanceAttributeType.vec3 => FmatType.vec3,
+        ShaderInstanceAttributeType.vec4 => FmatType.vec4,
+      };
+      slots.add(
+        InstanceAttributeSlot(
+          name: declaration.name,
+          type: type,
+          floatOffset: offset,
+        ),
+      );
+      offset += type == FmatType.vec3 ? 4 : type.componentCount;
+    }
+    return InstanceAttributeSchema(slots);
+  }
+
+  /// The schema built from the `instanceAttributes` declarations, or null
+  /// when this material declared none.
+  @override
+  InstanceAttributeSchema? get instanceAttributes => _instanceAttributes;
 
   Map<String, ByteData> _blocksFor(ShaderStage stage) =>
       stage == ShaderStage.vertex ? _vertexUniformBlocks : _uniformBlocks;

--- a/packages/flutter_scene/test/shader_material_test.dart
+++ b/packages/flutter_scene/test/shader_material_test.dart
@@ -5,13 +5,31 @@
 
 import 'dart:typed_data';
 
+// ignore: implementation_imports
+import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' show Matrix4, Vector3;
 // The revision counter the frame's scene-input summary is cached against is
 // internal, and asserting the invalidation is the point of the last test here.
 // ignore: implementation_imports
 import 'package:flutter_scene/src/material/material.dart'
     show materialSceneInputsRevision;
 import 'package:flutter_test/flutter_test.dart';
+
+class _StubGeometry extends Geometry {
+  @override
+  void bind(
+    gpu.RenderPass pass,
+    TransientWriter transientsBuffer,
+    Matrix4 modelTransform,
+    Matrix4 cameraTransform,
+    Vector3 cameraPosition, {
+    gpu.Shader? shaderOverride,
+    double depthBias = 0.0,
+  }) {
+    throw UnsupportedError('Stub geometry is not renderable');
+  }
+}
 
 void main() {
   group('ShaderMaterial uniform block storage', () {
@@ -71,6 +89,34 @@ void main() {
       expect(opaque.isOpaque(), isTrue);
       opaque.isOpaqueOverride = false;
       expect(opaque.isOpaque(), isFalse);
+    });
+  });
+
+  group('ShaderMaterial instance attributes', () {
+    test('raw materials declare values accepted by InstancedMesh', () {
+      final material = ShaderMaterial(
+        instanceAttributes: const [
+          ShaderInstanceAttribute('seed', ShaderInstanceAttributeType.float),
+          ShaderInstanceAttribute('state', ShaderInstanceAttributeType.vec3),
+        ],
+      );
+      final mesh = InstancedMesh(geometry: _StubGeometry(), material: material);
+      final index = mesh.addInstance(Matrix4.identity());
+      mesh
+        ..setInstanceAttribute(index, 'seed', 3.0)
+        ..setInstanceAttribute(index, 'state', Vector3(1.0, 2.0, 3.0));
+    });
+
+    test('rejects duplicate raw instance attribute names', () {
+      expect(
+        () => ShaderMaterial(
+          instanceAttributes: const [
+            ShaderInstanceAttribute('seed', ShaderInstanceAttributeType.float),
+            ShaderInstanceAttribute('seed', ShaderInstanceAttributeType.vec2),
+          ],
+        ),
+        throwsArgumentError,
+      );
     });
   });
 


### PR DESCRIPTION
A `.fmat` material can widen the instance record with typed per-instance data, but a raw shader pair could not, so a custom vertex shader had nothing to read past the fixed transform and color block. `ShaderInstanceAttribute` declares the same slots and `InstancedMesh.setInstanceAttribute` fills them, so both authoring paths reach the same `instance_<name>` vertex inputs.

The engine's standard vertex shader does not declare those inputs, so a material declaring attributes supplies its own.