### PR TITLE
Let flutter_scene_codegen resolve on current Flutter master

### DIFF
--- a/packages/flutter_scene_codegen/lib/src/extractor.dart
+++ b/packages/flutter_scene_codegen/lib/src/extractor.dart
@@ -590,10 +590,10 @@ class _Args {
   _Args(ArgumentList? list) {
     if (list == null) return;
     for (final argument in list.arguments) {
-      if (argument is NamedExpression) {
-        named[argument.name.label.name] = argument.expression;
+      if (argument is NamedArgument) {
+        named[argument.name.lexeme] = argument.argumentExpression;
       } else {
-        positional.add(argument);
+        positional.add(argument.argumentExpression);
       }
     }
   }
@@ -694,7 +694,7 @@ List<double>? _numArgs(ArgumentList args, int count) {
   if (args.arguments.length != count) return null;
   final out = <double>[];
   for (final argument in args.arguments) {
-    final value = _numLit(argument);
+    final value = _numLit(argument.argumentExpression);
     if (value == null) return null;
     out.add(value.toDouble());
   }
@@ -707,12 +707,12 @@ PropertyConstraint<Object?>? _constraintFromExpression(Expression expression) {
   final (typeName, constructorName, args) = split;
   final positional = [
     for (final argument in args.arguments)
-      if (argument is! NamedExpression) argument,
+      if (argument is! NamedArgument) argument.argumentExpression,
   ];
   final named = <String, Expression>{
     for (final argument in args.arguments)
-      if (argument is NamedExpression)
-        argument.name.label.name: argument.expression,
+      if (argument is NamedArgument)
+        argument.name.lexeme: argument.argumentExpression,
   };
   double? positionalNum(int index) =>
       index < positional.length ? _numLit(positional[index])?.toDouble() : null;

--- a/packages/flutter_scene_codegen/pubspec.yaml
+++ b/packages/flutter_scene_codegen/pubspec.yaml
@@ -7,10 +7,11 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  # The extractor targets the 12.x AST surface (ClassDeclaration.namePart
-  # and body landed in 12, ArgumentList.arguments changed shape in 13).
-  analyzer: ">=12.0.0 <13.0.0"
-  dart_style: ">=3.0.0 <3.1.9"
+  # The extractor reads the 13.x argument AST (ArgumentList.arguments is a
+  # NodeList<Argument> and named arguments are NamedArgument), and 13 is
+  # also the floor the SDK-pinned test package needs on current Flutter.
+  analyzer: ">=13.0.0 <15.0.0"
+  dart_style: ^3.1.9
   scene: ^0.3.0
   vector_math: ^2.1.4
 


### PR DESCRIPTION
Flutter master's flutter_test now pins test_api 0.7.13, which needs test 1.31.2 and therefore analyzer 13 or newer, so the codegen's analyzer 12 pin (and the dart_style pin that rode with it) made the workspace unsolvable and every CI job died at pub get.

The extractor now reads the 13.x argument AST (Argument nodes, NamedArgument for the named ones), and the constraints move to analyzer 13 to 14 and dart_style 3.1.9 or newer. Stable 3.47 still resolves both.