### PR TITLE
Let ThirdPersonControllerComponent move a node without turning it

### DIFF
--- a/packages/flutter_scene/CHANGELOG.md
+++ b/packages/flutter_scene/CHANGELOG.md
@@ -16,6 +16,7 @@
 * `Scene.smaa` (`SmaaSettings`) tunes SMAA's edge threshold, search steps, and corner rounding at runtime, previously compile-time constants.
 * `.fscene` stage effects now apply and serialize temporal anti-aliasing tuning and SMAA quality (the fields previously round-tripped through documents without reaching the scene).
 * Update `flutter_scene-idioms` skill (v5) with point light shadows and the runtime SMAA/TAA tuning surface.
+* `ThirdPersonControllerComponent.rotatesToMovement` keeps the node's authored rotation while still moving it, and `yaw` exposes the smoothed heading, now seeded from the node's rotation instead of snapping to zero on the first step. The `flutter_scene-kit` skill (v4) covers it.
 
 * `SceneView` measures `onTick` deltas with a wall clock instead of the ticker's frame-begin timestamps, whose deltas alternate between tiny and double-length values under GPU load and stagger any motion integrated against them. The new `SceneView.clock` injects a clock for tests and time-controlling drivers; the ambient `package:clock` clock (faked under `flutter_test`) is the default.
 * `Scene.punctualLightOverflowCount` reports how many drawable items dropped punctual lights last frame because more lights reached them than the per-object budget shades.

--- a/packages/flutter_scene/lib/src/kit/character/third_person_controller.dart
+++ b/packages/flutter_scene/lib/src/kit/character/third_person_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+
 import 'package:flutter_scene/src/components/component.dart';
 import 'package:flutter_scene/src/node.dart';
 import 'package:flutter_scene/src/raycast.dart';
