### PR TITLE
Pick an equirect's mip level from the projection, not from the screen

### DIFF
--- a/packages/flutter_scene/shaders/flutter_scene_skybox.vert
+++ b/packages/flutter_scene/shaders/flutter_scene_skybox.vert
@@ -30,9 +30,9 @@ void main() {
   // geometry at that pixel would occupy, with no orientation flip needed.
   vec4 world =
       frame_info.inverse_view_projection * vec4(position, 1.0, 1.0);
-  vec3 ray = world.xyz / world.w;
-  v_ray = mat3(frame_info.environment_transform) * ray;
+  v_ray = mat3(frame_info.environment_transform) * world.xyz;
   // Sit at the far plane so geometry (depth-tested lessEqual against the
   // cleared far value) always draws in front.
   gl_Position = vec4(position, 1.0, 1.0);
 }
+

--- a/packages/flutter_scene/shaders/flutter_scene_skybox_environment.frag
+++ b/packages/flutter_scene/shaders/flutter_scene_skybox_environment.frag
@@ -63,7 +63,18 @@ void main() {
     // SphericalToEquirectangular.
     vec2 uv = SphericalToEquirectangular(direction);
     uv.y = 1.0 - uv.y;
-    vec3 sharp = texture(environment_background, uv).rgb;
+    // The mip level comes from the projection's own geometry, not from the
+    // UV's screen derivatives. That is what fixes the one pixel line at the
+    // wrap and the fan of wedges at the poles; both are the hardware measuring
+    // an equirect's footprint with a difference that cannot see either
+    // singularity. See SampleEquirectByFootprint.
+    //
+    // Note this is NOT something the radiance cube could have carried instead.
+    // A cube has no pole of its own, but its mirror band is a POINT resample of
+    // this same equirect, so the fan is baked into it; the fix has to happen
+    // where the equirect is read, which is here.
+    vec3 sharp =
+        SampleEquirectByFootprint(environment_background, direction, uv);
     sharp =
         skybox_info.source_is_linear > 0.5 ? sharp : SRGBToLinear(sharp);
     // Hand off sharp -> cube over the low band, then let the cube's roughness

--- a/packages/flutter_scene/shaders/texture.glsl
+++ b/packages/flutter_scene/shaders/texture.glsl
@@ -17,9 +17,55 @@ vec2 SphericalToEquirectangular(vec3 direction) {
   return uv;
 }
 
+// Samples an equirect along a view direction, choosing the mip level from the
+// projection's own geometry rather than from the UV's screen derivatives.
+//
+// Letting the hardware pick gets it wrong at both singularities of the
+// projection, and both are visible:
+//
+//   * **The seam.** Longitude wraps, so U jumps a whole period where the
+//     panorama joins. The quad straddling that jump measures a footprint the
+//     width of the entire texture and selects the top of the mip chain, which
+//     is the average of the whole sky. It prints as a one pixel bright line
+//     from pole to pole.
+//
+//   * **The poles.** An equirect's texels are slivers 1/cos(latitude) wide, so
+//     approaching a pole one row of them fans out over the whole sky. The
+//     correct footprint there spans MANY columns, and a screen-space difference
+//     of a rapidly-turning atan2 across a 2x2 quad badly underestimates it. The
+//     level that gets picked is too fine, so instead of the row's average the
+//     pole shows a handful of its columns splayed into wedges.
+//
+// The footprint is analytic instead. For a screen pixel covering `w` radians,
+// the region it maps to spans `w` of latitude and `w / cos(latitude)` of
+// longitude, which is exactly the 1/cos blow-up the hardware misses. Feeding
+// that as an explicit gradient pair makes the pole resolve to the average of
+// however many columns really collapse into the pixel (smooth, and progressively
+// smoother toward the pole) and leaves the seam with the footprint it actually
+// has (small).
+//
+// `direction` must be normalised. Its derivatives are used rather than the UV's
+// because the direction is continuous everywhere, including across the seam.
+//
+// Any equirect read with an implicit mip level needs this. A texture with no
+// mip chain hides the seam half of it, which is how it survives being written
+// the obvious way.
+vec3 SampleEquirectByFootprint(sampler2D tex, vec3 direction, vec2 uv) {
+  // Radians per pixel, from the direction itself: for a unit vector the chord
+  // and the angle agree to first order.
+  float w = max(length(dFdx(direction)), length(dFdy(direction)));
+  // Guarded, because at the exact pole this is zero and the longitude span is
+  // the whole circle; the clamp lands the level at the top of the chain, which
+  // is the row average, which is the right answer there.
+  float cos_lat = max(sqrt(max(1.0 - direction.y * direction.y, 0.0)), 1e-4);
+  return textureGrad(tex, uv, vec2(w * kInvAtan.x / cos_lat, 0.0),
+                     vec2(0.0, w * kInvAtan.y))
+      .rgb;
+}
+
 vec3 SampleEnvironmentTexture(sampler2D tex, vec3 direction) {
-  vec2 uv = SphericalToEquirectangular(direction);
-  return texture(tex, uv).rgb;
+  return SampleEquirectByFootprint(tex, direction,
+                                   SphericalToEquirectangular(direction));
 }
 
 vec3 SampleEnvironmentTextureLod(sampler2D tex, vec3 direction, float lod) {


### PR DESCRIPTION
An equirect sky shows two artefacts from screen-space mip selection. Longitude wraps, so the quad straddling the seam measures a footprint the width of the whole texture, selects the top of the mip chain, and prints a one-pixel bright line from pole to pole. And an equirect's texels are 1/cos(latitude) wide, so near a pole the screen-space derivatives of a rapidly turning atan2 underestimate the footprint and the pole splays a handful of columns into wedges.

`SampleEquirectByFootprint` computes the footprint analytically from the ray direction (which is continuous across the seam) and feeds it as an explicit gradient pair. The skybox vertex shader also takes its ray from the homogeneous far point directly, without the divide.