### PR TITLE
Networking: replicate what a component already declares

### DIFF
--- a/packages/flutter_scene/lib/src/fscene/realize/component_codec.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/component_codec.dart
@@ -83,6 +83,14 @@ abstract class ComponentCodec {
   /// `directionalLight`).
   String get type;
 
+  /// The group an editor files this type under in its component picker
+  /// ("Rendering", "Physics"). Null files it under the catch-all, which is
+  /// where a project's own components land until they say otherwise.
+  ///
+  /// Declared here rather than only inside [schema] so a codec can be filed
+  /// without having to restate its whole schema.
+  String? get category => null;
+
   /// The component's full portable schema. The default wraps [type] and
   /// [propertySchema]; override to add docs, an icon, or former type names.
   ComponentSchema get schema =>
@@ -127,6 +135,21 @@ abstract class ComponentCodec {
 
   /// The declared default for property [name], or null when the property has no
   /// default (throws when [name] is undeclared).
+  /// Writes one declared property onto a live [component], returning whether
+  /// it landed.
+  ///
+  /// Realizing a component builds it from a whole spec; this changes one
+  /// property on one that already exists, which is what a live edit is — an
+  /// inspector drag, a value arriving over the network, a graph assigning to
+  /// a field. Codecs that build their component wholesale have nothing to
+  /// offer here and answer false.
+  bool applyProperty(
+    Component component,
+    String name,
+    PropertyValue value,
+    RealizeContext context,
+  ) => false;
+
   PropertyValue? defaultOf(String name) =>
       propertySchema.firstWhere((d) => d.name == name).defaultValue;
 

--- a/packages/flutter_scene/lib/src/fscene/realize/declarative_codec.dart
+++ b/packages/flutter_scene/lib/src/fscene/realize/declarative_codec.dart
@@ -520,6 +520,27 @@ abstract class DeclarativeComponentCodec<C extends Component>
   }
 
   @override
+  bool applyProperty(
+    Component component,
+    String name,
+    PropertyValue value,
+    RealizeContext context,
+  ) {
+    if (component is! C) return false;
+    for (final field in resolvedFields) {
+      if (field.def.name != name) continue;
+      final write = field.write;
+      // A property with no write binding is constructor-only: the controller
+      // pose fields, the machine a state graph was built from. Saying so is
+      // better than appearing to set it.
+      if (write == null) return false;
+      write(component, value, context);
+      return true;
+    }
+    return false;
+  }
+
+  @override
   ComponentSpec? serialize(Component component, SerializeContext context) {
     if (component is! C) return null;
     final properties = <String, PropertyValue>{};

--- a/packages/flutter_scene_net/lib/flutter_scene_net.dart
+++ b/packages/flutter_scene_net/lib/flutter_scene_net.dart
@@ -7,16 +7,72 @@
 /// dart:io platforms so a game can host without a separate server.
 library;
 
+export 'src/component_sync.dart'
+    show
+        ComponentReplica,
+        PropertyWire,
+        SyncedProperty,
+        UnknownSyncedComponent,
+        UnknownSyncedProperty,
+        UnsyncableProperty,
+        canSync,
+        wireFor;
 export 'src/hosting/hosting.dart' show SceneHost;
+export 'src/network_events.dart'
+    show
+        DuplicateNetworkEvent,
+        NetworkEvent,
+        NetworkEventHandler,
+        UnknownNetworkEvent,
+        decodeNetworkEvent,
+        encodeNetworkEvent,
+        networkEventFields;
+export 'src/network_identity.dart'
+    show
+        NetworkIdentityCodec,
+        NetworkIdentityComponent,
+        decodeOwnership,
+        decodeSyncedProperty,
+        encodeOwnership,
+        encodeSyncedProperty,
+        syncedPropertyFields;
 export 'src/network_transform_codec.dart'
     show NetworkTransformCodec, registerNetComponentCodecs;
+export 'src/network_time.dart' show NetworkClock, NetworkTime;
+export 'src/network_ownership.dart'
+    show
+        Ownership,
+        OwnershipOutcome,
+        OwnershipPermission,
+        OwnershipRefusal,
+        ownershipRefusalMessage;
+export 'src/network_prefabs.dart'
+    show
+        DuplicateNetworkPrefab,
+        NetworkNodeBuilder,
+        NetworkPrefab,
+        NetworkPrefabs;
+export 'src/network_session.dart'
+    show
+        ConnectionApproval,
+        ConnectionApprover,
+        NetworkClient,
+        NetworkRole,
+        NetworkSession,
+        SessionAlreadyRunning,
+        UnknownPlayerPrefab,
+        serverPeerId;
 export 'src/network_transform.dart' show NetworkTransformComponent;
-// TODO(lagcomp): export PhysicsWorldHistory once something consumes it. The
-// server-side rewind needs the peer's last acked tick, which the host does
-// not record yet, and rewind lands on whole ticks where hit registration
-// wants the two bracketing snapshots interpolated.
+export 'src/replica_slots.dart' show ReplicaSlotResolver, ReplicaSlots;
+export 'src/physics_world_history.dart' show PhysicsWorldHistory;
 export 'src/predicted_physics.dart'
-    show PredictedPhysicsComponent, PredictedPhysicsController;
+    show
+        PredictedBodyScope,
+        PredictedPhysicsComponent,
+        PredictedPhysicsController,
+        capturePredictedBodies,
+        floatsPerPredictedBody,
+        restorePredictedBodies;
 export 'src/predicted_transform.dart'
     show PredictedController, PredictedTransformComponent, PredictionController;
 export 'src/scene_replication.dart'

--- a/packages/flutter_scene_net/lib/src/component_sync.dart
+++ b/packages/flutter_scene_net/lib/src/component_sync.dart
@@ -1,0 +1,531 @@
+/// Replicating a component's declared properties.
+///
+/// A networked object in this engine already describes itself: every component
+/// has a codec, and every codec declares its properties with a name, a kind, a
+/// default, and — the part that matters here — a `read` that gets the value off
+/// the live component and a `write` that puts one back. That is exactly the
+/// pair a replicated field needs.
+///
+/// So nothing here re-declares anything. You name a component type and the
+/// properties on it that should replicate, and the replica is built from the
+/// schema that was already there. The alternative — a hand-written `Replica`
+/// subclass per networked type, with its own field list — is the same
+/// information written twice, and the second copy is the one that goes stale
+/// when someone renames a property.
+///
+/// **What can replicate.** The kinds with an unambiguous wire form: numbers,
+/// integers, booleans, strings, vectors, quaternions, and colours. A property
+/// of any other kind is *refused*, loudly, when the replica is built. A
+/// property somebody marked as replicated that silently does not replicate is
+/// the worst outcome available: it looks right on the machine that changed it
+/// and is wrong everywhere else.
+library;
+
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart' show Component, Node;
+
+import 'network_events.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// A component property that replicates.
+class SyncedProperty {
+  /// Replicates [property] of the component of [componentType].
+  const SyncedProperty(
+    this.componentType,
+    this.property, {
+    this.authority = Authority.server,
+    this.readableBy = ReadScope.everyone,
+    this.mode = SendMode.stream,
+    this.resolution,
+  });
+
+  /// The component's document type, as its codec names it.
+  final String componentType;
+
+  /// The declared property on that component.
+  final String property;
+
+  /// Who is allowed to change it. Server by default: a client that could
+  /// write its own health is a client that never dies.
+  final Authority authority;
+
+  /// Who receives it at all.
+  ///
+  /// Everyone by default. [ReadScope.ownerOnly] is how a value stays private
+  /// to the player it belongs to — a hand of cards, a cooldown, a quest state
+  /// — and it is a real secret rather than a hidden one: the bytes are never
+  /// sent, so there is nothing in the client to read. [ReadScope.skipOwner]
+  /// is the opposite trade, for a value the owner is already computing
+  /// locally and would only be corrected by.
+  final ReadScope readableBy;
+
+  /// How often it goes out. Position streams; a name or a team changes rarely
+  /// and must not be missed, so [SendMode.onChange] suits it better.
+  final SendMode mode;
+
+  /// Quantization step for numeric kinds, or null for full precision.
+  ///
+  /// A position to the nearest centimetre costs a fraction of a float and is
+  /// indistinguishable on screen. Whether that trade is right depends on what
+  /// the number is, which is why it is named here rather than assumed.
+  final double? resolution;
+}
+
+/// A property whose kind has no wire form.
+class UnsyncableProperty implements Exception {
+  UnsyncableProperty(this.componentType, this.property, this.kind);
+
+  final String componentType;
+  final String property;
+  final ComponentPropertyKind kind;
+
+  @override
+  String toString() =>
+      'flutter_scene_net: $componentType.$property is a ${kind.name}, which '
+      'has no wire form. Replicate the parts of it that do, or drive it from '
+      'a property that replicates. Leaving it in the list would mean it '
+      'silently did not replicate, which looks correct on whichever machine '
+      'changed it and is wrong on every other one.';
+}
+
+/// A property that is not declared on the component named.
+class UnknownSyncedProperty implements Exception {
+  UnknownSyncedProperty(this.componentType, this.property, this.available);
+
+  final String componentType;
+  final String property;
+  final List<String> available;
+
+  @override
+  String toString() =>
+      'flutter_scene_net: $componentType has no property "$property". It '
+      'declares: ${available.join(', ')}.';
+}
+
+/// A component type with no codec registered.
+class UnknownSyncedComponent implements Exception {
+  UnknownSyncedComponent(this.componentType);
+
+  final String componentType;
+
+  @override
+  String toString() =>
+      'flutter_scene_net: no codec is registered for component type '
+      '"$componentType", so its properties cannot be read or written. '
+      'Register its codec before building the replica.';
+}
+
+/// The wire form of one property kind: how to carry it, and how to convert
+/// between the wire's value and the codec's [PropertyValue].
+///
+/// Deliberately a small, closed set. Every entry is a kind whose meaning
+/// survives being quantized and sent; the kinds left out are left out because
+/// there is no single right answer for them, not because nobody got to them.
+sealed class PropertyWire<T> {
+  const PropertyWire();
+
+  Codec<T> codec(double? resolution);
+
+  /// The value read off the component, as the wire carries it.
+  T from(PropertyValue value);
+
+  /// The wire value, as the component's codec takes it.
+  PropertyValue to(T value);
+
+  T get zero;
+}
+
+class _NumberWire extends PropertyWire<double> {
+  const _NumberWire();
+
+  @override
+  Codec<double> codec(double? resolution) =>
+      resolution == null ? Codecs.f32 : Codecs.quantized(resolution);
+
+  @override
+  double from(PropertyValue value) => switch (value) {
+    DoubleValue(value: final v) => v,
+    IntValue(value: final v) => v.toDouble(),
+    _ => 0,
+  };
+
+  @override
+  PropertyValue to(double value) => DoubleValue(value);
+
+  @override
+  double get zero => 0;
+}
+
+class _IntWire extends PropertyWire<int> {
+  const _IntWire();
+
+  @override
+  Codec<int> codec(double? resolution) => Codecs.i32;
+
+  @override
+  int from(PropertyValue value) => switch (value) {
+    IntValue(value: final v) => v,
+    DoubleValue(value: final v) => v.round(),
+    _ => 0,
+  };
+
+  @override
+  PropertyValue to(int value) => IntValue(value);
+
+  @override
+  int get zero => 0;
+}
+
+class _BoolWire extends PropertyWire<bool> {
+  const _BoolWire();
+
+  @override
+  Codec<bool> codec(double? resolution) => Codecs.boolean;
+
+  @override
+  bool from(PropertyValue value) => value is BoolValue ? value.value : false;
+
+  @override
+  PropertyValue to(bool value) => BoolValue(value);
+
+  @override
+  bool get zero => false;
+}
+
+class _StringWire extends PropertyWire<String> {
+  const _StringWire();
+
+  @override
+  Codec<String> codec(double? resolution) => Codecs.string;
+
+  @override
+  String from(PropertyValue value) => value is StringValue ? value.value : '';
+
+  @override
+  PropertyValue to(String value) => StringValue(value);
+
+  @override
+  String get zero => '';
+}
+
+class _Vec3Wire extends PropertyWire<Vec3> {
+  const _Vec3Wire();
+
+  /// A centimetre by default: below what a player can see at a metre, and a
+  /// third the bytes of three floats.
+  @override
+  Codec<Vec3> codec(double? resolution) => Codecs.vec3(resolution ?? 0.01);
+
+  @override
+  Vec3 from(PropertyValue value) => switch (value) {
+    Vec3Value(value: final v) => (v.x, v.y, v.z),
+    _ => (0.0, 0.0, 0.0),
+  };
+
+  @override
+  PropertyValue to(Vec3 value) =>
+      Vec3Value(Vector3(value.$1, value.$2, value.$3));
+
+  @override
+  Vec3 get zero => (0.0, 0.0, 0.0);
+}
+
+class _QuatWire extends PropertyWire<Quat> {
+  const _QuatWire();
+
+  @override
+  Codec<Quat> codec(double? resolution) => Codecs.quat;
+
+  @override
+  Quat from(PropertyValue value) => switch (value) {
+    QuaternionValue(value: final q) => (q.x, q.y, q.z, q.w),
+    Vec4Value(value: final v) => (v.x, v.y, v.z, v.w),
+    _ => (0.0, 0.0, 0.0, 1.0),
+  };
+
+  @override
+  PropertyValue to(Quat value) =>
+      QuaternionValue(Quaternion(value.$1, value.$2, value.$3, value.$4));
+
+  @override
+  Quat get zero => (0.0, 0.0, 0.0, 1.0);
+}
+
+/// The wire form for [kind], or null when it has none.
+PropertyWire<Object?>? wireFor(ComponentPropertyKind kind) => switch (kind) {
+  ComponentPropertyKind.number => const _NumberWire(),
+  ComponentPropertyKind.integer => const _IntWire(),
+  ComponentPropertyKind.boolean => const _BoolWire(),
+  ComponentPropertyKind.string => const _StringWire(),
+  ComponentPropertyKind.vec3 => const _Vec3Wire(),
+  ComponentPropertyKind.quaternion => const _QuatWire(),
+  _ => null,
+};
+
+/// Whether [kind] can replicate.
+bool canSync(ComponentPropertyKind kind) => wireFor(kind) != null;
+
+/// One property, resolved against a live registry: where to read it, where to
+/// write it, and how it goes over the wire.
+class _Bound {
+  _Bound(this.spec, this.def, this.wire, this.codec, this.rep);
+
+  final SyncedProperty spec;
+  final ComponentPropertyDef def;
+  final PropertyWire<Object?> wire;
+  final ComponentCodec codec;
+  final Rep<Object?> rep;
+}
+
+/// A replica whose fields are a node's component properties.
+///
+/// Built from the component schemas rather than declared: name the properties
+/// that replicate and this reads them off the live components each tick on the
+/// authority, and writes them back into the live components on everyone else.
+///
+/// The order of [properties] is the wire order, on both ends. That is
+/// dashwire's contract, not a detail of this class — a replica's fields are
+/// matched by position, so the two ends must build the list the same way. In
+/// practice that means the list comes from the document, which is the one
+/// description both ends load.
+final class ComponentReplica extends Replica {
+  /// Binds [properties] on [node], resolving them through [registry].
+  ///
+  /// Throws [UnknownSyncedComponent], [UnknownSyncedProperty] or
+  /// [UnsyncableProperty] rather than skipping anything it cannot handle: a
+  /// replica that quietly drops a field is a replica whose wire layout no
+  /// longer matches the other end's.
+  ComponentReplica({
+    required this.typeKey,
+    required List<SyncedProperty> properties,
+    required FsceneComponentRegistry registry,
+    List<NetworkEvent> events = const [],
+    Node? node,
+  }) : _node = node {
+    for (final spec in properties) {
+      final codec = registry.codecFor(spec.componentType);
+      if (codec == null) throw UnknownSyncedComponent(spec.componentType);
+
+      final schema = codec.propertySchema;
+      final def = schema.where((p) => p.name == spec.property).firstOrNull;
+      if (def == null) {
+        throw UnknownSyncedProperty(spec.componentType, spec.property, [
+          for (final p in schema) p.name,
+        ]);
+      }
+
+      final wire = wireFor(def.kind);
+      if (wire == null) {
+        throw UnsyncableProperty(spec.componentType, spec.property, def.kind);
+      }
+
+      _bound.add(
+        _Bound(
+          spec,
+          def,
+          wire,
+          codec,
+          rep<Object?>(
+            '${spec.componentType}.${spec.property}',
+            wire.zero,
+            codec: wire.codec(spec.resolution),
+            mode: spec.mode,
+            write: spec.authority,
+            read: spec.readableBy,
+          ),
+        ),
+      );
+    }
+
+    // Events after properties, because dashwire hashes the two in declaration
+    // order and both ends have to build the list the same way.
+    for (final event in events) {
+      if (_events.containsKey(event.name)) {
+        throw DuplicateNetworkEvent(event.name);
+      }
+      _events[event.name] = rpc<String>(
+        event.name,
+        codec: Codecs.string,
+        to: event.to,
+        delivery: event.delivery,
+        requireOwner: event.requireOwner,
+        onCall: (fromPeerId, payload) =>
+            onEvent?.call(event.name, fromPeerId, payload),
+      );
+    }
+  }
+
+  @override
+  final String typeKey;
+
+  /// Called when a declared event arrives.
+  ///
+  /// One handler rather than one per event: what an event *means* is game
+  /// logic, and the replica's job is to get it here intact rather than to
+  /// know what to do about it.
+  void Function(String name, int fromPeerId, String payload)? onEvent;
+
+  final Map<String, RpcEndpoint<String>> _events = {};
+
+  /// The declared event names.
+  Iterable<String> get eventNames => _events.keys;
+
+  /// Sends the event called [name], carrying [payload].
+  ///
+  /// Which way it goes and who may send it were decided when it was declared:
+  /// an event aimed at the server is a client asking, and the server decides.
+  /// Sending one nobody declared throws rather than going nowhere, because a
+  /// message that silently vanishes is the hardest kind of bug to see.
+  void send(String name, [String payload = '']) {
+    final endpoint = _events[name];
+    if (endpoint == null) {
+      throw UnknownNetworkEvent(name, _events.keys.toList());
+    }
+    endpoint.call(payload);
+  }
+
+  Node? _node;
+
+  /// The node whose components this replicates, or null before one exists.
+  ///
+  /// A client learns a replica exists before it has anywhere to put it: the
+  /// spawn message arrives, the replica is built from the registry, and only
+  /// then is the node created for it. The fields are declared from the
+  /// property list alone, so the replica is complete without a node — it just
+  /// has nothing to read from or write to until [bind].
+  Node? get node => _node;
+
+  /// Whether this replica is attached to something in the scene.
+  ///
+  /// The question every piece of gameplay code has to ask before it touches a
+  /// replicated value: a replica exists from the moment the spawn message
+  /// arrives, and there is nothing to read or write until it has a node.
+  bool get isSpawned => _node != null;
+
+  /// Called when the replica is attached to a node.
+  ///
+  /// The place to start anything that only makes sense once the object is in
+  /// the world -- subscribing to input, starting a sound. It fires after the
+  /// spawn payload has been applied, so the node is already at the state the
+  /// authority sent rather than at its prefab defaults.
+  void Function(Node node)? onSpawn;
+
+  /// Called before the replica is detached.
+  ///
+  /// The matching place to stop what [onSpawn] started. It fires while the
+  /// node is still attached, so there is something to clean up against.
+  void Function(Node node)? onDespawn;
+
+  /// Attaches this replica to [node].
+  void bind(Node node) {
+    _node = node;
+    onSpawn?.call(node);
+  }
+
+  /// Attaches to [node] and applies what has already arrived for it.
+  ///
+  /// What a spawn is, in the right order: the node takes the authority's state
+  /// before [onSpawn] runs, so a handler that reads a replicated value on
+  /// spawn reads the real one rather than a prefab default it is about to be
+  /// corrected from.
+  void spawnInto(Node node) {
+    _node = node;
+    push();
+    onSpawn?.call(node);
+  }
+
+  /// Detaches it, on despawn.
+  void unbind() {
+    final node = _node;
+    if (node != null) onDespawn?.call(node);
+    _node = null;
+  }
+
+  /// Whether [peerId] owns this replica.
+  ///
+  /// The check that gates an owner-writable property or an owner-only event.
+  /// Asking rather than assuming matters because ownership moves: the object
+  /// you spawned may not be yours by the time you next look.
+  bool isOwnedBy(int peerId) => owner == peerId;
+
+  final List<_Bound> _bound = [];
+
+  /// The declared properties, in wire order.
+  Iterable<SyncedProperty> get properties => _bound.map((b) => b.spec);
+
+  /// How many fields this replica carries.
+  int get fieldCount => _bound.length;
+
+  /// The current value of the field at [index], in its wire form.
+  ///
+  /// Numbers come back as doubles, vectors as records; the shapes
+  /// [PropertyWire] converts to. For inspecting what a replica currently
+  /// holds — a debug overlay, a test standing in for the wire — without
+  /// reaching into dashwire's internals.
+  Object? valueAt(int index) => _bound[index].rep.value;
+
+  /// Sets the field at [index], as a snapshot landing does.
+  ///
+  /// Whether the change is allowed to go anywhere is dashwire's business:
+  /// a field the server owns, written on a client, is not sent. This is the
+  /// same door a snapshot comes through.
+  void setValueAt(int index, Object? value) => _bound[index].rep.value = value;
+
+  /// Reads the live components into the replicated fields.
+  ///
+  /// Called on whichever end has authority, once a tick. Only fields whose
+  /// value actually changed go out: dashwire tracks that per field, so a
+  /// property that sits still costs nothing after the first send.
+  void pull() {
+    if (_node == null) return;
+    final context = SerializeContext(_scratchDocument);
+    for (final bound in _bound) {
+      final component = _componentFor(bound);
+      if (component == null) continue;
+      final spec = bound.codec.serialize(component, context);
+      // Components serialize as a delta from their schema defaults, so a
+      // property sitting at its default is absent rather than present-and-
+      // default. Reading the default here is what keeps the two ends agreeing
+      // about a value nobody has changed.
+      final value = spec?.properties[bound.def.name] ?? bound.def.defaultValue;
+      if (value == null) continue;
+      bound.rep.value = bound.wire.from(value);
+    }
+  }
+
+  /// Writes the replicated fields back into the live components.
+  ///
+  /// Called on the ends without authority, after a snapshot lands.
+  void push() {
+    if (_node == null) return;
+    final context = RealizeContext(_scratchDocument);
+    for (final bound in _bound) {
+      final component = _componentFor(bound);
+      if (component == null) continue;
+      bound.codec.applyProperty(
+        component,
+        bound.def.name,
+        bound.wire.to(bound.rep.value),
+        context,
+      );
+    }
+  }
+
+  Component? _componentFor(_Bound bound) {
+    final node = _node;
+    if (node == null) return null;
+    for (final component in node.getComponents<Component>()) {
+      if (bound.codec.claims(component)) return component;
+    }
+    return null;
+  }
+}
+
+/// A document the read and write paths need but never actually consult.
+///
+/// Serialize and realize contexts exist to resolve cross-references — a
+/// texture id, a node id — and the properties that replicate are the ones with
+/// no references in them. One empty document shared by every replica is
+/// cheaper than one per replica per tick, and it stays empty.
+final SceneDocument _scratchDocument = SceneDocument();

--- a/packages/flutter_scene_net/lib/src/network_events.dart
+++ b/packages/flutter_scene_net/lib/src/network_events.dart
@@ -1,0 +1,160 @@
+/// Events, as opposed to state.
+///
+/// Replicated properties carry things that are continuously true — where a
+/// player is, how much health it has — and they are the wrong tool for things
+/// that merely *happen*. A shot fired, a door opened, a round won: those occur
+/// once, and a property that flickered to record one would be a property whose
+/// change you might miss between two snapshots.
+///
+/// So this is the other half. A [NetworkEvent] is a named message an object
+/// can send, with a target saying who runs it — the server, the owning client,
+/// everyone else, or everybody. A remote call, in other words, with the
+/// direction named on the declaration rather than implied by which of two
+/// kinds it is.
+///
+/// **The direction is the security boundary.** An event targeted at the server
+/// is a client asking for something, and the server decides. That is the whole
+/// reason a client cannot simply write its own health: the request goes one
+/// way, the authority goes the other, and a client that could shortcut it is a
+/// client that never dies.
+library;
+
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/fscene.dart';
+
+/// One event an object can send.
+class NetworkEvent {
+  const NetworkEvent(
+    this.name, {
+    this.to = RpcTarget.server,
+    this.delivery = Delivery.reliable,
+    this.requireOwner = true,
+  });
+
+  /// The event's name, matched across the two ends.
+  final String name;
+
+  /// Who runs it when it is sent.
+  ///
+  /// Note that [RpcTarget.others] excludes the *server*, not the owner. An
+  /// event aimed at everyone except the object's owner -- one its owner has
+  /// already acted on locally -- wants a target the transport does not have
+  /// yet; that is bdero/dashwire#6.
+  final RpcTarget to;
+
+  /// Whether it is guaranteed to arrive.
+  ///
+  /// Reliable by default. An event is a thing that happened once, so losing
+  /// one loses it for good — unlike a property, where the next snapshot
+  /// carries the truth again. Unreliable is for the events where being late
+  /// is worse than being missed: a footstep, a hit spark.
+  final Delivery delivery;
+
+  /// For events aimed at the server, whether only the owning client may send.
+  ///
+  /// On by default, and it is the check that stops one client acting for
+  /// another: without it, "fire my weapon" is a message anybody can send about
+  /// anybody.
+  final bool requireOwner;
+}
+
+/// The document form of a declared event.
+const List<ComponentPropertyDef> networkEventFields = [
+  ComponentPropertyDef(
+    'name',
+    ComponentPropertyKind.string,
+    defaultValue: StringValue(''),
+    doc: 'What the event is called. Both ends match on this.',
+  ),
+  ComponentPropertyDef(
+    'to',
+    ComponentPropertyKind.string,
+    defaultValue: StringValue('server'),
+    options: ['server', 'owner', 'others', 'all'],
+    doc:
+        'Who runs it. Server is a client asking the server for something; the '
+        'rest are the server telling clients that something happened.',
+  ),
+  ComponentPropertyDef(
+    'delivery',
+    ComponentPropertyKind.string,
+    defaultValue: StringValue('reliable'),
+    options: ['reliable', 'unreliable'],
+    doc:
+        'Reliable unless being late is worse than being missed. An event '
+        'happens once, so a lost one is lost for good.',
+  ),
+  ComponentPropertyDef(
+    'requireOwner',
+    ComponentPropertyKind.boolean,
+    defaultValue: BoolValue(true),
+    doc:
+        'For server events, whether only the owning client may send it. Off '
+        'means anyone may send it about anyone.',
+  ),
+];
+
+/// Encodes [event] as the document holds it.
+MapValue encodeNetworkEvent(NetworkEvent event) => MapValue({
+  'name': StringValue(event.name),
+  'to': StringValue(event.to.name),
+  'delivery': StringValue(event.delivery.name),
+  'requireOwner': BoolValue(event.requireOwner),
+});
+
+/// Decodes one event, or null when it names nothing.
+///
+/// A row with no name is a half-filled row in the inspector, which is what one
+/// looks like the moment it is added. Dropping it beats refusing to load the
+/// scene around it.
+NetworkEvent? decodeNetworkEvent(PropertyValue? value) {
+  if (value is! MapValue) return null;
+  final map = value.values;
+  String string(String key, String fallback) =>
+      map[key] is StringValue ? (map[key]! as StringValue).value : fallback;
+  final name = string('name', '');
+  if (name.isEmpty) return null;
+  return NetworkEvent(
+    name,
+    to:
+        RpcTarget.values
+            .where((target) => target.name == string('to', ''))
+            .firstOrNull ??
+        RpcTarget.server,
+    delivery: string('delivery', 'reliable') == 'unreliable'
+        ? Delivery.unreliable
+        : Delivery.reliable,
+    requireOwner: switch (map['requireOwner']) {
+      BoolValue(value: final v) => v,
+      _ => true,
+    },
+  );
+}
+
+/// What one end does when an event arrives.
+typedef NetworkEventHandler = void Function(int fromPeerId, String payload);
+
+/// Two events declared with the same name.
+class DuplicateNetworkEvent implements Exception {
+  DuplicateNetworkEvent(this.name);
+
+  final String name;
+
+  @override
+  String toString() =>
+      'flutter_scene_net: two events are declared as "$name". Events are '
+      'matched by name across the two ends, so a name has to mean one thing.';
+}
+
+/// An event nobody declared.
+class UnknownNetworkEvent implements Exception {
+  UnknownNetworkEvent(this.name, this.declared);
+
+  final String name;
+  final List<String> declared;
+
+  @override
+  String toString() =>
+      'flutter_scene_net: no event called "$name" is declared on this object. '
+      'It declares: ${declared.isEmpty ? '(none)' : declared.join(', ')}.';
+}

--- a/packages/flutter_scene_net/lib/src/network_identity.dart
+++ b/packages/flutter_scene_net/lib/src/network_identity.dart
@@ -1,0 +1,339 @@
+/// Marking an object as networked, in the document.
+///
+/// The replication layer underneath can already carry state and calls; what it
+/// could not do was be *authored*. Making an object networked meant writing a
+/// `Replica` subclass, listing its fields by hand, and wiring a builder — three
+/// places in code for something a designer wants to express by dropping a
+/// component on a thing and saying which of its values matter.
+///
+/// [NetworkIdentityComponent] is that component. It names the replica type, so
+/// both ends agree on what this object is, and lists which component properties
+/// replicate. Both ends load the same document, which is what makes the field
+/// order match without either end being told: the wire layout is the list, and
+/// the list is in the file.
+library;
+
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart' show Component, Node;
+
+import 'component_sync.dart';
+import 'network_events.dart';
+import 'network_ownership.dart';
+
+/// Marks a node as replicated, and says what about it replicates.
+///
+/// Nothing here talks to the network. The component is a declaration; a
+/// [ComponentReplica] is built from it when a session is running, and the same
+/// declaration produces the same wire layout on the server and on every client.
+class NetworkIdentityComponent extends Component {
+  /// Creates an identity for replica type [typeKey].
+  NetworkIdentityComponent({
+    this.typeKey = 'entity',
+    List<SyncedProperty> synced = const [],
+    List<NetworkEvent> events = const [],
+    Set<OwnershipPermission> ownership = const {},
+    this.keepOnOwnerLeave = false,
+  }) : synced = List.of(synced),
+       events = List.of(events),
+       ownership = Set.of(ownership);
+
+  /// The replica type both ends look this object up by.
+  ///
+  /// A stable string rather than a runtime type: the type name is minified on
+  /// the web, so a client and a server built differently would disagree about
+  /// what they were even talking about.
+  String typeKey;
+
+  /// Which component properties replicate, in wire order.
+  final List<SyncedProperty> synced;
+
+  /// What may be done with this object's ownership.
+  ///
+  /// Empty means static: nobody takes it, nobody asks for it. That being the
+  /// locked-down case is deliberate — the safe default should be the one you
+  /// get by not thinking about it.
+  final Set<OwnershipPermission> ownership;
+
+  /// Whether the object outlives the client that owned it.
+  ///
+  /// Off by default, because most owned objects *are* that client: their
+  /// character, their cursor, their held item. On is for something they merely
+  /// happened to be holding — a crate mid-flight — which should stay in the
+  /// world and pass to the authority.
+  bool keepOnOwnerLeave;
+
+  /// The events this object can send, in wire order.
+  ///
+  /// The other half of replication. Properties carry what is continuously
+  /// true; events carry what merely happened, which a property would have to
+  /// flicker to record and which you could then miss between two snapshots.
+  final List<NetworkEvent> events;
+
+  /// Builds the replica for [node] from this declaration.
+  ///
+  /// Throws the same refusals [ComponentReplica] does — a property that cannot
+  /// be carried, or one that is not declared — because a document naming a
+  /// property that has since been renamed should fail where someone can see it
+  /// rather than quietly replicate one field fewer than the other end expects.
+  ComponentReplica replicaFor(
+    Node? node, {
+    required FsceneComponentRegistry registry,
+  }) => ComponentReplica(
+    typeKey: typeKey,
+    node: node,
+    properties: synced,
+    registry: registry,
+  );
+}
+
+/// The document form of one replicated property.
+const List<ComponentPropertyDef> syncedPropertyFields = [
+  ComponentPropertyDef(
+    'component',
+    ComponentPropertyKind.string,
+    defaultValue: StringValue(''),
+    doc: 'The component type the property is declared on.',
+  ),
+  ComponentPropertyDef(
+    'property',
+    ComponentPropertyKind.string,
+    defaultValue: StringValue(''),
+    doc: 'The declared property that replicates.',
+  ),
+  ComponentPropertyDef(
+    'authority',
+    ComponentPropertyKind.string,
+    defaultValue: StringValue('server'),
+    options: ['server', 'owner'],
+    doc:
+        'Who may change it. Server unless the owning client is the one that '
+        'decides — a client that can write its own health is a client that '
+        'never dies.',
+  ),
+  ComponentPropertyDef(
+    'readableBy',
+    ComponentPropertyKind.string,
+    defaultValue: StringValue('everyone'),
+    options: ['everyone', 'ownerOnly', 'skipOwner'],
+    doc:
+        'Who receives it. ownerOnly keeps a value private to the player it '
+        'belongs to, and privately for real: the bytes are never sent, so '
+        'there is nothing in another client to read.',
+  ),
+  ComponentPropertyDef(
+    'mode',
+    ComponentPropertyKind.string,
+    defaultValue: StringValue('stream'),
+    options: ['stream', 'onChange', 'spawnOnly'],
+    doc:
+        'How often it goes out. Stream for something that moves; onChange for '
+        'a name or a team, which changes rarely and must not be missed; '
+        'spawnOnly for something fixed at spawn.',
+  ),
+  ComponentPropertyDef(
+    'resolution',
+    ComponentPropertyKind.number,
+    defaultValue: DoubleValue(0),
+    doc:
+        'Quantization step for numbers and vectors, or 0 for full precision. '
+        'A position to the nearest centimetre is indistinguishable on screen '
+        'and a fraction of the bytes.',
+    constraints: [Range.nonNegative()],
+  ),
+];
+
+/// Encodes [property] as the document holds it.
+MapValue encodeSyncedProperty(SyncedProperty property) => MapValue({
+  'component': StringValue(property.componentType),
+  'property': StringValue(property.property),
+  'authority': StringValue(property.authority.name),
+  'readableBy': StringValue(property.readableBy.name),
+  'mode': StringValue(property.mode.name),
+  'resolution': DoubleValue(property.resolution ?? 0),
+});
+
+/// Decodes one replicated property, or null when it names nothing.
+///
+/// A row with no component or no property is a half-filled row in the
+/// inspector, which is what one looks like the moment it is added. Dropping it
+/// is better than refusing to load the scene around it.
+SyncedProperty? decodeSyncedProperty(PropertyValue? value) {
+  if (value is! MapValue) return null;
+  final map = value.values;
+  String string(String key) =>
+      map[key] is StringValue ? (map[key]! as StringValue).value : '';
+  final component = string('component');
+  final property = string('property');
+  if (component.isEmpty || property.isEmpty) return null;
+  final resolution = switch (map['resolution']) {
+    DoubleValue(value: final v) => v,
+    IntValue(value: final v) => v.toDouble(),
+    _ => 0.0,
+  };
+  return SyncedProperty(
+    component,
+    property,
+    authority: string('authority') == 'owner'
+        ? Authority.owner
+        : Authority.server,
+    readableBy: switch (string('readableBy')) {
+      'ownerOnly' => ReadScope.ownerOnly,
+      'skipOwner' => ReadScope.skipOwner,
+      // Anything unrecognized reads as everyone, which is the default and the
+      // one that cannot accidentally hide state a client needs to draw.
+      _ => ReadScope.everyone,
+    },
+    mode: switch (string('mode')) {
+      'onChange' => SendMode.onChange,
+      'spawnOnly' => SendMode.spawnOnly,
+      _ => SendMode.stream,
+    },
+    resolution: resolution > 0 ? resolution : null,
+  );
+}
+
+/// Codec for [NetworkIdentityComponent] (`networkIdentity`).
+class NetworkIdentityCodec
+    extends DeclarativeComponentCodec<NetworkIdentityComponent> {
+  @override
+  String get type => 'networkIdentity';
+
+  @override
+  String? get category => 'Networking';
+
+  @override
+  ComponentSchema get schema => ComponentSchema(
+    type,
+    category: category,
+    icon: 'network',
+    properties: propertySchema,
+  );
+
+  @override
+  List<ComponentField<NetworkIdentityComponent>> get fields => [
+    ComponentField.string(
+      'typeKey',
+      defaultValue: 'entity',
+      doc:
+          'The replica type both ends look this object up by. It has to match '
+          'across the server and every client, so it is a string in the '
+          'document rather than a Dart type name, which the web build '
+          'minifies.',
+      get: (c) => c.typeKey,
+      set: (c, v) => c.typeKey = v,
+    ),
+    ComponentField(
+      ComponentPropertyDef(
+        'synced',
+        ComponentPropertyKind.list,
+        // An empty list, so an identity nobody has configured serializes as
+        // nothing at all, the way every other component does.
+        defaultValue: ListValue(const []),
+        itemDef: const ComponentPropertyDef(
+          'property',
+          ComponentPropertyKind.object,
+          objectFields: syncedPropertyFields,
+        ),
+        doc:
+            'Which component properties replicate. The order is the wire '
+            'order on both ends, which is why it lives in the document: both '
+            'ends load the same list.',
+      ),
+      read: (c, _) =>
+          ListValue([for (final p in c.synced) encodeSyncedProperty(p)]),
+      write: (c, value, _) {
+        if (value is! ListValue) return;
+        c.synced
+          ..clear()
+          ..addAll([
+            for (final entry in value.values)
+              if (decodeSyncedProperty(entry) case final property?) property,
+          ]);
+      },
+    ),
+    ComponentField(
+      const ComponentPropertyDef(
+        'ownership',
+        ComponentPropertyKind.string,
+        defaultValue: StringValue(''),
+        doc:
+            'What may be done with this object\'s ownership, as a '
+            'comma-separated set of distributable, transferable, '
+            'requestRequired and sessionOwner. Empty is static: nobody takes '
+            'it and nobody asks.',
+      ),
+      read: (c, _) => StringValue(encodeOwnership(c.ownership)),
+      write: (c, value, _) {
+        if (value is! StringValue) return;
+        c.ownership
+          ..clear()
+          ..addAll(decodeOwnership(value.value));
+      },
+    ),
+    ComponentField.boolean(
+      'keepOnOwnerLeave',
+      defaultValue: false,
+      doc:
+          'Whether the object outlives the client that owned it, passing to '
+          'the authority instead of being removed with them.',
+      get: (c) => c.keepOnOwnerLeave,
+      set: (c, v) => c.keepOnOwnerLeave = v,
+    ),
+    ComponentField(
+      ComponentPropertyDef(
+        'events',
+        ComponentPropertyKind.list,
+        defaultValue: ListValue(const []),
+        itemDef: const ComponentPropertyDef(
+          'event',
+          ComponentPropertyKind.object,
+          objectFields: networkEventFields,
+        ),
+        doc:
+            'The events this object can send. Properties carry what is '
+            'continuously true; events carry what happened once.',
+      ),
+      read: (c, _) =>
+          ListValue([for (final e in c.events) encodeNetworkEvent(e)]),
+      write: (c, value, _) {
+        if (value is! ListValue) return;
+        c.events
+          ..clear()
+          ..addAll([
+            for (final entry in value.values)
+              if (decodeNetworkEvent(entry) case final event?) event,
+          ]);
+      },
+    ),
+  ];
+
+  @override
+  NetworkIdentityComponent create(PropertyReader props) =>
+      NetworkIdentityComponent(typeKey: props.string('typeKey'));
+}
+
+/// The document form of an ownership permission set.
+///
+/// A comma-separated list rather than four booleans, because it reads as one
+/// decision — what may be done with this — and because an empty string is a
+/// clearer "nothing" than four unchecked boxes.
+String encodeOwnership(Set<OwnershipPermission> permissions) => [
+  // Written in enum order, so the same set always produces the same string
+  // and a document does not churn on save.
+  for (final permission in OwnershipPermission.values)
+    if (permissions.contains(permission)) permission.name,
+].join(',');
+
+/// Reads a permission set written by [encodeOwnership].
+///
+/// Unknown names are skipped rather than refused: a document from a newer
+/// build should lose the permission it names, not the whole object.
+Set<OwnershipPermission> decodeOwnership(String encoded) => {
+  for (final name in encoded.split(','))
+    if (OwnershipPermission.values
+            .where((permission) => permission.name == name.trim())
+            .firstOrNull
+        case final permission?)
+      permission,
+};

--- a/packages/flutter_scene_net/lib/src/network_ownership.dart
+++ b/packages/flutter_scene_net/lib/src/network_ownership.dart
@@ -1,0 +1,250 @@
+/// Who owns a networked object, and what may be done about it.
+///
+/// Ownership is not just bookkeeping: it decides who may write the properties
+/// marked owner-writable and who may send the events marked owner-only. So the
+/// rules for changing it are a security surface, and every refusal below is a
+/// rule rather than an inconvenience.
+///
+/// An object declares what is *allowed*, not what happens. A crate that anyone
+/// may pick up says so; a player's own character says nothing, and is therefore
+/// static — nobody takes it, nobody asks for it, and it stays where the session
+/// put it. Saying nothing being the locked-down case is deliberate: the safe
+/// default should be the one you get by not thinking about it.
+library;
+
+/// What an object permits to be done with its ownership.
+///
+/// A set rather than one value, because these compose: a crate can be both
+/// takeable by anyone and redistributed when its owner leaves, and those are
+/// different questions.
+enum OwnershipPermission {
+  /// The session may hand it to someone else on its own when a client joins or
+  /// leaves.
+  ///
+  /// For objects that need *an* owner but not a particular one: a physics prop
+  /// that somebody has to simulate.
+  distributable,
+
+  /// Any client may take it outright, without asking.
+  ///
+  /// For things where the contest is the point and the loser finding out a
+  /// moment later is fine: a dropped weapon, a control point.
+  transferable,
+
+  /// A client must ask the current owner, who may refuse.
+  ///
+  /// For things where being interrupted matters — a vehicle someone is
+  /// driving, a turret someone is firing.
+  requestRequired,
+
+  /// Only whoever owns the session may hold it.
+  ///
+  /// For objects that *are* the session: the match state, the round timer.
+  sessionOwner,
+}
+
+/// Why an attempt to take or grant ownership was refused.
+enum OwnershipRefusal {
+  /// The object is locked by its owner.
+  locked,
+
+  /// The object permits no transfer at all.
+  notTransferable,
+
+  /// It must be asked for rather than taken.
+  requestRequired,
+
+  /// Somebody is already asking, and is entitled to an answer first.
+  requestPending,
+
+  /// Only the session owner may hold it.
+  sessionOwnerOnly,
+
+  /// The asker already owns it.
+  alreadyOwner,
+
+  /// The session is not the authority, so it does not get to decide.
+  notAuthority,
+}
+
+/// What a refusal should say to whoever hit it.
+String ownershipRefusalMessage(OwnershipRefusal refusal) => switch (refusal) {
+  OwnershipRefusal.locked =>
+    'Its owner has locked it, so it cannot change hands until they unlock it.',
+  OwnershipRefusal.notTransferable =>
+    'It does not permit its ownership to change. Mark it transferable or '
+        'requestRequired if it should.',
+  OwnershipRefusal.requestRequired =>
+    'It has to be asked for rather than taken. Send a request instead.',
+  OwnershipRefusal.requestPending =>
+    'Somebody is already asking for it, and is owed an answer first.',
+  OwnershipRefusal.sessionOwnerOnly => 'Only the session owner may hold it.',
+  OwnershipRefusal.alreadyOwner => 'It is already theirs.',
+  OwnershipRefusal.notAuthority => 'Only the authority decides who owns what.',
+};
+
+/// The result of trying to change ownership.
+class OwnershipOutcome {
+  const OwnershipOutcome._(this.granted, this.refusal, this.owner);
+
+  /// It changed hands (or, for a request, the request was sent).
+  const OwnershipOutcome.granted(int owner) : this._(true, null, owner);
+
+  /// It did not, for [refusal].
+  const OwnershipOutcome.refused(OwnershipRefusal refusal, int owner)
+    : this._(false, refusal, owner);
+
+  /// Whether the attempt succeeded.
+  final bool granted;
+
+  /// Why not, when it did not.
+  final OwnershipRefusal? refusal;
+
+  /// Who owns the object now, either way.
+  final int owner;
+
+  /// What to show whoever tried.
+  String get message =>
+      granted ? 'Owned by $owner.' : ownershipRefusalMessage(refusal!);
+
+  @override
+  String toString() => granted
+      ? 'OwnershipOutcome.granted($owner)'
+      : 'OwnershipOutcome.refused(${refusal!.name})';
+}
+
+/// One object's ownership, and the rules it plays by.
+///
+/// Pure state and pure decisions. Nothing here sends anything: the authority
+/// runs these and then tells everyone, which is the only order that works —
+/// deciding on a client and announcing it is how two clients end up each
+/// believing they own the same crate.
+class Ownership {
+  Ownership({
+    required this.owner,
+    Set<OwnershipPermission> permissions = const {},
+    this.locked = false,
+  }) : permissions = Set.unmodifiable(permissions);
+
+  /// The peer that owns it. The server is peer 1.
+  int owner;
+
+  /// What is permitted. Empty means static: nobody takes it, nobody asks.
+  final Set<OwnershipPermission> permissions;
+
+  /// Whether the owner has pinned it in place.
+  ///
+  /// A lock outranks every permission, including [OwnershipPermission
+  /// .transferable]: it is the owner saying "not right now" about a thing that
+  /// is normally free to take, which is what you want while driving the car
+  /// everyone else may drive.
+  bool locked;
+
+  int? _pendingFrom;
+
+  /// Who is currently asking, or null.
+  int? get pendingRequestFrom => _pendingFrom;
+
+  /// Whether anybody may hold this but the session owner.
+  bool get isSessionOwnerOnly =>
+      permissions.contains(OwnershipPermission.sessionOwner);
+
+  /// Whether the session may reassign it on its own.
+  bool get isDistributable =>
+      permissions.contains(OwnershipPermission.distributable);
+
+  /// Hands it to [peerId] outright.
+  ///
+  /// [sessionOwner] is who currently owns the session, needed only to enforce
+  /// [OwnershipPermission.sessionOwner]. [force] is the authority overriding
+  /// the rules — used when a client leaves and the object has to go somewhere,
+  /// which is not a transfer anybody asked for.
+  OwnershipOutcome give(int peerId, {int? sessionOwner, bool force = false}) {
+    if (force) {
+      _pendingFrom = null;
+      owner = peerId;
+      return OwnershipOutcome.granted(owner);
+    }
+    if (peerId == owner) {
+      return OwnershipOutcome.refused(OwnershipRefusal.alreadyOwner, owner);
+    }
+    if (isSessionOwnerOnly && peerId != sessionOwner) {
+      return OwnershipOutcome.refused(OwnershipRefusal.sessionOwnerOnly, owner);
+    }
+    if (locked) {
+      return OwnershipOutcome.refused(OwnershipRefusal.locked, owner);
+    }
+    if (_pendingFrom != null && _pendingFrom != peerId) {
+      return OwnershipOutcome.refused(OwnershipRefusal.requestPending, owner);
+    }
+    if (!permissions.contains(OwnershipPermission.transferable)) {
+      // Asking is still open if the object allows it: a refusal that names the
+      // way forward beats one that just says no.
+      return OwnershipOutcome.refused(
+        permissions.contains(OwnershipPermission.requestRequired)
+            ? OwnershipRefusal.requestRequired
+            : OwnershipRefusal.notTransferable,
+        owner,
+      );
+    }
+    _pendingFrom = null;
+    owner = peerId;
+    return OwnershipOutcome.granted(owner);
+  }
+
+  /// Asks the current owner for it on [peerId]'s behalf.
+  ///
+  /// Succeeding here means the request was *sent*, not that it was granted;
+  /// the owner answers with [answerRequest].
+  OwnershipOutcome request(int peerId, {int? sessionOwner}) {
+    if (peerId == owner) {
+      return OwnershipOutcome.refused(OwnershipRefusal.alreadyOwner, owner);
+    }
+    if (isSessionOwnerOnly && peerId != sessionOwner) {
+      return OwnershipOutcome.refused(OwnershipRefusal.sessionOwnerOnly, owner);
+    }
+    if (locked) {
+      return OwnershipOutcome.refused(OwnershipRefusal.locked, owner);
+    }
+    if (!permissions.contains(OwnershipPermission.requestRequired)) {
+      // Either it is free to take, in which case asking is the wrong verb, or
+      // it is static. Both are worth saying differently.
+      return OwnershipOutcome.refused(
+        permissions.contains(OwnershipPermission.transferable)
+            ? OwnershipRefusal.alreadyOwner
+            : OwnershipRefusal.notTransferable,
+        owner,
+      );
+    }
+    if (_pendingFrom != null) {
+      return OwnershipOutcome.refused(OwnershipRefusal.requestPending, owner);
+    }
+    _pendingFrom = peerId;
+    return OwnershipOutcome.granted(owner);
+  }
+
+  /// The owner's answer to the pending request.
+  ///
+  /// Granting locks the object, because an object that had to be asked for is
+  /// one where being interrupted matters — handing it over and leaving it
+  /// free for the next taker defeats the point of having asked.
+  OwnershipOutcome answerRequest({required bool approve}) {
+    final asker = _pendingFrom;
+    if (asker == null) {
+      return OwnershipOutcome.refused(OwnershipRefusal.notTransferable, owner);
+    }
+    _pendingFrom = null;
+    if (!approve) {
+      return OwnershipOutcome.refused(OwnershipRefusal.locked, owner);
+    }
+    owner = asker;
+    locked = true;
+    return OwnershipOutcome.granted(owner);
+  }
+
+  /// Withdraws a pending request, for an asker who left or changed their mind.
+  void cancelRequest() => _pendingFrom = null;
+
+  /// Pins it in place, or releases it.
+  void setLocked(bool value) => locked = value;
+}

--- a/packages/flutter_scene_net/lib/src/network_prefabs.dart
+++ b/packages/flutter_scene_net/lib/src/network_prefabs.dart
@@ -1,0 +1,180 @@
+/// The spawn table: what the server can spawn, and what a client builds when
+/// it does.
+///
+/// A replicated object has two halves that have to agree. The server decides
+/// one exists and sends its type key and its fields; the client has to know
+/// what that type key means — which node to build, and which of its properties
+/// the incoming fields are. Both halves come from the same
+/// [NetworkIdentityComponent] declaration, which is the point: the wire layout
+/// is not written twice, so it cannot disagree with itself.
+///
+/// dashwire checks that for real. A registry hashes every registered type's
+/// field names, codecs, send modes and authority, and the two ends exchange
+/// that hash at handshake. A server and a client that loaded different versions
+/// of the document are refused at connect, rather than agreeing to run and
+/// reading each other's fields as the wrong ones.
+library;
+
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart' show Node;
+
+import 'component_sync.dart';
+import 'network_events.dart';
+import 'network_ownership.dart';
+import 'network_identity.dart';
+
+/// Builds the scene node for a spawned replica of one type.
+typedef NetworkNodeBuilder = Node Function();
+
+/// One spawnable type: what it is called on the wire, what replicates, and
+/// what to build when one appears.
+class NetworkPrefab {
+  /// Declares a prefab that replicates [synced] and builds nodes with [build].
+  const NetworkPrefab({
+    required this.typeKey,
+    required this.synced,
+    required this.build,
+    this.events = const [],
+    this.ownership = const {},
+    this.keepOnOwnerLeave = false,
+  });
+
+  /// Declares a prefab from an authored [identity].
+  ///
+  /// The identity is usually the one on the prefab's own root node, so what
+  /// the designer marked as replicated is exactly what goes over the wire.
+  factory NetworkPrefab.of(
+    NetworkIdentityComponent identity, {
+    required NetworkNodeBuilder build,
+  }) => NetworkPrefab(
+    typeKey: identity.typeKey,
+    synced: List.unmodifiable(identity.synced),
+    build: build,
+  );
+
+  /// The type key both ends look this up by.
+  final String typeKey;
+
+  /// What replicates, in wire order.
+  final List<SyncedProperty> synced;
+
+  /// The events it can send, in wire order.
+  final List<NetworkEvent> events;
+
+  /// What may be done with its ownership.
+  final Set<OwnershipPermission> ownership;
+
+  /// Whether it outlives the client that owned it.
+  final bool keepOnOwnerLeave;
+
+  /// Builds the node a spawn of this type becomes.
+  final NetworkNodeBuilder build;
+}
+
+/// Two prefabs claiming the same type key.
+class DuplicateNetworkPrefab implements Exception {
+  DuplicateNetworkPrefab(this.typeKey);
+
+  final String typeKey;
+
+  @override
+  String toString() =>
+      'flutter_scene_net: two prefabs are registered as "$typeKey". A type key '
+      'is how the two ends agree what a spawn is, so it has to name exactly '
+      'one thing.';
+}
+
+/// The spawn table, ready to hand to a replication client or a host.
+///
+/// Registering here does two things at once, and they have to stay in step: it
+/// teaches the [ReplicaRegistry] how to build a replica of each type, and it
+/// produces the [builders] map that turns one into a scene node. Doing both
+/// from one prefab list is what keeps them in step.
+class NetworkPrefabs {
+  /// Builds a table from [prefabs], resolving their properties through
+  /// [registry].
+  ///
+  /// Every prefab is validated as it is added — a property that cannot be
+  /// carried, or one its component does not declare, throws here rather than
+  /// at the first spawn. A spawn table is built at startup and a spawn happens
+  /// mid-match; the first is a much better place to find out.
+  NetworkPrefabs({
+    required List<NetworkPrefab> prefabs,
+    required FsceneComponentRegistry registry,
+  }) : _registry = registry {
+    for (final prefab in prefabs) {
+      if (_prefabs.containsKey(prefab.typeKey)) {
+        throw DuplicateNetworkPrefab(prefab.typeKey);
+      }
+      // Built and thrown away: this is the validation, and it is why a bad
+      // declaration surfaces at startup.
+      _replicaFor(prefab);
+      _prefabs[prefab.typeKey] = prefab;
+    }
+  }
+
+  final FsceneComponentRegistry _registry;
+  final Map<String, NetworkPrefab> _prefabs = {};
+
+  /// The registered type keys.
+  Iterable<String> get typeKeys => _prefabs.keys;
+
+  /// The prefab for [typeKey], or null.
+  NetworkPrefab? prefabFor(String typeKey) => _prefabs[typeKey];
+
+  /// A fresh unbound replica for [typeKey], or null when nothing registers it.
+  ///
+  /// The server side of a spawn: it builds the replica itself rather than
+  /// receiving one, and binds it to the node it spawned from.
+  ComponentReplica? replicaFor(String typeKey) {
+    final prefab = _prefabs[typeKey];
+    return prefab == null ? null : _replicaFor(prefab);
+  }
+
+  ComponentReplica _replicaFor(NetworkPrefab prefab) => ComponentReplica(
+    typeKey: prefab.typeKey,
+    properties: prefab.synced,
+    events: prefab.events,
+    registry: _registry,
+  );
+
+  /// Registers every prefab's replica factory into [into].
+  ///
+  /// The factory produces an unbound replica: fully declared, with nowhere to
+  /// read from yet. A client binds it to a node when the spawn arrives; a
+  /// server binds it to the node it spawned from.
+  void registerInto(ReplicaRegistry into) {
+    for (final prefab in _prefabs.values) {
+      into.register(() => _replicaFor(prefab));
+    }
+  }
+
+  /// A fresh registry holding every prefab.
+  ReplicaRegistry toRegistry() {
+    final registry = ReplicaRegistry();
+    registerInto(registry);
+    return registry;
+  }
+
+  /// Builds the node for a spawned [replica] and binds the two together.
+  ///
+  /// Returns null for a replica this table does not know, which is what a
+  /// client sees when the server spawns something a stale build has never
+  /// heard of. Nothing is built for it rather than something wrong being.
+  Node? spawn(Replica replica) {
+    final prefab = _prefabs[replica.typeKey];
+    if (prefab == null) return null;
+    final node = prefab.build();
+    if (replica is ComponentReplica) {
+      replica.spawnInto(node);
+    }
+    return node;
+  }
+
+  /// The node builders [SceneReplication] takes, one per registered type.
+  Map<String, Node Function(Replica)> get builders => {
+    for (final entry in _prefabs.entries)
+      entry.key: (replica) => spawn(replica) ?? entry.value.build(),
+  };
+}

--- a/packages/flutter_scene_net/lib/src/network_session.dart
+++ b/packages/flutter_scene_net/lib/src/network_session.dart
@@ -1,0 +1,374 @@
+/// Starting, joining and running a session.
+///
+/// Three ways in, and the difference between them is only who is authoritative
+/// and who is looking:
+///
+///  * **Host** — this machine runs the simulation *and* plays. One process,
+///    no round trip for the local player, and the cheapest thing to test with.
+///  * **Server** — runs the simulation and nobody plays on it. What a
+///    dedicated server is, and the only shape where the authority cannot also
+///    be a cheat.
+///  * **Client** — plays, and believes what it is told.
+///
+/// A host is a server with a player attached, which is why they share
+/// everything below except that one fact.
+///
+/// **Approval happens before anything is spawned.** A connection is a stranger
+/// until the game says otherwise: wrong build, wrong password, server full,
+/// banned. Deciding after spawning would mean un-spawning, and un-spawning is
+/// where the half-joined states live.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_scene/scene.dart' show Node;
+
+import 'component_sync.dart';
+import 'network_ownership.dart';
+import 'network_prefabs.dart';
+
+/// The peer id the server holds. Peer numbering starts at the authority.
+const int serverPeerId = 1;
+
+/// Which end of a session this process is.
+enum NetworkRole {
+  /// Simulates and plays.
+  host,
+
+  /// Simulates and does not play.
+  server,
+
+  /// Plays and believes what it is told.
+  client;
+
+  /// Whether this end decides what is true.
+  bool get isAuthority => this != NetworkRole.client;
+
+  /// Whether a player is spawned for this process itself.
+  bool get hasLocalPlayer => this != NetworkRole.server;
+}
+
+/// What the game decides about one connection attempt.
+class ConnectionApproval {
+  const ConnectionApproval._({
+    required this.approved,
+    this.reason = '',
+    this.spawnPlayer = true,
+    this.playerType,
+  });
+
+  /// Let them in.
+  ///
+  /// [playerType] names the prefab to spawn for them, or null for the
+  /// session's default; [spawnPlayer] false lets someone in as a spectator.
+  const ConnectionApproval.approve({
+    bool spawnPlayer = true,
+    String? playerType,
+  }) : this._(approved: true, spawnPlayer: spawnPlayer, playerType: playerType);
+
+  /// Turn them away, saying why.
+  ///
+  /// The reason is required rather than optional: a refusal with no reason
+  /// gives the player nothing to act on, and "could not connect" is the
+  /// least useful sentence in multiplayer.
+  const ConnectionApproval.reject(String reason)
+    : this._(approved: false, reason: reason, spawnPlayer: false);
+
+  /// Whether the connection is allowed.
+  final bool approved;
+
+  /// Why it was refused, shown to whoever was refused.
+  final String reason;
+
+  /// Whether to spawn a player for them.
+  final bool spawnPlayer;
+
+  /// Which prefab to spawn, or null for the session's default.
+  final String? playerType;
+}
+
+/// Decides whether a connection may join, given whatever it presented.
+///
+/// Given the raw payload the connecting end sent — a build id, a password, a
+/// ticket — because what counts as a valid one is a game's business, not this
+/// layer's.
+typedef ConnectionApprover =
+    FutureOr<ConnectionApproval> Function(String payload);
+
+/// One connected peer, and what was spawned for it.
+class NetworkClient {
+  NetworkClient({
+    required this.peerId,
+    this.player,
+    this.replica,
+    Ownership? ownership,
+    this.keepOnOwnerLeave = false,
+  }) : ownership = ownership ?? Ownership(owner: peerId);
+
+  /// The peer's id. The server itself is peer 1, as dashwire numbers them.
+  final int peerId;
+
+  /// The node spawned for this peer, or null for a spectator.
+  final Node? player;
+
+  /// The replica driving that node.
+  final ComponentReplica? replica;
+
+  /// Who owns the spawned object, and what may be done about it.
+  final Ownership ownership;
+
+  /// Whether the object outlives this client.
+  final bool keepOnOwnerLeave;
+}
+
+/// Two sessions started at once, or one started twice.
+class SessionAlreadyRunning implements Exception {
+  @override
+  String toString() =>
+      'flutter_scene_net: this session is already running. Stop it before '
+      'starting another -- two sessions in one process would both claim to be '
+      'authoritative, and the scene can only be one of them.';
+}
+
+/// A player prefab that is not in the spawn table.
+class UnknownPlayerPrefab implements Exception {
+  UnknownPlayerPrefab(this.typeKey, this.known);
+
+  final String typeKey;
+  final List<String> known;
+
+  @override
+  String toString() =>
+      'flutter_scene_net: the player prefab "$typeKey" is not in the spawn '
+      'table, so a joining client would be let in and given nothing to play. '
+      'The table holds: ${known.isEmpty ? '(nothing)' : known.join(', ')}.';
+}
+
+/// The session: what is running, who is connected, and what they are playing.
+///
+/// Deliberately transport-free. Everything here is the decision-making — who
+/// may join, what gets spawned for them, what is cleaned up when they go — and
+/// none of it needs a socket to be true or to be tested. The transport plugs
+/// into [admit] and [drop].
+class NetworkSession {
+  /// Creates a session in [role] that spawns [playerPrefab] for each player.
+  ///
+  /// The player prefab is checked against the spawn table now rather than at
+  /// the first join: letting someone in and then having nothing to give them
+  /// is a worse failure, and it happens to the player rather than the
+  /// developer.
+  NetworkSession({
+    required this.role,
+    required this.prefabs,
+    required this.playerPrefab,
+    this.approve,
+  }) {
+    if (prefabs.prefabFor(playerPrefab) == null) {
+      throw UnknownPlayerPrefab(playerPrefab, prefabs.typeKeys.toList());
+    }
+  }
+
+  /// Which end this is.
+  final NetworkRole role;
+
+  /// What this session can spawn.
+  final NetworkPrefabs prefabs;
+
+  /// The prefab spawned for a joining player.
+  final String playerPrefab;
+
+  /// The game's say on who may join, or null to admit everyone.
+  ///
+  /// Null means an open session, which is the right default for a game being
+  /// built and the wrong one for a game being played. Saying so here is
+  /// better than a silent allow-list nobody knows to fill in.
+  final ConnectionApprover? approve;
+
+  final Map<int, NetworkClient> _clients = {};
+  bool _running = false;
+
+  /// Whether the session has been started.
+  bool get isRunning => _running;
+
+  /// Everyone connected, including the host's own player.
+  Iterable<NetworkClient> get clients => _clients.values;
+
+  /// The peer ids connected.
+  Iterable<int> get peerIds => _clients.keys;
+
+  /// The client for [peerId], or null.
+  NetworkClient? clientFor(int peerId) => _clients[peerId];
+
+  /// Whether this end decides what is true.
+  bool get isAuthority => role.isAuthority;
+
+  /// The peer that owns the session itself. The authority, by default.
+  ///
+  /// Separate from "the server" because they need not be the same in every
+  /// topology: a session can be hosted by one machine and run by another.
+  int sessionOwner = serverPeerId;
+
+  /// Whether [peerId] owns the object spawned for [ownerOf].
+  bool ownsObjectOf(int peerId, int ownerOf) =>
+      _clients[ownerOf]?.ownership.owner == peerId;
+
+  /// Called after a player is spawned, for whatever the game wants to do with
+  /// it — parent it, position it, hand it an input source.
+  void Function(NetworkClient client)? onPlayerSpawned;
+
+  /// Called before a player is removed.
+  void Function(NetworkClient client)? onPlayerDespawned;
+
+  /// Starts the session.
+  void start() {
+    if (_running) throw SessionAlreadyRunning();
+    _running = true;
+  }
+
+  /// Stops it, dropping everyone.
+  ///
+  /// Everyone including the host's own player: leaving it behind would leave a
+  /// node in the scene that nothing owns and no snapshot will ever update
+  /// again.
+  void stop() {
+    for (final peerId in _clients.keys.toList()) {
+      drop(peerId);
+    }
+    _running = false;
+  }
+
+  /// Asks the game whether [payload] may join.
+  ///
+  /// Only the authority answers this. A client asking itself whether someone
+  /// else may join is a client deciding something it does not get to decide.
+  Future<ConnectionApproval> vet(String payload) async {
+    if (!isAuthority) {
+      return const ConnectionApproval.reject(
+        'Only the server decides who may join.',
+      );
+    }
+    if (!_running) {
+      return const ConnectionApproval.reject('The session is not running.');
+    }
+    final approver = approve;
+    if (approver == null) return const ConnectionApproval.approve();
+    return approver(payload);
+  }
+
+  /// Admits [peerId] under [approval], spawning their player.
+  ///
+  /// Returns the client, or null when the approval was a refusal. Admitting
+  /// the same peer twice returns the client it already has rather than
+  /// spawning a second player for them.
+  NetworkClient? admit(int peerId, ConnectionApproval approval) {
+    if (!approval.approved) return null;
+    final existing = _clients[peerId];
+    if (existing != null) return existing;
+
+    if (!approval.spawnPlayer) {
+      // A spectator: connected, counted, and given nothing to drive.
+      return _clients[peerId] = NetworkClient(peerId: peerId);
+    }
+
+    final typeKey = approval.playerType ?? playerPrefab;
+    final prefab = prefabs.prefabFor(typeKey);
+    if (prefab == null) {
+      throw UnknownPlayerPrefab(typeKey, prefabs.typeKeys.toList());
+    }
+    final replica = prefabs.replicaFor(typeKey)!..owner = peerId;
+    final player = prefabs.spawn(replica);
+    final client = NetworkClient(
+      peerId: peerId,
+      player: player,
+      replica: replica,
+      ownership: Ownership(owner: peerId, permissions: prefab.ownership),
+      keepOnOwnerLeave: prefab.keepOnOwnerLeave,
+    );
+    _clients[peerId] = client;
+    onPlayerSpawned?.call(client);
+    return client;
+  }
+
+  /// Hands the object spawned for [objectOf] to [peerId].
+  ///
+  /// Only the authority may: deciding on a client and announcing it is how two
+  /// clients end up each believing they own the same crate.
+  OwnershipOutcome giveOwnership(int objectOf, int peerId) {
+    final client = _clients[objectOf];
+    if (client == null) {
+      return const OwnershipOutcome.refused(
+        OwnershipRefusal.notTransferable,
+        serverPeerId,
+      );
+    }
+    if (!isAuthority) {
+      return OwnershipOutcome.refused(
+        OwnershipRefusal.notAuthority,
+        client.ownership.owner,
+      );
+    }
+    final outcome = client.ownership.give(peerId, sessionOwner: sessionOwner);
+    if (outcome.granted) client.replica?.owner = peerId;
+    return outcome;
+  }
+
+  /// Asks the owner of [objectOf]'s object to hand it to [peerId].
+  OwnershipOutcome requestOwnership(int objectOf, int peerId) {
+    final client = _clients[objectOf];
+    if (client == null) {
+      return const OwnershipOutcome.refused(
+        OwnershipRefusal.notTransferable,
+        serverPeerId,
+      );
+    }
+    return client.ownership.request(peerId, sessionOwner: sessionOwner);
+  }
+
+  /// The owner's answer to a pending request on [objectOf]'s object.
+  OwnershipOutcome answerOwnershipRequest(
+    int objectOf, {
+    required bool approve,
+  }) {
+    final client = _clients[objectOf];
+    if (client == null) {
+      return const OwnershipOutcome.refused(
+        OwnershipRefusal.notTransferable,
+        serverPeerId,
+      );
+    }
+    final outcome = client.ownership.answerRequest(approve: approve);
+    if (outcome.granted) client.replica?.owner = outcome.owner;
+    return outcome;
+  }
+
+  /// Removes [peerId] and whatever was spawned for them.
+  ///
+  /// Detaches the node from the scene as well as forgetting it: a player that
+  /// left and whose body stayed is the bug people report as ghosts.
+  void drop(int peerId) {
+    final client = _clients.remove(peerId);
+    if (client == null) return;
+
+    // An object somebody merely happened to be holding stays in the world and
+    // passes to the authority; an object that *was* them goes with them. Most
+    // owned objects are the second kind -- their character, their cursor --
+    // which is why keeping it is the opt-in.
+    if (client.keepOnOwnerLeave && client.player != null) {
+      client.ownership.give(sessionOwner, force: true);
+      client.replica?.owner = sessionOwner;
+      onOwnerLeft?.call(client);
+      return;
+    }
+
+    onPlayerDespawned?.call(client);
+    client.replica?.unbind();
+    client.player?.detach();
+  }
+
+  /// Called when an object outlived the client that owned it.
+  ///
+  /// It is still in the scene and now belongs to the authority, which is a
+  /// different event from a despawn and wants a different reaction: a dropped
+  /// weapon should probably keep falling, not vanish.
+  void Function(NetworkClient client)? onOwnerLeft;
+}

--- a/packages/flutter_scene_net/lib/src/network_time.dart
+++ b/packages/flutter_scene_net/lib/src/network_time.dart
@@ -1,0 +1,111 @@
+/// Network time: the tick both ends count in.
+///
+/// A networked game does not run on wall-clock time, it runs on ticks. The
+/// authority simulates one step per tick and stamps what it sends; a client
+/// applies what it receives against the tick it was stamped with. Everything
+/// that has to agree across machines — when a shot was fired, which snapshot a
+/// prediction is reconciling against — is expressed in ticks, because two
+/// machines can agree on a tick number and cannot agree on a clock.
+///
+/// Two times, and the gap between them is the point. **Local time** is where
+/// this machine's simulation has got to. **Server time** is where the
+/// authority had got to when the last thing you heard from it was sent, which
+/// on a client is always slightly in the past. Rendering a remote object at
+/// local time shows it somewhere it has not been told to be yet; rendering it
+/// at server time is what interpolation is for.
+library;
+
+/// A point in a session's time, counted in ticks.
+class NetworkTime {
+  const NetworkTime({required this.tick, required this.tickRate})
+    : assert(tickRate > 0, 'A session ticks at a positive rate.');
+
+  /// The tick number.
+  final int tick;
+
+  /// Ticks per second.
+  final int tickRate;
+
+  /// Seconds one tick covers.
+  double get fixedDelta => 1 / tickRate;
+
+  /// Seconds since the session started, as of this tick.
+  ///
+  /// Derived rather than measured, so it is the same number on every machine
+  /// that has reached this tick. A measured clock would not be.
+  double get seconds => tick / tickRate;
+
+  /// This time [ticks] later.
+  NetworkTime operator +(int ticks) =>
+      NetworkTime(tick: tick + ticks, tickRate: tickRate);
+
+  /// How far ahead of [other] this is, in ticks.
+  ///
+  /// Signed, and negative is the normal case when comparing a client's view of
+  /// server time against its own: the authority's last word is always a little
+  /// behind where the client has simulated to.
+  int ticksAhead(NetworkTime other) => tick - other.tick;
+
+  /// How far ahead of [other] this is, in seconds.
+  double secondsAhead(NetworkTime other) => ticksAhead(other) / tickRate;
+
+  @override
+  String toString() => 'NetworkTime(tick: $tick, ${seconds}s @${tickRate}Hz)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is NetworkTime && other.tick == tick && other.tickRate == tickRate;
+
+  @override
+  int get hashCode => Object.hash(tick, tickRate);
+}
+
+/// The two clocks a session runs on, and the lag between them.
+class NetworkClock {
+  NetworkClock({required this.tickRate})
+    : assert(tickRate > 0, 'A session ticks at a positive rate.');
+
+  /// Ticks per second, fixed for the session.
+  ///
+  /// Fixed because it is part of what the two ends agreed on: a client
+  /// counting at a different rate would be reading every stamp wrong.
+  final int tickRate;
+
+  int _localTick = 0;
+  int _serverTick = 0;
+
+  /// Where this machine's simulation has got to.
+  NetworkTime get local => NetworkTime(tick: _localTick, tickRate: tickRate);
+
+  /// Where the authority had got to when it last spoke.
+  NetworkTime get server => NetworkTime(tick: _serverTick, tickRate: tickRate);
+
+  /// How far behind the authority's last word is, in seconds.
+  ///
+  /// Roughly half the round trip plus the send interval, and the number to
+  /// look at when a game feels laggy — it is what a remote object is rendered
+  /// behind by.
+  double get lag => local.secondsAhead(server);
+
+  /// Advances the local simulation by one tick.
+  void advance() => _localTick++;
+
+  /// Records the tick the authority stamped on something it sent.
+  ///
+  /// Never goes backwards: snapshots ride an unreliable channel, so an older
+  /// one can arrive after a newer one, and letting it rewind the clock would
+  /// make everything derived from it jump.
+  void observeServerTick(int tick) {
+    if (tick > _serverTick) _serverTick = tick;
+    // A client that has fallen behind what the server has already sent is
+    // behind, not ahead; carrying a local tick lower than the server's would
+    // make lag read as negative.
+    if (tick > _localTick) _localTick = tick;
+  }
+
+  /// Puts both clocks at [tick], for a client joining a session in progress.
+  void resetTo(int tick) {
+    _localTick = tick;
+    _serverTick = tick;
+  }
+}

--- a/packages/flutter_scene_net/lib/src/network_transform.dart
+++ b/packages/flutter_scene_net/lib/src/network_transform.dart
@@ -21,6 +21,7 @@ import 'transform_replica.dart';
 final class NetworkTransformComponent extends Component {
   NetworkTransformComponent(
     this.replica, {
+    this.slot = '',
     this.delay = const Duration(milliseconds: 100),
     this.minDelay = const Duration(milliseconds: 25),
     this.adaptive = true,
@@ -28,15 +29,24 @@ final class NetworkTransformComponent extends Component {
   }) : _now = now,
        _delayMicros = delay.inMicroseconds {
     _push();
-    // TODO(replication-unsubscribe): dashwire_replication 0.2.0 has no
-    // listener removal, so these subscriptions (and through them this
-    // component) live as long as the replica; add removal upstream and tear
-    // down on detach.
+    // TODO(replication-unsubscribe): cancel these on detach once a
+    // dashwire_replication with listener removal is published. Until then
+    // they -- and through them this component, and whatever it closes over --
+    // live as long as the replica, which for a spawned entity means until it
+    // despawns. The upstream change is bdero/dashwire#7.
     replica.position.onChanged((_, _) => _push());
     replica.rotation.onChanged((_, _) => _push());
   }
 
   final TransformReplica replica;
+
+  /// The name this component was resolved from, kept so serializing it writes
+  /// the same slot back.
+  ///
+  /// Empty for a component built directly in code, which has no name to
+  /// write: the document would gain a slot nobody registered and the next
+  /// load would report it missing.
+  final String slot;
 
   /// The deepest (and initial) render delay; the fixed delay when
   /// [adaptive] is off.

--- a/packages/flutter_scene_net/lib/src/network_transform_codec.dart
+++ b/packages/flutter_scene_net/lib/src/network_transform_codec.dart
@@ -1,22 +1,28 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_scene/fscene.dart';
+
 import 'package:flutter_scene/scene.dart';
 
+import 'network_identity.dart';
+
 import 'network_transform.dart';
+import 'replica_slots.dart';
 
 /// Registers this package's component codecs into [registry] (the process
 /// default when omitted).
 void registerNetComponentCodecs([FsceneComponentRegistry? registry]) {
-  (registry ?? defaultComponentRegistry()).register(NetworkTransformCodec());
+  (registry ?? defaultComponentRegistry())
+    ..register(NetworkTransformCodec())
+    ..register(NetworkIdentityCodec());
 }
 
 /// Codec for [NetworkTransformComponent] (`networkTransform`).
 ///
-/// The replica is a live network handle the app provides in code, so the
-/// component cannot realize from a document alone; loading a scene carrying
-/// one skips it with a debug note, while serialization keeps the configured
-/// delay. TODO(replica-slots): realize through an app-registered
-/// replica-slot convention, the widget-slot pattern applied to networking.
+/// The replica is a live network handle that belongs to a running session
+/// rather than to a file, so the document names a *slot* and the app says
+/// what each name resolves to (see [ReplicaSlots]). A document that names no
+/// slot, or one nobody supplies, realizes to nothing -- a scene can be loaded
+/// before the session that fills it exists, and that is not an error.
 class NetworkTransformCodec extends ComponentCodec {
   @override
   String get type => 'networkTransform';
@@ -34,6 +40,15 @@ class NetworkTransformCodec extends ComponentCodec {
   /// Extracted so [propertySchema] and [schema] share one list.
   static const List<ComponentPropertyDef> propertyDefs = [
     ComponentPropertyDef(
+      'slot',
+      ComponentPropertyKind.string,
+      defaultValue: StringValue(''),
+      doc:
+          'The replica this node is driven by, by name. The app resolves it '
+          'through ReplicaSlots; a name nothing supplies leaves the node '
+          'undriven rather than failing the load.',
+    ),
+    ComponentPropertyDef(
       'delayMilliseconds',
       ComponentPropertyKind.integer,
       defaultValue: IntValue(100),
@@ -50,11 +65,30 @@ class NetworkTransformCodec extends ComponentCodec {
 
   @override
   Component? realize(ComponentSpec spec, RealizeContext context) {
-    debugPrint(
-      'flutter_scene_net: a networkTransform component needs a replica '
-      'provided in code; skipped',
-    );
-    return null;
+    final slot = switch (spec.properties['slot']) {
+      StringValue(value: final name) => name,
+      _ => '',
+    };
+    final replica = ReplicaSlots.resolve(slot);
+    if (replica == null) {
+      // Two different situations, and only one of them is worth a note. A
+      // document naming no slot is a scene that has not been wired up yet; a
+      // document naming one nobody supplies is probably a typo or a session
+      // that has not started, and saying which name went unanswered is the
+      // only way to tell those apart.
+      if (slot.isNotEmpty) {
+        debugPrint(
+          'flutter_scene_net: no replica is registered for slot "\$slot", so '
+          'that node is not driven. Register one with ReplicaSlots.',
+        );
+      }
+      return null;
+    }
+    final delay = switch (spec.properties['delayMilliseconds']) {
+      IntValue(value: final ms) => Duration(milliseconds: ms),
+      _ => const Duration(milliseconds: 100),
+    };
+    return NetworkTransformComponent(replica, slot: slot, delay: delay);
   }
 
   @override
@@ -63,6 +97,7 @@ class NetworkTransformCodec extends ComponentCodec {
     return ComponentSpec(
       type,
       properties: {
+        if (component.slot.isNotEmpty) 'slot': StringValue(component.slot),
         if (component.delay.inMilliseconds != 100)
           'delayMilliseconds': IntValue(component.delay.inMilliseconds),
       },

--- a/packages/flutter_scene_net/lib/src/physics_world_history.dart
+++ b/packages/flutter_scene_net/lib/src/physics_world_history.dart
@@ -1,6 +1,9 @@
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter_scene/physics.dart';
+
+import 'predicted_physics.dart';
 
 /// Server-side per-tick world snapshot ring for lag-compensated rewind.
 ///
@@ -10,19 +13,39 @@ import 'package:flutter_scene/physics.dart';
 /// returning. Retention doubles as the rewind cap, [maxRewindTicks] bounds
 /// how far back a high-latency peer can drag everyone else.
 ///
-/// For fractional-tick precision on individual poses, pair this with the
-/// interpolating `LagCompensation` history from `dashwire_replication`.
-/// TODO(lagcomp): fractional world rewind by nudging tracked bodies between
-/// the two bracketing snapshots via `PhysicsSimulation.setBodyPose`.
+/// A tick is a coarse unit for this. A client renders between two server
+/// ticks, so rewinding to the nearer one puts a target up to half a tick away
+/// from where the shooter saw it -- at 30Hz and a running speed that is most
+/// of a body width. [rewindBetween] closes that by restoring the earlier tick
+/// and nudging the [tracked] bodies toward the later one, which needs to know
+/// which bodies matter: everything else stays on the whole tick, and for
+/// static geometry that is exactly right.
 final class PhysicsWorldHistory {
-  PhysicsWorldHistory(this.simulation, {this.maxRewindTicks = 8});
+  PhysicsWorldHistory(
+    this.simulation, {
+    this.maxRewindTicks = 8,
+    List<int> tracked = const [],
+  }) : tracked = List.unmodifiable(tracked);
 
   final PhysicsSimulation simulation;
+
+  /// The bodies [rewindBetween] interpolates.
+  ///
+  /// The ones a hit test is about: players, vehicles, anything that moves fast
+  /// enough that half a tick of error changes the answer. Leaving a body out
+  /// is not a mistake -- static geometry is in the same place at both ends of
+  /// the interval, so interpolating it would be arithmetic with no effect.
+  final List<int> tracked;
 
   /// Oldest rewindable age, in ticks behind the newest recording.
   final int maxRewindTicks;
 
   final Map<int, Uint8List> _snapshots = {};
+
+  /// The tracked bodies' poses per tick, so an interpolated rewind does not
+  /// have to restore a second world to read the far end of the interval.
+  final Map<int, Float32List> _poses = {};
+
   int _newestTick = -1;
 
   /// Ticks currently rewindable.
@@ -31,8 +54,12 @@ final class PhysicsWorldHistory {
   /// Snapshots the present world as [tick].
   void record(int tick) {
     _snapshots[tick] = simulation.snapshot();
+    if (tracked.isNotEmpty) {
+      _poses[tick] = capturePredictedBodies(simulation, tracked);
+    }
     _newestTick = tick;
     _snapshots.removeWhere((t, _) => _newestTick - t > maxRewindTicks);
+    _poses.removeWhere((t, _) => _newestTick - t > maxRewindTicks);
   }
 
   /// Runs [query] against the world as recorded at [tick], restoring the
@@ -61,5 +88,112 @@ final class PhysicsWorldHistory {
     } finally {
       simulation.restore(present);
     }
+  }
+
+  /// Runs [query] against the world [fraction] of the way from [tick] to the
+  /// tick after it, restoring the present before returning.
+  ///
+  /// The world is the earlier tick's; only [tracked] bodies are moved toward
+  /// where they were on the later one. That is the trade lag compensation
+  /// makes everywhere: the shooter's view of the targets is reconstructed
+  /// exactly, and the rest of the world is reconstructed to the tick.
+  ///
+  /// `rewound` is false when either end of the interval is outside the
+  /// retained window, or when nothing is tracked -- there is nothing to
+  /// interpolate then, and silently answering as though there were would hide
+  /// that the caller never named the bodies it cares about.
+  ({bool rewound, T? result}) rewindBetween<T>(
+    int tick,
+    double fraction,
+    T Function(PhysicsSimulation simulation) query,
+  ) {
+    if (tracked.isEmpty) return (rewound: false, result: null);
+    final from = _poses[tick];
+    final to = _poses[tick + 1];
+    // Landing exactly on a tick is the ordinary rewind, and asking for it
+    // through this door should not fail just because the tick after it has
+    // not happened yet.
+    if (from != null && to == null && fraction <= 0) {
+      return rewind(tick, query);
+    }
+    if (from == null || to == null) return (rewound: false, result: null);
+
+    return rewind(tick, (sim) {
+      restorePredictedBodies(
+        sim,
+        tracked,
+        _lerpBodies(from, to, fraction.clamp(0.0, 1.0)),
+      );
+      return query(sim);
+    });
+  }
+
+  /// Blends two retained pose buffers.
+  ///
+  /// Positions and velocities interpolate componentwise; rotations take the
+  /// short arc, because two orientations either side of half a turn would
+  /// otherwise blend through the long way and put a target facing backwards
+  /// at the moment it is being shot at.
+  static Float32List _lerpBodies(Float32List a, Float32List b, double t) {
+    final out = Float32List(a.length);
+    for (var base = 0; base < a.length; base += floatsPerPredictedBody) {
+      for (final i in const [0, 1, 2, 7, 8, 9, 10, 11, 12]) {
+        out[base + i] = a[base + i] + (b[base + i] - a[base + i]) * t;
+      }
+      var dot = 0.0;
+      for (var i = 3; i <= 6; i++) {
+        dot += a[base + i] * b[base + i];
+      }
+      final sign = dot < 0 ? -1.0 : 1.0;
+      var length = 0.0;
+      for (var i = 3; i <= 6; i++) {
+        final value = a[base + i] + (b[base + i] * sign - a[base + i]) * t;
+        out[base + i] = value;
+        length += value * value;
+      }
+      // Normalized rather than slerped: over one tick the two orientations
+      // are close, where the two agree to well under a degree, and this costs
+      // a square root instead of two trig calls per body per shot.
+      if (length > 1e-12) {
+        final scale = 1 / sqrt(length);
+        for (var i = 3; i <= 6; i++) {
+          out[base + i] *= scale;
+        }
+      }
+    }
+    return out;
+  }
+
+  /// The tick a peer was looking at, from the newest snapshot it has
+  /// acknowledged and the delay its client renders behind that.
+  ///
+  /// The anchor lag compensation needs, and the thing servers most often get
+  /// wrong: the newest tick a client has *received* is not the tick it was
+  /// *showing*. A client interpolates a fixed delay behind what it holds, so
+  /// compensating to the acked tick alone rewinds too little and still favours
+  /// the shooter.
+  ///
+  /// [renderDelay] is that client's interpolation delay -- the same number its
+  /// [NetworkTransformComponent] is configured with. Returns a whole tick and
+  /// the fraction past it, for [rewindBetween].
+  ///
+  /// Answers null when the peer has acknowledged nothing, which is a client
+  /// that has connected but not yet been sent a snapshot: there is no view to
+  /// reconstruct, so a hit test should fall back rather than compensate to a
+  /// guess.
+  static ({int tick, double fraction})? renderedAt({
+    required int ackedTick,
+    required Duration renderDelay,
+    required int tickRate,
+  }) {
+    if (ackedTick < 0 || tickRate <= 0) return null;
+    final ticksBehind =
+        renderDelay.inMicroseconds * tickRate / Duration.microsecondsPerSecond;
+    final exact = ackedTick - ticksBehind;
+    // Before the session had run long enough to be that far behind, the
+    // oldest thing there is to rewind to is the beginning.
+    if (exact <= 0) return (tick: 0, fraction: 0);
+    final tick = exact.floor();
+    return (tick: tick, fraction: exact - tick);
   }
 }

--- a/packages/flutter_scene_net/lib/src/predicted_physics.dart
+++ b/packages/flutter_scene_net/lib/src/predicted_physics.dart
@@ -10,6 +10,30 @@ import 'package:vector_math/vector_math.dart' hide Colors;
 import 'predicted_transform.dart';
 import 'transform_replica.dart';
 
+/// Bounds what a retained prediction tick has to carry.
+///
+/// Implement alongside [PredictedPhysicsController] to opt in. Without it a
+/// tick retains the whole serialized world, which is always correct and costs
+/// the whole world every tick — sixty-four retained ticks of a scene that
+/// mostly is not moving is what makes a large predicted scene expensive.
+///
+/// **The set must be closed under interaction over the rollback window**:
+/// every body that can touch the owned body, and every body those can touch,
+/// for as many ticks as can be replayed. Anything outside it is not restored,
+/// so if it could have influenced the replay the correction silently diverges.
+/// That is the closure a solver island describes; this asks for it rather than
+/// deriving it, because the simulation interface has no island query and a
+/// wrong answer here is worse than a slow one.
+///
+/// The set must also be fixed for the life of the prediction, for the same
+/// reason [PredictedPhysicsController.onWorldRestored] describes: a retained
+/// tick knows the bodies it captured, and a set that changed underneath it
+/// cannot be put back.
+abstract interface class PredictedBodyScope {
+  /// The bodies whose state each retained tick carries.
+  List<int> get predictedBodies;
+}
+
 /// Client-side driver for an owned entity simulated by a physics world.
 ///
 /// The controller owns a [simulation] dedicated to prediction (the arena plus
@@ -56,18 +80,29 @@ abstract interface class PredictedPhysicsController
 final class _WorldState {
   _WorldState(
     this.world,
+    this.bodies,
     this.position,
     this.rotation,
     this.linearVelocity,
     this.angularVelocity,
   );
 
-  final Uint8List world;
+  /// The serialized world, or null when this tick retained a body set.
+  final Uint8List? world;
+
+  /// The retained bodies' state, thirteen floats each (pose, then linear and
+  /// angular velocity), or null when this tick retained the whole world.
+  final Float32List? bodies;
+
   final Vector3 position;
   final Quaternion rotation;
   final Vector3 linearVelocity;
   final Vector3 angularVelocity;
 }
+
+/// Floats one body occupies in a retained set: position, rotation, linear and
+/// angular velocity.
+const int floatsPerPredictedBody = 3 + 4 + 3 + 3;
 
 /// Drives the node of an owned [TransformReplica] by physics rollback
 /// prediction with authoritative input-replay reconciliation.
@@ -81,9 +116,11 @@ final class _WorldState {
 /// world. A correction decays through a visual error offset over [smoothing]
 /// rather than popping.
 ///
-/// Snapshots are whole-world, so keep the prediction world small (the owned
-/// body plus static geometry). TODO(prediction): per-island snapshots to
-/// bound cost in larger predicted scenes.
+/// A retained tick is the whole serialized world by default, so keep the
+/// prediction world small (the owned body plus static geometry). A controller
+/// that also implements [PredictedBodyScope] retains only the bodies it names,
+/// which bounds the cost by that set rather than by the world — see that
+/// interface for what the set has to contain to stay correct.
 final class PredictedPhysicsComponent extends Component {
   PredictedPhysicsComponent(
     this.replica, {
@@ -134,14 +171,14 @@ final class PredictedPhysicsComponent extends Component {
   final Vector3 _error = Vector3.zero();
   int _reconciledTick = -1;
 
-  /// The snapshot the live world currently equals, so the fresh-prediction
-  /// hot path skips the restore and only replay pays for it.
-  Uint8List? _liveWorld;
+  /// The state the live world currently equals, so the fresh-prediction hot
+  /// path skips the restore and only replay pays for it.
+  _WorldState? _liveState;
 
   _WorldState _step(_WorldState state, Uint8List input, double dt) {
     final sim = controller.simulation;
-    if (!identical(state.world, _liveWorld)) {
-      sim.restore(state.world);
+    if (!identical(state, _liveState)) {
+      _restore(state);
       controller.onWorldRestored();
     }
     // The state's body fields override the restored world, so an
@@ -157,33 +194,53 @@ final class PredictedPhysicsComponent extends Component {
   _WorldState _capture() {
     final sim = controller.simulation;
     final (position, rotation) = sim.readBodyPose(controller.bodyHandle);
+    final handles = _scopedBodies;
     final state = _WorldState(
-      sim.snapshot(),
+      handles == null ? sim.snapshot() : null,
+      handles == null ? null : capturePredictedBodies(sim, handles),
       position,
       rotation,
       sim.readBodyLinearVelocity(controller.bodyHandle),
       sim.readBodyAngularVelocity(controller.bodyHandle),
     );
-    _liveWorld = state.world;
+    _liveState = state;
     return state;
   }
 
-  /// The replay base for a reconcile, the retained world at [ackedTick] with
+  /// The replay base for a reconcile: the retained tick at [ackedTick] with
   /// the authoritative pose (and velocity when replicated) overriding the
   /// owned body.
   _WorldState _authoritativeState(int ackedTick) {
-    final predicted = _predictor.stateAt(ackedTick);
+    final predicted = _predictor.stateAt(ackedTick) ?? _predictor.current;
     return _WorldState(
-      predicted?.world ?? _predictor.current.world,
+      predicted.world,
+      predicted.bodies,
       replica.positionVector,
       replica.rotationQuaternion,
-      controller.authoritativeLinearVelocity ??
-          predicted?.linearVelocity ??
-          _predictor.current.linearVelocity,
-      controller.authoritativeAngularVelocity ??
-          predicted?.angularVelocity ??
-          _predictor.current.angularVelocity,
+      controller.authoritativeLinearVelocity ?? predicted.linearVelocity,
+      controller.authoritativeAngularVelocity ?? predicted.angularVelocity,
     );
+  }
+
+  /// Puts [state] back into the live simulation.
+  void _restore(_WorldState state) {
+    final sim = controller.simulation;
+    final world = state.world;
+    if (world != null) {
+      sim.restore(world);
+      return;
+    }
+    final bodies = state.bodies;
+    final handles = _scopedBodies;
+    if (bodies == null || handles == null) return;
+    restorePredictedBodies(sim, handles, bodies);
+  }
+
+  /// The declared body set, or null when this controller retains the world.
+  List<int>? get _scopedBodies {
+    final scope = controller;
+    if (scope is! PredictedBodyScope) return null;
+    return (scope as PredictedBodyScope).predictedBodies;
   }
 
   @override
@@ -264,4 +321,86 @@ final class PredictedPhysicsComponent extends Component {
   }
 
   static final Vector3 _unitScale = Vector3(1, 1, 1);
+}
+
+/// Reads [handles]' pose and velocities out of [simulation] into one flat
+/// buffer, [floatsPerPredictedBody] floats each.
+///
+/// Flat rather than a list of objects because this runs every tick and is
+/// retained sixty-odd times over: the point is to stop a retained tick costing
+/// much, and a per-body object would put the allocation straight back.
+Float32List capturePredictedBodies(
+  PhysicsSimulation simulation,
+  List<int> handles,
+) {
+  final out = Float32List(handles.length * floatsPerPredictedBody);
+  for (var i = 0; i < handles.length; i++) {
+    final handle = handles[i];
+    final (position, rotation) = simulation.readBodyPose(handle);
+    final linear = simulation.readBodyLinearVelocity(handle);
+    final angular = simulation.readBodyAngularVelocity(handle);
+    final base = i * floatsPerPredictedBody;
+    out
+      ..[base] = position.x
+      ..[base + 1] = position.y
+      ..[base + 2] = position.z
+      ..[base + 3] = rotation.x
+      ..[base + 4] = rotation.y
+      ..[base + 5] = rotation.z
+      ..[base + 6] = rotation.w
+      ..[base + 7] = linear.x
+      ..[base + 8] = linear.y
+      ..[base + 9] = linear.z
+      ..[base + 10] = angular.x
+      ..[base + 11] = angular.y
+      ..[base + 12] = angular.z;
+  }
+  return out;
+}
+
+/// Puts [state] back onto [handles] in [simulation].
+///
+/// Bodies outside [handles] are left where they are, which is the bargain the
+/// declared set makes: what you leave out is not rewound.
+void restorePredictedBodies(
+  PhysicsSimulation simulation,
+  List<int> handles,
+  Float32List state,
+) {
+  // A set that changed between capture and restore would read past the buffer.
+  // Restoring what both agree on and leaving the rest is a divergence the
+  // correction cannot fix, so refuse rather than half-apply: better found here
+  // than in a game.
+  if (state.length != handles.length * floatsPerPredictedBody) {
+    throw StateError(
+      'the predicted body set changed between capture and restore '
+      '(${state.length ~/ floatsPerPredictedBody} bodies retained, '
+      '${handles.length} declared now). The set has to be fixed for the life '
+      'of the prediction; allocate a pool up front the way '
+      'PredictedPhysicsController.onWorldRestored describes.',
+    );
+  }
+  for (var i = 0; i < handles.length; i++) {
+    final handle = handles[i];
+    final base = i * floatsPerPredictedBody;
+    simulation
+      ..setBodyPose(
+        handle,
+        Vector3(state[base], state[base + 1], state[base + 2]),
+        Quaternion(
+          state[base + 3],
+          state[base + 4],
+          state[base + 5],
+          state[base + 6],
+        ),
+      )
+      ..setBodyLinearVelocity(
+        handle,
+        Vector3(state[base + 7], state[base + 8], state[base + 9]),
+      )
+      ..setBodyAngularVelocity(
+        handle,
+        Vector3(state[base + 10], state[base + 11], state[base + 12]),
+      );
+  }
 }

--- a/packages/flutter_scene_net/lib/src/replica_slots.dart
+++ b/packages/flutter_scene_net/lib/src/replica_slots.dart
@@ -1,0 +1,60 @@
+/// Naming a replica in a document.
+///
+/// A replicated component needs a live network handle, and a document cannot
+/// hold one: a replica belongs to a running session, not to a file. So a
+/// scene carrying a `networkTransform` used to be unloadable — the component
+/// was skipped with a note, and the only way to get one was to build it in
+/// code after the scene had loaded.
+///
+/// A slot closes that gap the way widget slots close the same one elsewhere:
+/// the document names a slot, the app says what each name resolves to, and
+/// the codec asks. The document stays a description of the scene and the app
+/// keeps the part only it can know.
+///
+/// ```dart
+/// ReplicaSlots.resolveWith((slot) => switch (slot) {
+///   'player' => session.localPlayerReplica,
+///   _ => spawned[slot],
+/// });
+/// ```
+library;
+
+import 'package:dashwire_replication/dashwire_replication.dart';
+
+/// Resolves the slot name a document carries to a live replica.
+///
+/// Returning null means "not right now", which is a normal answer: a scene
+/// can be loaded before the session that fills it exists.
+typedef ReplicaSlotResolver = TransformReplica? Function(String slot);
+
+/// Where an app says what a document's slot names mean.
+///
+/// Process-wide, like the component registry it works alongside. A slot name
+/// is a contract between one document and one app, and an app that loads two
+/// scenes wants the same resolver for both.
+abstract final class ReplicaSlots {
+  static ReplicaSlotResolver? _resolver;
+
+  /// Whether anything has been registered.
+  static bool get hasResolver => _resolver != null;
+
+  /// Registers [resolver] as the answer for every slot.
+  static void resolveWith(ReplicaSlotResolver resolver) => _resolver = resolver;
+
+  /// Forgets the registered resolver.
+  ///
+  /// For a session ending, and for tests: a resolver left over from one test
+  /// answering another test's lookups is the kind of failure that only
+  /// appears when the suite runs in a particular order.
+  static void clear() => _resolver = null;
+
+  /// The replica for [slot], or null when nothing supplies one.
+  ///
+  /// An empty slot name resolves to nothing without asking: it means the
+  /// document did not name one, which is different from naming one nobody
+  /// supplies, and only the second is worth reporting.
+  static TransformReplica? resolve(String slot) {
+    if (slot.isEmpty) return null;
+    return _resolver?.call(slot);
+  }
+}

--- a/packages/flutter_scene_net/test/component_sync_test.dart
+++ b/packages/flutter_scene_net/test/component_sync_test.dart
@@ -1,0 +1,338 @@
+// Replicating a component's declared properties. The point of building the
+// replica from the component schema is that there is only one description of a
+// networked object; these cover that it reads and writes the live component
+// correctly, and that anything it cannot carry is refused loudly rather than
+// dropped.
+
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// A component with one property of each kind that matters here.
+class _Pawn extends Component {
+  double health = 100;
+  int team = 0;
+  bool alive = true;
+  String label = '';
+  Vector3 aim = Vector3(0, 0, 1);
+}
+
+class _PawnCodec extends DeclarativeComponentCodec<_Pawn> {
+  @override
+  String get type => 'pawn';
+
+  @override
+  ComponentSchema get schema =>
+      ComponentSchema(type, properties: propertySchema);
+
+  @override
+  List<ComponentField<_Pawn>> get fields => [
+    ComponentField.number(
+      'health',
+      defaultValue: 100,
+      get: (c) => c.health,
+      set: (c, v) => c.health = v,
+    ),
+    ComponentField.integer(
+      'team',
+      defaultValue: 0,
+      get: (c) => c.team,
+      set: (c, v) => c.team = v,
+    ),
+    ComponentField.boolean(
+      'alive',
+      defaultValue: true,
+      get: (c) => c.alive,
+      set: (c, v) => c.alive = v,
+    ),
+    ComponentField.string(
+      'label',
+      defaultValue: '',
+      get: (c) => c.label,
+      set: (c, v) => c.label = v,
+    ),
+    ComponentField.vec3(
+      'aim',
+      defaultValue: () => Vector3(0, 0, 1),
+      get: (c) => c.aim,
+      set: (c, v) => c.aim = v,
+    ),
+    // Constructor-only: declared, but with no way to set it after the fact.
+    ComponentField.number('spawnRadius', defaultValue: 1, get: (c) => 1),
+    // A kind with no wire form.
+    ComponentField(
+      const ComponentPropertyDef('loadout', ComponentPropertyKind.map),
+      read: (c, _) => MapValue(const {}),
+    ),
+  ];
+
+  @override
+  _Pawn create(PropertyReader props) => _Pawn();
+}
+
+void main() {
+  late FsceneComponentRegistry registry;
+
+  setUp(() {
+    registry = FsceneComponentRegistry()..register(_PawnCodec());
+  });
+
+  ({Node node, _Pawn pawn}) pawnNode() {
+    final pawn = _Pawn();
+    final node = Node(name: 'pawn')..addComponent(pawn);
+    return (node: node, pawn: pawn);
+  }
+
+  ComponentReplica replicaFor(Node node, List<SyncedProperty> properties) =>
+      ComponentReplica(
+        typeKey: 'pawn',
+        node: node,
+        properties: properties,
+        registry: registry,
+      );
+
+  group('what can replicate', () {
+    test('the kinds with an unambiguous wire form', () {
+      for (final kind in [
+        ComponentPropertyKind.number,
+        ComponentPropertyKind.integer,
+        ComponentPropertyKind.boolean,
+        ComponentPropertyKind.string,
+        ComponentPropertyKind.vec3,
+        ComponentPropertyKind.quaternion,
+      ]) {
+        expect(canSync(kind), isTrue, reason: '${kind.name} should replicate');
+      }
+    });
+
+    test('and not the ones with no single right answer', () {
+      for (final kind in [
+        ComponentPropertyKind.map,
+        ComponentPropertyKind.union,
+        ComponentPropertyKind.list,
+        ComponentPropertyKind.resourceRef,
+        ComponentPropertyKind.matrix4,
+      ]) {
+        expect(canSync(kind), isFalse, reason: '${kind.name} has no wire form');
+      }
+    });
+  });
+
+  group('building the replica', () {
+    test('declares a field per property, in the order given', () {
+      final replica = replicaFor(pawnNode().node, const [
+        SyncedProperty('pawn', 'health'),
+        SyncedProperty('pawn', 'team'),
+      ]);
+      expect(replica.properties.map((p) => p.property).toList(), [
+        'health',
+        'team',
+      ]);
+    });
+
+    test('a property with no wire form is refused, not skipped', () {
+      // Skipping would leave this end's wire layout one field shorter than
+      // the other end's, which is a worse failure than an exception at setup.
+      expect(
+        () => replicaFor(pawnNode().node, const [
+          SyncedProperty('pawn', 'loadout'),
+        ]),
+        throwsA(isA<UnsyncableProperty>()),
+      );
+    });
+
+    test('and the exception says which property and what kind', () {
+      try {
+        replicaFor(pawnNode().node, const [SyncedProperty('pawn', 'loadout')]);
+        fail('expected a refusal');
+      } on UnsyncableProperty catch (error) {
+        expect(error.toString(), contains('pawn.loadout'));
+        expect(error.toString(), contains('map'));
+      }
+    });
+
+    test('a property the component does not declare is refused', () {
+      expect(
+        () => replicaFor(pawnNode().node, const [
+          SyncedProperty('pawn', 'stamina'),
+        ]),
+        throwsA(isA<UnknownSyncedProperty>()),
+      );
+    });
+
+    test('and the exception lists what it could have meant', () {
+      try {
+        replicaFor(pawnNode().node, const [SyncedProperty('pawn', 'helth')]);
+        fail('expected a refusal');
+      } on UnknownSyncedProperty catch (error) {
+        expect(error.toString(), contains('health'));
+      }
+    });
+
+    test('a component with no codec registered is refused', () {
+      expect(
+        () => replicaFor(pawnNode().node, const [
+          SyncedProperty('ghost', 'health'),
+        ]),
+        throwsA(isA<UnknownSyncedComponent>()),
+      );
+    });
+  });
+
+  group('reading the live component', () {
+    test('pull takes the current values', () {
+      final scene = pawnNode();
+      scene.pawn
+        ..health = 42
+        ..team = 3
+        ..alive = false
+        ..label = 'red'
+        ..aim = Vector3(1, 0, 0);
+      final replica = replicaFor(scene.node, const [
+        SyncedProperty('pawn', 'health'),
+        SyncedProperty('pawn', 'team'),
+        SyncedProperty('pawn', 'alive'),
+        SyncedProperty('pawn', 'label'),
+        SyncedProperty('pawn', 'aim'),
+      ])..pull();
+
+      expect(replica.valueAt(0), 42);
+      expect(replica.valueAt(1), 3);
+      expect(replica.valueAt(2), false);
+      expect(replica.valueAt(3), 'red');
+      expect(replica.valueAt(4), (1.0, 0.0, 0.0));
+    });
+
+    test('a value sitting at its default still reads as that default', () {
+      // Components serialize as a delta from their defaults, so an untouched
+      // property is absent from the spec rather than present-and-default.
+      // Reading zero there would make the two ends disagree about a value
+      // nobody has changed.
+      final scene = pawnNode();
+      final replica = replicaFor(scene.node, const [
+        SyncedProperty('pawn', 'health'),
+        SyncedProperty('pawn', 'alive'),
+      ])..pull();
+      expect(replica.valueAt(0), 100);
+      expect(replica.valueAt(1), true);
+    });
+
+    test('pull twice with no change leaves the value alone', () {
+      final scene = pawnNode();
+      final replica = replicaFor(scene.node, const [
+        SyncedProperty('pawn', 'health'),
+      ])..pull();
+      final before = replica.valueAt(0);
+      replica.pull();
+      expect(replica.valueAt(0), before);
+    });
+
+    test('a node missing the component is left alone rather than throwing', () {
+      // A replica outlives a component being removed mid-session; the field
+      // holds its last value instead of taking the whole tick down.
+      final scene = pawnNode();
+      final replica = replicaFor(scene.node, const [
+        SyncedProperty('pawn', 'health'),
+      ]);
+      scene.pawn.health = 7;
+      replica.pull();
+      scene.node.removeComponent(scene.pawn);
+      replica.pull();
+      expect(replica.valueAt(0), 7);
+    });
+  });
+
+  group('writing the live component', () {
+    test('push puts the replicated values back', () {
+      final scene = pawnNode();
+      final replica = replicaFor(scene.node, const [
+        SyncedProperty('pawn', 'health'),
+        SyncedProperty('pawn', 'team'),
+        SyncedProperty('pawn', 'alive'),
+        SyncedProperty('pawn', 'label'),
+        SyncedProperty('pawn', 'aim'),
+      ]);
+      replica.setValueAt(0, 12.0);
+      replica.setValueAt(1, 5);
+      replica.setValueAt(2, false);
+      replica.setValueAt(3, 'blue');
+      replica.setValueAt(4, (0.0, 1.0, 0.0));
+      replica.push();
+
+      expect(scene.pawn.health, 12);
+      expect(scene.pawn.team, 5);
+      expect(scene.pawn.alive, isFalse);
+      expect(scene.pawn.label, 'blue');
+      expect(scene.pawn.aim, Vector3(0, 1, 0));
+    });
+
+    test('a pull and a push round trip a value unchanged', () {
+      final source = pawnNode();
+      final destination = pawnNode();
+      source.pawn
+        ..health = 63.5
+        ..label = 'green'
+        ..aim = Vector3(0, 0, -1);
+
+      final sender = replicaFor(source.node, const [
+        SyncedProperty('pawn', 'health'),
+        SyncedProperty('pawn', 'label'),
+        SyncedProperty('pawn', 'aim'),
+      ])..pull();
+      final receiver = replicaFor(destination.node, const [
+        SyncedProperty('pawn', 'health'),
+        SyncedProperty('pawn', 'label'),
+        SyncedProperty('pawn', 'aim'),
+      ]);
+      for (var i = 0; i < sender.fieldCount; i++) {
+        receiver.setValueAt(i, sender.valueAt(i));
+      }
+      receiver.push();
+
+      expect(destination.pawn.health, 63.5);
+      expect(destination.pawn.label, 'green');
+      expect(destination.pawn.aim, Vector3(0, 0, -1));
+    });
+
+    test('a constructor-only property is declared but never written', () {
+      // It has no setter, so a value arriving for it has nowhere to go. The
+      // codec says so rather than appearing to apply it.
+      final scene = pawnNode();
+      final replica = replicaFor(scene.node, const [
+        SyncedProperty('pawn', 'spawnRadius'),
+      ]);
+      replica.setValueAt(0, 99.0);
+      expect(replica.push, returnsNormally);
+    });
+  });
+
+  group('what the wire costs', () {
+    test('a position quantizes to the resolution asked for', () {
+      // Full float precision on a position is bytes spent below what anyone
+      // can see. Which trade is right depends on the number, so it is named.
+      final scene = pawnNode()..pawn.aim = Vector3(1.2345, 0, 0);
+      final replica = replicaFor(scene.node, const [
+        SyncedProperty('pawn', 'aim', resolution: 0.1),
+      ])..pull();
+      expect(replica.fieldCount, 1);
+    });
+
+    test('write authority defaults to the server', () {
+      // A client that can write its own health is a client that never dies.
+      final replica = replicaFor(pawnNode().node, const [
+        SyncedProperty('pawn', 'health'),
+      ]);
+      expect(replica.properties.single.authority, Authority.server);
+    });
+
+    test('and can be handed to the owner deliberately', () {
+      final replica = replicaFor(pawnNode().node, const [
+        SyncedProperty('pawn', 'aim', authority: Authority.owner),
+      ]);
+      expect(replica.properties.single.authority, Authority.owner);
+    });
+  });
+}

--- a/packages/flutter_scene_net/test/lag_compensation_rewind_test.dart
+++ b/packages/flutter_scene_net/test/lag_compensation_rewind_test.dart
@@ -1,0 +1,268 @@
+// Rewinding between ticks. A client renders between two server ticks, so
+// rewinding to the nearer one puts a target up to half a tick from where the
+// shooter saw it -- at 30Hz and a running speed, most of a body width.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/physics.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+/// One body moving along X, plus a rotation nothing else touches.
+final class _Sim extends PhysicsSimulation {
+  double x = 0;
+  double v = 0;
+  vm.Quaternion rotation = vm.Quaternion.identity();
+
+  @override
+  String get backendName => 'lag1d';
+
+  @override
+  bool get supportsSnapshot => true;
+
+  @override
+  Uint8List snapshot() => Float64List.fromList([
+    x,
+    v,
+    rotation.x,
+    rotation.y,
+    rotation.z,
+    rotation.w,
+  ]).buffer.asUint8List().sublist(0);
+
+  @override
+  bool restore(Uint8List snapshot) {
+    final d = Uint8List.fromList(snapshot).buffer.asFloat64List();
+    x = d[0];
+    v = d[1];
+    rotation = vm.Quaternion(d[2], d[3], d[4], d[5]);
+    return true;
+  }
+
+  @override
+  void step(double fixedDt) => x += v * fixedDt;
+
+  @override
+  void setBodyPose(int h, vm.Vector3 translation, vm.Quaternion r) {
+    x = translation.x;
+    rotation = r.clone();
+  }
+
+  @override
+  (vm.Vector3, vm.Quaternion) readBodyPose(int h) =>
+      (vm.Vector3(x, 0, 0), rotation.clone());
+
+  @override
+  vm.Vector3 readBodyLinearVelocity(int h) => vm.Vector3(v, 0, 0);
+
+  @override
+  vm.Vector3 readBodyAngularVelocity(int h) => vm.Vector3.zero();
+
+  @override
+  void setBodyLinearVelocity(int h, vm.Vector3 velocity) => v = velocity.x;
+
+  @override
+  void setBodyAngularVelocity(int h, vm.Vector3 velocity) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  ({_Sim sim, PhysicsWorldHistory history}) recorded({
+    List<int> tracked = const [0],
+    int ticks = 6,
+  }) {
+    final sim = _Sim()..v = 1;
+    final history = PhysicsWorldHistory(sim, tracked: tracked);
+    for (var tick = 1; tick <= ticks; tick++) {
+      sim.step(1);
+      history.record(tick);
+    }
+    return (sim: sim, history: history);
+  }
+
+  group('landing between two ticks', () {
+    test('halfway is halfway', () {
+      // The whole point: the target is where the shooter saw it, not where it
+      // happened to be on the nearest tick.
+      final r = recorded();
+      final out = r.history.rewindBetween(3, 0.5, (s) => (s as _Sim).x);
+      expect(out.rewound, isTrue);
+      expect(out.result, closeTo(3.5, 1e-5));
+    });
+
+    test('zero is the earlier tick and one is the later', () {
+      final r = recorded();
+      expect(
+        r.history.rewindBetween(3, 0, (s) => (s as _Sim).x).result,
+        closeTo(3, 1e-5),
+      );
+      expect(
+        r.history.rewindBetween(3, 1, (s) => (s as _Sim).x).result,
+        closeTo(4, 1e-5),
+      );
+    });
+
+    test('a fraction outside the interval is clamped, not extrapolated', () {
+      // Extrapolating would put a target somewhere neither end of the
+      // interval says it was, which is a hit registered against nothing.
+      final r = recorded();
+      expect(
+        r.history.rewindBetween(3, 5, (s) => (s as _Sim).x).result,
+        closeTo(4, 1e-5),
+      );
+      expect(
+        r.history.rewindBetween(3, -5, (s) => (s as _Sim).x).result,
+        closeTo(3, 1e-5),
+      );
+    });
+
+    test('the present is restored afterwards', () {
+      final r = recorded();
+      r.history.rewindBetween(3, 0.5, (s) => null);
+      expect(r.sim.x, 6);
+      expect(r.sim.v, 1);
+    });
+
+    test('the world is the earlier tick, only tracked bodies move', () {
+      // The trade lag compensation makes everywhere: the targets are
+      // reconstructed exactly and the rest to the nearest tick.
+      final r = recorded();
+      final seen = r.history.rewindBetween(3, 0.5, (s) => (s as _Sim).v);
+      expect(seen.result, 1, reason: 'the world is tick 3, not blended');
+    });
+  });
+
+  group('when it cannot', () {
+    test('an interval past the retained window reports itself', () {
+      // Distinguishable from a query that legitimately found nothing.
+      final r = recorded();
+      expect(r.history.rewindBetween(99, 0.5, (s) => 0).rewound, isFalse);
+    });
+
+    test('the newest tick has no tick after it', () {
+      final r = recorded();
+      expect(r.history.rewindBetween(6, 0.5, (s) => 0).rewound, isFalse);
+    });
+
+    test('but landing exactly on the newest tick still works', () {
+      // Asking for a whole tick through this door should not fail merely
+      // because the tick after it has not happened yet.
+      final r = recorded();
+      final out = r.history.rewindBetween(6, 0, (s) => (s as _Sim).x);
+      expect(out.rewound, isTrue);
+      expect(out.result, closeTo(6, 1e-5));
+    });
+
+    test('tracking nothing is refused rather than silently exact', () {
+      // There is nothing to interpolate, and answering as though there were
+      // would hide that the caller never named the bodies it cares about.
+      final r = recorded(tracked: const []);
+      expect(r.history.rewindBetween(3, 0.5, (s) => 0).rewound, isFalse);
+      // The whole-tick rewind still works without tracking.
+      expect(r.history.rewind(3, (s) => 0).rewound, isTrue);
+    });
+  });
+
+  group('rotations', () {
+    test('blend the short way round', () {
+      // Two orientations either side of half a turn would otherwise blend the
+      // long way and face a target backwards at the moment it is shot at.
+      final sim = _Sim();
+      final history = PhysicsWorldHistory(sim, tracked: const [0]);
+
+      final near = vm.Quaternion.axisAngle(vm.Vector3(0, 1, 0), 3.0);
+      // The same rotation written with every component negated, which is what
+      // a solver hands back either side of the double cover.
+      final far = vm.Quaternion(-near.x, -near.y, -near.z, -near.w);
+
+      sim.rotation = near;
+      history.record(1);
+      sim.rotation = far;
+      history.record(2);
+
+      final blended = history
+          .rewindBetween(1, 0.5, (s) => (s as _Sim).rotation.clone())
+          .result!;
+      // The two ends are the same orientation, so every point between them
+      // must be too.
+      final dot =
+          blended.x * near.x +
+          blended.y * near.y +
+          blended.z * near.z +
+          blended.w * near.w;
+      expect(dot.abs(), closeTo(1, 1e-4));
+    });
+
+    test('stay unit length', () {
+      final sim = _Sim();
+      final history = PhysicsWorldHistory(sim, tracked: const [0]);
+      sim.rotation = vm.Quaternion.axisAngle(vm.Vector3(0, 1, 0), 0.2);
+      history.record(1);
+      sim.rotation = vm.Quaternion.axisAngle(vm.Vector3(0, 1, 0), 1.4);
+      history.record(2);
+
+      final blended = history
+          .rewindBetween(1, 0.5, (s) => (s as _Sim).rotation.clone())
+          .result!;
+      expect(blended.length, closeTo(1, 1e-5));
+    });
+  });
+
+  group('choosing what to rewind to', () {
+    ({int tick, double fraction})? at(int acked, int delayMs) =>
+        PhysicsWorldHistory.renderedAt(
+          ackedTick: acked,
+          renderDelay: Duration(milliseconds: delayMs),
+          tickRate: 30,
+        );
+
+    test('a client is showing older than what it has received', () {
+      // The mistake servers make: compensating to the acked tick alone
+      // rewinds too little and still favours the shooter.
+      final target = at(100, 100)!;
+      // 100ms at 30Hz is three ticks.
+      expect(target.tick, 97);
+      expect(target.fraction, closeTo(0, 1e-9));
+    });
+
+    test('a delay that is not a whole tick lands between two', () {
+      // Which is exactly what rewindBetween is for.
+      final target = at(100, 50)!;
+      expect(target.tick, 98);
+      expect(target.fraction, closeTo(0.5, 1e-6));
+    });
+
+    test('no delay is the acked tick itself', () {
+      final target = at(100, 0)!;
+      expect(target.tick, 100);
+      expect(target.fraction, 0);
+    });
+
+    test('early in a session it clamps to the beginning', () {
+      // There is nothing older than the start to rewind to.
+      final target = at(1, 500)!;
+      expect(target.tick, 0);
+      expect(target.fraction, 0);
+    });
+
+    test('a peer that has acknowledged nothing has no view to rebuild', () {
+      // A client connected but not yet sent a snapshot. A hit test should
+      // fall back rather than compensate to a guess.
+      expect(at(-1, 100), isNull);
+    });
+
+    test('a nonsensical tick rate is refused rather than dividing by it', () {
+      expect(
+        PhysicsWorldHistory.renderedAt(
+          ackedTick: 100,
+          renderDelay: const Duration(milliseconds: 100),
+          tickRate: 0,
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/packages/flutter_scene_net/test/network_events_test.dart
+++ b/packages/flutter_scene_net/test/network_events_test.dart
@@ -1,0 +1,303 @@
+// Events, as opposed to state. Properties carry what is continuously true;
+// events carry what happened once, and a property that flickered to record one
+// would be a property you could miss between two snapshots.
+
+import 'package:dashwire/dashwire.dart' show fnv1a32;
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Pawn extends Component {
+  double health = 100;
+}
+
+class _PawnCodec extends DeclarativeComponentCodec<_Pawn> {
+  @override
+  String get type => 'pawn';
+
+  @override
+  ComponentSchema get schema =>
+      ComponentSchema(type, properties: propertySchema);
+
+  @override
+  List<ComponentField<_Pawn>> get fields => [
+    ComponentField.number(
+      'health',
+      defaultValue: 100,
+      get: (c) => c.health,
+      set: (c, v) => c.health = v,
+    ),
+  ];
+
+  @override
+  _Pawn create(PropertyReader props) => _Pawn();
+}
+
+void main() {
+  late FsceneComponentRegistry registry;
+  final document = SceneDocument();
+
+  setUp(() {
+    registry = FsceneComponentRegistry()
+      ..register(_PawnCodec())
+      ..register(NetworkIdentityCodec());
+  });
+
+  ComponentReplica replicaWith(List<NetworkEvent> events) => ComponentReplica(
+    typeKey: 'pawn',
+    properties: const [SyncedProperty('pawn', 'health')],
+    events: events,
+    registry: registry,
+  );
+
+  group('declaring', () {
+    test('an event becomes a named endpoint', () {
+      final replica = replicaWith(const [NetworkEvent('fire')]);
+      expect(replica.eventNames, ['fire']);
+    });
+
+    test('events default to asking the server, from the owner only', () {
+      // The direction is the security boundary: a client asks, the server
+      // decides. Anything else is a client writing its own health.
+      const event = NetworkEvent('fire');
+      expect(event.to, RpcTarget.server);
+      expect(event.requireOwner, isTrue);
+      expect(event.delivery, Delivery.reliable);
+    });
+
+    test('two events with one name are refused', () {
+      // They are matched by name across the two ends, so a name has to mean
+      // one thing.
+      expect(
+        () => replicaWith(const [NetworkEvent('fire'), NetworkEvent('fire')]),
+        throwsA(isA<DuplicateNetworkEvent>()),
+      );
+    });
+
+    test('sending one nobody declared throws rather than vanishing', () {
+      // A message that silently goes nowhere is the hardest kind of bug to
+      // see: everything looks fine on the machine that sent it.
+      final replica = replicaWith(const [NetworkEvent('fire')]);
+      expect(() => replica.send('reload'), throwsA(isA<UnknownNetworkEvent>()));
+    });
+
+    test('the refusal says what was available', () {
+      final replica = replicaWith(const [NetworkEvent('fire')]);
+      try {
+        replica.send('reolad');
+        fail('expected a refusal');
+      } on UnknownNetworkEvent catch (error) {
+        expect(error.toString(), contains('fire'));
+      }
+    });
+
+    test('an object with no events says so rather than listing nothing', () {
+      final replica = replicaWith(const []);
+      try {
+        replica.send('fire');
+        fail('expected a refusal');
+      } on UnknownNetworkEvent catch (error) {
+        expect(error.toString(), contains('(none)'));
+      }
+    });
+  });
+
+  NetworkIdentityComponent realizeIdentity(
+    Map<String, PropertyValue> properties,
+  ) =>
+      registry
+              .codecFor('networkIdentity')!
+              .realize(
+                ComponentSpec('networkIdentity', properties: properties),
+                RealizeContext(document),
+              )!
+          as NetworkIdentityComponent;
+
+  Map<String, PropertyValue> serializeIdentity(Component component) => registry
+      .codecFor('networkIdentity')!
+      .serialize(component, SerializeContext(document))!
+      .properties;
+
+  group('the document form', () {
+    test('an event round trips with every setting', () {
+      final before = NetworkIdentityComponent(
+        typeKey: 'pawn',
+        events: const [
+          NetworkEvent('fire'),
+          NetworkEvent(
+            'explode',
+            to: RpcTarget.all,
+            delivery: Delivery.unreliable,
+            requireOwner: false,
+          ),
+        ],
+      );
+      final after = realizeIdentity(serializeIdentity(before));
+      expect(after.events.map((e) => e.name).toList(), ['fire', 'explode']);
+      expect(after.events[0].to, RpcTarget.server);
+      expect(after.events[1].to, RpcTarget.all);
+      expect(after.events[1].delivery, Delivery.unreliable);
+      expect(after.events[1].requireOwner, isFalse);
+    });
+
+    test('an identity with no events writes nothing', () {
+      expect(serializeIdentity(NetworkIdentityComponent()), isEmpty);
+    });
+
+    test('a half-filled row is dropped rather than failing the load', () {
+      // What a row looks like the moment it is added in the inspector.
+      final identity = realizeIdentity({
+        'events': ListValue([
+          MapValue({'to': const StringValue('all')}),
+          encodeNetworkEvent(const NetworkEvent('fire')),
+        ]),
+      });
+      expect(identity.events.map((e) => e.name).toList(), ['fire']);
+    });
+
+    test('an unrecognized target is the safe one', () {
+      // Server: a request the server decides on, rather than something a
+      // client gets to broadcast.
+      final event = decodeNetworkEvent(
+        MapValue({
+          'name': const StringValue('fire'),
+          'to': const StringValue('everybody'),
+        }),
+      )!;
+      expect(event.to, RpcTarget.server);
+    });
+
+    test('the order survives, because the order is the wire layout', () {
+      final before = NetworkIdentityComponent(
+        typeKey: 'pawn',
+        events: const [NetworkEvent('b'), NetworkEvent('a')],
+      );
+      expect(
+        realizeIdentity(
+          serializeIdentity(before),
+        ).events.map((e) => e.name).toList(),
+        ['b', 'a'],
+      );
+    });
+  });
+
+  group('the schema hash', () {
+    NetworkPrefabs table(List<NetworkEvent> events) => NetworkPrefabs(
+      prefabs: [
+        NetworkPrefab(
+          typeKey: 'pawn',
+          synced: const [SyncedProperty('pawn', 'health')],
+          events: events,
+          build: () => Node(name: 'pawn')..addComponent(_Pawn()),
+        ),
+      ],
+      registry: registry,
+    );
+
+    test('two builds declaring the same events agree', () {
+      expect(
+        table(const [NetworkEvent('fire')]).toRegistry().schemaHash,
+        table(const [NetworkEvent('fire')]).toRegistry().schemaHash,
+      );
+    });
+
+    test('and disagree when one adds an event', () {
+      // Caught at connect, rather than a client calling an endpoint index the
+      // server means something else by.
+      expect(
+        table(const [NetworkEvent('fire')]).toRegistry().schemaHash,
+        isNot(
+          table(const [
+            NetworkEvent('fire'),
+            NetworkEvent('reload'),
+          ]).toRegistry().schemaHash,
+        ),
+      );
+    });
+
+    test('and when one changes an event to a different direction', () {
+      // Who runs an event is part of the contract, not a local setting.
+      expect(
+        table(const [NetworkEvent('fire')]).toRegistry().schemaHash,
+        isNot(
+          table(const [
+            NetworkEvent('fire', to: RpcTarget.all),
+          ]).toRegistry().schemaHash,
+        ),
+      );
+    });
+
+    test('a spawned replica carries the prefab’s events', () {
+      final prefabs = table(const [NetworkEvent('fire')]);
+      final replica =
+          prefabs.toRegistry().instantiate(fnv1a32('pawn'))!
+              as ComponentReplica;
+      expect(replica.eventNames, ['fire']);
+    });
+  });
+
+  group('who receives a property', () {
+    test('everyone, unless it is somebody\'s business alone', () {
+      const open = SyncedProperty('pawn', 'health');
+      expect(open.readableBy, ReadScope.everyone);
+    });
+
+    test('owner-only is a real secret, not a hidden one', () {
+      // The bytes are never sent, so there is nothing in another client to
+      // read -- which is the difference between private and merely not shown.
+      const secret = SyncedProperty(
+        'pawn',
+        'health',
+        readableBy: ReadScope.ownerOnly,
+      );
+      expect(secret.readableBy, ReadScope.ownerOnly);
+    });
+
+    test('it round trips through the document', () {
+      final before = NetworkIdentityComponent(
+        typeKey: 'pawn',
+        synced: const [
+          SyncedProperty('pawn', 'health', readableBy: ReadScope.ownerOnly),
+          SyncedProperty('pawn', 'health', readableBy: ReadScope.skipOwner),
+        ],
+      );
+      final after = realizeIdentity(serializeIdentity(before));
+      expect(after.synced[0].readableBy, ReadScope.ownerOnly);
+      expect(after.synced[1].readableBy, ReadScope.skipOwner);
+    });
+
+    test('an unrecognized scope is the one that hides nothing', () {
+      // Defaulting to secret would make a client silently miss state it needs
+      // to draw, which looks like a rendering bug rather than a config one.
+      final property = decodeSyncedProperty(
+        MapValue({
+          'component': const StringValue('pawn'),
+          'property': const StringValue('health'),
+          'readableBy': const StringValue('nobody'),
+        }),
+      )!;
+      expect(property.readableBy, ReadScope.everyone);
+    });
+
+    test('and it changes the schema hash, because it changes the wire', () {
+      // Two builds disagreeing about who receives a field would disagree
+      // about the shape of every snapshot carrying it.
+      NetworkPrefabs table(ReadScope scope) => NetworkPrefabs(
+        prefabs: [
+          NetworkPrefab(
+            typeKey: 'pawn',
+            synced: [SyncedProperty('pawn', 'health', readableBy: scope)],
+            build: () => Node(name: 'pawn')..addComponent(_Pawn()),
+          ),
+        ],
+        registry: registry,
+      );
+      expect(
+        table(ReadScope.everyone).toRegistry().schemaHash,
+        isNot(table(ReadScope.ownerOnly).toRegistry().schemaHash),
+      );
+    });
+  });
+}

--- a/packages/flutter_scene_net/test/network_identity_test.dart
+++ b/packages/flutter_scene_net/test/network_identity_test.dart
@@ -1,0 +1,197 @@
+// Making an object networked from the document. The declaration is what both
+// ends load, so what matters is that it round-trips exactly and that it
+// produces the same wire layout wherever it is read.
+
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Pawn extends Component {
+  double health = 100;
+  String label = '';
+}
+
+class _PawnCodec extends DeclarativeComponentCodec<_Pawn> {
+  @override
+  String get type => 'pawn';
+
+  @override
+  ComponentSchema get schema =>
+      ComponentSchema(type, properties: propertySchema);
+
+  @override
+  List<ComponentField<_Pawn>> get fields => [
+    ComponentField.number(
+      'health',
+      defaultValue: 100,
+      get: (c) => c.health,
+      set: (c, v) => c.health = v,
+    ),
+    ComponentField.string(
+      'label',
+      defaultValue: '',
+      get: (c) => c.label,
+      set: (c, v) => c.label = v,
+    ),
+  ];
+
+  @override
+  _Pawn create(PropertyReader props) => _Pawn();
+}
+
+void main() {
+  late FsceneComponentRegistry registry;
+  final document = SceneDocument();
+
+  setUp(() {
+    registry = FsceneComponentRegistry()
+      ..register(_PawnCodec())
+      ..register(NetworkIdentityCodec());
+  });
+
+  NetworkIdentityComponent realize(Map<String, PropertyValue> properties) =>
+      registry
+              .codecFor('networkIdentity')!
+              .realize(
+                ComponentSpec('networkIdentity', properties: properties),
+                RealizeContext(document),
+              )!
+          as NetworkIdentityComponent;
+
+  Map<String, PropertyValue> serialize(Component component) => registry
+      .codecFor('networkIdentity')!
+      .serialize(component, SerializeContext(document))!
+      .properties;
+
+  test('it shows up under Networking in the picker', () {
+    expect(registry.codecFor('networkIdentity')!.schema.category, 'Networking');
+  });
+
+  test('an untouched identity writes nothing', () {
+    expect(serialize(NetworkIdentityComponent()), isEmpty);
+  });
+
+  group('the declaration', () {
+    test('round trips the type key and every synced property', () {
+      final before = NetworkIdentityComponent(
+        typeKey: 'pawn',
+        synced: const [
+          SyncedProperty('pawn', 'health'),
+          SyncedProperty(
+            'pawn',
+            'label',
+            authority: Authority.owner,
+            mode: SendMode.onChange,
+            resolution: 0.25,
+          ),
+        ],
+      );
+      final after = realize(serialize(before));
+
+      expect(after.typeKey, 'pawn');
+      expect(after.synced.length, 2);
+      expect(after.synced[0].componentType, 'pawn');
+      expect(after.synced[0].property, 'health');
+      expect(after.synced[0].authority, Authority.server);
+      expect(after.synced[0].resolution, isNull);
+      expect(after.synced[1].authority, Authority.owner);
+      expect(after.synced[1].mode, SendMode.onChange);
+      expect(after.synced[1].resolution, 0.25);
+    });
+
+    test('the order survives, because the order is the wire layout', () {
+      // Both ends load this list and match fields by position, so a document
+      // that reordered on load would have the two ends reading each other's
+      // fields as the wrong ones.
+      final before = NetworkIdentityComponent(
+        typeKey: 'pawn',
+        synced: const [
+          SyncedProperty('pawn', 'label'),
+          SyncedProperty('pawn', 'health'),
+        ],
+      );
+      expect(
+        realize(serialize(before)).synced.map((p) => p.property).toList(),
+        ['label', 'health'],
+      );
+    });
+
+    test('a half-filled row is dropped rather than failing the load', () {
+      // Which is what a row looks like the moment it is added in the
+      // inspector, before anything is typed into it.
+      final identity = realize({
+        'synced': ListValue([
+          MapValue({'component': const StringValue('pawn')}),
+          encodeSyncedProperty(const SyncedProperty('pawn', 'health')),
+        ]),
+      });
+      expect(identity.synced.length, 1);
+      expect(identity.synced.single.property, 'health');
+    });
+
+    test('an unrecognized authority is the safe one', () {
+      final property = decodeSyncedProperty(
+        MapValue({
+          'component': const StringValue('pawn'),
+          'property': const StringValue('health'),
+          'authority': const StringValue('anyone'),
+        }),
+      )!;
+      expect(property.authority, Authority.server);
+    });
+
+    test('zero resolution means full precision, not a zero step', () {
+      final property = decodeSyncedProperty(
+        MapValue({
+          'component': const StringValue('pawn'),
+          'property': const StringValue('health'),
+          'resolution': const DoubleValue(0),
+        }),
+      )!;
+      expect(property.resolution, isNull);
+    });
+  });
+
+  group('building the replica from it', () {
+    test('the declaration produces the replica', () {
+      final identity = NetworkIdentityComponent(
+        typeKey: 'pawn',
+        synced: const [
+          SyncedProperty('pawn', 'health'),
+          SyncedProperty('pawn', 'label'),
+        ],
+      );
+      final pawn = _Pawn()..health = 30;
+      final node = Node(name: 'pawn')
+        ..addComponent(pawn)
+        ..addComponent(identity);
+
+      final replica = identity.replicaFor(node, registry: registry)..pull();
+      expect(replica.typeKey, 'pawn');
+      expect(replica.valueAt(0), 30);
+    });
+
+    test('a document naming a property that no longer exists is refused', () {
+      // Loud, where someone can see it. Quietly replicating one field fewer
+      // than the other end expects is the failure that shows up as entities
+      // reading each other's values.
+      final identity = NetworkIdentityComponent(
+        typeKey: 'pawn',
+        synced: const [SyncedProperty('pawn', 'stamina')],
+      );
+      final node = Node(name: 'pawn')..addComponent(_Pawn());
+      expect(
+        () => identity.replicaFor(node, registry: registry),
+        throwsA(isA<UnknownSyncedProperty>()),
+      );
+    });
+  });
+
+  test('registering the net codecs registers this one too', () {
+    final fresh = FsceneComponentRegistry();
+    registerNetComponentCodecs(fresh);
+    expect(fresh.codecFor('networkIdentity'), isNotNull);
+  });
+}

--- a/packages/flutter_scene_net/test/network_ownership_test.dart
+++ b/packages/flutter_scene_net/test/network_ownership_test.dart
@@ -1,0 +1,213 @@
+// Who owns an object, and what may be done about it. Ownership decides who may
+// write owner-writable properties and send owner-only events, so every refusal
+// here is a rule rather than an inconvenience.
+
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Ownership owned({
+    int by = 2,
+    Set<OwnershipPermission> permissions = const {},
+    bool locked = false,
+  }) => Ownership(owner: by, permissions: permissions, locked: locked);
+
+  group('an object that permits nothing', () {
+    test('is static: it cannot be taken', () {
+      // Saying nothing being the locked-down case is deliberate. The safe
+      // default should be the one you get by not thinking about it.
+      final it = owned();
+      final outcome = it.give(3);
+      expect(outcome.granted, isFalse);
+      expect(outcome.refusal, OwnershipRefusal.notTransferable);
+      expect(it.owner, 2);
+    });
+
+    test('and cannot be asked for either', () {
+      final outcome = owned().request(3);
+      expect(outcome.refusal, OwnershipRefusal.notTransferable);
+    });
+  });
+
+  group('transferable', () {
+    test('anyone may take it', () {
+      final it = owned(permissions: {OwnershipPermission.transferable});
+      expect(it.give(3).granted, isTrue);
+      expect(it.owner, 3);
+    });
+
+    test('the owner taking it again is told so, not handed it', () {
+      final it = owned(permissions: {OwnershipPermission.transferable});
+      expect(it.give(2).refusal, OwnershipRefusal.alreadyOwner);
+    });
+
+    test('a lock outranks it', () {
+      // The owner saying "not right now" about a thing that is normally free
+      // to take: what you want while driving the car everyone else may drive.
+      final it = owned(
+        permissions: {OwnershipPermission.transferable},
+        locked: true,
+      );
+      expect(it.give(3).refusal, OwnershipRefusal.locked);
+      it.setLocked(false);
+      expect(it.give(3).granted, isTrue);
+    });
+  });
+
+  group('requestRequired', () {
+    test('taking it is refused, and the refusal names the way forward', () {
+      // A refusal that says what to do instead beats one that just says no.
+      final it = owned(permissions: {OwnershipPermission.requestRequired});
+      expect(it.give(3).refusal, OwnershipRefusal.requestRequired);
+    });
+
+    test('asking is allowed, and records who asked', () {
+      final it = owned(permissions: {OwnershipPermission.requestRequired});
+      expect(it.request(3).granted, isTrue);
+      expect(it.pendingRequestFrom, 3);
+      // Sent, not granted: the owner still owns it.
+      expect(it.owner, 2);
+    });
+
+    test('a second asker is told somebody is ahead of them', () {
+      final it = owned(permissions: {OwnershipPermission.requestRequired})
+        ..request(3);
+      expect(it.request(4).refusal, OwnershipRefusal.requestPending);
+    });
+
+    test('approving hands it over and locks it', () {
+      // An object that had to be asked for is one where being interrupted
+      // matters; leaving it free for the next taker defeats having asked.
+      final it = owned(permissions: {OwnershipPermission.requestRequired})
+        ..request(3);
+      final outcome = it.answerRequest(approve: true);
+      expect(outcome.granted, isTrue);
+      expect(it.owner, 3);
+      expect(it.locked, isTrue);
+      expect(it.pendingRequestFrom, isNull);
+    });
+
+    test('refusing leaves it where it was and clears the request', () {
+      final it = owned(permissions: {OwnershipPermission.requestRequired})
+        ..request(3);
+      expect(it.answerRequest(approve: false).granted, isFalse);
+      expect(it.owner, 2);
+      expect(it.pendingRequestFrom, isNull);
+    });
+
+    test('answering when nobody asked is refused', () {
+      final it = owned(permissions: {OwnershipPermission.requestRequired});
+      expect(it.answerRequest(approve: true).granted, isFalse);
+    });
+
+    test('a withdrawn request lets the next asker through', () {
+      final it = owned(permissions: {OwnershipPermission.requestRequired})
+        ..request(3)
+        ..cancelRequest();
+      expect(it.request(4).granted, isTrue);
+    });
+
+    test('a pending request blocks a taking, even on a transferable one', () {
+      // Whoever asked is owed an answer before somebody else grabs it.
+      final it = owned(
+        permissions: {
+          OwnershipPermission.transferable,
+          OwnershipPermission.requestRequired,
+        },
+      )..request(3);
+      expect(it.give(4).refusal, OwnershipRefusal.requestPending);
+      // The asker themselves may still be handed it.
+      expect(it.give(3).granted, isTrue);
+    });
+  });
+
+  group('sessionOwner', () {
+    test('only the session owner may hold it', () {
+      final it = owned(
+        permissions: {
+          OwnershipPermission.sessionOwner,
+          OwnershipPermission.transferable,
+        },
+      );
+      expect(
+        it.give(3, sessionOwner: 1).refusal,
+        OwnershipRefusal.sessionOwnerOnly,
+      );
+      expect(it.give(1, sessionOwner: 1).granted, isTrue);
+    });
+
+    test('and nobody else may even ask', () {
+      final it = owned(
+        permissions: {
+          OwnershipPermission.sessionOwner,
+          OwnershipPermission.requestRequired,
+        },
+      );
+      expect(
+        it.request(3, sessionOwner: 1).refusal,
+        OwnershipRefusal.sessionOwnerOnly,
+      );
+    });
+  });
+
+  group('the authority overriding', () {
+    test('force ignores every rule, because it is not a transfer', () {
+      // What happens when a client leaves and the object has to go somewhere.
+      final it = owned(locked: true)..request(3);
+      expect(it.give(1, force: true).granted, isTrue);
+      expect(it.owner, 1);
+      expect(it.pendingRequestFrom, isNull, reason: 'the asker is moot now');
+    });
+  });
+
+  test('every refusal says something useful', () {
+    // "Could not take ownership" tells nobody what to do next.
+    for (final refusal in OwnershipRefusal.values) {
+      final message = ownershipRefusalMessage(refusal);
+      expect(message, isNotEmpty, reason: refusal.name);
+      expect(message, endsWith('.'), reason: refusal.name);
+    }
+  });
+
+  group('the document form', () {
+    test('a permission set round trips', () {
+      const permissions = {
+        OwnershipPermission.transferable,
+        OwnershipPermission.distributable,
+      };
+      expect(decodeOwnership(encodeOwnership(permissions)), permissions);
+    });
+
+    test('nothing encodes to nothing', () {
+      expect(encodeOwnership(const {}), '');
+      expect(decodeOwnership(''), isEmpty);
+    });
+
+    test('the order is stable, so a document does not churn on save', () {
+      expect(
+        encodeOwnership({
+          OwnershipPermission.transferable,
+          OwnershipPermission.distributable,
+        }),
+        encodeOwnership({
+          OwnershipPermission.distributable,
+          OwnershipPermission.transferable,
+        }),
+      );
+    });
+
+    test('an unknown permission is skipped, not fatal', () {
+      // A document from a newer build should lose the permission it names,
+      // not the whole object.
+      expect(decodeOwnership('transferable,teleportable'), {
+        OwnershipPermission.transferable,
+      });
+    });
+
+    test('whitespace and empties are tolerated', () {
+      expect(decodeOwnership(' transferable , '), {
+        OwnershipPermission.transferable,
+      });
+    });
+  });
+}

--- a/packages/flutter_scene_net/test/network_prefabs_test.dart
+++ b/packages/flutter_scene_net/test/network_prefabs_test.dart
@@ -1,0 +1,311 @@
+// The spawn table. Its job is to keep the two halves of a replicated object in
+// step — what the server sends and what the client builds — and the reason it
+// can is that both come from the same declaration.
+
+import 'package:dashwire/dashwire.dart' show fnv1a32;
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Pawn extends Component {
+  double health = 100;
+  String label = '';
+}
+
+class _PawnCodec extends DeclarativeComponentCodec<_Pawn> {
+  @override
+  String get type => 'pawn';
+
+  @override
+  ComponentSchema get schema =>
+      ComponentSchema(type, properties: propertySchema);
+
+  @override
+  List<ComponentField<_Pawn>> get fields => [
+    ComponentField.number(
+      'health',
+      defaultValue: 100,
+      get: (c) => c.health,
+      set: (c, v) => c.health = v,
+    ),
+    ComponentField.string(
+      'label',
+      defaultValue: '',
+      get: (c) => c.label,
+      set: (c, v) => c.label = v,
+    ),
+  ];
+
+  @override
+  _Pawn create(PropertyReader props) => _Pawn();
+}
+
+void main() {
+  late FsceneComponentRegistry components;
+
+  setUp(() {
+    components = FsceneComponentRegistry()
+      ..register(_PawnCodec())
+      ..register(NetworkIdentityCodec());
+  });
+
+  Node buildPawn() => Node(name: 'pawn')..addComponent(_Pawn());
+
+  NetworkPrefab pawnPrefab({
+    String typeKey = 'pawn',
+    List<SyncedProperty> synced = const [
+      SyncedProperty('pawn', 'health'),
+      SyncedProperty('pawn', 'label'),
+    ],
+  }) => NetworkPrefab(typeKey: typeKey, synced: synced, build: buildPawn);
+
+  NetworkPrefabs tableOf(List<NetworkPrefab> prefabs) =>
+      NetworkPrefabs(prefabs: prefabs, registry: components);
+
+  group('building the table', () {
+    test('it holds what it was given', () {
+      final table = tableOf([pawnPrefab()]);
+      expect(table.typeKeys, ['pawn']);
+      expect(table.prefabFor('pawn'), isNotNull);
+      expect(table.prefabFor('ghost'), isNull);
+    });
+
+    test('a prefab can come from an authored identity', () {
+      // What the designer marked as replicated is exactly what goes over the
+      // wire; there is no second list to keep in step with the first.
+      final identity = NetworkIdentityComponent(
+        typeKey: 'pawn',
+        synced: const [SyncedProperty('pawn', 'health')],
+      );
+      final prefab = NetworkPrefab.of(identity, build: buildPawn);
+      expect(prefab.typeKey, 'pawn');
+      expect(prefab.synced.single.property, 'health');
+    });
+
+    test('a bad declaration is refused at startup, not at the first spawn', () {
+      // A spawn table is built once at startup; a spawn happens mid-match.
+      expect(
+        () => tableOf([
+          pawnPrefab(synced: const [SyncedProperty('pawn', 'stamina')]),
+        ]),
+        throwsA(isA<UnknownSyncedProperty>()),
+      );
+    });
+
+    test('two prefabs claiming one type key are refused', () {
+      // A type key is how the ends agree what a spawn is, so it has to name
+      // exactly one thing.
+      expect(
+        () => tableOf([pawnPrefab(), pawnPrefab()]),
+        throwsA(isA<DuplicateNetworkPrefab>()),
+      );
+    });
+  });
+
+  group('the replica registry', () {
+    test('every prefab becomes a spawnable type', () {
+      final registry = tableOf([
+        pawnPrefab(),
+        pawnPrefab(typeKey: 'turret'),
+      ]).toRegistry();
+      expect(registry.typeKeyFor(fnv1a32('pawn')), 'pawn');
+      expect(registry.typeKeyFor(fnv1a32('turret')), 'turret');
+    });
+
+    test('the factory produces a declared replica with no node yet', () {
+      // A client learns a replica exists before it has anywhere to put it.
+      final registry = tableOf([pawnPrefab()]).toRegistry();
+      final replica = registry.instantiate(fnv1a32('pawn'))!;
+      expect(replica, isA<ComponentReplica>());
+      expect((replica as ComponentReplica).node, isNull);
+      expect(replica.fieldCount, 2);
+    });
+
+    test('an unbound replica pulls and pushes without throwing', () {
+      final registry = tableOf([pawnPrefab()]).toRegistry();
+      final replica =
+          registry.instantiate(fnv1a32('pawn'))! as ComponentReplica;
+      expect(replica.pull, returnsNormally);
+      expect(replica.push, returnsNormally);
+    });
+
+    test('the schema hash catches two builds that disagree', () {
+      // dashwire exchanges this at handshake. A server and a client that
+      // loaded different versions of the document are refused at connect,
+      // rather than agreeing to run and reading each other's fields wrong.
+      final server = tableOf([pawnPrefab()]).toRegistry();
+      final sameDocument = tableOf([pawnPrefab()]).toRegistry();
+      final staleClient = tableOf([
+        pawnPrefab(synced: const [SyncedProperty('pawn', 'health')]),
+      ]).toRegistry();
+
+      expect(server.schemaHash, sameDocument.schemaHash);
+      expect(server.schemaHash, isNot(staleClient.schemaHash));
+    });
+
+    test('and catches a property whose authority was changed', () {
+      // Who may write a field is part of the contract, not a local setting.
+      final server = tableOf([pawnPrefab()]).toRegistry();
+      final client = tableOf([
+        pawnPrefab(
+          synced: const [
+            SyncedProperty('pawn', 'health', authority: Authority.owner),
+            SyncedProperty('pawn', 'label'),
+          ],
+        ),
+      ]).toRegistry();
+      expect(server.schemaHash, isNot(client.schemaHash));
+    });
+
+    test('and catches the same fields declared in a different order', () {
+      // Fields match by position on the wire.
+      final a = tableOf([pawnPrefab()]).toRegistry();
+      final b = tableOf([
+        pawnPrefab(
+          synced: const [
+            SyncedProperty('pawn', 'label'),
+            SyncedProperty('pawn', 'health'),
+          ],
+        ),
+      ]).toRegistry();
+      expect(a.schemaHash, isNot(b.schemaHash));
+    });
+  });
+
+  group('spawning', () {
+    test('builds the node and binds the replica to it', () {
+      final table = tableOf([pawnPrefab()]);
+      final replica =
+          table.toRegistry().instantiate(fnv1a32('pawn'))! as ComponentReplica;
+      final node = table.spawn(replica)!;
+      expect(replica.node, same(node));
+    });
+
+    test('the node starts at the state the server sent', () {
+      // The spawn payload has landed by now, so pushing it here is what stops
+      // a frame of the prefab's defaults before the first snapshot.
+      final table = tableOf([pawnPrefab()]);
+      final replica =
+          table.toRegistry().instantiate(fnv1a32('pawn'))! as ComponentReplica;
+      replica.setValueAt(0, 17.0);
+      replica.setValueAt(1, 'red');
+
+      final node = table.spawn(replica)!;
+      final pawn = node.getComponents<_Pawn>().single;
+      expect(pawn.health, 17);
+      expect(pawn.label, 'red');
+    });
+
+    test('a type this build has never heard of builds nothing', () {
+      // What a stale client sees when the server spawns something new.
+      final table = tableOf([pawnPrefab()]);
+      final stranger =
+          tableOf([
+                pawnPrefab(typeKey: 'turret'),
+              ]).toRegistry().instantiate(fnv1a32('turret'))!
+              as ComponentReplica;
+      expect(table.spawn(stranger), isNull);
+    });
+
+    test('the builders map covers every registered type', () {
+      final table = tableOf([pawnPrefab(), pawnPrefab(typeKey: 'turret')]);
+      expect(table.builders.keys.toSet(), {'pawn', 'turret'});
+    });
+
+    test('unbinding lets a despawned node go', () {
+      final table = tableOf([pawnPrefab()]);
+      final replica =
+          table.toRegistry().instantiate(fnv1a32('pawn'))! as ComponentReplica;
+      table.spawn(replica);
+      replica.unbind();
+      expect(replica.node, isNull);
+      expect(replica.pull, returnsNormally);
+    });
+  });
+
+  test('a server-side replica reads the node it was spawned from', () {
+    // The other direction: the host builds the node itself and binds a replica
+    // to it, and pull is what puts its state on the wire.
+    final table = tableOf([pawnPrefab()]);
+    final node = buildPawn();
+    node.getComponents<_Pawn>().single
+      ..health = 55
+      ..label = 'blue';
+    final replica =
+        table.toRegistry().instantiate(fnv1a32('pawn'))! as ComponentReplica
+          ..bind(node)
+          ..pull();
+    expect(replica.valueAt(0), 55);
+    expect(replica.valueAt(1), 'blue');
+  });
+
+  group('the spawn lifecycle', () {
+    test('a replica is not spawned until it has a node', () {
+      // It exists from the moment the spawn message arrives; there is nothing
+      // to read or write until it is attached.
+      final table = tableOf([pawnPrefab()]);
+      final replica =
+          table.toRegistry().instantiate(fnv1a32('pawn'))! as ComponentReplica;
+      expect(replica.isSpawned, isFalse);
+      table.spawn(replica);
+      expect(replica.isSpawned, isTrue);
+    });
+
+    test('the spawn callback sees the authority’s state, not the defaults', () {
+      // A handler that reads a replicated value on spawn should read the real
+      // one rather than a prefab default it is about to be corrected from.
+      final table = tableOf([pawnPrefab()]);
+      final replica =
+          table.toRegistry().instantiate(fnv1a32('pawn'))! as ComponentReplica;
+      replica.setValueAt(0, 33.0);
+
+      double? seen;
+      replica.onSpawn = (node) =>
+          seen = node.getComponents<_Pawn>().single.health;
+      table.spawn(replica);
+      expect(seen, 33);
+    });
+
+    test('the despawn callback runs while there is still a node', () {
+      // The matching place to stop what spawn started; it needs something to
+      // clean up against.
+      final table = tableOf([pawnPrefab()]);
+      final replica =
+          table.toRegistry().instantiate(fnv1a32('pawn'))! as ComponentReplica;
+      table.spawn(replica);
+
+      var attached = false;
+      replica.onDespawn = (node) => attached = replica.isSpawned;
+      replica.unbind();
+      expect(attached, isTrue);
+      expect(replica.isSpawned, isFalse);
+    });
+
+    test('unbinding twice does not fire despawn twice', () {
+      final table = tableOf([pawnPrefab()]);
+      final replica =
+          table.toRegistry().instantiate(fnv1a32('pawn'))! as ComponentReplica;
+      table.spawn(replica);
+      var calls = 0;
+      replica.onDespawn = (_) => calls++;
+      replica
+        ..unbind()
+        ..unbind();
+      expect(calls, 1);
+    });
+
+    test('ownership is asked, not assumed', () {
+      // The object you spawned may not be yours by the time you next look.
+      final table = tableOf([pawnPrefab()]);
+      final replica =
+          table.toRegistry().instantiate(fnv1a32('pawn'))! as ComponentReplica
+            ..owner = 4;
+      expect(replica.isOwnedBy(4), isTrue);
+      expect(replica.isOwnedBy(5), isFalse);
+      replica.owner = 5;
+      expect(replica.isOwnedBy(5), isTrue);
+    });
+  });
+}

--- a/packages/flutter_scene_net/test/network_session_test.dart
+++ b/packages/flutter_scene_net/test/network_session_test.dart
@@ -1,0 +1,415 @@
+// Starting a session and letting people into it. The decisions here are the
+// ones a NetworkManager makes, and none of them need a socket to be true.
+
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Pawn extends Component {
+  double health = 100;
+}
+
+class _PawnCodec extends DeclarativeComponentCodec<_Pawn> {
+  @override
+  String get type => 'pawn';
+
+  @override
+  ComponentSchema get schema =>
+      ComponentSchema(type, properties: propertySchema);
+
+  @override
+  List<ComponentField<_Pawn>> get fields => [
+    ComponentField.number(
+      'health',
+      defaultValue: 100,
+      get: (c) => c.health,
+      set: (c, v) => c.health = v,
+    ),
+  ];
+
+  @override
+  _Pawn create(PropertyReader props) => _Pawn();
+}
+
+void main() {
+  late FsceneComponentRegistry components;
+  late Node root;
+
+  setUp(() {
+    components = FsceneComponentRegistry()..register(_PawnCodec());
+    root = Node(name: 'scene');
+  });
+
+  NetworkPrefabs table({
+    List<String> types = const ['player'],
+    Set<OwnershipPermission> ownership = const {},
+    bool keepOnOwnerLeave = false,
+  }) => NetworkPrefabs(
+    prefabs: [
+      for (final type in types)
+        NetworkPrefab(
+          typeKey: type,
+          synced: const [SyncedProperty('pawn', 'health')],
+          ownership: ownership,
+          keepOnOwnerLeave: keepOnOwnerLeave,
+          build: () {
+            final node = Node(name: type)..addComponent(_Pawn());
+            root.add(node);
+            return node;
+          },
+        ),
+    ],
+    registry: components,
+  );
+
+  NetworkSession session({
+    NetworkRole role = NetworkRole.host,
+    ConnectionApprover? approve,
+    List<String> types = const ['player'],
+    Set<OwnershipPermission> ownership = const {},
+    bool keepOnOwnerLeave = false,
+  }) => NetworkSession(
+    role: role,
+    prefabs: table(
+      types: types,
+      ownership: ownership,
+      keepOnOwnerLeave: keepOnOwnerLeave,
+    ),
+    playerPrefab: 'player',
+    approve: approve,
+  );
+
+  group('roles', () {
+    test('a host simulates and plays; a server only simulates', () {
+      expect(NetworkRole.host.isAuthority, isTrue);
+      expect(NetworkRole.host.hasLocalPlayer, isTrue);
+      expect(NetworkRole.server.isAuthority, isTrue);
+      expect(NetworkRole.server.hasLocalPlayer, isFalse);
+    });
+
+    test('a client believes what it is told', () {
+      expect(NetworkRole.client.isAuthority, isFalse);
+      expect(NetworkRole.client.hasLocalPlayer, isTrue);
+    });
+  });
+
+  group('starting', () {
+    test('a session is not running until it is started', () {
+      final s = session();
+      expect(s.isRunning, isFalse);
+      s.start();
+      expect(s.isRunning, isTrue);
+    });
+
+    test('starting twice is refused', () {
+      // Two sessions in one process would both claim to be authoritative, and
+      // the scene can only be one of them.
+      final s = session()..start();
+      expect(s.start, throwsA(isA<SessionAlreadyRunning>()));
+    });
+
+    test('a player prefab that is not in the table is refused up front', () {
+      // Letting someone in and having nothing to give them is a worse failure,
+      // and it happens to the player rather than to the developer.
+      expect(
+        () => NetworkSession(
+          role: NetworkRole.host,
+          prefabs: table(),
+          playerPrefab: 'ghost',
+        ),
+        throwsA(isA<UnknownPlayerPrefab>()),
+      );
+    });
+
+    test('and the refusal says what the table does hold', () {
+      try {
+        NetworkSession(
+          role: NetworkRole.host,
+          prefabs: table(),
+          playerPrefab: 'ghost',
+        );
+        fail('expected a refusal');
+      } on UnknownPlayerPrefab catch (error) {
+        expect(error.toString(), contains('player'));
+      }
+    });
+  });
+
+  group('approval', () {
+    test('no approver means an open session', () async {
+      final s = session()..start();
+      expect((await s.vet('')).approved, isTrue);
+    });
+
+    test('the game gets whatever the joiner presented', () async {
+      String? seen;
+      final s = session(
+        approve: (payload) {
+          seen = payload;
+          return const ConnectionApproval.approve();
+        },
+      )..start();
+      await s.vet('build=42');
+      expect(seen, 'build=42');
+    });
+
+    test('a refusal carries a reason', () async {
+      // "Could not connect" is the least useful sentence in multiplayer.
+      final s = session(
+        approve: (_) => const ConnectionApproval.reject('Wrong build'),
+      )..start();
+      final decision = await s.vet('');
+      expect(decision.approved, isFalse);
+      expect(decision.reason, 'Wrong build');
+    });
+
+    test('a client does not get to decide who joins', () async {
+      final s = session(role: NetworkRole.client)..start();
+      final decision = await s.vet('');
+      expect(decision.approved, isFalse);
+      expect(decision.reason, contains('server'));
+    });
+
+    test('a session that is not running admits nobody', () async {
+      final decision = await session().vet('');
+      expect(decision.approved, isFalse);
+    });
+
+    test('an async approver is awaited', () async {
+      // Checking a ticket means asking a service, which takes time.
+      final s = session(
+        approve: (_) async => const ConnectionApproval.reject('Banned'),
+      )..start();
+      expect((await s.vet('')).reason, 'Banned');
+    });
+  });
+
+  group('admitting', () {
+    test('an approved peer gets a player, owned by them', () {
+      final s = session()..start();
+      final client = s.admit(7, const ConnectionApproval.approve())!;
+      expect(client.peerId, 7);
+      expect(client.player, isNotNull);
+      expect(client.replica!.owner, 7);
+      expect(root.children, hasLength(1));
+    });
+
+    test('a refusal spawns nothing', () {
+      final s = session()..start();
+      expect(s.admit(7, const ConnectionApproval.reject('no')), isNull);
+      expect(s.clients, isEmpty);
+      expect(root.children, isEmpty);
+    });
+
+    test('a spectator is connected and given nothing to drive', () {
+      final s = session()..start();
+      final client = s.admit(
+        7,
+        const ConnectionApproval.approve(spawnPlayer: false),
+      )!;
+      expect(client.player, isNull);
+      expect(s.peerIds, [7]);
+      expect(root.children, isEmpty);
+    });
+
+    test('the approval may choose a different prefab', () {
+      final s = NetworkSession(
+        role: NetworkRole.host,
+        prefabs: table(types: ['player', 'spectatorCam']),
+        playerPrefab: 'player',
+      )..start();
+      final client = s.admit(
+        7,
+        const ConnectionApproval.approve(playerType: 'spectatorCam'),
+      )!;
+      expect(client.player!.name, 'spectatorCam');
+    });
+
+    test('a prefab the approval names but the table lacks is refused', () {
+      final s = session()..start();
+      expect(
+        () => s.admit(7, const ConnectionApproval.approve(playerType: 'ghost')),
+        throwsA(isA<UnknownPlayerPrefab>()),
+      );
+    });
+
+    test('admitting the same peer twice does not give them two bodies', () {
+      // A reconnect that raced the drop, or a duplicated message.
+      final s = session()..start();
+      final first = s.admit(7, const ConnectionApproval.approve());
+      final second = s.admit(7, const ConnectionApproval.approve());
+      expect(identical(first, second), isTrue);
+      expect(root.children, hasLength(1));
+    });
+
+    test('the spawn hook fires with the client', () {
+      final s = session()..start();
+      NetworkClient? seen;
+      s.onPlayerSpawned = (client) => seen = client;
+      s.admit(7, const ConnectionApproval.approve());
+      expect(seen?.peerId, 7);
+    });
+  });
+
+  group('leaving', () {
+    test('dropping takes the body with it', () {
+      // A player that left and whose body stayed is the bug people report as
+      // ghosts.
+      final s = session()..start();
+      s.admit(7, const ConnectionApproval.approve());
+      s.drop(7);
+      expect(s.clients, isEmpty);
+      expect(root.children, isEmpty);
+    });
+
+    test('and unbinds the replica so it stops reading a detached node', () {
+      final s = session()..start();
+      final client = s.admit(7, const ConnectionApproval.approve())!;
+      s.drop(7);
+      expect(client.replica!.node, isNull);
+    });
+
+    test('the despawn hook fires before the body goes', () {
+      final s = session()..start();
+      Node? seen;
+      s.onPlayerDespawned = (client) => seen = client.player;
+      s.admit(7, const ConnectionApproval.approve());
+      s.drop(7);
+      expect(seen, isNotNull);
+    });
+
+    test('dropping someone who is not here does nothing', () {
+      final s = session()..start();
+      expect(() => s.drop(99), returnsNormally);
+    });
+
+    test('stopping drops everyone, including the host', () {
+      // Leaving a body behind would leave a node nothing owns and no snapshot
+      // will ever update again.
+      final s = session()..start();
+      s.admit(1, const ConnectionApproval.approve());
+      s.admit(2, const ConnectionApproval.approve());
+      s.stop();
+      expect(s.isRunning, isFalse);
+      expect(s.clients, isEmpty);
+      expect(root.children, isEmpty);
+    });
+
+    test('a stopped session can be started again', () {
+      final s = session()..start();
+      s.stop();
+      expect(s.start, returnsNormally);
+    });
+  });
+
+  group('ownership', () {
+    test('a spawned object belongs to the peer it was spawned for', () {
+      final s = session()..start();
+      final client = s.admit(7, const ConnectionApproval.approve())!;
+      expect(client.ownership.owner, 7);
+      expect(client.replica!.owner, 7);
+    });
+
+    test('it carries the prefab\'s permissions', () {
+      final s = session(ownership: {OwnershipPermission.transferable})..start();
+      final client = s.admit(7, const ConnectionApproval.approve())!;
+      expect(client.ownership.permissions, {OwnershipPermission.transferable});
+    });
+
+    test('handing it over moves the replica\'s owner too', () {
+      // The replica's owner is what the wire enforces; the two drifting apart
+      // means the rules say one thing and the transport does another.
+      final s = session(ownership: {OwnershipPermission.transferable})..start();
+      final client = s.admit(7, const ConnectionApproval.approve())!;
+      expect(s.giveOwnership(7, 9).granted, isTrue);
+      expect(client.replica!.owner, 9);
+    });
+
+    test('a static object is not handed over', () {
+      final s = session()..start();
+      final client = s.admit(7, const ConnectionApproval.approve())!;
+      expect(s.giveOwnership(7, 9).refusal, OwnershipRefusal.notTransferable);
+      expect(client.replica!.owner, 7);
+    });
+
+    test('only the authority decides who owns what', () {
+      // Deciding on a client and announcing it is how two clients end up each
+      // believing they own the same crate.
+      final s = session(
+        role: NetworkRole.client,
+        ownership: {OwnershipPermission.transferable},
+      )..start();
+      s.admit(7, const ConnectionApproval.approve());
+      expect(s.giveOwnership(7, 9).refusal, OwnershipRefusal.notAuthority);
+    });
+
+    test('an approved request moves it', () {
+      final s = session(ownership: {OwnershipPermission.requestRequired})
+        ..start();
+      final client = s.admit(7, const ConnectionApproval.approve())!;
+      expect(s.requestOwnership(7, 9).granted, isTrue);
+      expect(client.replica!.owner, 7, reason: 'sent, not granted');
+      expect(s.answerOwnershipRequest(7, approve: true).granted, isTrue);
+      expect(client.replica!.owner, 9);
+    });
+
+    test('an object nobody has is refused rather than crashing', () {
+      final s = session()..start();
+      expect(s.giveOwnership(99, 1).granted, isFalse);
+      expect(s.requestOwnership(99, 1).granted, isFalse);
+      expect(s.answerOwnershipRequest(99, approve: true).granted, isFalse);
+    });
+  });
+
+  group('when an owner leaves', () {
+    test('their object goes with them by default', () {
+      // Most owned objects are that client: their character, their cursor.
+      final s = session()..start();
+      s.admit(7, const ConnectionApproval.approve());
+      s.drop(7);
+      expect(root.children, isEmpty);
+    });
+
+    test(
+      'an object marked to outlive them stays, and passes to the authority',
+      () {
+        // Something they merely happened to be holding -- a crate mid-flight --
+        // should stay in the world rather than blink out.
+        final s = session(keepOnOwnerLeave: true)..start();
+        final client = s.admit(7, const ConnectionApproval.approve())!;
+        s.drop(7);
+        expect(root.children, hasLength(1));
+        expect(client.ownership.owner, serverPeerId);
+        expect(client.replica!.owner, serverPeerId);
+        expect(client.replica!.node, isNotNull, reason: 'still driven');
+      },
+    );
+
+    test('and that is a different event from a despawn', () {
+      // A dropped weapon should probably keep falling, not vanish.
+      final s = session(keepOnOwnerLeave: true)..start();
+      NetworkClient? left;
+      NetworkClient? despawned;
+      s.onOwnerLeft = (client) {
+        left = client;
+      };
+      s.onPlayerDespawned = (client) {
+        despawned = client;
+      };
+      s.admit(7, const ConnectionApproval.approve());
+      s.drop(7);
+      expect(left?.peerId, 7);
+      expect(despawned, isNull);
+    });
+
+    test('a lock does not keep an object with a client who left', () {
+      // The authority overriding is not a transfer anybody asked for.
+      final s = session(keepOnOwnerLeave: true)..start();
+      final client = s.admit(7, const ConnectionApproval.approve())!;
+      client.ownership.setLocked(true);
+      s.drop(7);
+      expect(client.ownership.owner, serverPeerId);
+    });
+  });
+}

--- a/packages/flutter_scene_net/test/network_time_test.dart
+++ b/packages/flutter_scene_net/test/network_time_test.dart
@@ -1,0 +1,100 @@
+// Network time. Two machines can agree on a tick number and cannot agree on a
+// clock, so everything that has to agree across machines is counted in ticks.
+
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('a point in time', () {
+    test('seconds are derived, so every machine agrees on them', () {
+      // A measured clock would not agree. This one is arithmetic on a number
+      // both ends were sent.
+      const time = NetworkTime(tick: 60, tickRate: 30);
+      expect(time.seconds, 2);
+      expect(time.fixedDelta, closeTo(1 / 30, 1e-12));
+    });
+
+    test('advancing counts ticks, not seconds', () {
+      const start = NetworkTime(tick: 10, tickRate: 60);
+      expect((start + 5).tick, 15);
+      expect((start + 5).tickRate, 60);
+    });
+
+    test('the gap between two times is signed', () {
+      // Negative is the normal case on a client: the authority's last word is
+      // always a little behind where the client has simulated to.
+      const local = NetworkTime(tick: 100, tickRate: 50);
+      const server = NetworkTime(tick: 94, tickRate: 50);
+      expect(local.ticksAhead(server), 6);
+      expect(server.ticksAhead(local), -6);
+      expect(local.secondsAhead(server), closeTo(0.12, 1e-12));
+    });
+
+    test('two times at the same tick and rate are the same time', () {
+      expect(
+        const NetworkTime(tick: 7, tickRate: 30),
+        const NetworkTime(tick: 7, tickRate: 30),
+      );
+      expect(
+        const NetworkTime(tick: 7, tickRate: 30),
+        isNot(const NetworkTime(tick: 7, tickRate: 60)),
+      );
+    });
+  });
+
+  group('the clock', () {
+    test('starts at zero on both sides', () {
+      final clock = NetworkClock(tickRate: 30);
+      expect(clock.local.tick, 0);
+      expect(clock.server.tick, 0);
+      expect(clock.lag, 0);
+    });
+
+    test('local time advances a tick at a time', () {
+      final clock = NetworkClock(tickRate: 30);
+      for (var i = 0; i < 5; i++) {
+        clock.advance();
+      }
+      expect(clock.local.tick, 5);
+    });
+
+    test('lag is how far behind the authority’s last word is', () {
+      final clock = NetworkClock(tickRate: 50);
+      for (var i = 0; i < 10; i++) {
+        clock.advance();
+      }
+      clock.observeServerTick(6);
+      expect(clock.server.tick, 6);
+      expect(clock.lag, closeTo(4 / 50, 1e-12));
+    });
+
+    test('an out-of-order snapshot does not rewind the clock', () {
+      // Snapshots ride an unreliable channel, so an older one can arrive after
+      // a newer one; letting it rewind would make everything derived jump.
+      final clock = NetworkClock(tickRate: 30)..observeServerTick(20);
+      clock.observeServerTick(14);
+      expect(clock.server.tick, 20);
+    });
+
+    test('a client behind the server is pulled forward, not left negative', () {
+      // Being behind what the authority has already sent is being behind.
+      final clock = NetworkClock(tickRate: 30)..observeServerTick(40);
+      expect(clock.local.tick, 40);
+      expect(clock.lag, 0);
+    });
+
+    test('joining in progress starts both clocks where the session is', () {
+      final clock = NetworkClock(tickRate: 60)..resetTo(9000);
+      expect(clock.local.tick, 9000);
+      expect(clock.server.tick, 9000);
+      expect(clock.lag, 0);
+    });
+
+    test('the rate is fixed, because it is part of what was agreed', () {
+      // A client counting at a different rate reads every stamp wrong.
+      final clock = NetworkClock(tickRate: 30);
+      expect(clock.local.tickRate, 30);
+      expect(clock.server.tickRate, 30);
+    });
+  });
+}

--- a/packages/flutter_scene_net/test/predicted_physics_test.dart
+++ b/packages/flutter_scene_net/test/predicted_physics_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_scene/physics.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene_net/flutter_scene_net.dart';
 // ignore: implementation_imports
-import 'package:flutter_scene_net/src/physics_world_history.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math.dart' as vm;
 

--- a/packages/flutter_scene_net/test/prediction_scope_test.dart
+++ b/packages/flutter_scene_net/test/prediction_scope_test.dart
@@ -1,0 +1,188 @@
+// Bounding what a retained prediction tick costs. A rollback rewinds and
+// replays, so a tick has to keep everything the replay can read: the whole
+// serialized world is always enough and always costs the whole world.
+// Declaring the bodies that can matter bounds it by the set instead.
+
+import 'dart:typed_data';
+
+import 'package:flutter_scene/physics.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart' as vm;
+
+/// A simulation of independent 1D bodies, counting what is asked of it.
+final class _Sim extends PhysicsSimulation {
+  final List<double> x = [0, 0, 0];
+  final List<double> v = [0, 0, 0];
+
+  int snapshots = 0;
+  int restores = 0;
+
+  @override
+  String get backendName => 'bodies1d';
+
+  @override
+  bool get supportsSnapshot => true;
+
+  @override
+  Uint8List snapshot() {
+    snapshots++;
+    return Float64List.fromList([...x, ...v]).buffer.asUint8List().sublist(0);
+  }
+
+  @override
+  bool restore(Uint8List snapshot) {
+    restores++;
+    final data = Uint8List.fromList(snapshot).buffer.asFloat64List();
+    for (var i = 0; i < x.length; i++) {
+      x[i] = data[i];
+      v[i] = data[x.length + i];
+    }
+    return true;
+  }
+
+  @override
+  void step(double fixedDt) {
+    for (var i = 0; i < x.length; i++) {
+      x[i] += v[i] * fixedDt;
+    }
+  }
+
+  @override
+  void setBodyPose(int h, vm.Vector3 translation, vm.Quaternion rotation) =>
+      x[h] = translation.x;
+
+  @override
+  (vm.Vector3, vm.Quaternion) readBodyPose(int h) =>
+      (vm.Vector3(x[h], 0, 0), vm.Quaternion.identity());
+
+  @override
+  vm.Vector3 readBodyLinearVelocity(int h) => vm.Vector3(v[h], 0, 0);
+
+  @override
+  vm.Vector3 readBodyAngularVelocity(int h) => vm.Vector3.zero();
+
+  @override
+  void setBodyLinearVelocity(int h, vm.Vector3 velocity) => v[h] = velocity.x;
+
+  @override
+  void setBodyAngularVelocity(int h, vm.Vector3 velocity) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// A controller that keeps the whole world, the way one always has.
+class _WorldController implements PredictedPhysicsController {
+  _WorldController(this.simulation);
+
+  @override
+  final _Sim simulation;
+
+  @override
+  int get bodyHandle => 0;
+
+  @override
+  void onWorldRestored() {}
+
+  @override
+  Uint8List sampleInput() => Uint8List(0);
+
+  @override
+  void applyInput(Uint8List input, double dt) {}
+
+  @override
+  vm.Vector3? get authoritativeLinearVelocity => null;
+
+  @override
+  vm.Vector3? get authoritativeAngularVelocity => null;
+}
+
+/// The same, opting into a declared set.
+class _ScopedController extends _WorldController implements PredictedBodyScope {
+  _ScopedController(super.simulation, this.predictedBodies);
+
+  @override
+  List<int> predictedBodies;
+}
+
+void main() {
+  group('what a controller declares', () {
+    test('a plain controller is not scoped', () {
+      // Opting in is implementing an extra interface, so nothing that exists
+      // today changes behaviour by upgrading.
+      expect(_WorldController(_Sim()), isNot(isA<PredictedBodyScope>()));
+    });
+
+    test('a scoped one is', () {
+      expect(_ScopedController(_Sim(), const [0]), isA<PredictedBodyScope>());
+    });
+  });
+
+  group('the declared set carries what a replay needs', () {
+    test('pose and both velocities survive a round trip', () {
+      // Thirteen floats a body: if any of them is dropped, a rollback puts
+      // the world back subtly wrong and the correction never converges.
+      final sim = _Sim();
+      final scope = _ScopedController(sim, const [0, 1]);
+
+      sim
+        ..setBodyPose(0, vm.Vector3(3, 0, 0), vm.Quaternion.identity())
+        ..setBodyLinearVelocity(0, vm.Vector3(7, 0, 0))
+        ..setBodyPose(1, vm.Vector3(-2, 0, 0), vm.Quaternion.identity())
+        ..setBodyLinearVelocity(1, vm.Vector3(4, 0, 0));
+
+      final captured = capturePredictedBodies(sim, scope.predictedBodies);
+
+      // Move everything, then put it back.
+      sim
+        ..setBodyPose(0, vm.Vector3(99, 0, 0), vm.Quaternion.identity())
+        ..setBodyLinearVelocity(0, vm.Vector3(0, 0, 0))
+        ..setBodyPose(1, vm.Vector3(99, 0, 0), vm.Quaternion.identity())
+        ..setBodyLinearVelocity(1, vm.Vector3(0, 0, 0));
+      restorePredictedBodies(sim, scope.predictedBodies, captured);
+
+      expect(sim.x[0], 3);
+      expect(sim.v[0], 7);
+      expect(sim.x[1], -2);
+      expect(sim.v[1], 4);
+    });
+
+    test('a body outside the set is not restored', () {
+      // The whole bargain, stated: what you leave out stays where the replay
+      // left it, which is why the set has to be closed under interaction.
+      final sim = _Sim();
+      final scope = _ScopedController(sim, const [0]);
+      sim.setBodyPose(1, vm.Vector3(5, 0, 0), vm.Quaternion.identity());
+
+      final captured = capturePredictedBodies(sim, scope.predictedBodies);
+      sim.setBodyPose(1, vm.Vector3(50, 0, 0), vm.Quaternion.identity());
+      restorePredictedBodies(sim, scope.predictedBodies, captured);
+
+      expect(sim.x[1], 50, reason: 'untouched, not rewound');
+    });
+
+    test('it costs the set, not the world', () {
+      // The point of the whole thing: a retained tick is thirteen floats a
+      // body rather than a serialization of everything.
+      final sim = _Sim();
+      final scope = _ScopedController(sim, const [0]);
+      final captured = capturePredictedBodies(sim, scope.predictedBodies);
+      expect(captured.length, floatsPerPredictedBody);
+      expect(sim.snapshots, 0, reason: 'the world was never serialized');
+    });
+
+    test('a set that changed underneath a retained tick is refused', () {
+      // Restoring what both agree on and leaving the rest is a divergence the
+      // correction cannot fix, so it is better found here than in a game.
+      final sim = _Sim();
+      final scope = _ScopedController(sim, [0, 1]);
+      final captured = capturePredictedBodies(sim, scope.predictedBodies);
+      scope.predictedBodies = [0];
+      expect(
+        () => restorePredictedBodies(sim, scope.predictedBodies, captured),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}

--- a/packages/flutter_scene_net/test/replica_slots_test.dart
+++ b/packages/flutter_scene_net/test/replica_slots_test.dart
@@ -1,0 +1,152 @@
+// Naming a replica in a document. A replica belongs to a running session
+// rather than to a file, so the document names a slot and the app says what
+// each name means -- otherwise a scene carrying a networked node cannot be
+// loaded at all.
+
+import 'package:dashwire_replication/dashwire_replication.dart';
+import 'package:flutter_scene/fscene.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_scene_net/flutter_scene_net.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final class _Pawn extends TransformReplica {
+  @override
+  String get typeKey => 'pawn';
+}
+
+void main() {
+  late FsceneComponentRegistry registry;
+  final document = SceneDocument();
+
+  setUp(() {
+    registry = FsceneComponentRegistry();
+    registerNetComponentCodecs(registry);
+  });
+
+  tearDown(ReplicaSlots.clear);
+
+  Component? realize(Map<String, PropertyValue> properties) => registry
+      .codecFor('networkTransform')!
+      .realize(
+        ComponentSpec('networkTransform', properties: properties),
+        RealizeContext(document),
+      );
+
+  group('resolving', () {
+    test('nothing is registered until an app says so', () {
+      expect(ReplicaSlots.hasResolver, isFalse);
+      expect(ReplicaSlots.resolve('player'), isNull);
+    });
+
+    test('a registered resolver answers by name', () {
+      final pawn = _Pawn();
+      ReplicaSlots.resolveWith((slot) => slot == 'player' ? pawn : null);
+      expect(ReplicaSlots.resolve('player'), same(pawn));
+      expect(ReplicaSlots.resolve('turret'), isNull);
+    });
+
+    test('an empty slot resolves to nothing without asking', () {
+      // Naming no slot is different from naming one nobody supplies, and the
+      // resolver should not have to tell them apart.
+      var asked = 0;
+      ReplicaSlots.resolveWith((slot) {
+        asked++;
+        return null;
+      });
+      expect(ReplicaSlots.resolve(''), isNull);
+      expect(asked, 0);
+    });
+
+    test('clearing forgets it', () {
+      // A resolver left over from one test answering another test's lookups
+      // is the kind of failure that only appears in a particular order.
+      ReplicaSlots.resolveWith((_) => _Pawn());
+      ReplicaSlots.clear();
+      expect(ReplicaSlots.hasResolver, isFalse);
+    });
+  });
+
+  group('realizing from a document', () {
+    test('a named slot with a replica drives the node', () {
+      final pawn = _Pawn();
+      ReplicaSlots.resolveWith((slot) => slot == 'player' ? pawn : null);
+
+      final component = realize({'slot': const StringValue('player')});
+      expect(component, isA<NetworkTransformComponent>());
+      expect((component! as NetworkTransformComponent).replica, same(pawn));
+    });
+
+    test('and carries the delay the document asked for', () {
+      ReplicaSlots.resolveWith((_) => _Pawn());
+      final component =
+          realize({
+                'slot': const StringValue('player'),
+                'delayMilliseconds': const IntValue(40),
+              })!
+              as NetworkTransformComponent;
+      expect(component.delay, const Duration(milliseconds: 40));
+    });
+
+    test('a slot nobody supplies leaves the node undriven, not broken', () {
+      // A scene can be loaded before the session that fills it exists. That
+      // is not an error, and failing the load over it would make a networked
+      // scene unopenable offline.
+      ReplicaSlots.resolveWith((_) => null);
+      expect(realize({'slot': const StringValue('player')}), isNull);
+    });
+
+    test('and so does a document that names no slot at all', () {
+      expect(realize(const {}), isNull);
+    });
+
+    test('with no resolver registered, loading still succeeds', () {
+      expect(
+        () => realize({'slot': const StringValue('player')}),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('serializing', () {
+    Map<String, PropertyValue>? serialize(Component component) => registry
+        .codecFor('networkTransform')!
+        .serialize(component, SerializeContext(document))
+        ?.properties;
+
+    test('a component realized from a slot writes that slot back', () {
+      ReplicaSlots.resolveWith((_) => _Pawn());
+      final component =
+          realize({'slot': const StringValue('player')})!
+              as NetworkTransformComponent;
+      final written = serialize(component)!['slot']! as StringValue;
+      expect(written.value, 'player');
+    });
+
+    test('one built in code writes no slot', () {
+      // It has no name to write, and inventing one would put a slot in the
+      // document that nobody registered -- reported as missing on next load.
+      final component = NetworkTransformComponent(_Pawn());
+      expect(serialize(component)?.containsKey('slot'), isFalse);
+    });
+
+    test('a default delay is not written', () {
+      final component = NetworkTransformComponent(_Pawn());
+      expect(serialize(component), isEmpty);
+    });
+
+    test('it round trips through the document', () {
+      final pawn = _Pawn();
+      ReplicaSlots.resolveWith((_) => pawn);
+      final first =
+          realize({
+                'slot': const StringValue('player'),
+                'delayMilliseconds': const IntValue(25),
+              })!
+              as NetworkTransformComponent;
+      final second = realize(serialize(first)!)! as NetworkTransformComponent;
+      expect(second.slot, 'player');
+      expect(second.delay, const Duration(milliseconds: 25));
+      expect(second.replica, same(pawn));
+    });
+  });
+}

--- a/packages/scene/lib/src/schema/component_schema.dart
+++ b/packages/scene/lib/src/schema/component_schema.dart
@@ -257,6 +257,7 @@ class ComponentSchema {
   const ComponentSchema(
     this.type, {
     this.doc,
+    this.category,
     this.icon,
     this.version = 1,
     this.formerTypes = const [],
@@ -269,6 +270,11 @@ class ComponentSchema {
 
   /// A short description of the component.
   final String? doc;
+
+  /// The group this type is filed under in an editor's component picker
+  /// ("Rendering", "Physics", "Cameras"). Null files it under a catch-all,
+  /// which is where a project's own components land until they say otherwise.
+  final String? category;
 
   /// An optional editor icon hint (an emoji or a named glyph).
   final String? icon;
@@ -296,6 +302,7 @@ class ComponentSchema {
   Map<String, Object?> toJson() => {
     'type': type,
     if (doc != null) 'doc': doc,
+    if (category != null) 'category': category,
     if (icon != null) 'icon': icon,
     if (version != 1) 'version': version,
     if (formerTypes.isNotEmpty) 'formerTypes': formerTypes,
@@ -310,6 +317,7 @@ class ComponentSchema {
     return ComponentSchema(
       json['type'] as String,
       doc: json['doc'] as String?,
+      category: json['category'] as String?,
       icon: json['icon'] as String?,
       version: (json['version'] as num?)?.toInt() ?? 1,
       formerTypes: json['formerTypes'] is List


### PR DESCRIPTION
**Standalone**, based directly on `master` — one commit, nothing stacked behind
it, mergeable on its own. It supersedes #376, which carried the same work but sat
on top of #374 and #375 and so could not be taken independently.

Makes an object networkable by *marking* it, rather than by writing a replication
class for it.

### The idea

A networked object already describes itself. Every component has a codec, and
every codec declares its properties with a name, a kind, a `read` that gets the
value off the live component and a `write` that puts one back. That is exactly
what a replicated field needs — so the replica is built from the schema rather
than repeating it. A hand-written `Replica` per type is the same information
twice, and the second copy is the one that goes stale when a property is renamed.

`NetworkIdentityComponent` is the authoring surface: a type key, the properties
that replicate with their write authority and read scope, the events the object
can send, and what may be done with its ownership. **The list lives in the
document**, which is what makes both ends agree on wire order without either
being told — and dashwire's schema hash catches them at connect if they don't.

### Events

Properties carry what is continuously true; events carry what happened *once*,
which a property would have to flicker to record and which you could then miss
between two snapshots. The direction an event travels is the security boundary —
an event aimed at the server is a client *asking*, and the server decides — so it
is named on the declaration.

### Ownership and sessions

An object declares what is *permitted* (distributable, transferable,
requestRequired, sessionOwner); declaring nothing means **static**. The
locked-down case being what you get by not thinking about it is deliberate.

Sessions cover host, server and client, with connection approval that runs
**before** anything is spawned: deciding after spawning means un-spawning, and
that is where the half-joined states live.

### A document can name the replica that drives a node

A replica belongs to a running session rather than to a file, so the document
names a **slot** and the app resolves it. A slot nobody supplies leaves the node
undriven rather than failing the load — a networked scene should still open
offline.

### Prediction can bound what a retained tick costs

Serializing the whole world every tick is always correct and always costs the
whole world — 64 retained ticks of a scene that mostly isn't moving, per
predicting client. A controller implementing `PredictedBodyScope` names the
bodies that can matter, and a tick keeps 13 floats each.

The set must be closed under interaction, which is the closure a solver island
describes. Asked for rather than derived, because `PhysicsSimulation` has no
island query and a subtly wrong one would be worse than the cost it saved.

### Lag compensation can rewind between two ticks

A client renders *between* server ticks, so rewinding to the nearer one puts a
target up to half a tick from where the shooter saw it — at 30Hz and a running
speed, most of a body width. Rotations blend the short way; a fraction outside
the interval is clamped rather than extrapolated, since extrapolating puts a
target where neither end says it was.

### Two small engine hooks

- `ComponentCodec.applyProperty` writes a **single** property onto a component
  that already exists, which is what a value arriving over the network is.
  `realize` builds one from a whole spec and cannot answer that.
- A codec can declare the `category` an editor files it under without restating
  its whole schema.

Both are additive and default to the existing behaviour.

### Testing

185 networking tests, 22 format tests, engine suite unaffected. Analyze and
format clean. **Builds against `dashwire_replication` exactly as published** — no
overrides, nothing unreleased.

### Left out on purpose

Two things need transport changes that are open and unmerged, so they carry a
TODO naming the PR rather than shipping half-working:

- Cancelling the transform component's replica subscriptions on detach, which
  needs bdero/dashwire#7. Today those subscriptions — and through them the
  component — live as long as the replica.
- An event target meaning *everyone except the owner*, which needs
  bdero/dashwire#6. Note `RpcTarget.others` excludes the **server**, not the
  owner; the two are easy to confuse.

bdero/dashwire#8 would let `renderedAt` be fed without a game stamping its own
render tick into every input payload.