@@ -23,6 +24,11 @@ class ThirdPersonControllerComponent extends Component {
   /// Speed at which the character turns to face the movement direction (rad/s).
   double turnSpeed;
 
+  /// Whether the node is turned to face the movement direction. When false
+  /// the node keeps whatever rotation it has and only its position moves,
+  /// while [yaw] still tracks the heading for driving a child mesh or animation.
+  bool rotatesToMovement;
+
   /// Upward velocity impulse applied on jump.
   double jumpVelocity;
 
@@ -35,7 +41,7 @@ class ThirdPersonControllerComponent extends Component {
   /// Time window (in seconds) after leaving a ledge during which a jump is still allowed.
   double coyoteTimeWindow;
 
-  /// Time window (in seconds)  /// Time buffer window for jump inputs before landing (in seconds).
+  /// Time window (in seconds) during which a jump pressed before landing still fires.
   double jumpBufferWindow;
 
   /// Delay after landing before another jump can be initiated (in seconds).
@@ -74,11 +80,17 @@ class ThirdPersonControllerComponent extends Component {
   double _landingTimer = 0.0;
   double _airborneTime = 0.0;
   double _currentYaw = 0.0;
+  bool _yawSeeded = false;
+
+  /// The smoothed heading, in radians about +Y, the character is turning
+  /// toward. Seeded from the node's rotation on the first step.
+  double get yaw => _currentYaw;
 
   ThirdPersonControllerComponent({
     this.walkSpeed = 4.5,
     this.runMultiplier = 1.8,
     this.turnSpeed = 12.0,
+    this.rotatesToMovement = true,
     this.jumpVelocity = 6.5,
     this.gravity = 18.0,
     this.maxSlopeAngleDegrees = 45.0,
@@ -135,6 +147,14 @@ class ThirdPersonControllerComponent extends Component {
   @override
   void fixedUpdate(double fixedDt) {
     if (fixedDt <= 0.0 || !isAttached) return;
+
+    if (!_yawSeeded) {
+      _yawSeeded = true;
+      final forward = node.globalTransform.getColumn(2).xyz;
+      if (forward.length2 > 1e-12) {
+        _currentYaw = math.atan2(forward.x, forward.z);
+      }
+    }
 
     // Update timers
     if (_coyoteTimer > 0.0) _coyoteTimer -= fixedDt;
@@ -325,19 +345,24 @@ class ThirdPersonControllerComponent extends Component {
       newWorldPos.y = groundY + footOffset;
     }
 
+    final parent = node.parent;
+    final invParent = parent == null
+        ? null
+        : (parent.globalTransform.clone()..invert());
+
+    if (!rotatesToMovement) {
+      node.position = invParent == null
+          ? newWorldPos
+          : invParent.transform3(newWorldPos);
+      return;
+    }
+
     final newWorldRot = vm.Quaternion.axisAngle(
       vm.Vector3(0, 1, 0),
       _currentYaw,
     );
     final worldMat = vm.Matrix4.compose(newWorldPos, newWorldRot, node.scale);
-
-    final parent = node.parent;
-    if (parent != null) {
-      final invParent = parent.globalTransform.clone()..invert();
-      node.localTransform = invParent * worldMat;
-    } else {
-      node.localTransform = worldMat;
-    }
+    node.localTransform = invParent == null ? worldMat : invParent * worldMat;
   }
 
   @override
@@ -346,6 +371,7 @@ class ThirdPersonControllerComponent extends Component {
       walkSpeed: walkSpeed,
       runMultiplier: runMultiplier,
       turnSpeed: turnSpeed,
+      rotatesToMovement: rotatesToMovement,
       jumpVelocity: jumpVelocity,
       gravity: gravity,
       maxSlopeAngleDegrees: maxSlopeAngleDegrees,

--- a/packages/flutter_scene/skills/flutter_scene-kit/SKILL.md
+++ b/packages/flutter_scene/skills/flutter_scene-kit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flutter_scene-kit
-version: 3
+version: 4
 description: Build interactive 3D gameplay, character controllers, camera rigs, dynamic day/night cycles, water surfaces, audio, pooling, and debug overlays in flutter_scene. Use when creating game mechanics, camera controls, NPC behaviors, atmospheric environments, or diagnostic HUDs.
 ---
 
@@ -77,6 +77,8 @@ final controller = ThirdPersonControllerComponent(
 );
 playerNode.addComponent(controller);
 
+// Pass rotatesToMovement: false to move the node without turning it; read
+// controller.yaw to drive a child mesh or animation from the heading instead.
 // When using VirtualJoystick (where up is -Y in screen space), invert Y:
 // controller.setMoveInput(vm.Vector2(joystickDir.x, -joystickDir.y), isRunning: isSprinting);
 if (jumpPressed) controller.jump();

--- a/packages/flutter_scene/test/kit/third_person_controller_test.dart
+++ b/packages/flutter_scene/test/kit/third_person_controller_test.dart
@@ -1,4 +1,6 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
+
 import 'package:flutter_scene/kit.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:flutter_scene/src/gpu/gpu.dart' as gpu;
@@ -317,6 +319,59 @@ void main() {
 
       expect(controller.velocity.x, greaterThan(0.5));
       expect(controller.velocity.z, closeTo(0.0, 0.1));
+    });
+
+    vm.Vector3 forwardOf(Node node) => node.localTransform.getColumn(2).xyz;
+
+    test('turns the node to face the movement direction by default', () {
+      final player = Node();
+      final controller = ThirdPersonControllerComponent(
+        walkSpeed: 5.0,
+        groundPlaneHeight: 0.0,
+      );
+      player.addComponent(controller);
+
+      controller.setMoveInput(vm.Vector2(1, 0));
+      for (var i = 0; i < 30; i++) {
+        controller.fixedUpdate(0.1);
+      }
+
+      expect(controller.yaw, closeTo(math.pi / 2, 0.01));
+      expect(forwardOf(player).x, closeTo(1.0, 0.01));
+    });
+
+    test('rotatesToMovement false keeps the authored rotation', () {
+      final player = Node()
+        ..rotation = vm.Quaternion.axisAngle(vm.Vector3(0, 1, 0), 1.0);
+      final controller = ThirdPersonControllerComponent(
+        walkSpeed: 5.0,
+        groundPlaneHeight: 0.0,
+        rotatesToMovement: false,
+      );
+      player.addComponent(controller);
+
+      controller.setMoveInput(vm.Vector2(1, 0));
+      for (var i = 0; i < 30; i++) {
+        controller.fixedUpdate(0.1);
+      }
+
+      expect(player.position.x, greaterThan(1.0));
+      expect(forwardOf(player).x, closeTo(math.sin(1.0), 1e-6));
+      expect(forwardOf(player).z, closeTo(math.cos(1.0), 1e-6));
+      // The heading still tracks movement for callers driving their own facing.
+      expect(controller.yaw, closeTo(math.pi / 2, 0.01));
+    });
+
+    test('seeds yaw from the node rotation instead of snapping to zero', () {
+      final player = Node()
+        ..rotation = vm.Quaternion.axisAngle(vm.Vector3(0, 1, 0), 1.0);
+      final controller = ThirdPersonControllerComponent(groundPlaneHeight: 0.0);
+      player.addComponent(controller);
+
+      controller.fixedUpdate(0.1);
+
+      expect(controller.yaw, closeTo(1.0, 1e-6));
+      expect(forwardOf(player).x, closeTo(math.sin(1.0), 1e-6));
     });
 
     test('maintains footOffset height above ground plane', () {


### PR DESCRIPTION
Adds `rotatesToMovement` (default true) to `ThirdPersonControllerComponent` so a node can keep its authored rotation while the controller moves it, requested by a user who drives the model's facing themselves.

The smoothed heading is exposed as `yaw` so callers can still turn a child mesh or blend animation from it, and it now seeds from the node's rotation instead of snapping to zero on the first step. The kit skill bumps to v4 to mention the option.