### PR TITLE
Prepare the 0.23 release train

### DIFF
--- a/apps/flutter_scene_editor_app/flutter.version
+++ b/apps/flutter_scene_editor_app/flutter.version
@@ -2,5 +2,5 @@
 # release workflow clones this exact revision, so the packaged engine, the
 # bundled impellerc, and the shader bundle format stay in lockstep by
 # construction. Tracks the Flutter stable the editor pairs with, currently
-# 3.47.0. Update deliberately (build + smoke locally first).
-4cf24164269a5ebf0c16a028a00727d0e77bbb05
+# 3.47.1. Update deliberately (build + smoke locally first).
+6655482ec06e547f90abf8ae7590466f4415978d

--- a/apps/flutter_scene_editor_app/pubspec.yaml
+++ b/apps/flutter_scene_editor_app/pubspec.yaml
@@ -3,7 +3,7 @@ description: The standalone Flutter Scene Editor desktop application.
 publish_to: none
 
 # Tracks the flutter_scene release this build pairs with.
-version: 0.22.0
+version: 0.23.0
 
 resolution: workspace
 

--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -1,9 +1,9 @@
-## 0.24.0
+## 0.23.0
 
 * Build hooks no longer crash on a target OS `package:code_assets` cannot name, which is how a third-party embedder announces tvOS or visionOS.
 * tvOS, visionOS, and watchOS select the iOS Metal shader variant, so an app on an Apple embedded platform finds its shader bundles and materials instead of looking for a target nothing builds.
 * Added `package:flutter_scene/kit.dart`, high-level gameplay, camera boom, character controller, day/night cycle, water surface, audio, pooling, and debug visualization components.
-* Standardized model-space front-face winding to Counter-Clockwise (CCW) across primitives, procedural builders, materials, and `.fscene` version 5.
+* BREAKING: model-space front faces wind Counter-Clockwise (CCW) now, across primitives, procedural builders, materials, and `.fscene` version 5, matching glTF and the rest of the ecosystem. Version 4 documents swap index pairs on read and version 4 containers migrate at realization, so assets need no action, but hand-authored index buffers and custom `Geometry` subclasses wind the other way and need their triangles swapped.
 * World-space global illumination via `Scene.globalIllumination`, a grid of octahedral irradiance probes fed by scattering the visible surfaces' shaded radiance, so bounce light persists for geometry the camera is not looking at and colored bleed reads correctly. Off by default.
 * Probe visibility via `GlobalIlluminationSettings.visibility`, per-direction depth moments and a Chebyshev bound so the field does not leak through walls.
 * Emissive surfaces light the probe field, scaled by `GlobalIlluminationSettings.emissiveGiBoost` so a small bright emitter can light a room without brightening the direct image.
@@ -11,6 +11,9 @@
 * `IrradianceVolumeComponent` places the irradiance volume on a node, for authored placement instead of fitting the scene or following the camera.
 * `Scene.invalidateGlobalIllumination` discards the accumulated field so it refills from scratch after a hard camera cut.
 * The lit shaders read the environment's diffuse coefficients with `texelFetch` from a texture the probe atlas extends, so global illumination costs no additional fragment sampler.
+* Add the `flutter_scene-kit` agent skill, covering the gameplay, camera rig, character controller, day/night, water, audio, pooling, and debug components in `kit.dart`.
+* Update `flutter_scene-idioms` skill (v4) with the reflection probes and lens flares the engine gained, and the traps that came with them.
+* Update `flutter_scene-performance` skill (v2) with SMAA's cost next to FXAA and the per-frame reflection-probe recapture trap.
 * Update `flutter_scene-procedural` skill (v2) with natural formation recipes (rock fractures, incised trails, pebble scatter, Gerstner waves, tree branching, and procedural island topographies).
 * Update `flutter_scene-looks` skill (v4) with micro-surface and anti-waxiness tuning guidance.
 * Update `flutter_scene-verification-loop` skill (v2) with empirical verification disciplines and blind-pairwise review rules.
@@ -47,9 +50,6 @@
 * `.fmat` `instance_attributes` declare typed per-instance data, set via `InstancedMesh.setInstanceAttribute`.
 * A raw `ShaderMaterial` declares the same per-instance data through `ShaderInstanceAttribute`, so a custom vertex shader reads the `instance_<name>` inputs a `.fmat` would have generated.
 * `PlanarReflectorComponent` renders a mirrored scene capture that `.fmat` materials sample via the `planar_reflection` engine input.
-
-## 0.23.0
-
 * `ShaderMaterial.sceneInputs` declares the engine's per-frame scene textures, so a raw shader can refract and measure its own thickness like a `.fmat` material. Include `<scene_inputs.glsl>` for the samplers and their accessors; `buildTargetShaderBundleJson` puts flutter_scene's `shaders/` on the include path so it resolves with no setup.
 * Parallax-corrected reflection probes via `ReflectionProbeComponent`, capturing the scene into a local environment whose reflections track the probe's box.
 * `Scene.captureEnvironment` renders the scene's lighting at a point into a new `EnvironmentMap`.

--- a/packages/flutter_scene_box3d/CHANGELOG.md
+++ b/packages/flutter_scene_box3d/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Widen the `scene` constraint to `^0.3.0`. No API changes.
+
 ## 0.2.0
 
 * BREAKING: the backend now implements the `PhysicsSimulation` contract from `package:scene`; the runtime dependency moved from `flutter_scene` to `scene`.

--- a/packages/flutter_scene_box3d/pubspec.yaml
+++ b/packages/flutter_scene_box3d/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_scene_box3d
 description: box3d physics backend for flutter_scene. Implements the physics simulation contract from package:scene against the box3d engine.
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
-version: 0.2.0
+version: 0.2.1
 
 topics:
   - physics

--- a/packages/flutter_scene_fmod/CHANGELOG.md
+++ b/packages/flutter_scene_fmod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Widen the `flutter_scene` constraint to `^0.23.0`. No API changes.
+
 ## 0.1.1
 
 * Add `registerFmodAudioBackend()`, so documents naming `fmod` as their audio engine realize an `FmodAudioEngine`.

--- a/packages/flutter_scene_fmod/pubspec.yaml
+++ b/packages/flutter_scene_fmod/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_scene_fmod
 description: FMOD Studio audio backend for flutter_scene. Implements the abstract audio contract from flutter_scene over the fmod package, against a user-supplied FMOD Engine SDK.
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
-version: 0.1.1
+version: 0.1.2
 
 resolution: workspace
 

--- a/packages/flutter_scene_net/CHANGELOG.md
+++ b/packages/flutter_scene_net/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+- Widen the `flutter_scene` constraint to `^0.23.0` and the `scene` constraint to `^0.3.0`. No API changes.
+
 ## 0.2.0
 
 - `PredictedTransformComponent` with `PredictedController`, client-side prediction of an owned entity with authoritative input-replay reconciliation, so local input renders instantly while the sim stays server-authoritative. Selected per entity through `SceneReplication`'s `localPrediction` seam.

--- a/packages/flutter_scene_net/pubspec.yaml
+++ b/packages/flutter_scene_net/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_scene_net
 description: dashwire multiplayer for flutter_scene. Replica-to-node binding, interpolated transform sync, and in-app hosting.
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
-version: 0.2.0
+version: 0.2.1
 
 topics:
   - multiplayer

--- a/packages/flutter_scene_soloud/CHANGELOG.md
+++ b/packages/flutter_scene_soloud/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Widen the `flutter_scene` constraint to `^0.23.0`. No API changes.
+
 ## 0.1.1
 
 * Add `registerSoloudAudioBackend()`, so documents naming `soloud` as their audio engine realize a `SoloudAudioEngine`.

--- a/packages/flutter_scene_soloud/pubspec.yaml
+++ b/packages/flutter_scene_soloud/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_scene_soloud
 description: SoLoud audio backend for flutter_scene. Implements the abstract audio contract from flutter_scene over the SoLoud engine via flutter_soloud.
 repository: https://github.com/bdero/flutter_scene
 homepage: https://github.com/bdero/flutter_scene
-version: 0.1.1
+version: 0.1.2
 
 resolution: workspace
 


### PR DESCRIPTION
Cuts flutter_scene 0.23.0 and the packages that follow it. The unreleased changelog entries had split across a 0.23.0 and a 0.24.0 heading while nothing shipped, so they merge under 0.23.0, and the CCW winding standardization is marked breaking since hand-authored index buffers do not migrate the way assets do.

The `scene` 0.3.0 minor bump falls outside every published sibling's caret, so rapier, box3d, net, soloud, and fmod each get a release carrying the widened constraint. The editor app goes to 0.23.0 and its pinned Flutter revision goes back to 3.47.1, the current stable, which master had regressed off when the 0.22.1 release was cut on a branch that never merged.